### PR TITLE
remove tracing_subscriber.init() from Loader

### DIFF
--- a/mistralrs-core/src/pipeline/ggml.rs
+++ b/mistralrs-core/src/pipeline/ggml.rs
@@ -30,9 +30,7 @@ use std::str::FromStr;
 use std::sync::Arc;
 use tokenizers::Tokenizer;
 use tokio::sync::Mutex;
-use tracing::level_filters::LevelFilter;
 use tracing::{info, warn};
-use tracing_subscriber::EnvFilter;
 
 enum Model {
     Llama(QLlama),
@@ -224,15 +222,6 @@ impl Loader for GGMLLoader {
             .unwrap_or_default()
             .contains('1');
         DEBUG.store(is_debug, std::sync::atomic::Ordering::Relaxed);
-
-        let filter = EnvFilter::builder()
-            .with_default_directive(if is_debug {
-                LevelFilter::INFO.into()
-            } else {
-                LevelFilter::DEBUG.into()
-            })
-            .from_env_lossy();
-        tracing_subscriber::fmt().with_env_filter(filter).init();
 
         if in_situ_quant.is_some() {
             anyhow::bail!(

--- a/mistralrs-core/src/pipeline/mod.rs
+++ b/mistralrs-core/src/pipeline/mod.rs
@@ -1311,6 +1311,7 @@ pub(crate) fn get_chat_template(
     } else {
         paths.get_template_filename().clone()
     };
+
     if template_filename
         .extension()
         .expect("Template filename must be a file")

--- a/mistralrs-core/src/pipeline/normal.rs
+++ b/mistralrs-core/src/pipeline/normal.rs
@@ -34,8 +34,6 @@ use std::sync::Arc;
 use tokenizers::Tokenizer;
 use tokio::sync::Mutex;
 use tracing::info;
-use tracing::level_filters::LevelFilter;
-use tracing_subscriber::EnvFilter;
 
 pub struct NormalPipeline {
     model: Box<dyn NormalModel + Send + Sync>,
@@ -207,15 +205,6 @@ impl Loader for NormalLoader {
             .unwrap_or_default()
             .contains('1');
         DEBUG.store(is_debug, std::sync::atomic::Ordering::Relaxed);
-
-        let filter = EnvFilter::builder()
-            .with_default_directive(if is_debug {
-                LevelFilter::INFO.into()
-            } else {
-                LevelFilter::DEBUG.into()
-            })
-            .from_env_lossy();
-        tracing_subscriber::fmt().with_env_filter(filter).init();
 
         let config = std::fs::read_to_string(paths.get_config_filename())?;
         let default_dtype = if device.is_cuda() && mapper.is_dummy() {


### PR DESCRIPTION
- Running `tracing_subscriber.init()` within a library will break most uses of this library.