### PR TITLE
Optimize streaming

### DIFF
--- a/examples/server/stream_completion_bench.py
+++ b/examples/server/stream_completion_bench.py
@@ -1,0 +1,49 @@
+import openai
+from datetime import datetime
+
+Runs = 4
+
+ENDPOINT = "http://localhost:1234/v1/"
+
+
+def request(stream: bool):
+    client = openai.Client(api_key="foobar", base_url=ENDPOINT)
+    return client.chat.completions.create(
+        model="mistral",
+        messages=[
+            {
+                "role": "user",
+                "content": "What is the meaning of life? Write a long story.",
+            }
+        ],
+        stream=stream,
+        max_tokens=400,
+        temperature=0.0,
+    )
+
+
+def run():
+    for run in range(Runs):
+        print("\nCompletion: ")
+        print("=" * 15)
+
+        now = datetime.now()
+        answer = request(stream=False)
+        finished = datetime.now()
+
+        print(f"Duration: {finished-now}")
+
+        print("\nStreaming: ")
+        print("=" * 15)
+
+        now = datetime.now()
+        stream = request(stream=True)
+        for _message in stream:
+            pass
+        finished = datetime.now()
+
+        print(f"Duration: {finished-now}")
+
+
+if __name__ == "__main__":
+    run()

--- a/mistralrs-core/src/sequence.rs
+++ b/mistralrs-core/src/sequence.rs
@@ -465,17 +465,20 @@ impl SequenceGroup {
 
     pub fn maybe_send_streaming_response(&mut self, seq: &Sequence, model: String) {
         if self.streaming_chunks.len() == self.n_choices && self.is_streaming {
+            let mut swap_streaming_chunks = vec![];
+
+            std::mem::swap(&mut swap_streaming_chunks, &mut self.streaming_chunks);
+
             seq.responder()
                 .send(Response::Chunk(ChatCompletionChunkResponse {
                     id: seq.id.to_string(),
-                    choices: self.streaming_chunks.clone(),
+                    choices: swap_streaming_chunks,
                     created: seq.timestamp,
                     model: model.clone(),
                     system_fingerprint: SYSTEM_FINGERPRINT.to_string(),
                     object: "chat.completion.chunk".to_string(),
                 }))
                 .unwrap();
-            self.streaming_chunks.clear();
         }
     }
 


### PR DESCRIPTION
It seems Axum/OpenAI libraries add ~300ms of overhead on opening/closing the stream.

I can always get this 300ms diff no matter the prompt length.

Using 400 tokens like in the .py file I'm sending I get 96% efficiency, close to Ollama's 97%.

It doesn't look like there's much to improve here.

Closes #99 