### PR TITLE
Mark sequence as `Canceled` if the `responder` isn't there

### DIFF
--- a/mistralrs-core/src/sequence.rs
+++ b/mistralrs-core/src/sequence.rs
@@ -1,7 +1,7 @@
 use std::{
     cell::{Cell, RefCell, RefMut},
     rc::Rc,
-    sync::mpsc::Sender,
+    sync::mpsc::{SendError, Sender},
     time::{SystemTime, UNIX_EPOCH},
 };
 
@@ -30,6 +30,7 @@ pub enum StopReason {
         stop_string_idx: usize,
         completion_bytes_pos: usize,
     },
+    Canceled,
 }
 
 impl ToString for StopReason {
@@ -38,6 +39,7 @@ impl ToString for StopReason {
             StopReason::Eos => "stop".to_string(),
             StopReason::Length(_) | StopReason::ModelLength(_) => "length".to_string(),
             StopReason::StopTok(_) | StopReason::StopString { .. } => "stop".to_string(),
+            StopReason::Canceled => "canceled".to_string(),
         }
     }
 }
@@ -485,7 +487,11 @@ impl SequenceGroup {
         }
     }
 
-    pub fn maybe_send_streaming_response(&mut self, seq: &Sequence, model: String) {
+    pub fn maybe_send_streaming_response(
+        &mut self,
+        seq: &Sequence,
+        model: String,
+    ) -> Result<(), Box<SendError<Response>>> {
         if self.streaming_chunks.len() == self.n_choices && self.is_streaming {
             let mut swap_streaming_chunks = vec![];
 
@@ -499,9 +505,9 @@ impl SequenceGroup {
                     model: model.clone(),
                     system_fingerprint: SYSTEM_FINGERPRINT.to_string(),
                     object: "chat.completion.chunk".to_string(),
-                }))
-                .expect("Expected receiver.");
+                }))?;
         }
+        Ok(())
     }
 
     pub fn maybe_send_completion_done_response(


### PR DESCRIPTION
Fixes #213

I don't know if this is the correct way to fix this but we should probably have some mechanism, that cancels and cleans up a sequence if we can't send the results anywhere.  

