### PR TITLE
Add custom logits processor API

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2326,6 +2326,7 @@ dependencies = [
  "image",
  "indexmap 2.4.0",
  "mistralrs-core",
+ "rand",
  "reqwest",
  "serde",
  "serde_json",

--- a/README.md
+++ b/README.md
@@ -102,6 +102,7 @@ Mistal.rs supports several model categories:
     - Please suggest more by raising an issue!
 - Tool calling: [docs](docs/TOOL_CALLING.md)
 - Prompt chunking (only without PagedAttention for now): handle larger prompts where the activation size would cause an OOM by sending chunks
+- Custom logits processor API in Rust: [example](mistralrs/examples/custom_logits_processor/main.rs)
 
 
 This is a demo of interactive mode with streaming running Phi 3 128k mini with quantization via ISQ to Q4K.

--- a/mistralrs-bench/src/main.rs
+++ b/mistralrs-bench/src/main.rs
@@ -80,6 +80,7 @@ fn run_bench(
         adapters: None,
         tools: None,
         tool_choice: None,
+        logits_processors: None,
     });
 
     let mut usages = Vec::new();
@@ -246,6 +247,7 @@ fn warmup_run(mistralrs: Arc<MistralRs>) {
         adapters: None,
         tools: None,
         tool_choice: None,
+        logits_processors: None,
     });
 
     sender

