### PR TITLE
Add support for 'none' token source

### DIFF
--- a/mistralrs-core/src/pipeline/mod.rs
+++ b/mistralrs-core/src/pipeline/mod.rs
@@ -90,6 +90,7 @@ pub enum TokenSource {
     EnvVar(String),
     Path(String),
     CacheToken,
+    None,
 }
 
 impl FromStr for TokenSource {
@@ -113,6 +114,7 @@ impl FromStr for TokenSource {
                 .map(|&value| TokenSource::Path(value.to_string()))
                 .ok_or_else(|| "Expected a value for 'path'".to_string()),
             "cache" => Ok(TokenSource::CacheToken),
+            "none" => Ok(TokenSource::None),
             _ => Err("Invalid token source format".to_string()),
         }
     }
@@ -125,6 +127,7 @@ impl fmt::Display for TokenSource {
             TokenSource::EnvVar(value) => write!(f, "env:{}", value),
             TokenSource::Path(value) => write!(f, "path:{}", value),
             TokenSource::CacheToken => write!(f, "cache"),
+            TokenSource::None => write!(f, "none"),
         }
     }
 }

--- a/mistralrs-core/src/utils/tokens.rs
+++ b/mistralrs-core/src/utils/tokens.rs
@@ -28,6 +28,7 @@ pub(crate) fn get_token(source: &TokenSource) -> Result<String> {
             fs::read_to_string(home.clone())
                 .map_err(|_| anyhow::Error::msg(format!("Could not load token at `{home}`")))?
         }
+        TokenSource::None => "".to_string(),
     }
     .trim()
     .to_string())

--- a/mistralrs-server/src/main.rs
+++ b/mistralrs-server/src/main.rs
@@ -84,7 +84,7 @@ struct Args {
     chat_template: Option<String>,
 
     /// Source of the token for authentication.
-    /// Can be in the formats: "literal:<value>", "env:<value>", "path:<value>", or "cache" to use a cached token.
+    /// Can be in the formats: "literal:<value>", "env:<value>", "path:<value>", "cache" to use a cached token or "none" to use no token.
     /// Defaults to using a cached token.
     #[arg(long, default_value_t = TokenSource::CacheToken, value_parser = parse_token_source)]
     token_source: TokenSource,


### PR DESCRIPTION
This is useful for models which do not require authentication and when the HF token does not need to be provided.