### PR TITLE
Resolve "Status code of HTTP error messages is not 4xx or 5xx"

### DIFF
--- a/mistralrs-core/src/engine/mod.rs
+++ b/mistralrs-core/src/engine/mod.rs
@@ -413,6 +413,7 @@ impl Engine {
                             format!("Stop sequence '{s:?}' encodes to multiple tokens when it should only encode to 1.").into(),
                         ))
                         .unwrap();
+                    return;
                 }
                 stop_toks.push(toks[0]);
                 stop_toks

--- a/mistralrs-server/src/main.rs
+++ b/mistralrs-server/src/main.rs
@@ -139,7 +139,7 @@ struct JsonError {
 }
 
 impl JsonError {
-    pub fn new(message: String) -> Self {
+    fn new(message: String) -> Self {
         Self { message }
     }
 }


### PR DESCRIPTION
Closes https://github.com/EricLBuehler/mistral.rs/issues/97

```
curl -v http://localhost:1234/v1/chat/completions \
-H "Content-Type: application/json" \
-H "Authorization: Bearer EMPTY" \
-d '{
"model": "mistral",
"stop": "\n\n\n",
"temperature": 0,
"top_p": 0.1,
"frequency_penalty": 1.0,
"max_tokens": 256,
"messages": [
{
    "role": "user",
    "content": "Write a story about Rust error handling."
}
]
}'
*   Trying 127.0.0.1:1234...
* Connected to localhost (127.0.0.1) port 1234 (#0)
> POST /v1/chat/completions HTTP/1.1
> Host: localhost:1234
> User-Agent: curl/7.81.0
> Accept: */*
> Content-Type: application/json
> Authorization: Bearer EMPTY
> Content-Length: 216
> 
* Mark bundle as not supporting multiuse
< HTTP/1.1 500 Internal Server Error
< content-type: application/json
< content-length: 105
< date: Tue, 09 Apr 2024 22:42:53 GMT
< 
* Connection #0 to host localhost left intact
{"message":"Stop sequence '[\"\\n\\n\\n\"]' encodes to multiple tokens when it should only encode to 1."}l
```

```
$ python3 chat.py 
Enter system prompt >>> A
>>> 

Traceback (most recent call last):
  File "/home/lucas/oss/mistral.rs/examples/server/chat.py", line 17, in <module>
    completion = openai.chat.completions.create(
  File "/home/lucas/.local/lib/python3.10/site-packages/openai/_utils/_utils.py", line 299, in wrapper
    return func(*args, **kwargs)
  File "/home/lucas/.local/lib/python3.10/site-packages/openai/resources/chat/completions.py", line 598, in create
    return self._post(
  File "/home/lucas/.local/lib/python3.10/site-packages/openai/_base_client.py", line 1055, in post
    return cast(ResponseT, self.request(cast_to, opts, stream=stream, stream_cls=stream_cls))
  File "/home/lucas/.local/lib/python3.10/site-packages/openai/_base_client.py", line 834, in request
    return self._request(
  File "/home/lucas/.local/lib/python3.10/site-packages/openai/_base_client.py", line 865, in _request
    return self._retry_request(
  File "/home/lucas/.local/lib/python3.10/site-packages/openai/_base_client.py", line 925, in _retry_request
    return self._request(
  File "/home/lucas/.local/lib/python3.10/site-packages/openai/_base_client.py", line 865, in _request
    return self._retry_request(
  File "/home/lucas/.local/lib/python3.10/site-packages/openai/_base_client.py", line 925, in _retry_request
    return self._request(
  File "/home/lucas/.local/lib/python3.10/site-packages/openai/_base_client.py", line 877, in _request
    raise self._make_status_error_from_response(err.response) from None
openai.InternalServerError: Error code: 500 - {'message': 'invalid operation: Conversation roles must alternate user/assistant/user/assistant/... (in chat_template:1)'}
```