### PR TITLE
Implement cache shifting for Llama models

### DIFF
--- a/mistralrs-core/src/models/llama.rs
+++ b/mistralrs-core/src/models/llama.rs
@@ -88,8 +88,13 @@ impl CausalSelfAttention {
                 .contiguous()?;
         }
 
-        let (k, v) =
-            crate::pipeline::Cache::update_kv_cache(&mut kv_cache[block_idx], k, v, false)?;
+        let (k, v) = crate::pipeline::Cache::update_kv_cache_cache_shifting(
+            &mut kv_cache[block_idx],
+            k,
+            v,
+            false,
+            self.max_seq_len,
+        )?;
 
         let k = repeat_kv(k, self.num_attention_heads / self.num_key_value_heads)?.contiguous()?;
         let v = repeat_kv(v, self.num_attention_heads / self.num_key_value_heads)?.contiguous()?;

--- a/mistralrs-core/src/xlora_models/llama.rs
+++ b/mistralrs-core/src/xlora_models/llama.rs
@@ -99,8 +99,13 @@ impl CausalSelfAttention {
                 .contiguous()?;
         }
 
-        let (k, v) =
-            crate::pipeline::Cache::update_kv_cache(&mut kv_cache[block_idx], k, v, false)?;
+        let (k, v) = crate::pipeline::Cache::update_kv_cache_cache_shifting(
+            &mut kv_cache[block_idx],
+            k,
+            v,
+            false,
+            self.max_seq_len,
+        )?;
 
         let k = repeat_kv(k, self.num_attention_heads / self.num_key_value_heads)?.contiguous()?;
         let v = repeat_kv(v, self.num_attention_heads / self.num_key_value_heads)?.contiguous()?;


### PR DESCRIPTION
If this works, we can extend it to the other models.

Hopefully, this will fix the problem in #339 for models without sliding window attention.