### PR TITLE
chore: Simplify `utils/token.rs:get_token()`

### DIFF
--- a/mistralrs-core/src/pipeline/macros.rs
+++ b/mistralrs-core/src/pipeline/macros.rs
@@ -134,7 +134,7 @@ macro_rules! get_paths {
     ($path_name:ident, $token_source:expr, $revision:expr, $this:expr, $quantized_model_id:expr, $quantized_filename:expr, $silent:expr) => {{
         let api = ApiBuilder::new()
             .with_progress(!$silent)
-            .with_token(Some(get_token($token_source)?))
+            .with_token(get_token($token_source)?)
             .build()?;
         let revision = $revision.unwrap_or("main".to_string());
         let api = api.repo(Repo::with_revision(

--- a/mistralrs-core/src/pipeline/mod.rs
+++ b/mistralrs-core/src/pipeline/mod.rs
@@ -912,7 +912,7 @@ fn get_xlora_paths(
     Ok(if let Some(ref xlora_id) = xlora_model_id {
         let api = ApiBuilder::new()
             .with_progress(true)
-            .with_token(Some(get_token(token_source)?))
+            .with_token(get_token(token_source)?)
             .build()?;
         let api = api.repo(Repo::with_revision(
             xlora_id.clone(),
@@ -1134,7 +1134,7 @@ fn get_model_paths(
             id => {
                 let qapi = ApiBuilder::new()
                     .with_progress(true)
-                    .with_token(Some(get_token(token_source)?))
+                    .with_token(get_token(token_source)?)
                     .build()?;
                 let qapi = qapi.repo(Repo::with_revision(
                     id.to_string(),

--- a/mistralrs-core/src/utils/tokens.rs
+++ b/mistralrs-core/src/utils/tokens.rs
@@ -22,16 +22,8 @@ pub(crate) fn get_token(source: &TokenSource) -> Result<Option<String>> {
 
     let token = match source {
         TokenSource::Literal(data) => Some(data.clone()),
-        TokenSource::EnvVar(envvar) => {
-            env::var(envvar)
-                .ok()
-                .or_else(|| skip_token(envvar))
-        },
-        TokenSource::Path(path) => {
-            fs::read_to_string(path)
-                .ok()
-                .or_else(|| skip_token(path))
-        },
+        TokenSource::EnvVar(envvar) => env::var(envvar).ok().or_else(|| skip_token(envvar)),
+        TokenSource::Path(path) => fs::read_to_string(path).ok().or_else(|| skip_token(path)),
         TokenSource::CacheToken => {
             let home = format!(
                 "{}/.cache/huggingface/token",
@@ -43,7 +35,7 @@ pub(crate) fn get_token(source: &TokenSource) -> Result<Option<String>> {
             fs::read_to_string(home.clone())
                 .ok()
                 .or_else(|| skip_token(&home))
-        },
+        }
         TokenSource::None => None,
     };
 

--- a/mistralrs-core/src/utils/tokens.rs
+++ b/mistralrs-core/src/utils/tokens.rs
@@ -14,27 +14,24 @@ enum TokenRetrievalError {
 
 /// This reads a token from a specified source. If the token cannot be read, a warning is logged with `tracing`
 /// and *no token is used*.
-pub(crate) fn get_token(source: &TokenSource) -> Result<String> {
-    Ok(match source {
-        TokenSource::Literal(data) => data.clone(),
+pub(crate) fn get_token(source: &TokenSource) -> Result<Option<String>> {
+    fn skip_token(input: &str) -> Option<String> {
+        info!("Could not load token at {input:?}, using no HF token.");
+        None
+    }
+
+    let token = match source {
+        TokenSource::Literal(data) => Some(data.clone()),
         TokenSource::EnvVar(envvar) => {
-            let tok = env::var(envvar);
-            if let Ok(tok) = tok {
-                tok
-            } else {
-                info!("Could not load token at {envvar:?}, using no HF token.");
-                "".to_string()
-            }
-        }
+            env::var(envvar)
+                .ok()
+                .or_else(|| skip_token(envvar))
+        },
         TokenSource::Path(path) => {
-            let tok = fs::read_to_string(path);
-            if let Ok(tok) = tok {
-                tok
-            } else {
-                info!("Could not load token at {path:?}, using no HF token.");
-                "".to_string()
-            }
-        }
+            fs::read_to_string(path)
+                .ok()
+                .or_else(|| skip_token(path))
+        },
         TokenSource::CacheToken => {
             let home = format!(
                 "{}/.cache/huggingface/token",
@@ -42,16 +39,13 @@ pub(crate) fn get_token(source: &TokenSource) -> Result<String> {
                     .ok_or(TokenRetrievalError::HomeDirectoryMissing)?
                     .display()
             );
-            let tok = fs::read_to_string(home.clone());
-            if let Ok(tok) = tok {
-                tok
-            } else {
-                info!("Could not load token at {home:?}, using no HF token.");
-                "".to_string()
-            }
-        }
-        TokenSource::None => "".to_string(),
-    }
-    .trim()
-    .to_string())
+
+            fs::read_to_string(home.clone())
+                .ok()
+                .or_else(|| skip_token(&home))
+        },
+        TokenSource::None => None,
+    };
+
+    Ok(token.map(|s| s.trim().to_string()))
 }


### PR DESCRIPTION
Presently when a token is not considered valid via this utility method, it is treated as an empty string `Some("")` to hand over to the `hf-hub` crate API, but it should have instead been provided as `None`?

From the `hf-hub` crate, you can see that this would [avoid adding a blank authorization HTTP header](https://github.com/huggingface/hf-hub/blob/9d6502f5bc2e69061c132f523c76a76dad470477/src/api/sync.rs#L143-L157)

```rs
    /// Sets the token to be used in the API
    pub fn with_token(mut self, token: Option<String>) -> Self {
        self.token = token;
        self
    }

    fn build_headers(&self) -> HeaderMap {
        let mut headers = HeaderMap::new();
        let user_agent = format!("unkown/None; {NAME}/{VERSION}; rust/unknown");
        headers.insert(USER_AGENT, user_agent);
        if let Some(token) = &self.token {
            headers.insert(AUTHORIZATION, format!("Bearer {token}"));
        }
        headers
    }
```

---

This PR change won't avoid this info log showing multiple times however:

```
INFO hf_hub: Token file not found "/root/.cache/huggingface/token"
```

Which is due to calling [`ApiBuilder::new()`](https://github.com/EricLBuehler/mistral.rs/blob/ca9bf7d1a8a67bd69a3eed89841a106d2e518c45/mistralrs-core/src/pipeline/macros.rs#L133-L138) which [initializes by checking a cache dir path for a `token` file](https://github.com/huggingface/hf-hub/blob/9d6502f5bc2e69061c132f523c76a76dad470477/src/api/sync.rs#L105-L118) (_via [`cache.token()`](https://github.com/huggingface/hf-hub/blob/9d6502f5bc2e69061c132f523c76a76dad470477/src/lib.rs#L50-L68)_)

<details>
<summary>Added context</summary>

```rs
    pub fn new() -> Self {
        let cache = Cache::default();
        Self::from_cache(cache)
    }

// ...

    pub fn from_cache(cache: Cache) -> Self {
        let token = cache.token();
```

Since `mistral.rs` is already setting the token via `with_token()` the upstream internal `cache.token()` seems redundant? But would presently require recreating `from_cache()` without the `cache.token()` line and providing a [default `Cache` input](https://github.com/huggingface/hf-hub/blob/9d6502f5bc2e69061c132f523c76a76dad470477/src/lib.rs#L194-L208):

```rs
// hf-hub should really have a separate default method similar to:
pub fn new_api_builder() -> ApiBuilder {
    Self {
        endpoint: "https://huggingface.co".to_string(),
        url_template: "{endpoint}/{repo_id}/resolve/{revision}/{filename}".to_string(),
        cache: Cache::default(),
        token: None,
        progress: true,
    }
}

// ...

let api = new_api_builder()
  .with_progress(true)
  .with_token(get_token(token_source)?)
  .build()?;
```

</details>

**UPDATE:** I've sent a [PR upstream to address that](https://github.com/huggingface/hf-hub/pull/60), however it doesn't look like the crate is being maintained? Simple to review contributions already exist but have had no response.