### PR TITLE
Handle errors in forward pass, delete cache and cancel all sequences (Survive OOM)

### DIFF
--- a/examples/server/chat.py
+++ b/examples/server/chat.py
@@ -1,8 +1,9 @@
 import openai
+import httpx
 
 openai.api_key = "EMPTY"
-
 openai.base_url = "http://localhost:1234/v1/"
+openai.http_client = httpx.Client(event_hooks={"request": [print], "response": [print]})
 
 messages = []
 prompt = input("Enter system prompt >>> ")

--- a/examples/server/chat.py
+++ b/examples/server/chat.py
@@ -1,9 +1,39 @@
 import openai
 import httpx
+import textwrap, json
+
+
+def log_response(response: httpx.Response):
+    request = response.request
+    print(f"Request: {request.method} {request.url}")
+    print("  Headers:")
+    for key, value in request.headers.items():
+        if key.lower() == "authorization":
+            value = "[...]"
+        if key.lower() == "cookie":
+            value = value.split("=")[0] + "=..."
+        print(f"    {key}: {value}")
+    print("  Body:")
+    try:
+        request_body = json.loads(request.content)
+        print(textwrap.indent(json.dumps(request_body, indent=2), "    "))
+    except json.JSONDecodeError:
+        print(textwrap.indent(request.content.decode(), "    "))
+    print(f"Response: status_code={response.status_code}")
+    print("  Headers:")
+    for key, value in response.headers.items():
+        if key.lower() == "set-cookie":
+            value = value.split("=")[0] + "=..."
+        print(f"    {key}: {value}")
+
 
 openai.api_key = "EMPTY"
 openai.base_url = "http://localhost:1234/v1/"
-openai.http_client = httpx.Client(event_hooks={"request": [print], "response": [print]})
+
+# Enable this to log requests and responses
+# openai.http_client = httpx.Client(
+#     event_hooks={"request": [print], "response": [log_response]}
+# )
 
 messages = []
 prompt = input("Enter system prompt >>> ")

--- a/mistralrs-core/src/engine/mod.rs
+++ b/mistralrs-core/src/engine/mod.rs
@@ -68,7 +68,7 @@ impl Engine {
                     Self::clone_in_cache(&mut *pipeline, &mut scheduled.completion);
                 }
                 let logits = pipeline.forward(&scheduled.completion, false);
