### PR TITLE
Fix generation issue for the paged-attention approach.

### DIFF
--- a/mistralrs-core/src/models/quantized_llama.rs
+++ b/mistralrs-core/src/models/quantized_llama.rs
@@ -15,7 +15,6 @@ use crate::utils::gguf_metadata::ContentMetadata;
 use crate::utils::model_config as ModelConfig;
 use crate::utils::progress::NiceProgressBar;
 use crate::DeviceMapMetadata;
-use std::iter::zip;
 const MAX_SEQ_LEN: u32 = 4096;
 
 #[derive(Debug, Clone)]
@@ -177,7 +176,7 @@ impl LayerWeights {
                     .forward(
                         &q,
                         &k,
-                        &v.contiguous()?,
+                        &v,
                         mask,
                         Some(key_cache),
                         Some(value_cache),

--- a/mistralrs-core/src/paged_attention/layers/mod.rs
+++ b/mistralrs-core/src/paged_attention/layers/mod.rs
@@ -1,3 +1,3 @@
-mod paged_attention;
+pub mod paged_attention;
 
 pub use paged_attention::PagedAttention;

--- a/mistralrs-core/src/paged_attention/mod.rs
+++ b/mistralrs-core/src/paged_attention/mod.rs
@@ -9,7 +9,6 @@ mod cache_engine;
 mod config;
 mod layers;
 mod scheduler;
-
 pub const _PAD_SLOT_ID: i64 = -1;
 
 pub use block_engine::{BlockEngine, BlockTables, LogicalTokenBlock, PhysicalTokenBlock};

--- a/mistralrs-core/src/pipeline/gguf.rs
+++ b/mistralrs-core/src/pipeline/gguf.rs
@@ -433,8 +433,8 @@ impl Loader for GGUFLoader {
         } else {
             GgufTokenizerConversion {
                 tokenizer: get_tokenizer(paths.get_tokenizer_filename(), None)?,
-                bos: None,
-                eos: None,
+                bos: Some("<s>".to_string()),
+                eos: Some("</s>".to_string()),
                 unk: None,
             }
         };

--- a/mistralrs-core/src/pipeline/paths.rs
+++ b/mistralrs-core/src/pipeline/paths.rs
@@ -258,17 +258,22 @@ pub fn get_model_paths(
             let mut files = Vec::new();
 
             for name in names {
-                let qapi = ApiBuilder::new()
-                    .with_progress(true)
-                    .with_token(get_token(token_source)?)
-                    .build()?;
-                let qapi = qapi.repo(Repo::with_revision(
-                    id.to_string(),
-                    RepoType::Model,
-                    revision.clone(),
-                ));
-                let model_id = Path::new(&id);
-                files.push(api_get_file!(qapi, name, model_id));
+                if Path::new(&name).exists() {
+                    //local file
+                    files.push(PathBuf::from(name));
+                } else {
+                    let qapi = ApiBuilder::new()
+                        .with_progress(true)
+                        .with_token(get_token(token_source)?)
+                        .build()?;
+                    let qapi = qapi.repo(Repo::with_revision(
+                        id.to_string(),
+                        RepoType::Model,
+                        revision.clone(),
+                    ));
+                    let model_id = Path::new(&id);
+                    files.push(api_get_file!(qapi, name, model_id));
+                }
             }
             Ok(files)
         }


### PR DESCRIPTION
This PR fix the generation issue for the newly introduced paged-attention approach, I have only tested the quantized_llama model with command line:

```
cargo run --release --features cuda -- --port 2000 --chat-template ./chat_templates/llama2.json -i gguf -t /home/llama2_7b/ -m TheBloke/Llama-2-7B-Chat-GGUF -f /home/llama-2-7b-chat.Q4_K_M.gguf
```

I also changed the `-f` parameter to accept local gguf model file.