--- a/mistralrs-core/src/engine/mod.rs
+++ b/mistralrs-core/src/engine/mod.rs
@@ -650,6 +650,7 @@ impl Engine {
             topk,
             topp,
             minp,
+            request.logits_processors.unwrap_or_default(),
         );
 
         if request.sampling_params.n_choices == 0 {

--- a/mistralrs-core/src/lib.rs
+++ b/mistralrs-core/src/lib.rs
@@ -76,7 +76,7 @@ pub use pipeline::{
 pub use request::{Constraint, MessageContent, NormalRequest, Request, RequestMessage};
 pub use response::Response;
 pub use response::*;
-pub use sampler::{GenericLogitsProcessor, SamplingParams, StopTokens, TopLogprob};
+pub use sampler::{CustomLogitsProcessor, SamplingParams, StopTokens, TopLogprob};
 pub use scheduler::{DefaultSchedulerMethod, SchedulerConfig};
 use serde::Serialize;
 use tokio::runtime::Runtime;

--- a/mistralrs-core/src/lib.rs
+++ b/mistralrs-core/src/lib.rs
@@ -76,7 +76,7 @@ pub use pipeline::{
 pub use request::{Constraint, MessageContent, NormalRequest, Request, RequestMessage};
 pub use response::Response;
 pub use response::*;
-pub use sampler::{SamplingParams, StopTokens, TopLogprob};
+pub use sampler::{GenericLogitsProcessor, SamplingParams, StopTokens, TopLogprob};
 pub use scheduler::{DefaultSchedulerMethod, SchedulerConfig};
 use serde::Serialize;
 use tokio::runtime::Runtime;

--- a/mistralrs-core/src/pipeline/amoe.rs
+++ b/mistralrs-core/src/pipeline/amoe.rs
@@ -352,9 +352,10 @@ impl AnyMoePipelineMixin for AnyMoePipeline {
         let mut rng = thread_rng();
         let mut samples = inputs.into_inner();
 
-        // Create several dummy objects for the sequences.
+        // Create several dummy objects for the sequences. No custom logits processors.
         let (dummy_sender, _) = tokio::sync::mpsc::channel(10000);
-        let dummy_sampler = Sampler::new(None, 0, tokenizer.clone(), None, None, -1, 0.0, 0.0);
+        let dummy_sampler =
+            Sampler::new(None, 0, tokenizer.clone(), None, None, -1, 0.0, 0.0, vec![]);
 
         let dummy_group = Arc::new(tokio::sync::Mutex::new(SequenceGroup::new(
             1, false, false, 0,

--- a/mistralrs-core/src/pipeline/sampling.rs
+++ b/mistralrs-core/src/pipeline/sampling.rs
@@ -287,14 +287,14 @@ pub async fn sample_sequence(
     let logits = logits.squeeze(0)?.squeeze(0)?.to_dtype(DType::F32)?;
 
     let sampler = seq.sampler();
-    let ctx_clone = seq.get_toks()[seq.prompt_tokens()..].to_vec();
+    let ctx_clone = seq.get_toks().to_vec();
     let rng_clone = rng.clone();
     let logits_clone = logits.clone();
     let first_lobprobs_response = if use_async_pool {
         tokio_rayon::spawn(move || {
             sampler.sample(
                 logits_clone,
-                Some(&ctx_clone),
+                &ctx_clone,
                 return_logprobs,
                 rng_clone,
                 sample_speculative,
@@ -304,7 +304,7 @@ pub async fn sample_sequence(
     } else {
         sampler.sample(
             logits_clone,
-            Some(&ctx_clone),
+            &ctx_clone,
             return_logprobs,
             rng_clone,
             sample_speculative,
@@ -326,14 +326,14 @@ pub async fn sample_sequence(
             token_set.apply_to(&mut acc);
             let new_logits = (logits + Tensor::from_slice(&acc, acc.len(), &Device::Cpu)?)?;
 
-            let ctx_clone = seq.get_toks()[seq.prompt_tokens()..].to_vec();
+            let ctx_clone = seq.get_toks().to_vec();
             let rng_clone = rng.clone();
             let sampler = seq.sampler();
             if use_async_pool {
                 tokio_rayon::spawn(move || {
                     sampler.sample(
                         new_logits,
-                        Some(&ctx_clone),
+                        &ctx_clone,
                         return_logprobs,
                         rng_clone,
                         sample_speculative,
@@ -343,7 +343,7 @@ pub async fn sample_sequence(
             } else {
                 sampler.sample(
                     new_logits,
-                    Some(&ctx_clone),
+                    &ctx_clone,
                     return_logprobs,
                     rng_clone,
                     sample_speculative,

--- a/mistralrs-core/src/request.rs
+++ b/mistralrs-core/src/request.rs
@@ -45,7 +45,7 @@ pub enum RequestMessage {
 /// - `return_logprobs`: Whether to return logprobs
 /// - `is_streaming`: Control whether the request is streaming, if so chunk responses will be sent
 /// - `id`: Request ID
-/// - `contraint`: Contraint to use during generation
+/// - `constraint`: Constraint to use during generation
 /// - `suffix`: Suffix to add
 /// - `adapters`: Adapters to use in this request
 /// - `tools`: Tools available in this request

--- a/mistralrs-core/src/request.rs
+++ b/mistralrs-core/src/request.rs
@@ -6,9 +6,9 @@ use crate::{
     response::Response,
     sampler::SamplingParams,
     tools::{Tool, ToolChoice},
-    GenericLogitsProcessor,
+    CustomLogitsProcessor,
 };
-use std::fmt::Debug;
+use std::{fmt::Debug, sync::Arc};
 use tokio::sync::mpsc::Sender;
 
 #[derive(Clone)]
@@ -67,7 +67,7 @@ pub struct NormalRequest {
     pub adapters: Option<Vec<String>>,
     pub tools: Option<Vec<Tool>>,
     pub tool_choice: Option<ToolChoice>,
-    pub logits_processors: Option<Vec<GenericLogitsProcessor>>,
+    pub logits_processors: Option<Vec<Arc<dyn CustomLogitsProcessor>>>,
 }
 
 impl NormalRequest {

--- a/mistralrs-pyo3/src/lib.rs
+++ b/mistralrs-pyo3/src/lib.rs
@@ -793,6 +793,7 @@ impl Runner {
                 adapters: request.adapters.clone(),
                 tool_choice,
                 tools,
+                logits_processors: None,
             });
 
             MistralRs::maybe_log_request(self.runner.clone(), format!("{request:?}"));
@@ -905,6 +906,7 @@ impl Runner {
                 adapters: request.adapters.clone(),
                 tool_choice,
                 tools,
+                logits_processors: None,
             });
 
             MistralRs::maybe_log_request(self.runner.clone(), format!("{request:?}"));

--- a/mistralrs-server/src/chat_completion.rs
+++ b/mistralrs-server/src/chat_completion.rs
@@ -324,6 +324,7 @@ async fn parse_request(
             adapters: oairequest.adapters,
             tool_choice: oairequest.tool_choice,
             tools: oairequest.tools,
+            logits_processors: None,
         }),
         is_streaming,
     ))

--- a/mistralrs-server/src/completions.rs
+++ b/mistralrs-server/src/completions.rs
@@ -193,6 +193,7 @@ fn parse_request(
             adapters: oairequest.adapters,
             tool_choice: oairequest.tool_choice,
             tools: oairequest.tools,
+            logits_processors: None,
         }),
         is_streaming,
     )

--- a/mistralrs-server/src/interactive_mode.rs
+++ b/mistralrs-server/src/interactive_mode.rs
@@ -144,6 +144,7 @@ pub async fn interactive_mode(mistralrs: Arc<MistralRs>, vision_chat: bool, thro
             adapters: None,
             tool_choice: None,
             tools: None,
+            logits_processors: None,
         });
         sender.send(req).await.unwrap();
 

--- a/mistralrs/Cargo.toml
+++ b/mistralrs/Cargo.toml
@@ -23,6 +23,7 @@ indexmap.workspace = true
 either.workspace = true
 futures.workspace = true
 reqwest.workspace = true
+rand = "0.8.5"
 
 [features]
 cuda = ["mistralrs-core/cuda"]

--- a/mistralrs/examples/anymoe/main.rs
+++ b/mistralrs/examples/anymoe/main.rs
@@ -93,6 +93,7 @@ fn main() -> anyhow::Result<()> {
         adapters: None,
         tools: None,
         tool_choice: None,
+        logits_processors: None,
     });
     mistralrs.get_sender()?.blocking_send(request)?;
 

--- a/mistralrs/examples/anymoe_lora/main.rs
+++ b/mistralrs/examples/anymoe_lora/main.rs
@@ -97,6 +97,7 @@ fn main() -> anyhow::Result<()> {
         adapters: None,
         tools: None,
         tool_choice: None,
+        logits_processors: None,
     });
     mistralrs.get_sender()?.blocking_send(request)?;
 

--- a/mistralrs/examples/batching/main.rs
+++ b/mistralrs/examples/batching/main.rs
@@ -81,6 +81,7 @@ async fn bench_mistralrs(n_requests: usize) -> anyhow::Result<()> {
             adapters: None,
             tools: None,
             tool_choice: None,
+            logits_processors: None,
         });
         mistralrs.get_sender()?.send(request).await?;
         handles.push(rx);

--- a/mistralrs/examples/gemma2/main.rs
+++ b/mistralrs/examples/gemma2/main.rs
@@ -74,6 +74,7 @@ fn main() -> anyhow::Result<()> {
         adapters: None,
         tools: None,
         tool_choice: None,
+        logits_processors: None,
     });
     mistralrs.get_sender()?.blocking_send(request)?;
 

--- a/mistralrs/examples/gguf_locally/main.rs
+++ b/mistralrs/examples/gguf_locally/main.rs
@@ -74,6 +74,7 @@ fn main() -> anyhow::Result<()> {
         adapters: None,
         tools: None,
         tool_choice: None,
+        logits_processors: None,
     });
     mistralrs.get_sender()?.blocking_send(request)?;
 

--- a/mistralrs/examples/grammar/main.rs
+++ b/mistralrs/examples/grammar/main.rs
@@ -74,6 +74,7 @@ fn main() -> anyhow::Result<()> {
         adapters: None,
         tool_choice: None,
         tools: None,
+        logits_processors: None,
     });
     mistralrs.get_sender()?.blocking_send(request)?;
 

--- a/mistralrs/examples/idefics2/main.rs
+++ b/mistralrs/examples/idefics2/main.rs
@@ -95,6 +95,7 @@ fn main() -> anyhow::Result<()> {
         adapters: None,
         tools: None,
         tool_choice: None,
+        logits_processors: None,
     });
     mistralrs.get_sender()?.blocking_send(request)?;
 

--- a/mistralrs/examples/isq/main.rs
+++ b/mistralrs/examples/isq/main.rs
@@ -75,6 +75,7 @@ fn main() -> anyhow::Result<()> {
         adapters: None,
         tools: None,
         tool_choice: None,
+        logits_processors: None,
     });
     mistralrs.get_sender()?.blocking_send(request)?;
 

--- a/mistralrs/examples/llava/main.rs
+++ b/mistralrs/examples/llava/main.rs
@@ -69,6 +69,7 @@ fn main() -> anyhow::Result<()> {
         adapters: None,
         tools: None,
         tool_choice: None,
+        logits_processors: None,
     });
     mistralrs.get_sender()?.blocking_send(request)?;
     let response = rx.blocking_recv().unwrap();

--- a/mistralrs/examples/llava_next/main.rs
+++ b/mistralrs/examples/llava_next/main.rs
@@ -70,6 +70,7 @@ fn main() -> anyhow::Result<()> {
         adapters: None,
         tools: None,
         tool_choice: None,
+        logits_processors: None,
     });
     mistralrs.get_sender()?.blocking_send(request)?;
     let response = rx.blocking_recv().unwrap();

--- a/mistralrs/examples/lora/main.rs
+++ b/mistralrs/examples/lora/main.rs
@@ -81,6 +81,7 @@ fn main() -> anyhow::Result<()> {
         adapters: None,
         tools: None,
         tool_choice: None,
+        logits_processors: None,
     });
 
     // Example: Make adapter_3 the active adapter

--- a/mistralrs/examples/lora_activation/main.rs
+++ b/mistralrs/examples/lora_activation/main.rs
@@ -81,6 +81,7 @@ fn main() -> anyhow::Result<()> {
         adapters: Some(vec!["adapter_2".to_string()]),
         tool_choice: None,
         tools: None,
+        logits_processors: None,
     });
 
     mistralrs.get_sender()?.blocking_send(request)?;

--- a/mistralrs/examples/paged_attn/main.rs
+++ b/mistralrs/examples/paged_attn/main.rs
@@ -93,6 +93,7 @@ fn main() -> anyhow::Result<()> {
         adapters: None,
         tools: None,
         tool_choice: None,
+        logits_processors: None,
     });
     mistralrs.get_sender()?.blocking_send(request)?;
 

--- a/mistralrs/examples/quantized/main.rs
+++ b/mistralrs/examples/quantized/main.rs
@@ -72,6 +72,7 @@ fn main() -> anyhow::Result<()> {
         adapters: None,
         tools: None,
         tool_choice: None,
+        logits_processors: None,
     });
     mistralrs.get_sender()?.blocking_send(request)?;
 

--- a/mistralrs/examples/simple/main.rs
+++ b/mistralrs/examples/simple/main.rs
@@ -74,6 +74,7 @@ fn main() -> anyhow::Result<()> {
         adapters: None,
         tools: None,
         tool_choice: None,
+        logits_processors: None,
     });
     mistralrs.get_sender()?.blocking_send(request)?;
 

