### PR TITLE
Add some QoL features to the Server

### DIFF
--- a/mistralrs-server/Cargo.toml
+++ b/mistralrs-server/Cargo.toml
@@ -17,6 +17,8 @@ candle-core.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 axum = { version = "0.7.4", features = ["tokio"] }
+utoipa = { version = "4.2", features = ["axum_extras"] }
+utoipa-swagger-ui = { version = "6.0", features = ["axum"]}
 clap = { version = "4.5.1", features = ["derive"] }
 mistralrs-core = { version = "0.1.0", path = "../mistralrs-core" }
 tokio = { version = "1.36.0", features = ["rt-multi-thread"] }

--- a/mistralrs-server/src/main.rs
+++ b/mistralrs-server/src/main.rs
@@ -40,7 +40,6 @@ use tracing::{info, warn};
 use utoipa::OpenApi;
 use utoipa_swagger_ui::SwaggerUi;
 
-
 fn parse_token_source(s: &str) -> Result<TokenSource, String> {
     s.parse()
 }

--- a/mistralrs-server/src/main.rs
+++ b/mistralrs-server/src/main.rs
@@ -237,10 +237,15 @@ async fn models(State(state): State<Arc<MistralRs>>) -> String {
     .unwrap()
 }
 
+async fn health() -> &'static str {
+    "OK"
+}
+
 fn get_router(state: Arc<MistralRs>) -> Router {
     Router::new()
         .route("/v1/chat/completions", post(chatcompletions))
         .route("/v1/models", get(models))
+        .route("/health", get(health))
         .with_state(state)
 }
 

--- a/mistralrs-server/src/main.rs
+++ b/mistralrs-server/src/main.rs
@@ -1,4 +1,5 @@
 use std::{
+    env,
     error::Error,
     fs::File,
     pin::Pin,
@@ -198,7 +199,11 @@ async fn chatcompletions(
         ChatCompletionResponder::Sse(
             Sse::new(streamer).keep_alive(
                 KeepAlive::new()
-                    .interval(Duration::from_secs(1))
+                    .interval(Duration::from_millis(
+                        env::var("KEEP_ALIVE_INTERVAL")
+                            .map(|val| val.parse::<u64>().unwrap_or(1000))
+                            .unwrap_or(1000),
+                    ))
                     .text("keep-alive-text"),
             ),
         )

--- a/mistralrs-server/src/openai.rs
+++ b/mistralrs-server/src/openai.rs
@@ -1,15 +1,15 @@
-use std::collections::HashMap;
-
 use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+use utoipa::ToSchema;
 
-#[derive(Debug, Clone, Deserialize, Serialize)]
+#[derive(Debug, Clone, Deserialize, Serialize, ToSchema)]
 pub struct Message {
     pub content: String,
     pub role: String,
     pub name: Option<String>,
 }
 
-#[derive(Debug, Clone, Deserialize, Serialize)]
+#[derive(Debug, Clone, Deserialize, Serialize, ToSchema)]
 #[serde(untagged)]
 pub enum StopTokens {
     Multi(Vec<String>),
@@ -26,32 +26,46 @@ fn default_1usize() -> usize {
     1
 }
 
-#[derive(Debug, Clone, Deserialize, Serialize)]
+#[derive(Debug, Clone, Deserialize, Serialize, ToSchema)]
 pub struct ChatCompletionRequest {
+    #[schema(example = json!(vec![Message{content:"Why did the crab cross the road?".to_string(), role:"user".to_string(), name: None}]))]
     pub messages: Vec<Message>,
+    #[schema(example = "mistral")]
     pub model: String,
+    #[schema(example = json!(Option::None::<HashMap<u32, f32>>))]
     pub logit_bias: Option<HashMap<u32, f32>>,
     #[serde(default = "default_false")]
+    #[schema(example = false)]
     pub logprobs: bool,
+    #[schema(example = json!(Option::None::<usize>))]
     pub top_logprobs: Option<usize>,
+    #[schema(example = 256)]
     pub max_tokens: Option<usize>,
     #[serde(rename = "n")]
     #[serde(default = "default_1usize")]
+    #[schema(example = 1)]
     pub n_choices: usize,
+    #[schema(example = json!(Option::None::<f32>))]
     pub presence_penalty: Option<f32>,
     #[serde(rename = "frequency_penalty")]
+    #[schema(example = json!(Option::None::<f32>))]
     pub repetition_penalty: Option<f32>,
     #[serde(rename = "stop")]
+    #[schema(example = json!(Option::None::<StopTokens>))]
     pub stop_seqs: Option<StopTokens>,
+    #[schema(example = 0.7)]
     pub temperature: Option<f64>,
+    #[schema(example = json!(Option::None::<f64>))]
     pub top_p: Option<f64>,
+    #[schema(example = true)]
     pub stream: Option<bool>,
 
     // mistral.rs additional
+    #[schema(example = json!(Option::None::<usize>))]
     pub top_k: Option<usize>,
 }
 
-#[derive(Debug, Serialize)]
+#[derive(Debug, Serialize, ToSchema)]
 pub struct ModelObject {
     pub id: String,
     pub object: &'static str,
@@ -59,7 +73,7 @@ pub struct ModelObject {
     pub owned_by: &'static str,
 }
 
-#[derive(Debug, Serialize)]
+#[derive(Debug, Serialize, ToSchema)]
 pub struct ModelObjects {
     pub object: &'static str,
     pub data: Vec<ModelObject>,


### PR DESCRIPTION
Just adds some basic QoL features: 

- Configurable keep-alive-interval for sse via `KEEP_ALIVE_INTERVAL` environment variable
- Health check route on `/health` and `/` (mainly usefull for docker compose)
- OpenAPI doc and Swagger-UI via `utoipa` on `/docs` with example for `/v1/chat/completions`