### PR TITLE
Propogating Regex init error

### DIFF
--- a/mistralrs-core/src/aici/recognizer.rs
+++ b/mistralrs-core/src/aici/recognizer.rs
@@ -30,6 +30,12 @@ impl<S: Copy, R: FunctionalRecognizer<S>> StackRecognizer<S, R> {
         };
         Ok(rec)
     }
+
+    pub fn reset(&mut self) -> anyhow::Result<()> {
+        self.stack_ptr = 0;
+        self.stack[0] = self.rec.initial()?;
+        Ok(())
+    }
 }
 
 impl<S: Copy + Debug, R: FunctionalRecognizer<S>> Debug for StackRecognizer<S, R> {

--- a/mistralrs-core/src/aici/recognizer.rs
+++ b/mistralrs-core/src/aici/recognizer.rs
@@ -1,9 +1,10 @@
 use crate::aici::toktree::{Recognizer, SpecialToken};
+use anyhow;
 use std::fmt::Debug;
 
 pub trait FunctionalRecognizer<S: Copy> {
     /// Initial state
-    fn initial(&self) -> S;
+    fn initial(&self) -> Result<S, anyhow::Error>;
     /// Extend the recognizer with given byte.
     fn append(&self, state: S, byte: u8) -> S;
     /// Check if given byte is allowed in given state.
@@ -20,18 +21,14 @@ pub struct StackRecognizer<S: Copy, R: FunctionalRecognizer<S>> {
 }
 
 impl<S: Copy, R: FunctionalRecognizer<S>> StackRecognizer<S, R> {
-    pub fn from(rec: R) -> Self {
-        let stack = vec![rec.initial(); 130];
-        StackRecognizer {
+    pub fn from(rec: R) -> anyhow::Result<Self> {
+        let stack = vec![rec.initial()?; 130];
+        let rec = StackRecognizer {
             rec,
             stack,
             stack_ptr: 0,
-        }
-    }
-
-    pub fn reset(&mut self) {
-        self.stack_ptr = 0;
-        self.stack[0] = self.rec.initial();
+        };
+        Ok(rec)
     }
 }
 

--- a/mistralrs-core/src/aici/recognizer.rs
+++ b/mistralrs-core/src/aici/recognizer.rs
@@ -1,5 +1,4 @@
 use crate::aici::toktree::{Recognizer, SpecialToken};
-use anyhow;
 use std::fmt::Debug;
 
 pub trait FunctionalRecognizer<S: Copy> {

--- a/mistralrs-core/src/aici/rx.rs
+++ b/mistralrs-core/src/aici/rx.rs
@@ -1,5 +1,4 @@
 use crate::aici::{recognizer::FunctionalRecognizer, toktree::SpecialToken};
-use anyhow;
 use regex_automata::{
     dfa::{dense, Automaton},
     util::{primitives::StateID, syntax},

--- a/mistralrs-core/src/aici/rx.rs
+++ b/mistralrs-core/src/aici/rx.rs
@@ -1,4 +1,5 @@
 use crate::aici::{recognizer::FunctionalRecognizer, toktree::SpecialToken};
+use anyhow;
 use regex_automata::{
     dfa::{dense, Automaton},
     util::{primitives::StateID, syntax},
@@ -29,10 +30,20 @@ impl RecRx {
 }
 
 impl FunctionalRecognizer<RecRxState> for RecRx {
-    fn initial(&self) -> RecRxState {
-        self.dfa
-            .universal_start_state(regex_automata::Anchored::Yes)
-            .expect("dfa has no universal start state; make sure it doesn't match empty string")
+    fn initial(&self) -> anyhow::Result<RecRxState> {
+        let state = self
+            .dfa
+            .universal_start_state(regex_automata::Anchored::Yes);
+
+        match state {
+            Some(state) => Ok(state),
+            None => {
+                let err = anyhow::Error::msg(
+                    "dfa has no universal start state; make sure it doesn't match empty string",
+                );
+                Err(err)
+            }
+        }
     }
 
     #[inline(always)]

--- a/mistralrs-core/src/engine/mod.rs
+++ b/mistralrs-core/src/engine/mod.rs
@@ -244,7 +244,7 @@ impl Engine {
     fn build_sequence_recognizer(constraint: &Constraint) -> anyhow::Result<SequenceRecognizer> {
         let recognizer = match constraint {
             Constraint::Regex(rx) => {
-                SequenceRecognizer::Regex(StackRecognizer::from(RecRx::from_rx(rx)?).into())
+                SequenceRecognizer::Regex(StackRecognizer::from(RecRx::from_rx(rx)?)?.into())
             }
             Constraint::Yacc(cfg) => SequenceRecognizer::Cfg(CfgParser::from_yacc(cfg)?.into()),
             Constraint::None => SequenceRecognizer::None,


### PR DESCRIPTION
I found that certain Regex constraints can panic and bring down the whole engine. For example, take this constraint: `constraint: Constraint::Regex("[a-z]*".to_string()).` We get:

```
thread '<unnamed>' panicked at mistralrs-core/src/aici/rx.rs:35:14:
dfa has no universal start state; make sure it doesn't match empty string
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
thread 'main' panicked at mistralrs/examples/quantized/main.rs:57:39:
called `Option::unwrap()` on a `None` value
fish: Job 1, 'cargo run --example quantized -…' terminated by signal SIGSEGV (Address boundary error)
```

Not sure if this is a solid fix, but I just pushed the error up into StackRecognizer creation. Now, the engine can handle this initialization error and return a Validation error to the client, rather than killing the whole engine.