### PR TITLE
Allow input prompt message to be a String prompt

### DIFF
--- a/examples/http.md
+++ b/examples/http.md
@@ -79,7 +79,7 @@ curl http://localhost:<port>/docs
 OpenAI compatible request.
 ```rust
 pub struct ChatCompletionRequest {
-    pub messages: Vec<Message>,
+    pub messages: Either<Vec<Message>, String>,
     pub model: String,
     pub logit_bias: Option<HashMap<u32, f32>>,
     // Default false

--- a/mistralrs-core/src/request.rs
+++ b/mistralrs-core/src/request.rs
@@ -1,10 +1,11 @@
+use either::Either;
 use indexmap::IndexMap;
 
 use crate::{response::Response, sampler::SamplingParams};
 use std::{fmt::Debug, sync::mpsc::Sender};
 
 pub struct Request {
-    pub messages: Vec<IndexMap<String, String>>,
+    pub messages: Either<Vec<IndexMap<String, String>>, String>,
     pub sampling_params: SamplingParams,
     pub response: Sender<Response>,
     pub return_logprobs: bool,

--- a/mistralrs-pyo3/Cargo.toml
+++ b/mistralrs-pyo3/Cargo.toml
@@ -16,7 +16,7 @@ crate-type = ["cdylib"]
 doc = false
 
 [dependencies]
-pyo3 = "0.21.0" # { version = "0.21.0", features = ["extension-module"] }
+pyo3 = { version = "0.21.0", features = ["either"] } # { version = "0.21.0", features = ["extension-module"] }
 mistralrs = { version = "0.1.0", path = "../mistralrs" }
 serde.workspace = true
 serde_json.workspace = true
@@ -24,6 +24,7 @@ candle-core.workspace = true
 indexmap.workspace = true
 accelerate-src = { workspace = true, optional = true }
 intel-mkl-src = { workspace = true, optional = true }
+either.workspace = true
 
 [features]
 cuda = ["candle-core/cuda", "mistralrs/cuda"]

--- a/mistralrs-pyo3/mistralrs.pyi
+++ b/mistralrs-pyo3/mistralrs.pyi
@@ -8,7 +8,7 @@ class ChatCompletionRequest:
     about input data, sampling, and how to return the response.
     """
 
-    messages: list[dict[str, str]]
+    messages: list[dict[str, str]] | str
     model: str
     logit_bias: dict[int, float] | None = None
     logprobs: bool = False

--- a/mistralrs-pyo3/src/lib.rs
+++ b/mistralrs-pyo3/src/lib.rs
@@ -203,22 +203,12 @@ impl ChatCompletionRequest {
                     }
                     messages_vec.push(messages_map);
                 }
-                Ok::<
-                    Either<
-                        Vec<IndexMap<std::string::String, std::string::String>>,
-                        std::string::String,
-                    >,
-                    PyErr,
-                >(Either::Left(messages_vec))
+                Ok::<Either<Vec<IndexMap<String, String>>, String>, PyErr>(Either::Left(
+                    messages_vec,
+                ))
             } else if let Ok(messages) = messages.bind(py).downcast_exact::<PyString>() {
                 let prompt = messages.extract::<String>()?;
-                Ok::<
-                    Either<
-                        Vec<IndexMap<std::string::String, std::string::String>>,
-                        std::string::String,
-                    >,
-                    PyErr,
-                >(Either::Right(prompt))
+                Ok::<Either<Vec<IndexMap<String, String>>, String>, PyErr>(Either::Right(prompt))
             } else {
                 return Err(PyTypeError::new_err("Expected a string or list of dicts."));
             }

--- a/mistralrs-pyo3/src/lib.rs
+++ b/mistralrs-pyo3/src/lib.rs
@@ -1,4 +1,5 @@
 use candle_core::Result;
+use either::Either;
 use indexmap::IndexMap;
 use std::{
     cell::RefCell,
@@ -14,9 +15,9 @@ use loaders::{
     NormalLoader, QuantizedLoader, XLoraLoader, XLoraQuantizedLoader,
 };
 use pyo3::{
-    exceptions::PyValueError,
+    exceptions::{PyTypeError, PyValueError},
     prelude::*,
-    types::{PyDict, PyString},
+    types::{PyDict, PyList, PyString},
 };
 mod loaders;
 
@@ -144,7 +145,7 @@ impl Runner {
 #[derive(Debug)]
 /// An OpenAI API compatible chat completion request.
 struct ChatCompletionRequest {
-    messages: Vec<IndexMap<String, String>>,
+    messages: Either<Vec<IndexMap<String, String>>, String>,
     _model: String,
     logit_bias: Option<HashMap<u32, f32>>,
     logprobs: bool,
@@ -166,7 +167,7 @@ impl ChatCompletionRequest {
     #[pyo3(signature = (messages, model, logprobs = false, n_choices = 1, logit_bias = None, top_logprobs = None, max_tokens = None, presence_penalty = None, repetition_penalty = None, stop_token_ids = None, temperature = None, top_p = None, top_k = None, stream=false))]
     #[allow(clippy::too_many_arguments)]
     fn new(
-        messages: Vec<Py<PyDict>>,
+        messages: Py<PyAny>,
         model: String,
         logprobs: bool,
         n_choices: usize,
@@ -181,30 +182,49 @@ impl ChatCompletionRequest {
         top_k: Option<usize>,
         stream: Option<bool>,
     ) -> PyResult<Self> {
-        let mut messages_vec = Vec::new();
-        for message in messages {
-            let messages_map = Python::with_gil(|py| {
-                let mapping = message.bind(py).as_mapping();
-                let mut messages_map = IndexMap::new();
-                for i in 0..mapping.len()? {
-                    let k = mapping
-                        .keys()?
-                        .get_item(i)?
-                        .downcast::<PyString>()?
-                        .extract::<String>()?;
-                    let v = mapping
-                        .values()?
-                        .get_item(i)?
-                        .downcast::<PyString>()?
-                        .extract::<String>()?;
-                    messages_map.insert(k, v);
+        let messages = Python::with_gil(|py| {
+            if let Ok(messages) = messages.bind(py).downcast_exact::<PyList>() {
+                let mut messages_vec = Vec::new();
+                for message in messages {
+                    let mapping = message.downcast::<PyDict>()?.as_mapping();
+                    let mut messages_map = IndexMap::new();
+                    for i in 0..mapping.len()? {
+                        let k = mapping
+                            .keys()?
+                            .get_item(i)?
+                            .downcast::<PyString>()?
+                            .extract::<String>()?;
+                        let v = mapping
+                            .values()?
+                            .get_item(i)?
+                            .downcast::<PyString>()?
+                            .extract::<String>()?;
+                        messages_map.insert(k, v);
+                    }
+                    messages_vec.push(messages_map);
                 }
-                Ok::<IndexMap<std::string::String, std::string::String>, PyErr>(messages_map)
-            })?;
-            messages_vec.push(messages_map);
-        }
+                Ok::<
+                    Either<
+                        Vec<IndexMap<std::string::String, std::string::String>>,
+                        std::string::String,
+                    >,
+                    PyErr,
+                >(Either::Left(messages_vec))
+            } else if let Ok(messages) = messages.bind(py).downcast_exact::<PyString>() {
+                let prompt = messages.extract::<String>()?;
+                Ok::<
+                    Either<
+                        Vec<IndexMap<std::string::String, std::string::String>>,
+                        std::string::String,
+                    >,
+                    PyErr,
+                >(Either::Right(prompt))
+            } else {
+                return Err(PyTypeError::new_err("Expected a string or list of dicts."));
+            }
+        })?;
         Ok(Self {
-            messages: messages_vec,
+            messages,
             _model: model,
             logit_bias,
             logprobs,

--- a/mistralrs-server/Cargo.toml
+++ b/mistralrs-server/Cargo.toml
@@ -30,6 +30,7 @@ intel-mkl-src = { workspace = true, optional = true }
 futures = "0.3"
 tracing.workspace = true
 tracing-subscriber.workspace = true
+either.workspace = true
 
 
 [features]

--- a/mistralrs-server/src/openai.rs
+++ b/mistralrs-server/src/openai.rs
@@ -1,3 +1,4 @@
+use either::Either;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use utoipa::ToSchema;
@@ -29,7 +30,8 @@ fn default_1usize() -> usize {
 #[derive(Debug, Clone, Deserialize, Serialize, ToSchema)]
 pub struct ChatCompletionRequest {
     #[schema(example = json!(vec![Message{content:"Why did the crab cross the road?".to_string(), role:"user".to_string(), name: None}]))]
-    pub messages: Vec<Message>,
+    #[serde(with = "either::serde_untagged")]
+    pub messages: Either<Vec<Message>, String>,
     #[schema(example = "mistral")]
     pub model: String,
     #[schema(example = json!(Option::None::<HashMap<u32, f32>>))]


### PR DESCRIPTION
Updates:
- `http.md` docs
- `mistralrs.pyi` type hints

Changes:
- `ChatCompletionReuqest::new` parsing/downcasting
- `ChatCompletionRequest` handles the string
- `Engine` handles not running the chat template if the prompt is already provided.