### PR TITLE
Skip cloning cache in redundantly

### DIFF
--- a/mistralrs-core/src/engine/mod.rs
+++ b/mistralrs-core/src/engine/mod.rs
@@ -84,7 +84,7 @@ impl Engine {
 
     pub fn run(&mut self) {
         let mut last_run = Instant::now();
-        let mut last_completion: Vec<usize> = vec![];
+        let mut last_completion_ids: Vec<usize> = vec![];
         'lp: loop {
             while let Ok(request) = self.rx.try_recv() {
                 self.add_request(request);
@@ -98,10 +98,10 @@ impl Engine {
             }
 
             if scheduled.completion.len() > 0 {
-                let current_completion: Vec<usize> =
+                let current_completion_ids: Vec<usize> =
                     scheduled.completion.iter().map(|seq| *seq.id()).collect();
                 // Run the completion seqs
-                if !self.no_kv_cache && last_completion != current_completion {
+                if !self.no_kv_cache && last_completion_ids != current_completion_ids {
                     Self::clone_in_cache(&mut *pipeline, &mut scheduled.completion);
                 }
                 let logits = pipeline.forward(&scheduled.completion, false);
@@ -128,7 +128,7 @@ impl Engine {
                     'lp,
                     self.prefix_cacher
                 );
-                last_completion = current_completion;
+                last_completion_ids = current_completion_ids;
             }
 
             if scheduled.prompt.len() > 0 {
@@ -170,7 +170,7 @@ impl Engine {
                     seq.prompt_tok_per_sec = prompt_tok_per_sec * 1000.;
                     seq.prompt_timestamp = Some(now);
                 }
-                last_completion = vec![];
+                last_completion_ids = vec![];
             }
 
             if self.is_debug {

--- a/mistralrs-core/src/engine/mod.rs
+++ b/mistralrs-core/src/engine/mod.rs
@@ -128,7 +128,7 @@ impl Engine {
                     'lp,
                     self.prefix_cacher
                 );
-                last_completion = scheduled.completion.iter().map(|seq| *seq.id()).collect();
+                last_completion = current_completion;
             }
 
             if scheduled.prompt.len() > 0 {


### PR DESCRIPTION
```
./target/profiling/mistralrs-bench -p 0 -g 64 -r 1 -c 8  gguf -t mistralai/Mistral-7B-Instruct-v0.1 -m TheBloke/Mistral-7B-Instruct-v0.1-GGUF -f mistral-7b-instruct-v0.1.Q4_K_M.gguf
```

Master

![image](https://github.com/EricLBuehler/mistral.rs/assets/12750442/108fd723-e1f7-4498-8c1f-7f813dfb6e56)



This PR

![image](https://github.com/EricLBuehler/mistral.rs/assets/12750442/35ee1e95-e6f5-4633-aec1-019b2e214f8a)


Saves the highlighted 2ms when copying the 63th token's cache in.