### PR TITLE
Fix Phi3 128k finally: use position ids to switch between short/long scaling

### DIFF
--- a/mistralrs-core/src/layers.rs
+++ b/mistralrs-core/src/layers.rs
@@ -183,11 +183,11 @@ impl PhiRotaryEmbedding {
     }
 
     /// Returns (sin, cos) taking into account LongRope
-    fn get_long_or_short_sin_cos(&self, seqlen_offsets: &[usize]) -> (&Tensor, &Tensor) {
+    fn get_long_or_short_sin_cos(&self, position_ids: &[usize]) -> (&Tensor, &Tensor) {
         if self.long_cos.is_none() {
             return (&self.short_sin, &self.short_cos);
         }
-        let seq_len = seqlen_offsets.iter().max().unwrap() + 1;
+        let seq_len = position_ids.iter().max().unwrap() + 1;
         if seq_len > self.original_max_position_embeddings {
             (
                 self.long_sin.as_ref().unwrap(),
@@ -203,11 +203,12 @@ impl PhiRotaryEmbedding {
         q: &Tensor,
         k: &Tensor,
         seqlen_offsets: &[usize],
+        position_ids: &[usize],
     ) -> Result<(Tensor, Tensor)> {
         let (_b_sz, _h, seq_len, _n_embd) = q.dims4()?;
         let mut q_embeds = Vec::new();
         let mut k_embeds = Vec::new();
-        let (sin, cos) = self.get_long_or_short_sin_cos(seqlen_offsets);
+        let (sin, cos) = self.get_long_or_short_sin_cos(position_ids);
         for offset in seqlen_offsets {
             let cos = cos.narrow(0, *offset, seq_len)?;
             let sin = sin.narrow(0, *offset, seq_len)?;

--- a/mistralrs-core/src/models/gemma.rs
+++ b/mistralrs-core/src/models/gemma.rs
@@ -454,6 +454,7 @@ impl NormalModel for Model {
         seqlen_offsets: &[usize],
         start_offsets_kernel: Tensor,
         context_lens: Vec<usize>,
+        _position_ids: Vec<usize>,
     ) -> Result<Tensor> {
         self.forward(
             input_ids,
@@ -473,6 +474,7 @@ impl NormalModel for Model {
         _no_kv_cache: bool,
         _non_granular_state: &Option<crate::xlora_models::NonGranularState>,
         _context_lens: Vec<usize>,
+        _position_ids: Vec<usize>,
     ) -> Result<Tensor> {
         unimplemented!()
     }

--- a/mistralrs-core/src/models/llama.rs
+++ b/mistralrs-core/src/models/llama.rs
@@ -413,6 +413,7 @@ impl NormalModel for Llama {
         seqlen_offsets: &[usize],
         start_offsets_kernel: Tensor,
         context_lens: Vec<usize>,
+        _position_ids: Vec<usize>,
     ) -> Result<Tensor> {
         self.forward(
             input_ids,
@@ -432,6 +433,7 @@ impl NormalModel for Llama {
         _no_kv_cache: bool,
         _non_granular_state: &Option<crate::xlora_models::NonGranularState>,
         _context_lens: Vec<usize>,
+        _position_ids: Vec<usize>,
     ) -> Result<Tensor> {
         unimplemented!()
     }

--- a/mistralrs-core/src/models/mistral.rs
+++ b/mistralrs-core/src/models/mistral.rs
@@ -470,6 +470,7 @@ impl NormalModel for Model {
         seqlen_offsets: &[usize],
         start_offsets_kernel: Tensor,
         context_lens: Vec<usize>,
+        _position_ids: Vec<usize>,
     ) -> Result<Tensor> {
         self.forward(
             input_ids,
@@ -489,6 +490,7 @@ impl NormalModel for Model {
         _no_kv_cache: bool,
         _non_granular_state: &Option<crate::xlora_models::NonGranularState>,
         _context_lens: Vec<usize>,
+        _position_ids: Vec<usize>,
     ) -> Result<Tensor> {
         unimplemented!()
     }

--- a/mistralrs-core/src/models/mixtral.rs
+++ b/mistralrs-core/src/models/mixtral.rs
@@ -568,6 +568,7 @@ impl NormalModel for Model {
         seqlen_offsets: &[usize],
         start_offsets_kernel: Tensor,
         context_lens: Vec<usize>,
+        _position_ids: Vec<usize>,
     ) -> Result<Tensor> {
         self.forward(
             input_ids,
@@ -587,6 +588,7 @@ impl NormalModel for Model {
         _no_kv_cache: bool,
         _non_granular_state: &Option<crate::xlora_models::NonGranularState>,
         _context_lens: Vec<usize>,
+        _position_ids: Vec<usize>,
     ) -> Result<Tensor> {
         unimplemented!()
     }

--- a/mistralrs-core/src/models/phi2.rs
+++ b/mistralrs-core/src/models/phi2.rs
@@ -425,6 +425,7 @@ impl NormalModel for Model {
         seqlen_offsets: &[usize],
         start_offsets_kernel: Tensor,
         context_lens: Vec<usize>,
+        _position_ids: Vec<usize>,
     ) -> Result<Tensor> {
         self.forward(
             input_ids,
@@ -444,6 +445,7 @@ impl NormalModel for Model {
         _no_kv_cache: bool,
         _non_granular_state: &Option<crate::xlora_models::NonGranularState>,
         _context_lens: Vec<usize>,
+        _position_ids: Vec<usize>,
     ) -> Result<Tensor> {
         unimplemented!()
     }

--- a/mistralrs-core/src/models/phi3.rs
+++ b/mistralrs-core/src/models/phi3.rs
@@ -471,14 +471,9 @@ impl NormalModel for Model {
         seqlen_offsets: &[usize],
         _start_offsets_kernel: Tensor,
         context_lens: Vec<usize>,
+        position_ids: Vec<usize>,
     ) -> Result<Tensor> {
-        // NOTE(EricLBuehler): hacky yes, but passing the context lens to start the position ids calculation works
-        self.forward(
-            input_ids,
-            seqlen_offsets,
-            &context_lens,
-            context_lens.clone(),
-        )
+        self.forward(input_ids, seqlen_offsets, &position_ids, context_lens)
     }
     fn xlora_forward(
         &mut self,
@@ -491,6 +486,7 @@ impl NormalModel for Model {
         _no_kv_cache: bool,
         _non_granular_state: &Option<crate::xlora_models::NonGranularState>,
         _context_lens: Vec<usize>,
+        _position_ids: Vec<usize>,
     ) -> Result<Tensor> {
         unimplemented!()
     }

--- a/mistralrs-core/src/models/qwen2.rs
+++ b/mistralrs-core/src/models/qwen2.rs
@@ -436,6 +436,7 @@ impl NormalModel for Model {
         seqlen_offsets: &[usize],
         start_offsets_kernel: Tensor,
         context_lens: Vec<usize>,
+        _position_ids: Vec<usize>,
     ) -> Result<Tensor> {
         self.forward(
             input_ids,
@@ -455,6 +456,7 @@ impl NormalModel for Model {
         _no_kv_cache: bool,
         _non_granular_state: &Option<crate::xlora_models::NonGranularState>,
         _context_lens: Vec<usize>,
+        _position_ids: Vec<usize>,
     ) -> Result<Tensor> {
         unimplemented!()
     }

--- a/mistralrs-core/src/pipeline/ggml.rs
+++ b/mistralrs-core/src/pipeline/ggml.rs
@@ -359,6 +359,7 @@ impl Pipeline for GGMLPipeline {
             seqlen_offsets_kernel,
             seqlen_offsets_kernel_full,
             context_lens,
+            position_ids: _, // NOTE(EricLBuehler): ignore, it is for phi3
         } = calculate_inputs(
             input_toks,
             is_prompt,

--- a/mistralrs-core/src/pipeline/gguf.rs
+++ b/mistralrs-core/src/pipeline/gguf.rs
@@ -412,6 +412,7 @@ impl Pipeline for GGUFPipeline {
             seqlen_offsets_kernel,
             seqlen_offsets_kernel_full,
             context_lens,
+            position_ids: _, // NOTE(EricLBuehler): ignore, it is for phi3
         } = calculate_inputs(
             input_toks,
             is_prompt,

--- a/mistralrs-core/src/pipeline/normal.rs
+++ b/mistralrs-core/src/pipeline/normal.rs
@@ -327,6 +327,7 @@ impl Pipeline for NormalPipeline {
             seqlen_offsets_kernel,
             seqlen_offsets_kernel_full,
             context_lens,
+            position_ids,
         } = calculate_inputs(
             input_toks,
             is_prompt,
@@ -341,6 +342,7 @@ impl Pipeline for NormalPipeline {
                 &seqlen_offsets,
                 seqlen_offsets_kernel,
                 context_lens,
+                position_ids,
             ),
             true => self.model.xlora_forward(
                 &input_ids,
@@ -352,6 +354,7 @@ impl Pipeline for NormalPipeline {
                 self.no_kv_cache,
                 &self.non_granular_state,
                 context_lens,
+                position_ids,
             ),
         }
     }

--- a/mistralrs-core/src/xlora_models/gemma.rs
+++ b/mistralrs-core/src/xlora_models/gemma.rs
@@ -679,6 +679,7 @@ impl XLoraModel {
                 &start_offsets_kernel_full,
                 no_kv_cache,
                 non_granular_state,
+                &context_lens,
             )?;
 
             if no_kv_cache {
@@ -837,6 +838,7 @@ impl ScalingsMaker for XLoraModel {
         is_full_pass: bool,
         no_kv_cache: bool,
         is_scaling_pass: Option<f64>,
+        _context_lens: &[usize],
     ) -> Result<Tensor> {
         self.inner_forward(
             input_ids,

--- a/mistralrs-core/src/xlora_models/gemma.rs
+++ b/mistralrs-core/src/xlora_models/gemma.rs
@@ -743,6 +743,7 @@ impl NormalModel for XLoraModel {
         _seqlen_offsets: &[usize],
         _start_offsets_kernel: Tensor,
         _context_lens: Vec<usize>,
+        _position_ids: Vec<usize>,
     ) -> Result<Tensor> {
         unreachable!()
     }
@@ -757,6 +758,7 @@ impl NormalModel for XLoraModel {
         no_kv_cache: bool,
         non_granular_state: &Option<crate::xlora_models::NonGranularState>,
         context_lens: Vec<usize>,
+        _position_ids: Vec<usize>,
     ) -> Result<Tensor> {
         self.forward(
             input_ids,

--- a/mistralrs-core/src/xlora_models/llama.rs
+++ b/mistralrs-core/src/xlora_models/llama.rs
@@ -526,6 +526,7 @@ impl XLoraLlama {
                 &start_offsets_kernel_full,
                 no_kv_cache,
                 non_granular_state,
+                &context_lens,
             )?;
 
             if no_kv_cache {
@@ -781,6 +782,7 @@ impl ScalingsMaker for XLoraLlama {
         is_full_pass: bool,
         no_kv_cache: bool,
         is_scaling_pass: Option<f64>,
+        _context_lens: &[usize],
     ) -> Result<Tensor> {
         self.inner_forward(
             input_ids,

--- a/mistralrs-core/src/xlora_models/llama.rs
+++ b/mistralrs-core/src/xlora_models/llama.rs
@@ -693,6 +693,7 @@ impl NormalModel for XLoraLlama {
         _seqlen_offsets: &[usize],
         _start_offsets_kernel: Tensor,
         _context_lens: Vec<usize>,
+        _position_ids: Vec<usize>,
     ) -> Result<Tensor> {
         unreachable!()
     }
@@ -707,6 +708,7 @@ impl NormalModel for XLoraLlama {
         no_kv_cache: bool,
         non_granular_state: &Option<crate::xlora_models::NonGranularState>,
         context_lens: Vec<usize>,
+        _position_ids: Vec<usize>,
     ) -> Result<Tensor> {
         self.forward(
             input_ids,

--- a/mistralrs-core/src/xlora_models/mistral.rs
+++ b/mistralrs-core/src/xlora_models/mistral.rs
@@ -682,6 +682,7 @@ impl XLoraModel {
                 &start_offsets_kernel_full,
                 no_kv_cache,
                 non_granular_state,
+                &context_lens,
             )?;
 
             if no_kv_cache {
@@ -840,6 +841,7 @@ impl ScalingsMaker for XLoraModel {
         is_full_pass: bool,
         no_kv_cache: bool,
         is_scaling_pass: Option<f64>,
+        _context_lens: &[usize],
     ) -> Result<Tensor> {
         self.inner_forward(
             input_ids,

--- a/mistralrs-core/src/xlora_models/mistral.rs
+++ b/mistralrs-core/src/xlora_models/mistral.rs
@@ -746,6 +746,7 @@ impl NormalModel for XLoraModel {
         _seqlen_offsets: &[usize],
         _start_offsets_kernel: Tensor,
         _context_lens: Vec<usize>,
+        _position_ids: Vec<usize>,
     ) -> Result<Tensor> {
         unreachable!()
     }
@@ -760,6 +761,7 @@ impl NormalModel for XLoraModel {
         no_kv_cache: bool,
         non_granular_state: &Option<crate::xlora_models::NonGranularState>,
         context_lens: Vec<usize>,
+        _position_ids: Vec<usize>,
     ) -> Result<Tensor> {
         self.forward(
             input_ids,

--- a/mistralrs-core/src/xlora_models/mixtral.rs
+++ b/mistralrs-core/src/xlora_models/mixtral.rs
@@ -872,6 +872,7 @@ impl NormalModel for XLoraModel {
         _seqlen_offsets: &[usize],
         _start_offsets_kernel: Tensor,
         _context_lens: Vec<usize>,
+        _position_ids: Vec<usize>,
     ) -> Result<Tensor> {
         unreachable!()
     }
@@ -886,6 +887,7 @@ impl NormalModel for XLoraModel {
         no_kv_cache: bool,
         non_granular_state: &Option<crate::xlora_models::NonGranularState>,
         context_lens: Vec<usize>,
+        _position_ids: Vec<usize>,
     ) -> Result<Tensor> {
         self.forward(
             input_ids,

--- a/mistralrs-core/src/xlora_models/mixtral.rs
+++ b/mistralrs-core/src/xlora_models/mixtral.rs
@@ -808,6 +808,7 @@ impl XLoraModel {
                 &start_offsets_kernel_full,
                 no_kv_cache,
                 non_granular_state,
+                &context_lens,
             )?;
 
             if no_kv_cache {
@@ -965,6 +966,7 @@ impl ScalingsMaker for XLoraModel {
         is_full_pass: bool,
         no_kv_cache: bool,
         is_scaling_pass: Option<f64>,
+        _context_lens: &[usize],
     ) -> Result<Tensor> {
         self.inner_forward(
             input_ids,

--- a/mistralrs-core/src/xlora_models/mod.rs
+++ b/mistralrs-core/src/xlora_models/mod.rs
@@ -59,7 +59,7 @@ trait ScalingsMaker {
         start_offsets_kernel_full: &Tensor,
         no_kv_cache: bool,
         non_granular_state: &Option<NonGranularState>,
-        context_lens: &[usize],
+        position_ids: &[usize],
     ) -> Result<Tensor> {
         let (b_size, _) = input_ids_full.dims2()?;
         let (_, seq_len) = input_ids.dims2()?;
@@ -89,7 +89,7 @@ trait ScalingsMaker {
                 true,
                 no_kv_cache,
                 Some(self.get_classifier().config.scaling_pass_value),
-                context_lens,
+                position_ids,
             )?;
 
             let mut new_cache = Vec::new();
@@ -111,7 +111,7 @@ trait ScalingsMaker {
                 false,
                 no_kv_cache,
                 Some(self.get_classifier().config.scaling_pass_value),
-                context_lens,
+                position_ids,
             )?
         };
 

--- a/mistralrs-core/src/xlora_models/mod.rs
+++ b/mistralrs-core/src/xlora_models/mod.rs
@@ -44,6 +44,7 @@ trait ScalingsMaker {
         is_full_pass: bool,
         no_kv_cache: bool,
         is_scaling_pass: Option<f64>,
+        context_lens: &[usize],
     ) -> Result<Tensor>;
     fn get_cache(&self) -> &Cache;
 
@@ -58,6 +59,7 @@ trait ScalingsMaker {
         start_offsets_kernel_full: &Tensor,
         no_kv_cache: bool,
         non_granular_state: &Option<NonGranularState>,
+        context_lens: &[usize],
     ) -> Result<Tensor> {
         let (b_size, _) = input_ids_full.dims2()?;
         let (_, seq_len) = input_ids.dims2()?;
@@ -87,6 +89,7 @@ trait ScalingsMaker {
                 true,
                 no_kv_cache,
                 Some(self.get_classifier().config.scaling_pass_value),
+                context_lens,
             )?;
 
             let mut new_cache = Vec::new();
@@ -108,6 +111,7 @@ trait ScalingsMaker {
                 false,
                 no_kv_cache,
                 Some(self.get_classifier().config.scaling_pass_value),
+                context_lens,
             )?
         };
 

--- a/mistralrs-core/src/xlora_models/phi2.rs
+++ b/mistralrs-core/src/xlora_models/phi2.rs
@@ -674,6 +674,7 @@ impl NormalModel for Model {
         _seqlen_offsets: &[usize],
         _start_offsets_kernel: Tensor,
         _context_lens: Vec<usize>,
+        _position_ids: Vec<usize>,
     ) -> Result<Tensor> {
         unreachable!()
     }
@@ -688,6 +689,7 @@ impl NormalModel for Model {
         no_kv_cache: bool,
         non_granular_state: &Option<crate::xlora_models::NonGranularState>,
         context_lens: Vec<usize>,
+        _position_ids: Vec<usize>,
     ) -> Result<Tensor> {
         self.forward(
             input_ids,

--- a/mistralrs-core/src/xlora_models/phi2.rs
+++ b/mistralrs-core/src/xlora_models/phi2.rs
@@ -610,6 +610,7 @@ impl Model {
                 &start_offsets_kernel_full,
                 no_kv_cache,
                 non_granular_state,
+                &context_lens,
             )?;
 
             if no_kv_cache {
@@ -758,6 +759,7 @@ impl ScalingsMaker for Model {
         is_full_pass: bool,
         no_kv_cache: bool,
         is_scaling_pass: Option<f64>,
+        _context_lens: &[usize],
     ) -> Result<Tensor> {
         self.inner_forward(
             input_ids,

--- a/mistralrs-core/src/xlora_models/phi3.rs
+++ b/mistralrs-core/src/xlora_models/phi3.rs
@@ -614,8 +614,8 @@ impl Model {
         no_kv_cache: bool,
         non_granular_state: &Option<NonGranularState>,
         context_lens: Vec<usize>,
+        position_ids: Vec<usize>,
     ) -> Result<Tensor> {
-        // NOTE(EricLBuehler): hacky yes, but passing the context lens to start the position ids calculation works
         if self.xlora_classifier.is_some() {
             let scalings = self.get_scalings(
                 input_ids,
@@ -626,7 +626,7 @@ impl Model {
                 &start_offsets_kernel_full,
                 no_kv_cache,
                 non_granular_state,
-                &context_lens,
+                &position_ids,
             )?;
 
             if no_kv_cache {
@@ -634,7 +634,7 @@ impl Model {
                     .inner_forward(
                         input_ids_full,
                         seqlen_offsets_full,
-                        &context_lens,
+                        &position_ids,
                         Some(scalings),
                         true,
                         no_kv_cache,
@@ -651,7 +651,7 @@ impl Model {
                     .inner_forward(
                         input_ids,
                         seqlen_offsets,
-                        &context_lens,
+                        &position_ids,
                         Some(scalings),
                         true,
                         no_kv_cache,
@@ -668,7 +668,7 @@ impl Model {
                 .inner_forward(
                     input_ids,
                     seqlen_offsets,
-                    &context_lens,
+                    &position_ids,
                     None,
                     false,
                     no_kv_cache,
@@ -690,6 +690,7 @@ impl NormalModel for Model {
         _seqlen_offsets: &[usize],
         _start_offsets_kernel: Tensor,
         _context_lens: Vec<usize>,
+        _position_ids: Vec<usize>,
     ) -> Result<Tensor> {
         unreachable!()
     }
@@ -704,6 +705,7 @@ impl NormalModel for Model {
         no_kv_cache: bool,
         non_granular_state: &Option<crate::xlora_models::NonGranularState>,
         context_lens: Vec<usize>,
+        position_ids: Vec<usize>,
     ) -> Result<Tensor> {
         self.forward(
             input_ids,
@@ -715,6 +717,7 @@ impl NormalModel for Model {
             no_kv_cache,
             non_granular_state,
             context_lens,
+            position_ids,
         )
     }
     fn cache(&self) -> &Cache {

--- a/mistralrs-core/src/xlora_models/quantized_llama.rs
+++ b/mistralrs-core/src/xlora_models/quantized_llama.rs
@@ -789,6 +789,7 @@ impl ModelWeights {
                 &start_offsets_kernel_full,
                 no_kv_cache,
                 non_granular_state,
+                &context_lens,
             )?;
 
             if no_kv_cache {
@@ -864,6 +865,7 @@ impl ScalingsMaker for ModelWeights {
         is_full_pass: bool,
         no_kv_cache: bool,
         is_scaling_pass: Option<f64>,
+        _context_lens: &[usize],
     ) -> Result<Tensor> {
         self.inner_forward(
             input_ids,


### PR DESCRIPTION
Before, we used the start offset. This is not correct. Now, we use position ids based on the context length and past KV length.