### PR TITLE
Fix interactive mode stripping end of message

### DIFF
--- a/mistralrs-server/src/interactive_mode.rs
+++ b/mistralrs-server/src/interactive_mode.rs
@@ -59,15 +59,14 @@ pub fn interactive_mode(mistralrs: Arc<MistralRs>) {
                 match resp {
                     Response::Chunk(chunk) => {
                         let choice = &chunk.choices[0];
+                        assistant_output.push_str(&choice.delta.content);
+                        print!("{}", choice.delta.content);
+                        io::stdout().flush().unwrap();
                         if choice.stopreason.is_some() {
                             if matches!(choice.stopreason.as_ref().unwrap().as_str(), "length") {
                                 print!("...");
                             }
                             break;
-                        } else {
-                            assistant_output.push_str(&choice.delta.content);
-                            print!("{}", choice.delta.content);
-                            io::stdout().flush().unwrap();
                         }
                     }
                     Response::InternalError(e) => {


### PR DESCRIPTION
Due to the stream rate limit there was a chance we'd not print the latest 2 tokens of the message.