### PR TITLE
Fix debug log timing of first token

### DIFF
--- a/mistralrs-core/src/engine/mod.rs
+++ b/mistralrs-core/src/engine/mod.rs
@@ -83,12 +83,12 @@ impl Engine {
     }
 
     pub fn run(&mut self) {
-        let mut last_run = Instant::now();
         let mut last_completion_ids: Vec<usize> = vec![];
         'lp: loop {
             while let Ok(request) = self.rx.try_recv() {
                 self.add_request(request);
             }
+            let run_start = Instant::now();
             let mut scheduled = self.scheduler.schedule();
             let mut pipeline = get_mut_arcmutex!(self.pipeline);
             if let Ok(dtype) = self.isq_rx.try_recv() {
@@ -174,8 +174,7 @@ impl Engine {
             }
 
             if self.is_debug {
-                let ms_from_last_run = last_run.elapsed().as_millis();
-                last_run = Instant::now();
+                let ms_from_last_run = run_start.elapsed().as_millis();
                 let total_len = scheduled.prompt.len() + scheduled.completion.len();
                 if total_len > 0 {
                     let prompt_lengths = scheduled


### PR DESCRIPTION
If running in interactive mode it was calculating the time it takes to type the message as time of the first token