### PR TITLE
Remove sampling metrics

### DIFF
--- a/mistralrs-core/src/engine/mod.rs
+++ b/mistralrs-core/src/engine/mod.rs
@@ -93,12 +93,7 @@ impl Engine {
                     Self::set_none_cache(&mut *pipeline);
                 }
 
-                let before_sample = Instant::now();
                 handle_pipeline_forward_error!("sampling", Self::sample_seqs(&mut *pipeline, &mut scheduled.completion, logits, &mut self.prefix_cacher), &mut scheduled.completion, pipeline, 'lp);
-                let sampling_time = before_sample.elapsed().as_millis();
-                for seq in scheduled.completion.iter_mut() {
-                    seq.total_sampling_time += sampling_time;
-                }
             }
 
             if scheduled.prompt.len() > 0 {
@@ -125,12 +120,7 @@ impl Engine {
                     seq.prompt_timestamp = Some(now);
                 }
 
-                let before_sample = Instant::now();
                 handle_pipeline_forward_error!("sampling", Self::sample_seqs(&mut *pipeline, &mut scheduled.prompt, logits, &mut self.prefix_cacher), &mut scheduled.prompt, pipeline, 'lp);
-                let sampling_time = before_sample.elapsed().as_millis();
-                for seq in scheduled.prompt.iter_mut() {
-                    seq.total_sampling_time += sampling_time;
-                }
             }
 
             if self.is_debug {

--- a/mistralrs-core/src/response.rs
+++ b/mistralrs-core/src/response.rs
@@ -57,11 +57,9 @@ pub struct Usage {
     pub avg_tok_per_sec: f32,
     pub avg_prompt_tok_per_sec: f32,
     pub avg_compl_tok_per_sec: f32,
-    pub avg_sample_tok_per_sec: f32,
     pub total_time_sec: f32,
     pub total_prompt_time_sec: f32,
     pub total_completion_time_sec: f32,
-    pub total_sampling_time_sec: f32,
 }
 
 #[derive(Debug, Clone, Serialize)]

--- a/mistralrs-core/src/sequence.rs
+++ b/mistralrs-core/src/sequence.rs
@@ -92,7 +92,6 @@ pub struct Sequence {
     pub prompt_tok_per_sec: f32,
     pub prompt_timestamp: Option<u128>,
     group: Rc<RefCell<SequenceGroup>>,
-    pub total_sampling_time: u128,
     state: Cell<SequenceState>,
 }
 impl Sequence {
@@ -140,7 +139,6 @@ impl Sequence {
             prompt_timestamp: None,
             group,
             scaling_cache: None,
-            total_sampling_time: 0,
             response_index,
             creation_time,
             recognizer,
@@ -357,8 +355,6 @@ impl Sequence {
 
         get_mut_group!(self).total_prompt_toks += self.prompt_len;
         get_mut_group!(self).total_toks += self.len();
-
-        get_mut_group!(self).total_sampling_time += self.total_sampling_time;
     }
 
     pub fn add_choice_to_group(&self, choice: Choice) {
@@ -400,7 +396,6 @@ pub struct SequenceGroup {
     pub total_prompt_time: u128,
     pub total_time: u128,
     pub total_completion_time: u128,
-    pub total_sampling_time: u128,
     choices: Vec<Choice>,
     completion_choices: Vec<(f32, CompletionChoice)>,
     pub streaming_chunks: Vec<ChunkChoice>,
@@ -424,7 +419,6 @@ impl SequenceGroup {
             total_prompt_time: 0,
             total_time: 0,
             total_completion_time: 0,
-            total_sampling_time: 0,
             streaming_chunks: Vec::new(),
             is_streaming,
             is_chat,
@@ -461,12 +455,9 @@ impl SequenceGroup {
             avg_compl_tok_per_sec: ((self.total_toks - self.total_prompt_toks) as f32
                 / self.total_completion_time as f32)
                 * 1000.,
-            avg_sample_tok_per_sec: (self.total_toks as f32 / self.total_sampling_time as f32)
-                * 1000.,
             total_time_sec: self.total_time as f32 / 1000.,
             total_completion_time_sec: self.total_completion_time as f32 / 1000.,
             total_prompt_time_sec: self.total_prompt_time as f32 / 1000.,
-            total_sampling_time_sec: self.total_sampling_time as f32 / 1000.,
         }
     }
 

--- a/mistralrs-server/src/prompt_mode.rs
+++ b/mistralrs-server/src/prompt_mode.rs
@@ -68,7 +68,6 @@ pub fn prompt_mode(
                     println!("=======================");
                     println!("Completion T/s = {}", res.usage.avg_compl_tok_per_sec);
                     println!("Prompt T/s = {}", res.usage.avg_prompt_tok_per_sec);
-                    println!("Sampling T/s = {}", res.usage.avg_sample_tok_per_sec);
                 }
                 Response::Chunk(_) => unreachable!(),
                 Response::CompletionDone(_) => unreachable!(),


### PR DESCRIPTION
Sampling is done on the GPU, so it's not possible to measure this timing without GPU synchronization.

It is misleading and I think it can be removed.

The only way to measure sampling is through nvidia profiler.