### PR TITLE
Sampling optimizations

### DIFF
--- a/mistralrs-core/src/engine/mod.rs
+++ b/mistralrs-core/src/engine/mod.rs
@@ -1,6 +1,6 @@
 use std::{
     cell::RefCell,
-    collections::VecDeque,
+    collections::{HashMap, VecDeque},
     iter::zip,
     rc::Rc,
     sync::{mpsc::Receiver, Mutex},
@@ -463,6 +463,23 @@ impl Engine {
         Ok(recognizer)
     }
 
+    fn alloc_logits_bias(&self, logits_bias: Option<HashMap<u32, f32>>) -> Result<Option<Tensor>> {
+        let device = get_mut_arcmutex!(self.pipeline).device().clone();
+        let tokenizer = get_mut_arcmutex!(self.pipeline).tokenizer();
+        let vocab_size = tokenizer.get_vocab_size(true);
+
+        match logits_bias {
+            Some(bias) => {
+                let mut logits_bias = vec![0.0; vocab_size];
+                for (k, v) in bias {
+                    logits_bias[k as usize] = v;
+                }
+                Ok(Some(Tensor::from_vec(logits_bias, vocab_size, &device)?))
+            }
+            None => Ok(None),
+        }
+    }
+
     fn add_request(&mut self, request: Request) {
         if request.messages.is_left()
             && !get_mut_arcmutex!(self.pipeline)
@@ -599,6 +616,18 @@ impl Engine {
             .duration_since(UNIX_EPOCH)
             .expect("Time travel has occurred!");
 
+        let logits_bias = match self.alloc_logits_bias(request.sampling_params.logits_bias) {
+            Ok(logits_bias) => logits_bias,
+            Err(err) => {
+                request
+                    .response
+                    .send(Response::ValidationError(
+                        format!("Failed creation of logits bias. {}", err).into(),
+                    ))
+                    .unwrap();
+                return;
+            }
+        };
         let tokenizer = get_mut_arcmutex!(self.pipeline).tokenizer();
 
         let sampler = Sampler::new(
@@ -608,7 +637,7 @@ impl Engine {
             tokenizer,
             request.sampling_params.frequency_penalty,
             request.sampling_params.presence_penalty,
-            request.sampling_params.logits_bias.clone(),
+            logits_bias,
             topk,
             topp,
         );

--- a/mistralrs-core/src/engine/mod.rs
+++ b/mistralrs-core/src/engine/mod.rs
@@ -629,7 +629,6 @@ impl Engine {
             }
         };
         let tokenizer = get_mut_arcmutex!(self.pipeline).tokenizer();
-        let device = get_mut_arcmutex!(self.pipeline).device().clone();
 
         let sampler = Sampler::new(
             SEED,
@@ -641,7 +640,6 @@ impl Engine {
             logits_bias,
             topk,
             topp,
-            device,
         );
         let recognizer = match Self::build_sequence_recognizer(&request.constraint) {
             Ok(recognizer) => recognizer,

--- a/mistralrs-core/src/engine/mod.rs
+++ b/mistralrs-core/src/engine/mod.rs
@@ -629,6 +629,7 @@ impl Engine {
             }
         };
         let tokenizer = get_mut_arcmutex!(self.pipeline).tokenizer();
+        let device = get_mut_arcmutex!(self.pipeline).device().clone();
 
         let sampler = Sampler::new(
             SEED,
@@ -640,6 +641,7 @@ impl Engine {
             logits_bias,
             topk,
             topp,
+            device,
         );
         let recognizer = match Self::build_sequence_recognizer(&request.constraint) {
             Ok(recognizer) => recognizer,

--- a/mistralrs-core/src/pipeline/mod.rs
+++ b/mistralrs-core/src/pipeline/mod.rs
@@ -298,7 +298,7 @@ pub trait Pipeline: Send + Sync {
         seq: &mut Sequence,
         return_logprobs: bool,
     ) -> Result<Logprobs> {
-        let logits = logits.squeeze(0)?.squeeze(0)?;
+        let logits = logits.squeeze(0)?.squeeze(0)?.to_dtype(DType::F32)?;
         let start_at = seq
             .get_toks()
             .len()

--- a/mistralrs-core/src/sampler.rs
+++ b/mistralrs-core/src/sampler.rs
@@ -212,7 +212,7 @@ impl Sampler {
         }
 
         // Sort by descending probability.
-        argsort_indices.sort_by(|&i, &j| probs[j].partial_cmp(&probs[i]).unwrap());
+        argsort_indices.sort_unstable_by(|&i, &j| probs[j].partial_cmp(&probs[i]).unwrap());
 
         if top_k > 0 {
             // Clamp smaller probabilities to zero.

--- a/mistralrs-core/src/sampler.rs
+++ b/mistralrs-core/src/sampler.rs
@@ -253,8 +253,6 @@ impl Sampler {
         context: &[u32],
     ) -> Result<Vec<f32>> {
         //mu[j] -> mu[j] - c[j] * alpha_frequency - float(c[j] > 0) * alpha_presence
-        // let device = logits.device();
-        // let mut logits = logits.to_vec1::<f32>()?;
         let mut logits = vec![0.0; vocab_size];
         for (token_id, logit) in logits.iter_mut().enumerate() {
             let count = context.iter().filter(|x| **x as usize == token_id).count();

--- a/mistralrs-core/src/sampler.rs
+++ b/mistralrs-core/src/sampler.rs
@@ -144,7 +144,7 @@ impl Sampler {
 
         if let Some(penalty) = penalty {
             for (token_id, logit) in probs.iter_mut().enumerate() {
-                *logit = *logit + penalty[token_id];
+                *logit += penalty[token_id];
             }
         }
 
@@ -207,7 +207,7 @@ impl Sampler {
 
         if let Some(penalty) = penalty {
             for (token_id, logit) in probs.iter_mut().enumerate() {
-                *logit = *logit + penalty[token_id];
+                *logit += penalty[token_id];
             }
         }
 
@@ -346,7 +346,7 @@ mod tests {
             0.1,
         );
 
-        let logits = Tensor::arange(0f64, 1024f64, &Device::Cpu).unwrap();
+        let logits = Tensor::arange(0f32, 1024f32, &Device::Cpu).unwrap();
         let res = sampler.sample(logits, None, false).unwrap();
         assert_eq!(res.token, 1023);
         assert_eq!(res.top_logprobs, None);


### PR DESCRIPTION
Makes sampling fully async, removing synchronizations.

Generation goes from 54t/s to 59t/s using `./target/profiling/mistralrs-server --prompt "Tell me 3 jokes." mistral-gguf`

Same generation speed as Llama.cpp :smile: 