### PR TITLE
Fix SWA order (flip it) for Gemma 2

### DIFF
--- a/mistralrs-core/src/models/gemma2.rs
+++ b/mistralrs-core/src/models/gemma2.rs
@@ -227,8 +227,9 @@ impl Attention {
             rotary_emb,
             query_pre_attn_scalar: cfg.query_pre_attn_scalar,
             attn_logit_softcapping: cfg.attn_logit_softcapping,
-            use_sliding_window: layer_idx % 2 != 0,
-            sliding_window: if layer_idx % 2 != 0 {
+            use_sliding_window: layer_idx % 2 == 0, // Order is SWA, global, SWA
+            sliding_window: if layer_idx % 2 == 0 {
+                // ^ Order is SWA, global, SWA
                 Some(cfg.sliding_window)
             } else {
                 None

--- a/mistralrs-core/src/xlora_models/gemma2.rs
+++ b/mistralrs-core/src/xlora_models/gemma2.rs
@@ -248,8 +248,9 @@ impl Attention {
             rotary_emb,
             query_pre_attn_scalar: cfg.query_pre_attn_scalar,
             attn_logit_softcapping: cfg.attn_logit_softcapping,
-            use_sliding_window: layer_idx % 2 != 0,
-            sliding_window: if layer_idx % 2 != 0 {
+            use_sliding_window: layer_idx % 2 == 0, // Order is SWA, global, SWA
+            sliding_window: if layer_idx % 2 == 0 {
+                // ^ Order is SWA, global, SWA
                 Some(cfg.sliding_window)
             } else {
                 None


### PR DESCRIPTION
At the time of porting, we used the Transformers implmentation which had the SWA order flipped w.r.t the [Google implementation](https://github.com/google/gemma_pytorch/blob/1814f8d0a6ba93b875c46a64e6ad1873df448eef/gemma/config.py#L118).

Refs huggingface/transformers#31775.