-                let logits = handle_pipeline_forward_error!(logits, &mut scheduled.completion, pipeline, 'lp);
+                let logits = handle_pipeline_forward_error!("completion", logits, &mut scheduled.completion, pipeline, 'lp);
 
                 if !self.no_kv_cache {
                     Self::clone_out_cache(&mut *pipeline, &mut scheduled.completion);
@@ -88,8 +88,7 @@ impl Engine {
                 // Run the prompt seqs
                 Self::set_none_cache(&mut *pipeline);
                 let logits = pipeline.forward(&scheduled.prompt, true);
-                let logits =
-                    handle_pipeline_forward_error!(logits, &mut scheduled.prompt, pipeline, 'lp);
+                let logits = handle_pipeline_forward_error!("prompt", logits, &mut scheduled.prompt, pipeline, 'lp);
 
                 if !self.no_kv_cache {
                     Self::clone_out_cache(&mut *pipeline, &mut scheduled.prompt);

--- a/mistralrs-core/src/engine/mod.rs
+++ b/mistralrs-core/src/engine/mod.rs
@@ -68,7 +68,6 @@ impl Engine {
                     Self::clone_in_cache(&mut *pipeline, &mut scheduled.completion);
                 }
                 let logits = pipeline.forward(&scheduled.completion, false);
-
                 let logits = handle_pipeline_forward_error!(logits, &mut scheduled.completion, pipeline, 'lp);
 
                 if !self.no_kv_cache {
@@ -368,7 +367,7 @@ impl Engine {
                 // NOTE(EricLBuehler): Unwrap reasoning: The receiver should really be there, otherwise it is their fault.
                 request
                     .response
-                    .send(Response::Error(
+                    .send(Response::ValidationError(
                         format!("Prompt sequence length is greater than {}, perhaps consider using `truncate_sequence`?", get_mut_arcmutex!(self.pipeline).get_max_seq_len()).into(),
                     ))
                     .unwrap();
@@ -413,7 +412,7 @@ impl Engine {
                     // NOTE(EricLBuehler): Unwrap reasoning: The receiver should really be there, otherwise it is their fault.
                     request
                         .response
-                        .send(Response::Error(
+                        .send(Response::ValidationError(
                             format!("Stop sequence '{s:?}' encodes to multiple tokens when it should only encode to 1.").into(),
                         ))
                         .unwrap();

--- a/mistralrs-core/src/pipeline/gemma.rs
+++ b/mistralrs-core/src/pipeline/gemma.rs
@@ -371,7 +371,11 @@ impl Loader for GemmaLoader {
 }
 
 impl Pipeline for GemmaPipeline {
-    fn forward(&mut self, input_toks: &[&mut Sequence], is_prompt: bool) -> Tensor {
+    fn forward(
+        &mut self,
+        input_toks: &[&mut Sequence],
+        is_prompt: bool,
+    ) -> Result<Tensor, candle_core::Error> {
         let ModelInputs {
             input_ids,
             input_ids_full,
@@ -402,12 +406,7 @@ impl Pipeline for GemmaPipeline {
                 &self.non_granular_state,
             ),
         };
-        match result {
-            Ok(v) => v,
-            Err(e) => {
-                panic!("Model failed with error `{e}`. Please raise an issue.");
-            }
-        }
+        result
     }
     fn device(&self) -> &Device {
         match self.model {

--- a/mistralrs-core/src/pipeline/gemma.rs
+++ b/mistralrs-core/src/pipeline/gemma.rs
@@ -391,7 +391,7 @@ impl Pipeline for GemmaPipeline {
             self.no_kv_cache,
         )
         .unwrap();
-        let result = match self.model {
+        match self.model {
             Model::Normal(ref mut model) => {
                 model.forward(&input_ids, &seqlen_offsets, seqlen_offsets_kernel)
             }
@@ -405,8 +405,7 @@ impl Pipeline for GemmaPipeline {
                 self.no_kv_cache,
                 &self.non_granular_state,
             ),
-        };
-        result
+        }
     }
     fn device(&self) -> &Device {
         match self.model {

--- a/mistralrs-core/src/pipeline/llama.rs
+++ b/mistralrs-core/src/pipeline/llama.rs
@@ -469,7 +469,11 @@ impl Loader for LlamaLoader {
 }
 
 impl Pipeline for LlamaPipeline {
-    fn forward(&mut self, input_toks: &[&mut Sequence], is_prompt: bool) -> Tensor {
+    fn forward(
+        &mut self,
+        input_toks: &[&mut Sequence],
+        is_prompt: bool,
+    ) -> Result<Tensor, candle_core::Error> {
         let ModelInputs {
             input_ids,
             input_ids_full,
@@ -513,12 +517,7 @@ impl Pipeline for LlamaPipeline {
                 &self.non_granular_state,
             ),
         };
-        match result {
-            Ok(v) => v,
-            Err(e) => {
-                panic!("Model failed with error `{e}`. Please raise an issue.");
-            }
-        }
+        result
     }
     fn device(&self) -> &Device {
         match self.model {

--- a/mistralrs-core/src/pipeline/llama.rs
+++ b/mistralrs-core/src/pipeline/llama.rs
@@ -489,7 +489,7 @@ impl Pipeline for LlamaPipeline {
             self.no_kv_cache,
         )
         .unwrap();
-        let result = match self.model {
+        match self.model {
             Model::Normal(ref mut model) => {
                 model.forward(&input_ids, &seqlen_offsets, seqlen_offsets_kernel)
             }
@@ -516,8 +516,7 @@ impl Pipeline for LlamaPipeline {
                 self.no_kv_cache,
                 &self.non_granular_state,
             ),
-        };
-        result
+        }
     }
     fn device(&self) -> &Device {
         match self.model {

--- a/mistralrs-core/src/pipeline/mistral.rs
+++ b/mistralrs-core/src/pipeline/mistral.rs
@@ -447,7 +447,7 @@ impl Pipeline for MistralPipeline {
             self.no_kv_cache,
         )
         .unwrap();
-        let result = match self.model {
+        match self.model {
             Model::Normal(ref mut model) => {
                 model.forward(&input_ids, &seqlen_offsets, seqlen_offsets_kernel)
             }
@@ -474,8 +474,7 @@ impl Pipeline for MistralPipeline {
                 self.no_kv_cache,
                 &self.non_granular_state,
             ),
-        };
-        result
+        }
     }
     fn device(&self) -> &Device {
         match self.model {

--- a/mistralrs-core/src/pipeline/mistral.rs
+++ b/mistralrs-core/src/pipeline/mistral.rs
@@ -427,7 +427,11 @@ impl Loader for MistralLoader {
 }
 
 impl Pipeline for MistralPipeline {
-    fn forward(&mut self, input_toks: &[&mut Sequence], is_prompt: bool) -> Tensor {
+    fn forward(
+        &mut self,
+        input_toks: &[&mut Sequence],
+        is_prompt: bool,
+    ) -> Result<Tensor, candle_core::Error> {
         let ModelInputs {
             input_ids,
             input_ids_full,
@@ -471,12 +475,7 @@ impl Pipeline for MistralPipeline {
                 &self.non_granular_state,
             ),
         };
-        match result {
-            Ok(v) => v,
-            Err(e) => {
-                panic!("Model failed with error `{e}`. Please raise an issue.");
-            }
-        }
+        result
     }
     fn device(&self) -> &Device {
         match self.model {

--- a/mistralrs-core/src/pipeline/mixtral.rs
+++ b/mistralrs-core/src/pipeline/mixtral.rs
@@ -431,7 +431,11 @@ impl Loader for MixtralLoader {
 }
 
 impl Pipeline for MixtralPipeline {
-    fn forward(&mut self, input_toks: &[&mut Sequence], is_prompt: bool) -> Tensor {
+    fn forward(
+        &mut self,
+        input_toks: &[&mut Sequence],
+        is_prompt: bool,
+    ) -> Result<Tensor, candle_core::Error> {
         let ModelInputs {
             input_ids,
             input_ids_full,
@@ -475,12 +479,7 @@ impl Pipeline for MixtralPipeline {
                 &self.non_granular_state,
             ),
         };
-        match result {
-            Ok(v) => v,
-            Err(e) => {
-                panic!("Model failed with error `{e}`. Please raise an issue.");
-            }
-        }
+        result
     }
     fn device(&self) -> &Device {
         match self.model {

--- a/mistralrs-core/src/pipeline/mixtral.rs
+++ b/mistralrs-core/src/pipeline/mixtral.rs
@@ -451,7 +451,7 @@ impl Pipeline for MixtralPipeline {
             self.no_kv_cache,
         )
         .unwrap();
-        let result = match self.model {
+        match self.model {
             Model::Normal(ref mut model) => {
                 model.forward(&input_ids, &seqlen_offsets, seqlen_offsets_kernel)
             }
@@ -478,8 +478,7 @@ impl Pipeline for MixtralPipeline {
                 self.no_kv_cache,
                 &self.non_granular_state,
             ),
-        };
-        result
+        }
     }
     fn device(&self) -> &Device {
         match self.model {

--- a/mistralrs-core/src/pipeline/mod.rs
+++ b/mistralrs-core/src/pipeline/mod.rs
@@ -225,7 +225,11 @@ fn apply_chat_template_to(
 }
 
 pub trait Pipeline: Send + Sync {
-    fn forward(&mut self, input_toks: &[&mut Sequence], is_prompt: bool) -> Tensor;
+    fn forward(
+        &mut self,
+        input_toks: &[&mut Sequence],
+        is_prompt: bool,
+    ) -> Result<Tensor, candle_core::Error>;
     fn tokenize_prompt(&self, prompt: &str) -> Result<Vec<u32>> {
         let encoding = self
             .tokenizer()

--- a/mistralrs-core/src/pipeline/phi2.rs
+++ b/mistralrs-core/src/pipeline/phi2.rs
@@ -387,7 +387,7 @@ impl Pipeline for Phi2Pipeline {
             self.no_kv_cache,
         )
         .unwrap();
-        let result = match self.model {
+        match self.model {
             Model::Normal(ref mut model) => {
                 model.forward(&input_ids, &seqlen_offsets, seqlen_offsets_kernel)
             }
@@ -401,8 +401,7 @@ impl Pipeline for Phi2Pipeline {
                 self.no_kv_cache,
                 &self.non_granular_state,
             ),
-        };
-        result
+        }
     }
     fn device(&self) -> &Device {
         match self.model {

--- a/mistralrs-core/src/pipeline/phi2.rs
+++ b/mistralrs-core/src/pipeline/phi2.rs
@@ -367,7 +367,11 @@ impl Loader for Phi2Loader {
 }
 
 impl Pipeline for Phi2Pipeline {
-    fn forward(&mut self, input_toks: &[&mut Sequence], is_prompt: bool) -> Tensor {
+    fn forward(
+        &mut self,
+        input_toks: &[&mut Sequence],
+        is_prompt: bool,
+    ) -> Result<Tensor, candle_core::Error> {
         let ModelInputs {
             input_ids,
             input_ids_full,
@@ -398,12 +402,7 @@ impl Pipeline for Phi2Pipeline {
                 &self.non_granular_state,
             ),
         };
-        match result {
-            Ok(v) => v,
-            Err(e) => {
-                panic!("Model failed with error `{e}`. Please raise an issue.");
-            }
-        }
+        result
     }
     fn device(&self) -> &Device {
         match self.model {

--- a/mistralrs-core/src/response.rs
+++ b/mistralrs-core/src/response.rs
@@ -88,6 +88,7 @@ pub struct ChatCompletionChunkResponse {
 pub enum Response {
     InternalError(Box<dyn Error + Send + Sync>),
     ValidationError(Box<dyn Error + Send + Sync>),
+    ModelError(String, ChatCompletionResponse),
     Done(ChatCompletionResponse),
     Chunk(ChatCompletionChunkResponse),
 }

--- a/mistralrs-core/src/response.rs
+++ b/mistralrs-core/src/response.rs
@@ -86,7 +86,8 @@ pub struct ChatCompletionChunkResponse {
 }
 
 pub enum Response {
-    Error(Box<dyn Error + Send + Sync>),
+    InternalError(Box<dyn Error + Send + Sync>),
+    ValidationError(Box<dyn Error + Send + Sync>),
     Done(ChatCompletionResponse),
     Chunk(ChatCompletionChunkResponse),
 }

--- a/mistralrs-core/src/sequence.rs
+++ b/mistralrs-core/src/sequence.rs
@@ -272,8 +272,11 @@ impl Sequence {
             .expect("Time travel has occurred!")
             .as_millis();
 
-        get_mut_group!(self).total_completion_time += now - self.prompt_timestamp.unwrap();
-        get_mut_group!(self).total_prompt_time += self.prompt_timestamp.unwrap() - self.timestamp;
+        if let Some(ts) = self.prompt_timestamp {
+            get_mut_group!(self).total_completion_time += now - ts;
+            get_mut_group!(self).total_prompt_time += ts - self.timestamp;
+        }
+
         get_mut_group!(self).total_time += now - self.timestamp;
 
         get_mut_group!(self).total_prompt_toks += self.prompt_len;

--- a/mistralrs-core/src/utils/mod.rs
+++ b/mistralrs-core/src/utils/mod.rs
@@ -46,17 +46,51 @@ macro_rules! handle_seq_error_stateaware {
 
 #[macro_export]
 macro_rules! handle_pipeline_forward_error {
-    ($fallible:expr, $seq_slice:expr, $pipeline:expr, $label:tt) => {
+    ($stage: tt, $fallible:expr, $seq_slice:expr, $pipeline:expr, $label:tt) => {
         match $fallible {
             Ok(v) => v,
             Err(e) => {
                 use $crate::response::Response;
                 use $crate::sequence::SequenceState;
                 use $crate::Engine;
-                println!("Model failed with error: {:?}", &e);
+                // use $crate::response::SYSTEM_FINGERPRINT;
+                println!("{} - Model failed with error: {:?}", $stage, &e);
+                // for seq in $seq_slice.iter_mut() {
+                //     let res = match $pipeline
+                //         .tokenizer()
+                //         .decode(&seq.get_toks()[seq.prompt_tokens()..], false)
+                //     {
+                //         Ok(v) => v,
+                //         Err(_) => "".to_string(),
+                //     };
+                //     let choice = Choice {
+                //         stopreason: "error".to_string(),
+                //         index: seq.get_response_index(),
+                //         message: ResponseMessage {
+                //             content: res,
+                //             role: "assistant".to_string(),
+                //         },
+                //         logprobs: None,
+                //     };
+                //     seq.add_choice_to_group(choice);
+                // }
                 for seq in $seq_slice.iter_mut() {
+                    // let group = seq.get_mut_group();
+
+                    // let partial_completion_response = ChatCompletionResponse {
+                    //     id: seq.id().to_string(),
+                    //     choices: group.get_choices().to_vec(),
+                    //     created: seq.creation_time(),
+                    //     model: $pipeline.name(),
+                    //     system_fingerprint: SYSTEM_FINGERPRINT.to_string(),
+                    //     object: "chat.completion".to_string(),
+                    //     usage: group.get_usage(),
+                    // };
+
                     seq.responder()
-                        .send(Response::InternalError(e.to_string().into()))
+                        .send(Response::InternalError(
+                            e.to_string().into()
+                        ))
                         .unwrap();
                     seq.set_state(SequenceState::Error);
                 }

--- a/mistralrs-core/src/utils/mod.rs
+++ b/mistralrs-core/src/utils/mod.rs
@@ -20,7 +20,7 @@ macro_rules! handle_seq_error {
             Err(e) => {
                 use $crate::response::Response;
                 // NOTE(EricLBuehler): Unwrap reasoning: The receiver should really be there, otherwise it is their fault.
-                $response.send(Response::Error(e.into())).unwrap();
+                $response.send(Response::InternalError(e.into())).unwrap();
                 return;
             }
         }
@@ -36,7 +36,7 @@ macro_rules! handle_seq_error_stateaware {
                 use $crate::response::Response;
                 use $crate::sequence::SequenceState;
                 // NOTE(EricLBuehler): Unwrap reasoning: The receiver should really be there, otherwise it is their fault.
-                $seq.responder().send(Response::Error(e.into())).unwrap();
+                $seq.responder().send(Response::InternalError(e.into())).unwrap();
                 $seq.set_state(SequenceState::Error);
                 return;
             }
@@ -56,7 +56,7 @@ macro_rules! handle_pipeline_forward_error {
                 println!("Model failed with error: {:?}", &e);
                 for seq in $seq_slice.iter_mut() {
                     seq.responder()
-                        .send(Response::Error(e.to_string().into()))
+                        .send(Response::InternalError(e.to_string().into()))
                         .unwrap();
                     seq.set_state(SequenceState::Error);
                 }

--- a/mistralrs-core/src/utils/mod.rs
+++ b/mistralrs-core/src/utils/mod.rs
@@ -54,7 +54,8 @@ macro_rules! handle_pipeline_forward_error {
                 use $crate::sequence::SequenceState;
                 use $crate::Engine;
                 use $crate::response::SYSTEM_FINGERPRINT;
-                println!("{} - Model failed with error: {:?}", $stage, &e);
+                use tracing::error;
+                error!("{} - Model failed with error: {:?}", $stage, &e);
                 for seq in $seq_slice.iter_mut() {
                     // Step 1: Add all choices to groups
                     let res = match $pipeline

--- a/mistralrs-pyo3/src/lib.rs
+++ b/mistralrs-pyo3/src/lib.rs
@@ -138,6 +138,7 @@ impl Runner {
                     Ok(serde_json::to_string(&response).unwrap())
                 }
                 Response::Chunk(_) => unreachable!(),
+                Response::ModelError(msg, _) => Err(PyValueError::new_err(msg.to_string())),
             }
         })
     }

--- a/mistralrs-pyo3/src/lib.rs
+++ b/mistralrs-pyo3/src/lib.rs
@@ -130,7 +130,9 @@ impl Runner {
             let response = rx.recv().unwrap();
 
             match response {
-                Response::Error(e) => Err(PyValueError::new_err(e.to_string())),
+                Response::ValidationError(e) | Response::InternalError(e) => {
+                    Err(PyValueError::new_err(e.to_string()))
+                }
                 Response::Done(response) => {
                     MistralRs::maybe_log_response(self.runner.clone(), &response);
                     Ok(serde_json::to_string(&response).unwrap())

--- a/mistralrs-server/src/main.rs
+++ b/mistralrs-server/src/main.rs
@@ -124,7 +124,10 @@ impl futures::Stream for Streamer {
                     );
                     Poll::Ready(Some(Ok(Event::default().data(msg))))
                 }
-                Response::ValidationError(e) | Response::InternalError(e) => {
+                Response::ValidationError(e) => {
+                    Poll::Ready(Some(Ok(Event::default().data(e.to_string()))))
+                }
+                Response::InternalError(e) => {
                     MistralRs::maybe_log_error(self.state.clone(), &*e);
                     Poll::Ready(Some(Ok(Event::default().data(e.to_string()))))
                 }
@@ -304,10 +307,7 @@ async fn chatcompletions(
                 MistralRs::maybe_log_response(state, &response);
                 ChatCompletionResponder::ModelError(msg, response)
             }
-            Response::ValidationError(e) => {
-                MistralRs::maybe_log_error(state, &*e);
-                ChatCompletionResponder::ValidationError(e)
-            }
+            Response::ValidationError(e) => ChatCompletionResponder::ValidationError(e),
             Response::Done(response) => {
                 MistralRs::maybe_log_response(state, &response);
                 ChatCompletionResponder::Json(response)


### PR DESCRIPTION
I was playing around with the codebase, adding a few dbg! around and seeing what goes on under the hood.

While doing so I stumbled upon an Out of Memory error. I was using a very long prompt, and it won't fit my GPU indeed.

When this happened, the server no longer worked, the process was still alive and GPU memory had not been freed.

This behavior can be simulated with panicking anywhere in the forward function of the pipeline: https://github.com/EricLBuehler/mistral.rs/blob/master/mistralrs-core/src/pipeline/mistral.rs#L371

I changed the Pipeline trait to return errors on the forward pass instead of panicking. I handled the errors by setting all sequence states to error, deleting the GPU cache and sending an error message to the receiver.

This makes the server continue to work and frees all GPU memory, allowing new requests to go on normally.

@EricLBuehler What are your thoughts?

If this approach is any good, I'll make the errors OpenAI API compatible too.

Also, I noticed the Status Code of the error message was 200, not 4xx or 5xx (but that's a different issue https://github.com/EricLBuehler/mistral.rs/issues/97)