### PR TITLE
Prevent divide by zero in cuda kernel

### DIFF
--- a/mistralrs-core/src/cuda/nonzero_bitwise.cu
+++ b/mistralrs-core/src/cuda/nonzero_bitwise.cu
@@ -66,7 +66,11 @@ __global__ void transform_indices(const uint32_t *temp_indices,
     int temp_index = temp_indices[idx];
     for (int i = num_dims - 1; i >= 0; i--) {
       d_out[idx * num_dims + i] = temp_index % dims[i];
-      temp_index /= dims[i];
+      if (dims[i] == 0) {
+        // Handle the error appropriately
+      } else {
+        temp_index /= dims[i];
+      }
     }
   }
 }


### PR DESCRIPTION
Fix for bug in issue [https://github.com/EricLBuehler/mistral.rs/issues/395](https://github.com/EricLBuehler/mistral.rs/issues/395).

I didn't add any error message so feel free to add one. I think it's okay to let it bypass that code when it's zero (prevent divide by zero). I ran llama and there was no issues on my end.