### PR TITLE
chore: `SimpleModelPaths` should be renamed to `LocalModelPaths`

### DIFF
--- a/mistralrs-core/src/pipeline/mod.rs
+++ b/mistralrs-core/src/pipeline/mod.rs
@@ -56,7 +56,7 @@ use crate::{
 pub use self::cache_manager::{Cache, CacheManager, LayerCaches};
 
 /// `ModelPaths` abstracts the mechanism to get all necessary files for running a model. For
-/// example `SimpleModelPaths` implements `ModelPaths` when all files are in the local file system.
+/// example `LocalModelPaths` implements `ModelPaths` when all files are in the local file system.
 pub trait ModelPaths {
     /// Model weights files (multiple files supported).
     fn get_weight_filenames(&self) -> &[PathBuf];


### PR DESCRIPTION
This was originally carried out in https://github.com/EricLBuehler/mistral.rs/commit/07ea5b3039ab7a92a4b9e38967bc5c1e1b8df026 as part of https://github.com/EricLBuehler/mistral.rs/pull/308

When I was troubleshooting https://github.com/EricLBuehler/mistral.rs/issues/326#issuecomment-2118647910 I came across this comment but wasn't quite sure what it was referencing. Later I spotted the mentioned commit when looking at recent history and realized this line was accidentally missed 😅 