### PR TITLE
More intelligent scheduler

### DIFF
--- a/mistralrs-core/src/sequence.rs
+++ b/mistralrs-core/src/sequence.rs
@@ -179,12 +179,12 @@ impl Sequence {
         self
     }
 
-    /// Simple metric: (scheduling urgency-1) * sqrt(length)
-    /// Takes into account urgency (scales linear) and length (to provide a boost to longer seqs)
-    /// We subtract 1 from urgency so that we give smaller sequences a chance.
+    /// Simple metric: (scheduling urgency) + log2(length)
+    /// Takes into account: urgency (scales linear) and length (scales logarithmic)
+    /// Scaling urgency is the number of scheduling passes where we have not been scheduled.
     pub fn compute_priority(&self) -> f64 {
         #![allow(clippy::cast_possible_truncation, clippy::cast_precision_loss)]
-        (self.scheduling_urgency.saturating_sub(1) as f64) * (self.len() as f64).sqrt()
+        (self.scheduling_urgency as f64) + (self.len() as f64).log2()
     }
 
     pub fn prefill(

--- a/mistralrs-core/src/sequence.rs
+++ b/mistralrs-core/src/sequence.rs
@@ -179,11 +179,12 @@ impl Sequence {
         self
     }
 
-    /// Simple metric: scheduling urgency * sqrt(length)
+    /// Simple metric: (scheduling urgency-1) * sqrt(length)
     /// Takes into account urgency (scales linear) and length (to provide a boost to longer seqs)
+    /// We subtract 1 from urgency so that we give smaller sequences a chance.
     pub fn compute_priority(&self) -> f64 {
         #![allow(clippy::cast_possible_truncation, clippy::cast_precision_loss)]
-        (self.scheduling_urgency as f64) * (self.len() as f64).sqrt()
+        (self.scheduling_urgency.saturating_sub(1) as f64) * (self.len() as f64).sqrt()
     }
 
     pub fn prefill(

--- a/mistralrs-core/src/sequence.rs
+++ b/mistralrs-core/src/sequence.rs
@@ -97,6 +97,7 @@ pub struct Sequence {
     completion_bytes: Vec<u8>,
     stream_idx: usize,
     pub recognizer: SequenceRecognizer,
+    scheduling_urgency: usize, // The number of passes since scheduling
 
     // GPU things
     pub prompt_tok_per_sec: f32,
@@ -164,7 +165,25 @@ impl Sequence {
             last_logprob: 0.0,
             last_is_done: None,
             is_tmp: false,
+            scheduling_urgency: 0,
         }
+    }
+
+    pub fn add_urgency(mut self) -> Self {
+        self.scheduling_urgency += 1;
+        self
+    }
+
+    pub fn reset_urgency(mut self) -> Self {
+        self.scheduling_urgency = 0;
+        self
+    }
+
+    /// Simple metric: scheduling urgency * sqrt(length)
+    /// Takes into account urgency (scales linear) and length (to provide a boost to longer seqs)
+    pub fn compute_priority(&self) -> f64 {
+        #![allow(clippy::cast_possible_truncation, clippy::cast_precision_loss)]
+        (self.scheduling_urgency as f64) * (self.len() as f64).sqrt()
     }
 
     pub fn prefill(


### PR DESCRIPTION
Introduces sequence priority, a function of the number of scheduling passes since it was run, and the length. This prepares for #262.

We multiply to ensure that if the sequence is long, but it was just scheduled, then newer sequences get a chance too.

Formula:
$Priority = \log_2{Length} + Urgency$

Where the urgency is the number of scheduler passes since the sequence was scheduled.