### PR TITLE
Expose some APIs on the Rust side

### DIFF
--- a/mistralrs/examples/grammar/main.rs
+++ b/mistralrs/examples/grammar/main.rs
@@ -1,9 +1,8 @@
 use std::sync::Arc;
 use tokio::sync::mpsc::channel;
 
-use candle_core::Device;
 use mistralrs::{
-    Constraint, DeviceMapMetadata, MistralRs, MistralRsBuilder, NormalLoaderBuilder,
+    Constraint, Device, DeviceMapMetadata, MistralRs, MistralRsBuilder, NormalLoaderBuilder,
     NormalLoaderType, NormalRequest, NormalSpecificConfig, Request, RequestMessage, Response,
     SamplingParams, SchedulerMethod, TokenSource,
 };

--- a/mistralrs/examples/isq/main.rs
+++ b/mistralrs/examples/isq/main.rs
@@ -1,11 +1,10 @@
 use std::sync::Arc;
 use tokio::sync::mpsc::channel;
 
-use candle_core::{quantized::GgmlDType, Device};
 use mistralrs::{
-    Constraint, DeviceMapMetadata, MistralRs, MistralRsBuilder, NormalLoaderBuilder,
-    NormalLoaderType, NormalRequest, NormalSpecificConfig, Request, RequestMessage, Response,
-    SamplingParams, SchedulerMethod, TokenSource,
+    Constraint, Device, DeviceMapMetadata, GgmlDType, MistralRs, MistralRsBuilder,
+    NormalLoaderBuilder, NormalLoaderType, NormalRequest, NormalSpecificConfig, Request,
+    RequestMessage, Response, SamplingParams, SchedulerMethod, TokenSource,
 };
 
 fn setup() -> anyhow::Result<Arc<MistralRs>> {

--- a/mistralrs/examples/lora/main.rs
+++ b/mistralrs/examples/lora/main.rs
@@ -1,9 +1,8 @@
 use std::{fs::File, sync::Arc};
 use tokio::sync::mpsc::channel;
 
-use candle_core::Device;
 use mistralrs::{
-    Constraint, DeviceMapMetadata, MistralRs, MistralRsBuilder, NormalLoaderBuilder,
+    Constraint, Device, DeviceMapMetadata, MistralRs, MistralRsBuilder, NormalLoaderBuilder,
     NormalLoaderType, NormalRequest, NormalSpecificConfig, Request, RequestMessage, Response,
     SamplingParams, SchedulerMethod, TokenSource,
 };

--- a/mistralrs/examples/lora_activation/main.rs
+++ b/mistralrs/examples/lora_activation/main.rs
@@ -1,9 +1,8 @@
 use std::{fs::File, sync::Arc};
 use tokio::sync::mpsc::channel;
 
-use candle_core::Device;
 use mistralrs::{
-    Constraint, DeviceMapMetadata, MistralRs, MistralRsBuilder, NormalLoaderBuilder,
+    Constraint, Device, DeviceMapMetadata, MistralRs, MistralRsBuilder, NormalLoaderBuilder,
     NormalLoaderType, NormalRequest, NormalSpecificConfig, Request, RequestMessage, Response,
     SamplingParams, SchedulerMethod, TokenSource,
 };

--- a/mistralrs/examples/quantized/main.rs
+++ b/mistralrs/examples/quantized/main.rs
@@ -1,9 +1,8 @@
 use std::sync::Arc;
 use tokio::sync::mpsc::channel;
 
-use candle_core::Device;
 use mistralrs::{
-    Constraint, DeviceMapMetadata, GGUFLoaderBuilder, GGUFSpecificConfig, MistralRs,
+    Constraint, Device, DeviceMapMetadata, GGUFLoaderBuilder, GGUFSpecificConfig, MistralRs,
     MistralRsBuilder, NormalRequest, Request, RequestMessage, Response, SamplingParams,
     SchedulerMethod, TokenSource,
 };

--- a/mistralrs/examples/simple/main.rs
+++ b/mistralrs/examples/simple/main.rs
@@ -1,9 +1,8 @@
 use std::sync::Arc;
 use tokio::sync::mpsc::channel;
 
-use candle_core::Device;
 use mistralrs::{
-    Constraint, DeviceMapMetadata, MistralRs, MistralRsBuilder, NormalLoaderBuilder,
+    Constraint, Device, DeviceMapMetadata, MistralRs, MistralRsBuilder, NormalLoaderBuilder,
     NormalLoaderType, NormalRequest, NormalSpecificConfig, Request, RequestMessage, Response,
     SamplingParams, SchedulerMethod, TokenSource,
 };

--- a/mistralrs/examples/xlora/main.rs
+++ b/mistralrs/examples/xlora/main.rs
@@ -1,9 +1,8 @@
 use std::{fs::File, sync::Arc};
 use tokio::sync::mpsc::channel;
 
-use candle_core::Device;
 use mistralrs::{
-    Constraint, DeviceMapMetadata, MistralRs, MistralRsBuilder, NormalLoaderBuilder,
+    Constraint, Device, DeviceMapMetadata, MistralRs, MistralRsBuilder, NormalLoaderBuilder,
     NormalLoaderType, NormalRequest, NormalSpecificConfig, Request, RequestMessage, Response,
     SamplingParams, SchedulerMethod, TokenSource,
 };

--- a/mistralrs/src/lib.rs
+++ b/mistralrs/src/lib.rs
@@ -1,1 +1,2 @@
+pub use candle_core::{quantized::GgmlDType, DType, Device, Result};
 pub use mistralrs_core::*;

--- a/mistralrs/src/lib.rs
+++ b/mistralrs/src/lib.rs
@@ -1,7 +1,1 @@
-pub use mistralrs_core::{
-    ChatCompletionResponse, CompletionResponse, Constraint, DeviceMapMetadata, GGMLLoaderBuilder,
-    GGMLSpecificConfig, GGUFLoaderBuilder, GGUFSpecificConfig, Loader, MistralRs, MistralRsBuilder,
-    NormalLoader, NormalLoaderBuilder, NormalLoaderType, NormalRequest, NormalSpecificConfig,
-    Request, RequestMessage, Response, SamplingParams, SchedulerMethod, StopTokens, TokenSource,
-    Usage,
-};
+pub use mistralrs_core::*;


### PR DESCRIPTION
- All public items from `mistralrs_core`
- Expose items from `candle_core` to avoid end users needing to add the candle dependancy: `GgmlDType`, `Device`, `DType`, `Result`.