### PR TITLE
Remove need for catchup KV cache scheduling

### DIFF
--- a/mistralrs-core/src/aici/recognizer.rs
+++ b/mistralrs-core/src/aici/recognizer.rs
@@ -63,7 +63,6 @@ impl<S: Copy + Debug, R: FunctionalRecognizer<S>> Recognizer for StackRecognizer
     }
 
     fn trie_finished(&mut self) {
-        // println!("{:?}", &self.stack[0..=self.stack_ptr]);
         assert!(self.stack_ptr == 0);
     }
 

--- a/mistralrs-core/src/aici/toktree.rs
+++ b/mistralrs-core/src/aici/toktree.rs
@@ -318,7 +318,6 @@ impl TokTrie {
 
     pub fn token_id(&self, bytes: &[u8]) -> Option<TokenId> {
         let (tok, len) = self.prefix_token_id(bytes);
-        // println!("tok_id {:?} {:?} {:?} ", bytes, tok, len);
         if len == bytes.len() {
             Some(tok)
         } else {
@@ -438,7 +437,6 @@ impl TokTrie {
     }
 
     pub fn append_token(&self, r: &mut impl Recognizer, t: TokenId) {
-        // println!("append_token: {}", self.token_dbg(t));
         let bytes = self.token(t);
         for &byte in bytes {
             r.push_byte(byte)

--- a/mistralrs-core/src/engine/mod.rs
+++ b/mistralrs-core/src/engine/mod.rs
@@ -308,7 +308,7 @@ impl Engine {
                 let cache = seq_cache.get(layer).unwrap();
                 // Note(EricLBuehler): Unwrap reasoning: We are handling completions seqs so unwrap is OK.
                 let cache = cache.as_ref().unwrap();
-                if cache.0.dims()[2] > max_seq_len {
+                if cache.0.dims()[2] < max_seq_len {
                     let offset = Tensor::zeros(
                         (
                             cache.0.dims()[0],

--- a/mistralrs-core/src/engine/mod.rs
+++ b/mistralrs-core/src/engine/mod.rs
@@ -73,11 +73,6 @@ impl Engine {
             let mut pipeline = get_mut_arcmutex!(self.pipeline);
 
             if scheduled.completion.len() > 0 {
-                dbg!(scheduled
-                    .completion
-                    .iter()
-                    .map(|x| x.id())
-                    .collect::<Vec<_>>());
                 // Run the completion seqs
                 if !self.no_kv_cache {
                     Self::clone_in_cache(&mut *pipeline, &mut scheduled.completion);
@@ -100,7 +95,6 @@ impl Engine {
             }
 
             if scheduled.prompt.len() > 0 {
-                dbg!(scheduled.prompt.iter().map(|x| x.id()).collect::<Vec<_>>());
                 // Run the prompt seqs
                 Self::set_none_cache(&mut *pipeline);
                 let logits = pipeline.forward(&scheduled.prompt, true);

--- a/mistralrs-core/src/engine/mod.rs
+++ b/mistralrs-core/src/engine/mod.rs
@@ -73,6 +73,7 @@ impl Engine {
             let mut pipeline = get_mut_arcmutex!(self.pipeline);
 
             if scheduled.completion.len() > 0 {
+                dbg!(scheduled.completion.len());
                 // Run the completion seqs
                 if !self.no_kv_cache {
                     Self::clone_in_cache(&mut *pipeline, &mut scheduled.completion);
@@ -95,6 +96,7 @@ impl Engine {
             }
 
             if scheduled.prompt.len() > 0 {
+                dbg!(scheduled.prompt.len());
                 // Run the prompt seqs
                 Self::set_none_cache(&mut *pipeline);
                 let logits = pipeline.forward(&scheduled.prompt, true);

--- a/mistralrs-core/src/engine/mod.rs
+++ b/mistralrs-core/src/engine/mod.rs
@@ -73,7 +73,7 @@ impl Engine {
             let mut pipeline = get_mut_arcmutex!(self.pipeline);
 
             if scheduled.completion.len() > 0 {
-                dbg!(scheduled.completion.len());
+                dbg!(scheduled.completion.iter().map(|x| x.id()).collect::<Vec<_>>());
                 // Run the completion seqs
                 if !self.no_kv_cache {
                     Self::clone_in_cache(&mut *pipeline, &mut scheduled.completion);
@@ -96,7 +96,7 @@ impl Engine {
             }
 
             if scheduled.prompt.len() > 0 {
-                dbg!(scheduled.prompt.len());
+                dbg!(scheduled.prompt.iter().map(|x| x.id()).collect::<Vec<_>>());
                 // Run the prompt seqs
                 Self::set_none_cache(&mut *pipeline);
                 let logits = pipeline.forward(&scheduled.prompt, true);

--- a/mistralrs-core/src/models/gemma.rs
+++ b/mistralrs-core/src/models/gemma.rs
@@ -318,6 +318,7 @@ impl Model {
         input_ids: &Tensor,
         seqlen_offsets: &[usize],
         start_offsets_kernel: Tensor,
+        context_lens: Vec<usize>,
     ) -> Result<Tensor> {
         let (b_size, seq_len) = input_ids.dims2()?;
         if seqlen_offsets.len() > b_size {
@@ -344,6 +345,6 @@ impl Model {
                 cache.get_mut(i).unwrap(),
             )?
         }
-        extract_logits(&xs.apply(&self.norm)?.apply(&self.lm_head)?, seqlen_offsets)
+        extract_logits(&xs.apply(&self.norm)?.apply(&self.lm_head)?, context_lens)
     }
 }

--- a/mistralrs-core/src/models/gemma.rs
+++ b/mistralrs-core/src/models/gemma.rs
@@ -5,7 +5,7 @@ use std::sync::Arc;
 use candle_core::{DType, Device, IndexOp, Module, Result, Tensor, D};
 use candle_nn::{linear_b as linear, Linear, RotaryEmbedding, VarBuilder};
 
-use crate::pipeline::GEMMA_IS_GPTX;
+use crate::pipeline::{extract_logits, GEMMA_IS_GPTX};
 
 use super::{Cache, RmsNorm};
 
@@ -344,8 +344,6 @@ impl Model {
                 cache.get_mut(i).unwrap(),
             )?
         }
-        xs.narrow(1, seq_len - 1, 1)?
-            .apply(&self.norm)?
-            .apply(&self.lm_head)
+        extract_logits(&xs.apply(&self.norm)?.apply(&self.lm_head)?, seqlen_offsets)
     }
 }

--- a/mistralrs-core/src/models/llama.rs
+++ b/mistralrs-core/src/models/llama.rs
@@ -329,6 +329,7 @@ impl Llama {
         x: &Tensor,
         seqlen_offsets: &[usize],
         start_offsets_kernel: Tensor,
+        context_lens: Vec<usize>,
     ) -> Result<Tensor> {
         let mut x = self.wte.forward(x)?;
         let mut cache = self.kv_cache.lock();
@@ -344,7 +345,7 @@ impl Llama {
         }
         let x = self.ln_f.forward(&x)?;
         let logits = self.lm_head.forward(&x)?;
-        extract_logits(&logits.to_dtype(DType::F32)?, seqlen_offsets)
+        extract_logits(&logits.to_dtype(DType::F32)?, context_lens)
     }
 
     pub fn load(vb: VarBuilder, cfg: &Config, device: &Device, no_kv_cache: bool) -> Result<Self> {

--- a/mistralrs-core/src/models/mistral.rs
+++ b/mistralrs-core/src/models/mistral.rs
@@ -6,7 +6,7 @@ use candle_nn::{Activation, RotaryEmbedding, VarBuilder};
 use candle_transformers::models::with_tracing::{linear_no_bias, Linear};
 use std::sync::Arc;
 
-use crate::pipeline::MISTRAL_IS_GPTX;
+use crate::pipeline::{extract_logits, MISTRAL_IS_GPTX};
 
 use super::{flash_attn, Cache, RmsNorm};
 
@@ -359,8 +359,6 @@ impl Model {
                 cache.get_mut(i).unwrap(),
             )?
         }
-        xs.apply(&self.norm)?
-            .apply(&self.lm_head)?
-            .narrow(1, seq_len - 1, 1)
+        extract_logits(&xs.apply(&self.norm)?.apply(&self.lm_head)?, seqlen_offsets)
     }
 }

--- a/mistralrs-core/src/models/mistral.rs
+++ b/mistralrs-core/src/models/mistral.rs
@@ -334,6 +334,7 @@ impl Model {
         input_ids: &Tensor,
         seqlen_offsets: &[usize],
         start_offsets_kernel: Tensor,
+        context_lens: Vec<usize>,
     ) -> Result<Tensor> {
         let (b_size, seq_len) = input_ids.dims2()?;
         if seqlen_offsets.len() > b_size {
@@ -359,6 +360,6 @@ impl Model {
                 cache.get_mut(i).unwrap(),
             )?
         }
-        extract_logits(&xs.apply(&self.norm)?.apply(&self.lm_head)?, seqlen_offsets)
+        extract_logits(&xs.apply(&self.norm)?.apply(&self.lm_head)?, context_lens)
     }
 }

--- a/mistralrs-core/src/models/mixtral.rs
+++ b/mistralrs-core/src/models/mixtral.rs
@@ -423,6 +423,7 @@ impl Model {
         input_ids: &Tensor,
         seqlen_offsets: &[usize],
         start_offsets_kernel: Tensor,
+        context_lens: Vec<usize>,
     ) -> Result<Tensor> {
         let (b_size, seq_len) = input_ids.dims2()?;
         let past_key_values_length = self.calculate_past_kv_len(seq_len)?;
@@ -444,6 +445,6 @@ impl Model {
                 cache.get_mut(i).unwrap(),
             )?
         }
-        extract_logits(&xs.apply(&self.norm)?.apply(&self.lm_head)?, seqlen_offsets)
+        extract_logits(&xs.apply(&self.norm)?.apply(&self.lm_head)?, context_lens)
     }
 }

--- a/mistralrs-core/src/models/mixtral.rs
+++ b/mistralrs-core/src/models/mixtral.rs
@@ -9,7 +9,7 @@ use candle_transformers::models::with_tracing::{linear_no_bias, Linear};
 use serde::Deserialize;
 use std::sync::Arc;
 
-use crate::pipeline::MIXTRAL_IS_GPTX;
+use crate::pipeline::{extract_logits, MIXTRAL_IS_GPTX};
 
 use super::{flash_attn, Cache, RmsNorm};
 
@@ -444,8 +444,6 @@ impl Model {
                 cache.get_mut(i).unwrap(),
             )?
         }
-        xs.narrow(1, seq_len - 1, 1)?
-            .apply(&self.norm)?
-            .apply(&self.lm_head)
+        extract_logits(&xs.apply(&self.norm)?.apply(&self.lm_head)?, seqlen_offsets)
     }
 }

--- a/mistralrs-core/src/models/phi2.rs
+++ b/mistralrs-core/src/models/phi2.rs
@@ -12,7 +12,7 @@ use candle_nn::{
 };
 use serde::Deserialize;
 
-use crate::pipeline::PHI2_IS_GPTX;
+use crate::pipeline::{extract_logits, PHI2_IS_GPTX};
 
 use super::{flash_attn, Cache};
 
@@ -353,8 +353,9 @@ impl Model {
                 cache.get_mut(i).unwrap(),
             )?;
         }
-        xs.apply(&self.final_layernorm)?
-            .narrow(1, seq_len - 1, 1)?
-            .apply(&self.lm_head)
+        extract_logits(
+            &xs.apply(&self.final_layernorm)?.apply(&self.lm_head)?,
+            seqlen_offsets,
+        )
     }
 }

--- a/mistralrs-core/src/models/phi2.rs
+++ b/mistralrs-core/src/models/phi2.rs
@@ -335,6 +335,7 @@ impl Model {
         xs: &Tensor,
         seqlen_offsets: &[usize],
         start_offsets_kernel: Tensor,
+        context_lens: Vec<usize>,
     ) -> Result<Tensor> {
         let (_b_size, seq_len) = xs.dims2()?;
         let mut xs = xs.apply(&self.embed_tokens)?;
@@ -355,7 +356,7 @@ impl Model {
         }
         extract_logits(
             &xs.apply(&self.final_layernorm)?.apply(&self.lm_head)?,
-            seqlen_offsets,
+            context_lens,
         )
     }
 }

--- a/mistralrs-core/src/models/quantized_llama.rs
+++ b/mistralrs-core/src/models/quantized_llama.rs
@@ -4,8 +4,10 @@ use std::collections::HashMap;
 
 use candle_core::quantized::QMatMul;
 use candle_core::quantized::{ggml_file, gguf_file};
-use candle_core::{DType, Device, IndexOp, Result, Tensor};
+use candle_core::{DType, Device, Result, Tensor};
 use candle_nn::{Embedding, Module, RotaryEmbedding};
+
+use crate::pipeline::extract_logits;
 
 use super::{verify_sanity_gguf, Cache, QRmsNorm};
 
@@ -449,7 +451,6 @@ impl ModelWeights {
             layer_in = x
         }
         let x = self.norm.forward(&layer_in)?;
-        let x = x.i((.., seq_len - 1, ..))?;
-        self.output.forward(&x.contiguous()?)
+        extract_logits(&self.output.forward(&x.contiguous()?)?, start_offsets)
     }
 }

--- a/mistralrs-core/src/models/quantized_llama.rs
+++ b/mistralrs-core/src/models/quantized_llama.rs
@@ -421,6 +421,7 @@ impl ModelWeights {
         x: &Tensor,
         start_offsets: &[usize],
         start_offsets_kernel: Tensor,
+        context_lens: Vec<usize>,
     ) -> Result<Tensor> {
         let (_b_sz, seq_len) = x.dims2()?;
         let mask = if seq_len == 1 {
@@ -451,6 +452,6 @@ impl ModelWeights {
             layer_in = x
         }
         let x = self.norm.forward(&layer_in)?;
-        extract_logits(&self.output.forward(&x.contiguous()?)?, start_offsets)
+        extract_logits(&self.output.forward(&x.contiguous()?)?, context_lens)
     }
 }

--- a/mistralrs-core/src/pipeline/gemma.rs
+++ b/mistralrs-core/src/pipeline/gemma.rs
@@ -388,6 +388,7 @@ impl Pipeline for GemmaPipeline {
             seqlen_offsets_full,
             seqlen_offsets_kernel,
             seqlen_offsets_kernel_full,
+            context_lens,
         } = calculate_inputs(
             input_toks,
             is_prompt,
@@ -397,9 +398,12 @@ impl Pipeline for GemmaPipeline {
         )
         .unwrap();
         match self.model {
-            Model::Normal(ref mut model) => {
-                model.forward(&input_ids, &seqlen_offsets, seqlen_offsets_kernel)
-            }
+            Model::Normal(ref mut model) => model.forward(
+                &input_ids,
+                &seqlen_offsets,
+                seqlen_offsets_kernel,
+                context_lens,
+            ),
             Model::XLoraNormal(ref mut model) => model.forward(
                 &input_ids,
                 input_ids_full.as_ref().unwrap_or(&input_ids),
@@ -409,6 +413,7 @@ impl Pipeline for GemmaPipeline {
                 seqlen_offsets_kernel_full.unwrap_or(seqlen_offsets_kernel),
                 self.no_kv_cache,
                 &self.non_granular_state,
+                context_lens,
             ),
         }
     }

--- a/mistralrs-core/src/pipeline/llama.rs
+++ b/mistralrs-core/src/pipeline/llama.rs
@@ -487,6 +487,7 @@ impl Pipeline for LlamaPipeline {
             seqlen_offsets_full,
             seqlen_offsets_kernel,
             seqlen_offsets_kernel_full,
+            context_lens,
         } = calculate_inputs(
             input_toks,
             is_prompt,
@@ -496,12 +497,18 @@ impl Pipeline for LlamaPipeline {
         )
         .unwrap();
         match self.model {
-            Model::Normal(ref mut model) => {
-                model.forward(&input_ids, &seqlen_offsets, seqlen_offsets_kernel)
-            }
-            Model::Quantized(ref mut model) => {
-                model.forward(&input_ids, &seqlen_offsets, seqlen_offsets_kernel)
-            }
+            Model::Normal(ref mut model) => model.forward(
+                &input_ids,
+                &seqlen_offsets,
+                seqlen_offsets_kernel,
+                context_lens,
+            ),
+            Model::Quantized(ref mut model) => model.forward(
+                &input_ids,
+                &seqlen_offsets,
+                seqlen_offsets_kernel,
+                context_lens,
+            ),
             Model::XLoraNormal(ref mut model) => model.forward(
                 &input_ids,
                 input_ids_full.as_ref().unwrap_or(&input_ids),
@@ -511,6 +518,7 @@ impl Pipeline for LlamaPipeline {
                 seqlen_offsets_kernel_full.unwrap_or(seqlen_offsets_kernel),
                 self.no_kv_cache,
                 &self.non_granular_state,
+                context_lens,
             ),
             Model::XLoraQuantized(ref mut model) => model.forward(
                 &input_ids,
@@ -521,6 +529,7 @@ impl Pipeline for LlamaPipeline {
                 seqlen_offsets_kernel_full.unwrap_or(seqlen_offsets_kernel),
                 self.no_kv_cache,
                 &self.non_granular_state,
+                context_lens,
             ),
         }
     }

--- a/mistralrs-core/src/pipeline/mistral.rs
+++ b/mistralrs-core/src/pipeline/mistral.rs
@@ -444,6 +444,7 @@ impl Pipeline for MistralPipeline {
             seqlen_offsets_full,
             seqlen_offsets_kernel,
             seqlen_offsets_kernel_full,
+            context_lens,
         } = calculate_inputs(
             input_toks,
             is_prompt,
@@ -453,12 +454,18 @@ impl Pipeline for MistralPipeline {
         )
         .unwrap();
         match self.model {
-            Model::Normal(ref mut model) => {
-                model.forward(&input_ids, &seqlen_offsets, seqlen_offsets_kernel)
-            }
-            Model::Quantized(ref mut model) => {
-                model.forward(&input_ids, &seqlen_offsets, seqlen_offsets_kernel)
-            }
+            Model::Normal(ref mut model) => model.forward(
+                &input_ids,
+                &seqlen_offsets,
+                seqlen_offsets_kernel,
+                context_lens,
+            ),
+            Model::Quantized(ref mut model) => model.forward(
+                &input_ids,
+                &seqlen_offsets,
+                seqlen_offsets_kernel,
+                context_lens,
+            ),
             Model::XLoraNormal(ref mut model) => model.forward(
                 &input_ids,
                 input_ids_full.as_ref().unwrap_or(&input_ids),
@@ -468,6 +475,7 @@ impl Pipeline for MistralPipeline {
                 seqlen_offsets_kernel_full.unwrap_or(seqlen_offsets_kernel),
                 self.no_kv_cache,
                 &self.non_granular_state,
+                context_lens,
             ),
             Model::XLoraQuantized(ref mut model) => model.forward(
                 &input_ids,
@@ -478,6 +486,7 @@ impl Pipeline for MistralPipeline {
                 seqlen_offsets_kernel_full.unwrap_or(seqlen_offsets_kernel),
                 self.no_kv_cache,
                 &self.non_granular_state,
+                context_lens,
             ),
         }
     }

--- a/mistralrs-core/src/pipeline/mixtral.rs
+++ b/mistralrs-core/src/pipeline/mixtral.rs
@@ -448,6 +448,7 @@ impl Pipeline for MixtralPipeline {
             seqlen_offsets_full,
             seqlen_offsets_kernel,
             seqlen_offsets_kernel_full,
+            context_lens,
         } = calculate_inputs(
             input_toks,
             is_prompt,
@@ -457,12 +458,18 @@ impl Pipeline for MixtralPipeline {
         )
         .unwrap();
         match self.model {
-            Model::Normal(ref mut model) => {
-                model.forward(&input_ids, &seqlen_offsets, seqlen_offsets_kernel)
-            }
-            Model::Quantized(ref mut model) => {
-                model.forward(&input_ids, &seqlen_offsets, seqlen_offsets_kernel)
-            }
+            Model::Normal(ref mut model) => model.forward(
+                &input_ids,
+                &seqlen_offsets,
+                seqlen_offsets_kernel,
+                context_lens,
+            ),
+            Model::Quantized(ref mut model) => model.forward(
+                &input_ids,
+                &seqlen_offsets,
+                seqlen_offsets_kernel,
+                context_lens,
+            ),
             Model::XLoraNormal(ref mut model) => model.forward(
                 &input_ids,
                 input_ids_full.as_ref().unwrap_or(&input_ids),
@@ -472,6 +479,7 @@ impl Pipeline for MixtralPipeline {
                 seqlen_offsets_kernel_full.unwrap_or(seqlen_offsets_kernel),
                 self.no_kv_cache,
                 &self.non_granular_state,
+                context_lens,
             ),
             Model::XLoraQuantized(ref mut model) => model.forward(
                 &input_ids,
@@ -482,6 +490,7 @@ impl Pipeline for MixtralPipeline {
                 seqlen_offsets_kernel_full.unwrap_or(seqlen_offsets_kernel),
                 self.no_kv_cache,
                 &self.non_granular_state,
+                context_lens,
             ),
         }
     }

--- a/mistralrs-core/src/pipeline/mod.rs
+++ b/mistralrs-core/src/pipeline/mod.rs
@@ -522,7 +522,7 @@ fn calculate_inputs(
 pub fn extract_logits(logits: &Tensor, seq_lens: Vec<usize>) -> candle_core::Result<Tensor> {
     let mut toks = Vec::new();
     for (dim, start) in logits.chunk(logits.dims()[0], 0)?.iter().zip(seq_lens) {
-        toks.push(dim.narrow(0, start, 1)?.unsqueeze(0)?);
+        toks.push(dim.narrow(1, start, 1)?);
     }
     Tensor::cat(&toks, 0)
 }

--- a/mistralrs-core/src/pipeline/mod.rs
+++ b/mistralrs-core/src/pipeline/mod.rs
@@ -504,6 +504,14 @@ fn calculate_inputs(
     }
 }
 
+pub fn extract_logits(logits: &Tensor, seq_lens: &[usize]) -> candle_core::Result<Tensor> {
+    let mut toks = Vec::new();
+    for (dim, start) in logits.chunk(logits.dims()[0], 0)?.iter().zip(seq_lens) {
+        toks.push(dim.narrow(0, *start, 1)?.unsqueeze(0)?);
+    }
+    Tensor::cat(&toks, 0)
+}
+
 struct XLoraPaths {
     adapter_configs: Option<Vec<(String, LoraConfig)>>,
     adapter_safetensors: Option<Vec<(String, PathBuf)>>,

--- a/mistralrs-core/src/pipeline/mod.rs
+++ b/mistralrs-core/src/pipeline/mod.rs
@@ -370,7 +370,7 @@ fn get_prompt_input(input_toks: &[&mut Sequence], device: &Device) -> Result<Inp
         seqlen_offsets.push(0);
 
         ctxt.extend(repeat(padding_tok).take(max_len - ctxt.len()));
-        context_lens.push(seq.len());
+        context_lens.push(seq.len() - 1);
 
         // NOTE(EricLBuehler): Unwrap reasoning: The dimensions must match.
         seqs_tensors.push(Tensor::new(ctxt, device).unwrap().unsqueeze(0).unwrap());

--- a/mistralrs-core/src/pipeline/phi2.rs
+++ b/mistralrs-core/src/pipeline/phi2.rs
@@ -300,7 +300,7 @@ impl Loader for Phi2Loader {
                     &config,
                     vb,
                     paths.get_adapter_configs().as_ref().unwrap(),
-                    paths.get_classifier_config().as_ref().unwrap().clone(),
+                    Some(paths.get_classifier_config().as_ref().unwrap().clone()),
                     paths.get_ordering().as_ref().unwrap().clone(),
                 )?;
                 Model::XLoraNormal(model)
@@ -328,7 +328,7 @@ impl Loader for Phi2Loader {
                     &config,
                     vb,
                     paths.get_adapter_configs().as_ref().unwrap(),
-                    paths.get_classifier_config().as_ref().unwrap().clone(),
+                    None,
                     paths.get_ordering().as_ref().unwrap().clone(),
                 )?;
                 is_lora = true;

--- a/mistralrs-core/src/pipeline/phi2.rs
+++ b/mistralrs-core/src/pipeline/phi2.rs
@@ -386,6 +386,7 @@ impl Pipeline for Phi2Pipeline {
             seqlen_offsets_full,
             seqlen_offsets_kernel,
             seqlen_offsets_kernel_full,
+            context_lens,
         } = calculate_inputs(
             input_toks,
             is_prompt,
@@ -395,9 +396,12 @@ impl Pipeline for Phi2Pipeline {
         )
         .unwrap();
         match self.model {
-            Model::Normal(ref mut model) => {
-                model.forward(&input_ids, &seqlen_offsets, seqlen_offsets_kernel)
-            }
+            Model::Normal(ref mut model) => model.forward(
+                &input_ids,
+                &seqlen_offsets,
+                seqlen_offsets_kernel,
+                context_lens,
+            ),
             Model::XLoraNormal(ref mut model) => model.forward(
                 &input_ids,
                 input_ids_full.as_ref().unwrap_or(&input_ids),
@@ -407,6 +411,7 @@ impl Pipeline for Phi2Pipeline {
                 seqlen_offsets_kernel_full.unwrap_or(seqlen_offsets_kernel),
                 self.no_kv_cache,
                 &self.non_granular_state,
+                context_lens,
             ),
         }
     }

--- a/mistralrs-core/src/scheduler.rs
+++ b/mistralrs-core/src/scheduler.rs
@@ -70,6 +70,7 @@ impl<Backer: FcfsBacker> Scheduler<Backer> {
             // prefill case
             self.running.push(seq);
         } else {
+            println!("Adding a seq");
             self.waiting.add(seq);
         }
     }

--- a/mistralrs-core/src/scheduler.rs
+++ b/mistralrs-core/src/scheduler.rs
@@ -131,12 +131,8 @@ impl<Backer: FcfsBacker> Scheduler<Backer> {
 
         // Now, get the sequences with the smallest sequence lengths, and allow them to catch up.
         let mut seq_buckets: HashMap<usize, Vec<Sequence>> = HashMap::new();
-        let mut min_len = usize::MAX;
         for seq in running {
             let len = seq.len();
-            if len < min_len {
-                min_len = len;
-            }
             match seq_buckets.get_mut(&len) {
                 Some(bucket) => bucket.push(seq),
                 None => {
@@ -156,7 +152,8 @@ impl<Backer: FcfsBacker> Scheduler<Backer> {
         } else {
             // Set the min seqs to be the running ones, and the rest to be waiting (but their states are not changed!)
             // Allow the min seqs to catch up.
-            let min_seqs = seq_buckets.remove(&min_len).unwrap();
+            let min = *seq_buckets.keys().min().unwrap();
+            let min_seqs = seq_buckets.remove(&min).unwrap();
             for (_, seqs) in seq_buckets {
                 for seq in seqs {
                     new_waiting.add(seq);

--- a/mistralrs-core/src/scheduler.rs
+++ b/mistralrs-core/src/scheduler.rs
@@ -67,6 +67,7 @@ impl<Backer: FcfsBacker> Scheduler<Backer> {
 
     pub fn add_seq(&mut self, seq: Sequence) {
         if seq.is_running() {
+            println!("Adding a prefill seq {}", seq.id());
             // prefill case
             self.running.push(seq);
         } else {

--- a/mistralrs-core/src/scheduler.rs
+++ b/mistralrs-core/src/scheduler.rs
@@ -67,11 +67,9 @@ impl<Backer: FcfsBacker> Scheduler<Backer> {
 
     pub fn add_seq(&mut self, seq: Sequence) {
         if seq.is_running() {
-            println!("Adding a prefill seq {}", seq.id());
             // prefill case
             self.running.push(seq);
         } else {
-            println!("Adding a seq {}", seq.id());
             self.waiting.add(seq);
         }
     }

--- a/mistralrs-core/src/scheduler.rs
+++ b/mistralrs-core/src/scheduler.rs
@@ -70,7 +70,7 @@ impl<Backer: FcfsBacker> Scheduler<Backer> {
             // prefill case
             self.running.push(seq);
         } else {
-            println!("Adding a seq");
+            println!("Adding a seq {}", seq.id());
             self.waiting.add(seq);
         }
     }

--- a/mistralrs-core/src/sequence.rs
+++ b/mistralrs-core/src/sequence.rs
@@ -170,6 +170,9 @@ impl Sequence {
     }
 
     pub fn len(&self) -> usize {
+        if let Some(toks) = &self.prefill_prompt_toks {
+            return toks.len();
+        }
         self.tokens.len()
     }
 

--- a/mistralrs-core/src/xlora_models/gemma.rs
+++ b/mistralrs-core/src/xlora_models/gemma.rs
@@ -514,6 +514,7 @@ impl XLoraModel {
         start_offsets_kernel_full: Tensor,
         no_kv_cache: bool,
         non_granular_state: &Option<NonGranularState>,
+        context_lens: Vec<usize>,
     ) -> Result<Tensor> {
         if self.xlora_classifier.is_some() {
             let scalings = self.get_scalings(
@@ -541,7 +542,7 @@ impl XLoraModel {
                         )?
                         .contiguous()?
                         .apply(&self.lm_head)?,
-                    seqlen_offsets_full,
+                    context_lens,
                 )
             } else {
                 // is_full_pass=true is ok because no_kv_cache=false
@@ -558,7 +559,7 @@ impl XLoraModel {
                         )?
                         .contiguous()?
                         .apply(&self.lm_head)?,
-                    seqlen_offsets,
+                    context_lens,
                 )
             }
         } else {
@@ -575,7 +576,7 @@ impl XLoraModel {
                     )?
                     .contiguous()?
                     .apply(&self.lm_head)?,
-                seqlen_offsets,
+                context_lens,
             )
         }
     }

--- a/mistralrs-core/src/xlora_models/llama.rs
+++ b/mistralrs-core/src/xlora_models/llama.rs
@@ -1,6 +1,6 @@
 #![allow(clippy::cast_possible_truncation, clippy::cast_precision_loss)]
 
-use candle_core::{DType, Device, IndexOp, Result, Tensor, D};
+use candle_core::{DType, Device, Result, Tensor, D};
 use candle_nn::{embedding, Embedding, Module, RotaryEmbedding, VarBuilder};
 use mistralrs_lora::{linear_no_bias as linear, LinearLayerLike, LoraConfig, Ordering};
 use std::{collections::HashMap, sync::Arc};
@@ -11,7 +11,7 @@ use crate::{
         llama::{Config, MAX_SEQ_LEN},
         LayerCaches, RmsNorm,
     },
-    pipeline::LLAMA_IS_GPTX,
+    pipeline::{extract_logits, LLAMA_IS_GPTX},
 };
 
 use super::{classifier::XLoraClassifier, NonGranularState, ScalingsMaker, XLoraConfig};
@@ -411,11 +411,7 @@ impl XLoraLlama {
         no_kv_cache: bool,
         non_granular_state: &Option<NonGranularState>,
     ) -> Result<Tensor> {
-        let (_, seq_len) = input_ids.dims2()?;
-
         if self.xlora_classifier.is_some() {
-            let (_b_size, seq_len_full) = input_ids_full.dims2()?;
-
             let scalings = self.get_scalings(
                 input_ids,
                 input_ids_full,
@@ -428,47 +424,55 @@ impl XLoraLlama {
             )?;
 
             if no_kv_cache {
-                self.inner_forward(
-                    input_ids_full,
+                extract_logits(
+                    &self
+                        .inner_forward(
+                            input_ids_full,
+                            seqlen_offsets_full,
+                            start_offsets_kernel_full,
+                            Some(scalings),
+                            true,
+                            no_kv_cache,
+                            None,
+                        )?
+                        .contiguous()?
+                        .apply(&self.lm_head)?,
                     seqlen_offsets_full,
-                    start_offsets_kernel_full,
-                    Some(scalings),
-                    true,
-                    no_kv_cache,
-                    None,
-                )?
-                .contiguous()?
-                .apply(&self.lm_head)?
-                .i((.., seq_len_full - 1, ..))
+                )
             } else {
                 // is_full_pass=true is ok because no_kv_cache=false
-                self.inner_forward(
-                    input_ids,
+                extract_logits(
+                    &self
+                        .inner_forward(
+                            input_ids,
+                            seqlen_offsets,
+                            start_offsets_kernel,
+                            Some(scalings),
+                            true,
+                            no_kv_cache,
+                            None,
+                        )?
+                        .contiguous()?
+                        .apply(&self.lm_head)?,
                     seqlen_offsets,
-                    start_offsets_kernel,
-                    Some(scalings),
-                    true,
-                    no_kv_cache,
-                    None,
-                )?
-                .contiguous()?
-                .apply(&self.lm_head)?
-                .i((.., seq_len - 1, ..))
+                )
             }
         } else {
-            let (_, seq_len) = input_ids.dims2()?;
-            self.inner_forward(
-                input_ids,
+            extract_logits(
+                &self
+                    .inner_forward(
+                        input_ids,
+                        seqlen_offsets,
+                        start_offsets_kernel,
+                        None,
+                        false,
+                        no_kv_cache,
+                        None,
+                    )?
+                    .contiguous()?
+                    .apply(&self.lm_head)?,
                 seqlen_offsets,
-                start_offsets_kernel,
-                None,
-                false,
-                no_kv_cache,
-                None,
-            )?
-            .contiguous()?
-            .apply(&self.lm_head)?
-            .i((.., seq_len - 1, ..))
+            )
         }
     }
 

--- a/mistralrs-core/src/xlora_models/llama.rs
+++ b/mistralrs-core/src/xlora_models/llama.rs
@@ -410,6 +410,7 @@ impl XLoraLlama {
         start_offsets_kernel_full: Tensor,
         no_kv_cache: bool,
         non_granular_state: &Option<NonGranularState>,
+        context_lens: Vec<usize>,
     ) -> Result<Tensor> {
         if self.xlora_classifier.is_some() {
             let scalings = self.get_scalings(
@@ -437,7 +438,7 @@ impl XLoraLlama {
                         )?
                         .contiguous()?
                         .apply(&self.lm_head)?,
-                    seqlen_offsets_full,
+                    context_lens,
                 )
             } else {
                 // is_full_pass=true is ok because no_kv_cache=false
@@ -454,7 +455,7 @@ impl XLoraLlama {
                         )?
                         .contiguous()?
                         .apply(&self.lm_head)?,
-                    seqlen_offsets,
+                    context_lens,
                 )
             }
         } else {
@@ -471,7 +472,7 @@ impl XLoraLlama {
                     )?
                     .contiguous()?
                     .apply(&self.lm_head)?,
-                seqlen_offsets,
+                context_lens,
             )
         }
     }

--- a/mistralrs-core/src/xlora_models/mistral.rs
+++ b/mistralrs-core/src/xlora_models/mistral.rs
@@ -8,7 +8,7 @@ use std::sync::Arc;
 
 use crate::{
     models::{flash_attn, mistral::Config, Cache, RmsNorm},
-    pipeline::MISTRAL_IS_GPTX,
+    pipeline::{extract_logits, MISTRAL_IS_GPTX},
 };
 
 use super::{classifier::XLoraClassifier, config::XLoraConfig, NonGranularState, ScalingsMaker};
@@ -526,11 +526,7 @@ impl XLoraModel {
         no_kv_cache: bool,
         non_granular_state: &Option<NonGranularState>,
     ) -> Result<Tensor> {
-        let (_, seq_len) = input_ids.dims2()?;
-
         if self.xlora_classifier.is_some() {
-            let (_b_size, seq_len_full) = input_ids_full.dims2()?;
-
             let scalings = self.get_scalings(
                 input_ids,
                 input_ids_full,
@@ -543,47 +539,55 @@ impl XLoraModel {
             )?;
 
             if no_kv_cache {
-                self.inner_forward(
-                    input_ids_full,
+                extract_logits(
+                    &self
+                        .inner_forward(
+                            input_ids_full,
+                            seqlen_offsets_full,
+                            start_offsets_kernel_full,
+                            Some(scalings),
+                            true,
+                            no_kv_cache,
+                            None,
+                        )?
+                        .contiguous()?
+                        .apply(&self.lm_head)?,
                     seqlen_offsets_full,
-                    start_offsets_kernel_full,
-                    Some(scalings),
-                    true,
-                    no_kv_cache,
-                    None,
-                )?
-                .contiguous()?
-                .apply(&self.lm_head)?
-                .i((.., seq_len_full - 1, ..))
+                )
             } else {
                 // is_full_pass=true is ok because no_kv_cache=false
-                self.inner_forward(
-                    input_ids,
+                extract_logits(
+                    &self
+                        .inner_forward(
+                            input_ids,
+                            seqlen_offsets,
+                            start_offsets_kernel,
+                            Some(scalings),
+                            true,
+                            no_kv_cache,
+                            None,
+                        )?
+                        .contiguous()?
+                        .apply(&self.lm_head)?,
                     seqlen_offsets,
-                    start_offsets_kernel,
-                    Some(scalings),
-                    true,
-                    no_kv_cache,
-                    None,
-                )?
-                .contiguous()?
-                .apply(&self.lm_head)?
-                .i((.., seq_len - 1, ..))
+                )
             }
         } else {
-            let (_, seq_len) = input_ids.dims2()?;
-            self.inner_forward(
-                input_ids,
+            extract_logits(
+                &self
+                    .inner_forward(
+                        input_ids,
+                        seqlen_offsets,
+                        start_offsets_kernel,
+                        None,
+                        false,
+                        no_kv_cache,
+                        None,
+                    )?
+                    .contiguous()?
+                    .apply(&self.lm_head)?,
                 seqlen_offsets,
-                start_offsets_kernel,
-                None,
-                false,
-                no_kv_cache,
-                None,
-            )?
-            .contiguous()?
-            .apply(&self.lm_head)?
-            .i((.., seq_len - 1, ..))
+            )
         }
     }
 }

--- a/mistralrs-core/src/xlora_models/mistral.rs
+++ b/mistralrs-core/src/xlora_models/mistral.rs
@@ -525,6 +525,7 @@ impl XLoraModel {
         start_offsets_kernel_full: Tensor,
         no_kv_cache: bool,
         non_granular_state: &Option<NonGranularState>,
+        context_lens: Vec<usize>,
     ) -> Result<Tensor> {
         if self.xlora_classifier.is_some() {
             let scalings = self.get_scalings(
@@ -552,7 +553,7 @@ impl XLoraModel {
                         )?
                         .contiguous()?
                         .apply(&self.lm_head)?,
-                    seqlen_offsets_full,
+                    context_lens,
                 )
             } else {
                 // is_full_pass=true is ok because no_kv_cache=false
@@ -569,7 +570,7 @@ impl XLoraModel {
                         )?
                         .contiguous()?
                         .apply(&self.lm_head)?,
-                    seqlen_offsets,
+                    context_lens,
                 )
             }
         } else {
@@ -586,7 +587,7 @@ impl XLoraModel {
                     )?
                     .contiguous()?
                     .apply(&self.lm_head)?,
-                seqlen_offsets,
+                context_lens,
             )
         }
     }

--- a/mistralrs-core/src/xlora_models/mixtral.rs
+++ b/mistralrs-core/src/xlora_models/mixtral.rs
@@ -626,6 +626,7 @@ impl XLoraModel {
         start_offsets_kernel_full: Tensor,
         no_kv_cache: bool,
         non_granular_state: &Option<NonGranularState>,
+        context_lens: Vec<usize>,
     ) -> Result<Tensor> {
         if self.xlora_classifier.is_some() {
             let scalings = self.get_scalings(
@@ -653,7 +654,7 @@ impl XLoraModel {
                         )?
                         .contiguous()?
                         .apply(&self.lm_head)?,
-                    seqlen_offsets_full,
+                    context_lens,
                 )
             } else {
                 // is_full_pass=true is ok because no_kv_cache=false
@@ -670,7 +671,7 @@ impl XLoraModel {
                         )?
                         .contiguous()?
                         .apply(&self.lm_head)?,
-                    seqlen_offsets,
+                    context_lens,
                 )
             }
         } else {
@@ -687,7 +688,7 @@ impl XLoraModel {
                     )?
                     .contiguous()?
                     .apply(&self.lm_head)?,
-                seqlen_offsets,
+                context_lens,
             )
         }
     }

--- a/mistralrs-core/src/xlora_models/mixtral.rs
+++ b/mistralrs-core/src/xlora_models/mixtral.rs
@@ -10,7 +10,7 @@ use std::sync::Arc;
 
 use crate::{
     models::{flash_attn, mixtral::Config, Cache, RmsNorm},
-    pipeline::MIXTRAL_IS_GPTX,
+    pipeline::{extract_logits, MIXTRAL_IS_GPTX},
 };
 
 use super::{classifier::XLoraClassifier, NonGranularState, ScalingsMaker, XLoraConfig};
@@ -627,45 +627,68 @@ impl XLoraModel {
         no_kv_cache: bool,
         non_granular_state: &Option<NonGranularState>,
     ) -> Result<Tensor> {
-        let (_b_size, seq_len_full) = input_ids_full.dims2()?;
-        let (_, seq_len) = input_ids.dims2()?;
-
-        let scalings = self.get_scalings(
-            input_ids,
-            input_ids_full,
-            seqlen_offsets,
-            seqlen_offsets_full,
-            &start_offsets_kernel,
-            &start_offsets_kernel_full,
-            no_kv_cache,
-            non_granular_state,
-        )?;
-
-        if no_kv_cache {
-            self.inner_forward(
-                input_ids_full,
-                seqlen_offsets_full,
-                start_offsets_kernel_full,
-                Some(scalings),
-                true,
-                no_kv_cache,
-                None,
-            )?
-            .apply(&self.lm_head)?
-            .narrow(1, seq_len_full - 1, 1)
-        } else {
-            // is_full_pass=true is ok because no_kv_cache=false
-            self.inner_forward(
+        if self.xlora_classifier.is_some() {
+            let scalings = self.get_scalings(
                 input_ids,
+                input_ids_full,
                 seqlen_offsets,
-                start_offsets_kernel,
-                Some(scalings),
-                true,
+                seqlen_offsets_full,
+                &start_offsets_kernel,
+                &start_offsets_kernel_full,
                 no_kv_cache,
-                None,
-            )?
-            .apply(&self.lm_head)?
-            .narrow(1, seq_len - 1, 1)
+                non_granular_state,
+            )?;
+
+            if no_kv_cache {
+                extract_logits(
+                    &self
+                        .inner_forward(
+                            input_ids_full,
+                            seqlen_offsets_full,
+                            start_offsets_kernel_full,
+                            Some(scalings),
+                            true,
+                            no_kv_cache,
+                            None,
+                        )?
+                        .contiguous()?
+                        .apply(&self.lm_head)?,
+                    seqlen_offsets_full,
+                )
+            } else {
+                // is_full_pass=true is ok because no_kv_cache=false
+                extract_logits(
+                    &self
+                        .inner_forward(
+                            input_ids,
+                            seqlen_offsets,
+                            start_offsets_kernel,
+                            Some(scalings),
+                            true,
+                            no_kv_cache,
+                            None,
+                        )?
+                        .contiguous()?
+                        .apply(&self.lm_head)?,
+                    seqlen_offsets,
+                )
+            }
+        } else {
+            extract_logits(
+                &self
+                    .inner_forward(
+                        input_ids,
+                        seqlen_offsets,
+                        start_offsets_kernel,
+                        None,
+                        false,
+                        no_kv_cache,
+                        None,
+                    )?
+                    .contiguous()?
+                    .apply(&self.lm_head)?,
+                seqlen_offsets,
+            )
         }
     }
 }

--- a/mistralrs-core/src/xlora_models/phi2.rs
+++ b/mistralrs-core/src/xlora_models/phi2.rs
@@ -495,6 +495,7 @@ impl Model {
         start_offsets_kernel_full: Tensor,
         no_kv_cache: bool,
         non_granular_state: &Option<NonGranularState>,
+        context_lens: Vec<usize>,
     ) -> Result<Tensor> {
         if self.xlora_classifier.is_some() {
             let scalings = self.get_scalings(
@@ -522,7 +523,7 @@ impl Model {
                         )?
                         .contiguous()?
                         .apply(&self.lm_head)?,
-                    seqlen_offsets_full,
+                    context_lens,
                 )
             } else {
                 // is_full_pass=true is ok because no_kv_cache=false
@@ -539,7 +540,7 @@ impl Model {
                         )?
                         .contiguous()?
                         .apply(&self.lm_head)?,
-                    seqlen_offsets,
+                    context_lens,
                 )
             }
         } else {
@@ -556,7 +557,7 @@ impl Model {
                     )?
                     .contiguous()?
                     .apply(&self.lm_head)?,
-                seqlen_offsets,
+                context_lens,
             )
         }
     }

--- a/mistralrs-core/src/xlora_models/quantized_llama.rs
+++ b/mistralrs-core/src/xlora_models/quantized_llama.rs
@@ -4,11 +4,12 @@ use std::collections::HashMap;
 
 use candle_core::quantized::QMatMul;
 use candle_core::quantized::{ggml_file, gguf_file};
-use candle_core::{DType, Device, IndexOp, Result, Tensor};
+use candle_core::{DType, Device, Result, Tensor};
 use candle_nn::{Embedding, Module, RotaryEmbedding, VarBuilder};
 use mistralrs_lora::{get_lora_cfg, LinearLayerLike, LoraConfig, Merge, Ordering, QLoraLinear};
 
 use crate::models::{verify_sanity_gguf, Cache, QRmsNorm};
+use crate::pipeline::extract_logits;
 
 use super::classifier::XLoraClassifier;
 use super::{verify_sanity_adapters, NonGranularState, ScalingsMaker, XLoraConfig};
@@ -766,11 +767,7 @@ impl ModelWeights {
         no_kv_cache: bool,
         non_granular_state: &Option<NonGranularState>,
     ) -> Result<Tensor> {
-        let (_, seq_len) = input_ids.dims2()?;
-
         if self.xlora_classifier.is_some() {
-            let (_b_size, seq_len_full) = input_ids_full.dims2()?;
-
             let scalings = self.get_scalings(
                 input_ids,
                 input_ids_full,
@@ -783,47 +780,55 @@ impl ModelWeights {
             )?;
 
             if no_kv_cache {
-                self.inner_forward(
-                    input_ids_full,
+                extract_logits(
+                    &self
+                        .inner_forward(
+                            input_ids_full,
+                            seqlen_offsets_full,
+                            start_offsets_kernel_full,
+                            Some(scalings),
+                            true,
+                            no_kv_cache,
+                            None,
+                        )?
+                        .contiguous()?
+                        .apply(&self.output)?,
                     seqlen_offsets_full,
-                    start_offsets_kernel_full,
-                    Some(scalings),
-                    true,
-                    no_kv_cache,
-                    None,
-                )?
-                .contiguous()?
-                .apply(&self.output)?
-                .i((.., seq_len_full - 1, ..))
+                )
             } else {
                 // is_full_pass=true is ok because no_kv_cache=false
-                self.inner_forward(
-                    input_ids,
+                extract_logits(
+                    &self
+                        .inner_forward(
+                            input_ids,
+                            seqlen_offsets,
+                            start_offsets_kernel,
+                            Some(scalings),
+                            true,
+                            no_kv_cache,
+                            None,
+                        )?
+                        .contiguous()?
+                        .apply(&self.output)?,
                     seqlen_offsets,
-                    start_offsets_kernel,
-                    Some(scalings),
-                    true,
-                    no_kv_cache,
-                    None,
-                )?
-                .contiguous()?
-                .apply(&self.output)?
-                .i((.., seq_len - 1, ..))
+                )
             }
         } else {
-            let (_, seq_len) = input_ids.dims2()?;
-            self.inner_forward(
-                input_ids,
+            extract_logits(
+                &self
+                    .inner_forward(
+                        input_ids,
+                        seqlen_offsets,
+                        start_offsets_kernel,
+                        None,
+                        false,
+                        no_kv_cache,
+                        None,
+                    )?
+                    .contiguous()?
+                    .apply(&self.output)?,
                 seqlen_offsets,
-                start_offsets_kernel,
-                None,
-                false,
-                no_kv_cache,
-                None,
-            )?
-            .contiguous()?
-            .apply(&self.output)?
-            .i((.., seq_len - 1, ..))
+            )
         }
     }
 }

--- a/mistralrs-core/src/xlora_models/quantized_llama.rs
+++ b/mistralrs-core/src/xlora_models/quantized_llama.rs
@@ -766,6 +766,7 @@ impl ModelWeights {
         start_offsets_kernel_full: Tensor,
         no_kv_cache: bool,
         non_granular_state: &Option<NonGranularState>,
+        context_lens: Vec<usize>,
     ) -> Result<Tensor> {
         if self.xlora_classifier.is_some() {
             let scalings = self.get_scalings(
@@ -793,7 +794,7 @@ impl ModelWeights {
                         )?
                         .contiguous()?
                         .apply(&self.output)?,
-                    seqlen_offsets_full,
+                    context_lens,
                 )
             } else {
                 // is_full_pass=true is ok because no_kv_cache=false
@@ -810,7 +811,7 @@ impl ModelWeights {
                         )?
                         .contiguous()?
                         .apply(&self.output)?,
-                    seqlen_offsets,
+                    context_lens,
                 )
             }
         } else {
@@ -827,7 +828,7 @@ impl ModelWeights {
                     )?
                     .contiguous()?
                     .apply(&self.output)?,
-                seqlen_offsets,
+                context_lens,
             )
         }
     }


### PR DESCRIPTION
- Fixes Phi2 LoRA
- Allows all prompt seqs to run at the same time, all the time