### PR TITLE
fix build on metal by returning Device

### DIFF
--- a/mistralrs-pyo3/src/lib.rs
+++ b/mistralrs-pyo3/src/lib.rs
@@ -47,7 +47,7 @@ fn get_device() -> Device {
         .clone()
 }
 #[cfg(feature = "metal")]
-fn get_device() -> Result<Device> {
+fn get_device() -> Device {
     DEVICE
         .get_or_init(|| Device::new_metal(0).expect("Failed to create device"))
         .clone()


### PR DESCRIPTION
Fixed the function return type to be a `Device` on `get_device()`.

-----

**Background**

With `cargo build --release --features metal` I was seeing this build error:

```
error[E0107]: enum takes 2 generic arguments but 1 generic argument was supplied
   --> mistralrs-pyo3/src/lib.rs:50:20
    |
50  | fn get_device() -> Result<Device> {
    |                    ^^^^^^ ------ supplied 1 generic argument
    |                    |
    |                    expected 2 generic arguments
    |
note: enum defined here, with 2 generic parameters: `T`, `E`
   --> /Users/kylekelley/.rustup/toolchains/nightly-aarch64-apple-darwin/lib/rustlib/src/rust/library/core/src/result.rs:527:10
    |
527 | pub enum Result<T, E> {
    |          ^^^^^^ -  -
help: add missing generic argument
    |
50  | fn get_device() -> Result<Device, E> {
    |                                 +++
```

I started changing it to a proper `Result<Device, E>` until I noticed that this function was returning a `Device`. Builds on MacOS again. 💪 