### PR TITLE
Support EOF in interactive mode

### DIFF
--- a/mistralrs-server/src/interactive_mode.rs
+++ b/mistralrs-server/src/interactive_mode.rs
@@ -31,6 +31,9 @@ pub async fn interactive_mode(mistralrs: Arc<MistralRs>) {
         io::stdin()
             .read_line(&mut prompt)
             .expect("Failed to get input");
+        if prompt.trim().is_empty() {
+            continue;
+        }
         let mut user_message = IndexMap::new();
         user_message.insert("role".to_string(), "user".to_string());
         user_message.insert("content".to_string(), prompt);

--- a/mistralrs-server/src/interactive_mode.rs
+++ b/mistralrs-server/src/interactive_mode.rs
@@ -31,8 +31,8 @@ pub async fn interactive_mode(mistralrs: Arc<MistralRs>) {
         io::stdin()
             .read_line(&mut prompt)
             .expect("Failed to get input");
-        if prompt.trim().is_empty() {
-            continue;
+        if prompt.is_empty() {
+            return;
         }
         let mut user_message = IndexMap::new();
         user_message.insert("role".to_string(), "user".to_string());


### PR DESCRIPTION
Resolves the issue reported in #266 by allowing piping data into interactive mode.

New behavior: if the input received by read_line is empty (there was an EOF) then interactive mode is stopped.