### PR TITLE
Add some "senseful" fallbacks for `isq`

### DIFF
--- a/mistralrs-core/src/pipeline/mod.rs
+++ b/mistralrs-core/src/pipeline/mod.rs
@@ -40,7 +40,7 @@ use std::sync::Arc;
 use std::{collections::HashMap, fs, iter::repeat, path::PathBuf, str::FromStr};
 use tokenizers::Tokenizer;
 use tokio::sync::Mutex;
-use tracing::info;
+use tracing::{info, warn};
 
 use anyhow::Result;
 use candle_core::{DType, Device, Tensor};
@@ -407,6 +407,50 @@ pub trait NormalModelLoader {
     fn get_config_repr(&self, config: &str, use_flash_attn: bool) -> Result<Box<dyn Debug>>;
 }
 
+pub enum QuantizationBehaviour {
+    Quantize(GgmlDType),
+    Skip,
+}
+
+/// Return the fallback dtype for the given dtype.
+fn get_fallback(dtype: GgmlDType) -> QuantizationBehaviour {
+    // The normal `Q` quants are a bit more lenient than the `K` quants.
+    // => Try to fallback to a similar `Q` quant.
+    // If that's not possible, skip this tensor.
+    match dtype {
+        GgmlDType::Q2K => QuantizationBehaviour::Quantize(GgmlDType::Q4_0),
+        GgmlDType::Q3K => QuantizationBehaviour::Quantize(GgmlDType::Q4_0),
+        GgmlDType::Q4K => QuantizationBehaviour::Quantize(GgmlDType::Q4_1),
+        GgmlDType::Q5K => QuantizationBehaviour::Quantize(GgmlDType::Q5_0),
+        GgmlDType::Q6K => QuantizationBehaviour::Quantize(GgmlDType::Q5_1),
+        GgmlDType::Q8K => QuantizationBehaviour::Quantize(GgmlDType::Q8_1),
+        _ => QuantizationBehaviour::Skip,
+    }
+}
+
+/// Check if the tensor can be quantized with the given dtype.
+fn can_quantize(tensor: &Tensor, dtype: GgmlDType) -> bool {
+    let dims = tensor.shape().dims();
+    // The tensor must not be empty and the last dimension must be a multiple of the block size.
+    !(dims.is_empty() || (dims[dims.len() - 1] % dtype.block_size() != 0))
+}
+
+/// Check if we should quantize the tensor and if so, with which dtype.
+fn get_quantization_behaviour(tensor: &Tensor, dtype: GgmlDType) -> QuantizationBehaviour {
+    if dtype == GgmlDType::F32 {
+        return QuantizationBehaviour::Skip;
+    }
+
+    if can_quantize(tensor, dtype) {
+        return QuantizationBehaviour::Quantize(dtype);
+    }
+    let fallback = get_fallback(dtype);
+    match fallback {
+        QuantizationBehaviour::Skip => fallback,
+        QuantizationBehaviour::Quantize(new_dtype) => get_quantization_behaviour(tensor, new_dtype),
+    }
+}
+
 pub trait NormalModel {
     fn forward(
         &mut self,
@@ -467,9 +511,19 @@ pub trait NormalModel {
             .progress_with(bar)
             .for_each(|((tensor, _), device)| {
                 if let QMatMul::Tensor(t) = tensor {
-                    n_quantized.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
                     let t = t.to_device(&device).unwrap();
-                    *tensor = QMatMul::QTensor(Arc::new(QTensor::quantize(&t, dtype).unwrap()));
+                    let quantization_behaviour = get_quantization_behaviour(&t, dtype);
+                    *tensor =  match quantization_behaviour{
+                        QuantizationBehaviour::Skip => {
+                            let shape = t.shape();
+                            warn!("Skipping quantization of tensor with shape {shape:?} as it is not quantizable.");
+                            QMatMul::QTensor(Arc::new(QTensor::quantize(&t, GgmlDType::F32).unwrap()))
+                        },
+                        QuantizationBehaviour::Quantize(dtype) => {
+                            n_quantized.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+                            QMatMul::QTensor(Arc::new(QTensor::quantize(&t, dtype).unwrap()))
+                        }
+                    }
                 }
             });
         info!("Applied in-situ quantization into {dtype:?} to {n_quantized:?} tensors out of {total_tensors} total tensors.");


### PR DESCRIPTION
Since the `k-quants` can be quite strict with their block size of `256` we can simply fallback to a simillar "normal" quantization level and if that doesnt work we should just skip the tensor and print a warning. 