### PR TITLE
Use tracing::info in hot loop debugging

### DIFF
--- a/mistralrs-core/src/engine/mod.rs
+++ b/mistralrs-core/src/engine/mod.rs
@@ -142,7 +142,7 @@ impl Engine {
                         .collect::<Vec<_>>()
                         .join(", ");
 
-                    tracing::debug!(
+                    tracing::info!(
                         "Prompt[{}] Completion[{}] - {}ms",
                         prompt_lengths,
                         completion_lengths,


### PR DESCRIPTION
https://github.com/lucasavila00/mistral.rs/commit/0e833feb794a7bfab76df12c76d86c7ae317190d removed tracing filters and this place used tracing::debug


Notice that regardless, it is still locked by the `RUST_LOG=debug` env var.
