### PR TITLE
refactor: DRY `varbuilder_utils.rs`

### DIFF
--- a/mistralrs-core/Cargo.toml
+++ b/mistralrs-core/Cargo.toml
@@ -57,6 +57,7 @@ strum = { version = "0.26", features = ["derive"] }
 derive_more = { version = "0.99.17", default-features = false, features = ["from"] }
 tracing-subscriber.workspace = true
 reqwest = { version = "0.12.4", features = ["blocking"] }
+derive-new = "0.6.0"
 
 [features]
 pyo3_macros = ["pyo3"]

--- a/mistralrs-core/src/utils/mod.rs
+++ b/mistralrs-core/src/utils/mod.rs
@@ -1,6 +1,6 @@
+pub(crate) mod progress;
 pub(crate) mod tokenizer;
 pub(crate) mod tokens;
-pub(crate) mod progress;
 pub(crate) mod varbuilder_utils;
 
 #[macro_export]

--- a/mistralrs-core/src/utils/mod.rs
+++ b/mistralrs-core/src/utils/mod.rs
@@ -1,5 +1,6 @@
 pub(crate) mod tokenizer;
 pub(crate) mod tokens;
+pub(crate) mod progress;
 pub(crate) mod varbuilder_utils;
 
 #[macro_export]

--- a/mistralrs-core/src/utils/progress.rs
+++ b/mistralrs-core/src/utils/progress.rs
@@ -1,0 +1,20 @@
+use tqdm::Iter;
+
+// Optionally display a progress bar via the `tqdm` crate:
+// Usage: `iter.with_progress(true)`
+// Similar to the `iter.tqdm()` feature except this supports opt-in via parameter.
+pub trait IterWithProgress<'a, T>: Iterator<Item = T> + 'a {
+    fn with_progress(self, is_silent: bool) -> Box<dyn Iterator<Item = T> + 'a>
+    where
+        Self: Sized,
+    {
+        // TODO: Should `is_silent` instead be referenced as a global read-only state? (`AtomicBool`)
+        if is_silent {
+            Box::new(self)
+        } else {
+            Box::new(self.tqdm())
+        }
+    }
+}
+
+impl<'a, T: Iterator + 'a> IterWithProgress<'a, T::Item> for T {}

--- a/mistralrs-core/src/utils/varbuilder_utils.rs
+++ b/mistralrs-core/src/utils/varbuilder_utils.rs
@@ -92,9 +92,7 @@ trait LoadTensors {
         // Take the filtered list of tensors to load, store with derived lookup key:
         let mut loaded_tensors = HashMap::new();
         for (load_name, key_name) in iter.with_progress(is_silent) {
-            let tensor = tensors
-                .load(&load_name, device)?
-                .to_dtype(dtype)?;
+            let tensor = tensors.load(&load_name, device)?.to_dtype(dtype)?;
 
             loaded_tensors.insert(key_name, tensor);
         }


### PR DESCRIPTION
The bulk of this file has 4 variants to accomodate common vs x-lora + optionally `tqdm` progress bar via `silent` bool condition.

Refactored to use iterators and a trait for handling divergence with x-lora. Much more easier to maintain and grok! 😎 

---

Additionally the approach for handling opt-in/out on progress when using `iter.tqdm()` has been extracted out to it's own utility (_thanks to the rust community for assisting with that as I was a bit stumped_ 😅 ).

Presently models in `mistralrs-core` use `tqdm()` but there is no opt-out like here. If you want that, perhaps the CLI could set a global static early on for the setting, no parameter would be needed to tossed through layers of functions then?

---

There was discussion to better name the parameters here, to clear up some ambiguity with xlora. I haven't adjusted that yet. Open to suggestions.