### PR TITLE
Optimize completion strings

### DIFF
--- a/mistralrs-core/src/engine/mod.rs
+++ b/mistralrs-core/src/engine/mod.rs
@@ -227,11 +227,12 @@ impl Engine {
             | StopReason::StopTok(_) => String::from_utf8_lossy(seq.completion_bytes())
                 .trim_start()
                 .to_string(),
-            StopReason::StopString(stop_str_index) => {
+            StopReason::StopString {
+                completion_bytes_pos,
+                ..
+            } => {
                 let txt = String::from_utf8_lossy(seq.completion_bytes());
-                let stop_str = seq.stop_strings().get(stop_str_index).unwrap();
-                let stop_str_pos = txt.rfind(stop_str).unwrap();
-                txt[..stop_str_pos].trim_start().to_string()
+                txt[..completion_bytes_pos].trim_start().to_string()
             }
         };
 

--- a/mistralrs-core/src/engine/mod.rs
+++ b/mistralrs-core/src/engine/mod.rs
@@ -221,28 +221,19 @@ impl Engine {
         };
 
         let text = match reason {
-            StopReason::Length(_) | StopReason::ModelLength(_) => pipeline
-                .tokenizer()
-                .decode(&seq.get_toks()[seq.prompt_tokens()..], false),
-
-            StopReason::Eos | StopReason::StopTok(_) => {
-                let toks = seq.get_toks();
-                pipeline
-                    .tokenizer()
-                    .decode(&toks[seq.prompt_tokens()..toks.len() - 1], false)
-            }
+            StopReason::Length(_)
+            | StopReason::ModelLength(_)
+            | StopReason::Eos
+            | StopReason::StopTok(_) => String::from_utf8_lossy(seq.completion_bytes())
+                .trim_start()
+                .to_string(),
             StopReason::StopString(stop_str_index) => {
+                let txt = String::from_utf8_lossy(seq.completion_bytes());
                 let stop_str = seq.stop_strings().get(stop_str_index).unwrap();
-                pipeline
-                    .tokenizer()
-                    .decode(&seq.get_toks()[seq.prompt_tokens()..], false)
-                    .map(|txt| {
-                        let stop_str_pos = txt.rfind(stop_str).unwrap();
-                        txt[..stop_str_pos].to_string()
-                    })
+                let stop_str_pos = txt.rfind(stop_str).unwrap();
+                txt[..stop_str_pos].trim_start().to_string()
             }
         };
-        let text = handle_seq_error!(text, seq.responder());
 
         if seq.get_mut_group().is_chat {
             let choice = Choice {


### PR DESCRIPTION
Use `completion_bytes` if streaming or in regular mode.

Avoid re-decoding tokens when finishing requests in regular mode.

Removes unsafe and 1 allocation from the streaming code.

Avoid searching for the stop string, store position in reason.