### PR TITLE
Improvements to hot loop request receiving

### DIFF
--- a/mistralrs-core/src/engine/mod.rs
+++ b/mistralrs-core/src/engine/mod.rs
@@ -165,6 +165,7 @@ impl Engine {
                 && scheduled.completion.len() == 0
                 && self.scheduler.waiting_len() == 0
             {
+                // If there is nothing to do, sleep until a request comes in
                 if let Ok(request) = self.rx.recv() {
                     self.add_request(request);
                 }

--- a/mistralrs-core/src/scheduler.rs
+++ b/mistralrs-core/src/scheduler.rs
@@ -74,6 +74,10 @@ impl<Backer: FcfsBacker> Scheduler<Backer> {
         }
     }
 
+    pub fn waiting_len(&self) -> usize {
+        self.waiting.iter().count()
+    }
+
     /// Move the seuqences into buckets, and run the ones with the shortest lengths.
     /// The others are moved to the waiting list (retaining high priority due to start time),
     /// without a state modification.


### PR DESCRIPTION
Receive multiple requests at once to parallelize inputs

If nothing is scheduled, wait for requests sleeping

Now 2 prompts can be batched, before this MR they wouldn't.

```
$ RUST_LOG=debug ./target/release/mistralrs-server --prompt "Tell me 3 jokes." --prompt-concurrency 2 mistral-gguf
...
2024-04-16T01:52:28.211352Z DEBUG mistralrs_core::engine: Prompt[15, 15] Completion[] - 230ms
2024-04-16T01:52:28.350200Z DEBUG mistralrs_core::engine: Prompt[] Completion[16, 16] - 138ms
....
```