### PR TITLE
Make `pyo3` an optional dependency in `mistralrs-core`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,6 @@
 FROM rust:latest as builder
 
 RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
-    python3-dev \
     && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /mistralrs
@@ -24,8 +23,6 @@ RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-ins
     libssl-dev \
     curl \
     pkg-config \
-    python3 \
-    python3-dev \
     && rm -rf /var/lib/apt/lists/*
 
 FROM base

--- a/Dockerfile-cuda-all
+++ b/Dockerfile-cuda-all
@@ -4,9 +4,6 @@ RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-ins
     curl \
     libssl-dev \
     pkg-config \
-    python3 \
-    python3-pip \
-    python3-dev \
     && rm -rf /var/lib/apt/lists/*
 
 RUN curl https://sh.rustup.rs -sSf | bash -s -- -y
@@ -46,7 +43,6 @@ RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-ins
     libssl-dev \
     curl \
     pkg-config \
-    libpython3.10-dev \
     && rm -rf /var/lib/apt/lists/*
 
 FROM base

--- a/mistralrs-core/Cargo.toml
+++ b/mistralrs-core/Cargo.toml
@@ -44,19 +44,21 @@ galil-seiferas = "0.1.5"
 clap.workspace = true
 radix_trie = "0.2.1"
 bytemuck = "1.15.0"
-pyo3.workspace = true
 rayon = "1.10.0"
 tokio.workspace = true
 tokio-rayon = "2.1.0"
 rand_isaac = "0.3.0"
 futures.workspace = true
+pyo3 = {workspace = true, optional = true }
 indicatif = { version = "0.17.8", features = ["rayon"] }
 async-trait = "0.1.80"
 once_cell = "1.19.0"
 toml = "0.8.12"
 ctrlc = "3.4.4"
 
+
 [features]
+pyo3_macros = ["pyo3"]
 cuda = ["candle-core/cuda", "candle-nn/cuda", "candle-transformers/cuda"]
 cudnn = ["candle-core/cudnn"]
 metal = ["candle-core/metal", "candle-nn/metal", "candle-transformers/metal"]

--- a/mistralrs-core/src/pipeline/loaders.rs
+++ b/mistralrs-core/src/pipeline/loaders.rs
@@ -5,7 +5,10 @@ use candle_core::Device;
 use candle_nn::{Activation, VarBuilder};
 use either::Either;
 use mistralrs_lora::{LoraConfig, Ordering};
+
+#[cfg(feature = "pyo3_macros")]
 use pyo3::pyclass;
+
 use serde::Deserialize;
 
 use super::{NormalModel, NormalModelLoader};
@@ -15,7 +18,7 @@ use crate::{
     DeviceMapMetadata,
 };
 
-#[pyclass]
+#[cfg_attr(feature = "pyo3_macros", pyclass)]
 #[derive(Clone, Debug, Deserialize)]
 /// The architecture to load the normal model as.
 pub enum NormalLoaderType {

--- a/mistralrs-core/src/response.rs
+++ b/mistralrs-core/src/response.rs
@@ -1,5 +1,6 @@
 use std::error::Error;
 
+#[cfg(feature = "pyo3_macros")]
 use pyo3::{pyclass, pymethods};
 use serde::Serialize;
 
@@ -9,6 +10,7 @@ pub const SYSTEM_FINGERPRINT: &str = "local";
 
 macro_rules! generate_repr {
     ($t:ident) => {
+        #[cfg(feature = "pyo3_macros")]
         #[pymethods]
         impl $t {
             fn __repr__(&self) -> String {
@@ -18,8 +20,8 @@ macro_rules! generate_repr {
     };
 }
 
-#[pyclass]
-#[pyo3(get_all)]
+#[cfg_attr(feature = "pyo3_macros", pyclass)]
+#[cfg_attr(feature = "pyo3_macros", pyo3(get_all))]
 #[derive(Debug, Clone, Serialize)]
 pub struct ResponseMessage {
     pub content: String,
@@ -28,8 +30,8 @@ pub struct ResponseMessage {
 
 generate_repr!(ResponseMessage);
 
-#[pyclass]
-#[pyo3(get_all)]
+#[cfg_attr(feature = "pyo3_macros", pyclass)]
+#[cfg_attr(feature = "pyo3_macros", pyo3(get_all))]
 #[derive(Debug, Clone, Serialize)]
 pub struct Delta {
     pub content: String,
@@ -38,8 +40,8 @@ pub struct Delta {
 
 generate_repr!(Delta);
 
-#[pyclass]
-#[pyo3(get_all)]
+#[cfg_attr(feature = "pyo3_macros", pyclass)]
+#[cfg_attr(feature = "pyo3_macros", pyo3(get_all))]
 #[derive(Debug, Clone, Serialize)]
 pub struct ResponseLogprob {
     pub token: String,
@@ -50,8 +52,8 @@ pub struct ResponseLogprob {
 
 generate_repr!(ResponseLogprob);
 
-#[pyclass]
-#[pyo3(get_all)]
+#[cfg_attr(feature = "pyo3_macros", pyclass)]
+#[cfg_attr(feature = "pyo3_macros", pyo3(get_all))]
 #[derive(Debug, Clone, Serialize)]
 pub struct Logprobs {
     pub content: Option<Vec<ResponseLogprob>>,
@@ -59,8 +61,8 @@ pub struct Logprobs {
 
 generate_repr!(Logprobs);
 
-#[pyclass]
-#[pyo3(get_all)]
+#[cfg_attr(feature = "pyo3_macros", pyclass)]
+#[cfg_attr(feature = "pyo3_macros", pyo3(get_all))]
 #[derive(Debug, Clone, Serialize)]
 pub struct Choice {
     pub finish_reason: String,
@@ -71,8 +73,8 @@ pub struct Choice {
 
 generate_repr!(Choice);
 
-#[pyclass]
-#[pyo3(get_all)]
+#[cfg_attr(feature = "pyo3_macros", pyclass)]
+#[cfg_attr(feature = "pyo3_macros", pyo3(get_all))]
 #[derive(Debug, Clone, Serialize)]
 pub struct ChunkChoice {
     pub finish_reason: Option<String>,
@@ -83,8 +85,8 @@ pub struct ChunkChoice {
 
 generate_repr!(ChunkChoice);
 
-#[pyclass]
-#[pyo3(get_all)]
+#[cfg_attr(feature = "pyo3_macros", pyclass)]
+#[cfg_attr(feature = "pyo3_macros", pyo3(get_all))]
 #[derive(Debug, Clone, Serialize)]
 /// OpenAI compatible (superset) usage during a request.
 pub struct Usage {
@@ -101,8 +103,8 @@ pub struct Usage {
 
 generate_repr!(Usage);
 
-#[pyclass]
-#[pyo3(get_all)]
+#[cfg_attr(feature = "pyo3_macros", pyclass)]
+#[cfg_attr(feature = "pyo3_macros", pyo3(get_all))]
 #[derive(Debug, Clone, Serialize)]
 /// An OpenAI compatible chat completion response.
 pub struct ChatCompletionResponse {
@@ -117,8 +119,8 @@ pub struct ChatCompletionResponse {
 
 generate_repr!(ChatCompletionResponse);
 
-#[pyclass]
-#[pyo3(get_all)]
+#[cfg_attr(feature = "pyo3_macros", pyclass)]
+#[cfg_attr(feature = "pyo3_macros", pyo3(get_all))]
 #[derive(Debug, Clone, Serialize)]
 pub struct ChatCompletionChunkResponse {
     pub id: String,
@@ -131,8 +133,8 @@ pub struct ChatCompletionChunkResponse {
 
 generate_repr!(ChatCompletionChunkResponse);
 
-#[pyclass]
-#[pyo3(get_all)]
+#[cfg_attr(feature = "pyo3_macros", pyclass)]
+#[cfg_attr(feature = "pyo3_macros", pyo3(get_all))]
 #[derive(Debug, Clone, Serialize)]
 pub struct CompletionChoice {
     pub finish_reason: String,
@@ -143,8 +145,8 @@ pub struct CompletionChoice {
 
 generate_repr!(CompletionChoice);
 
-#[pyclass]
-#[pyo3(get_all)]
+#[cfg_attr(feature = "pyo3_macros", pyclass)]
+#[cfg_attr(feature = "pyo3_macros", pyo3(get_all))]
 #[derive(Debug, Clone, Serialize)]
 /// An OpenAI compatible completion response.
 pub struct CompletionResponse {

--- a/mistralrs-core/src/sampler.rs
+++ b/mistralrs-core/src/sampler.rs
@@ -7,7 +7,9 @@ use std::{
 };
 
 use candle_core::{bail, Device, Error, Result, Tensor, D};
+#[cfg(feature = "pyo3_macros")]
 use pyo3::pyclass;
+
 use rand::distributions::{Distribution, WeightedIndex};
 use rand_isaac::Isaac64Rng;
 use serde::{Deserialize, Serialize};
@@ -65,8 +67,8 @@ pub struct Sampler {
     topp: f64,
 }
 
-#[pyclass]
-#[pyo3(get_all)]
+#[cfg_attr(feature = "pyo3_macros", pyclass)]
+#[cfg_attr(feature = "pyo3_macros", pyo3(get_all))]
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 // Top-n logprobs element
 pub struct TopLogprob {

--- a/mistralrs-pyo3/Cargo.toml
+++ b/mistralrs-pyo3/Cargo.toml
@@ -17,7 +17,7 @@ doc = false
 
 [dependencies]
 pyo3.workspace = true
-mistralrs-core = { version = "0.1.7", path = "../mistralrs-core" }
+mistralrs-core = { version = "0.1.7", path = "../mistralrs-core", features = ["pyo3_macros"] }
 serde.workspace = true
 serde_json.workspace = true
 candle-core.workspace = true

--- a/mistralrs-pyo3/Cargo_template.toml
+++ b/mistralrs-pyo3/Cargo_template.toml
@@ -17,7 +17,7 @@ doc = false
 
 [dependencies]
 pyo3.workspace = true
-mistralrs-core = { version = "0.1.7", path = "../mistralrs-core", features=["$feature_name"] }
+mistralrs-core = { version = "0.1.7", path = "../mistralrs-core", features=["pyo3_macros","$feature_name"] }
 serde.workspace = true
 serde_json.workspace = true
 candle-core = { git = "https://github.com/EricLBuehler/candle.git", version = "0.5.0", features=["$feature_name"] }


### PR DESCRIPTION
Puts `pyo3` behind the `pyo3_macros` feature flag, which is set per default in the `mistralrs-pyo3` create. 

This allows us to compile the benchmark/server without any python depencies via: 

```
cargo build --release --workspace --exclude mistralrs-pyo3
```