### PR TITLE
Add Rust convenience macros for loading

### DIFF
--- a/mistralrs/src/lib.rs
+++ b/mistralrs/src/lib.rs
@@ -48,3 +48,60 @@
 
 pub use candle_core::{quantized::GgmlDType, DType, Device, Result};
 pub use mistralrs_core::*;
+
+#[macro_export]
+macro_rules! load_normal_model {
+    (id = $model_id:expr, kind = $kind:ident, device = $device:expr, use_flash_attn = $use_flash:expr) => {
+        load_normal_model!(
+            id = $model_id,
+            kind = $kind,
+            dtype = Auto,
+            device = $device,
+            cache_tok = mistralrs::TokenSource::CacheToken,
+            mapper = mistralrs::DeviceMapMetadata::dummy(),
+            isq = None,
+            use_flash_attn = $use_flash
+        )
+    };
+
+    (id = $model_id:expr, kind = $kind:ident, device = $device:expr, use_flash_attn = $use_flash:expr, isq = $isq:expr) => {
+        load_normal_model!(
+            id = $model_id,
+            kind = $kind,
+            dtype = Auto,
+            device = $device,
+            cache_tok = mistralrs::TokenSource::CacheToken,
+            mapper = mistralrs::DeviceMapMetadata::dummy(),
+            isq = Some($isq),
+            use_flash_attn = $use_flash
+        )
+    };
+
+    (id = $model_id:expr, kind = $kind:ident, dtype = $ty:ident, device = $device:expr, cache_tok = $cache_tok:expr, mapper = $mapper:expr, isq = $isq:expr, use_flash_attn = $use_flash:expr) => {{
+        let loader = mistralrs::NormalLoaderBuilder::new(
+            mistralrs::NormalSpecificConfig {
+                use_flash_attn: $use_flash,
+                repeat_last_n: 64,
+            },
+            None,
+            None,
+            Some($model_id),
+        )
+        .build(mistralrs::NormalLoaderType::$kind);
+        // Load, into a Pipeline
+        let pipeline = loader.load_model_from_hf(
+            None,
+            $cache_tok,
+            &mistralrs::ModelDType::$ty,
+            &$device,
+            false,
+            $mapper,
+            $isq,
+        )?;
+        mistralrs::MistralRsBuilder::new(
+            pipeline,
+            mistralrs::SchedulerMethod::Fixed(32.try_into().unwrap()),
+        )
+        .build()
+    }};
+}


### PR DESCRIPTION
```rust
use mistralrs::{device, load_normal_model};
fn main() -> anyhow::Result<()> {
    let dev = Device::cuda_if_available(0)?;
    let runner = load_normal_model!(
        id = "mistralai/Mistral-7B-Instruct-v0.1".to_string(),
        kind = Mistral,
        device = dev,
        use_flash_attn = false
    );
    Ok(())
}
```