--- a/mistralrs/examples/topology/main.rs
+++ b/mistralrs/examples/topology/main.rs
@@ -101,6 +101,7 @@ fn main() -> anyhow::Result<()> {
         adapters: None,
         tools: None,
         tool_choice: None,
+        logits_processors: None,
     });
     mistralrs.get_sender()?.blocking_send(request)?;
 

--- a/mistralrs/examples/xlora/main.rs
+++ b/mistralrs/examples/xlora/main.rs
@@ -83,6 +83,7 @@ fn main() -> anyhow::Result<()> {
         adapters: None,
         tools: None,
         tool_choice: None,
+        logits_processors: None,
     });
     mistralrs.get_sender()?.blocking_send(request)?;
 

--- a/mistralrs/src/lib.rs
+++ b/mistralrs/src/lib.rs
@@ -48,5 +48,5 @@
 //! }
 //! ```
 
-pub use candle_core::{DType, Device, Result};
+pub use candle_core::{DType, Device, Result, Tensor};
 pub use mistralrs_core::*;

--- a/mistralrs/src/lib.rs
+++ b/mistralrs/src/lib.rs
@@ -36,6 +36,7 @@
 //!         adapters: None,
 //!         tool_choice: None,
 //!         tools: None,
+//!         logits_processors: None,
 //!     });
 //!     mistralrs.get_sender()?.blocking_send(request)?;
 //!


### PR DESCRIPTION
New sampling order:

1) Apply penalties from sampling_params
2) ⭐ Apply these custom logits processors sequentially
3) Apply temperature and softmax
4) Sample the next token (topk, topp, minp, etc)

@Dan-wanna-M would this API work? You can find an example of using it [here](https://github.com/EricLBuehler/mistral.rs/blob/9078786881b229f1d4f740b9cc570ee46be4e860/mistralrs/examples/custom_logits_processor/main.rs#L81-L83). Basically, you provide a Vec of `Arc<dyn Fn(&Tensor, &[u32]) -> Result<Tensor> + Send + Sync>`, which are applied. 

Please let me know if this works for you or what changes would be necessary, and I can merge this PR. [kbnf](https://github.com/Dan-wanna-M/kbnf) looks super cool!