### PR TITLE
ci: Upgrade actions

### DIFF
--- a/.github/workflows/analysis.yaml
+++ b/.github/workflows/analysis.yaml
@@ -21,7 +21,7 @@ jobs:
         run: tokei . > tokei_output.txt
 
       - name: Comment or Update PR
-        uses: actions/github-script@v6
+        uses: actions/github-script@v7
         with:
           script: |
             const fs = require('fs');

--- a/.github/workflows/build_cpu.yaml
+++ b/.github/workflows/build_cpu.yaml
@@ -22,19 +22,19 @@ jobs:
             security-events: write
         steps:
             - name: Checkout repository
-              uses: actions/checkout@v3
+              uses: actions/checkout@v4
 
             - name: Initialize Docker Buildx
-              uses: docker/setup-buildx-action@v2.0.0
+              uses: docker/setup-buildx-action@v3
               with:
                 install: true
 
             - name: Inject slug/short variables
-              uses: rlespinasse/github-slug-action@v4.4.1
+              uses: rlespinasse/github-slug-action@v4.5.0
 
             - name: Login to GitHub Container Registry
               if: github.event_name != 'pull_request'
-              uses: docker/login-action@v2
+              uses: docker/login-action@v3
               with:
                 registry: ghcr.io
                 username: ${{ github.actor }}
@@ -42,7 +42,7 @@ jobs:
 
             - name: Extract metadata (tags, labels) for Docker
               id: meta-cpu
-              uses: docker/metadata-action@v4.3.0
+              uses: docker/metadata-action@v5
               with:
                   images: |
                     ghcr.io/${{env.GITHUB_REPOSITORY_OWNER_PART}}/${{env.GITHUB_REPOSITORY_NAME_PART}}
@@ -55,7 +55,7 @@ jobs:
                     type=raw,value=cpu-sha-${{ env.GITHUB_SHA_SHORT }}
             - name: Build and push Docker image
               id: build-and-push-cpu
-              uses: docker/build-push-action@v4
+              uses: docker/build-push-action@v6
               with:
                 context: .
                 file: Dockerfile

--- a/.github/workflows/build_cuda_all.yaml
+++ b/.github/workflows/build_cuda_all.yaml
@@ -30,7 +30,7 @@ jobs:
               uses: actions/checkout@v3
 
             - name: Initialize Docker Buildx
-              uses: docker/setup-buildx-action@v2.0.0
+              uses: docker/setup-buildx-action@v3
               with:
                 install: true
             
@@ -43,11 +43,11 @@ jobs:
                   ${{ runner.os }}-buildx-
 
             - name: Inject slug/short variables
-              uses: rlespinasse/github-slug-action@v4.4.1
+              uses: rlespinasse/github-slug-action@v4.5.0
 
             - name: Login to GitHub Container Registry
               if: github.event_name != 'pull_request'
-              uses: docker/login-action@v2
+              uses: docker/login-action@v3
               with:
                 registry: ghcr.io
                 username: ${{ github.actor }}
@@ -55,7 +55,7 @@ jobs:
 
             - name: Extract metadata (tags, labels) for Docker
               id: meta-cuda
-              uses: docker/metadata-action@v4.3.0
+              uses: docker/metadata-action@v5
               with:
                   images: |
                     ghcr.io/${{env.GITHUB_REPOSITORY_OWNER_PART}}/${{env.GITHUB_REPOSITORY_NAME_PART}}
@@ -68,7 +68,7 @@ jobs:
                     type=raw,value=cuda-${{matrix.compute_capability}}-sha-${{ env.GITHUB_SHA_SHORT }}
             - name: Build and push Docker image
               id: build-and-push-cuda
-              uses: docker/build-push-action@v4
+              uses: docker/build-push-action@v6
               with:
                 context: .
                 file: Dockerfile.cuda-all

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -109,7 +109,7 @@ jobs:
           toolchain: stable
           override: true
       - name: Typos check with custom config file
-        uses: crate-ci/typos@v1
+        uses: crate-ci/typos@master
         with:
           config: .typos.toml
   

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
         os: [ubuntu-latest, windows-latest, macOS-latest]
         rust: [stable]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal
@@ -38,7 +38,7 @@ jobs:
         os: [ubuntu-latest, windows-latest, macOS-latest]
         rust: [stable]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal
@@ -55,7 +55,7 @@ jobs:
     name: Rustfmt
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal
@@ -71,7 +71,7 @@ jobs:
     name: Clippy
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal
@@ -87,7 +87,7 @@ jobs:
     name: Docs
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal
@@ -102,14 +102,14 @@ jobs:
     name: Typos
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal
           toolchain: stable
           override: true
       - name: Typos check with custom config file
-        uses: crate-ci/typos@master
+        uses: crate-ci/typos@v1
         with:
           config: .typos.toml
   
@@ -117,5 +117,5 @@ jobs:
   # markdown-link-check:
   #   runs-on: ubuntu-latest
   #   steps:
-  #     - uses: actions/checkout@master
+  #     - uses: actions/checkout@v4
   #     - uses: gaurav-nelson/github-action-markdown-link-check@v1

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -23,14 +23,14 @@ jobs:
         rust: [stable]
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal
           toolchain: ${{ matrix.rust }}
           override: true
       - name: Setup Pages
-        uses: actions/configure-pages@v3
+        uses: actions/configure-pages@v5
       - uses: actions-rs/cargo@v1
         with:
           command: doc

--- a/.github/workflows/release_python.yml
+++ b/.github/workflows/release_python.yml
@@ -25,7 +25,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         
       - uses: actions-rs/toolchain@v1
         with:


### PR DESCRIPTION
Minor house keeping for the CI. I don't think there are any breaking changes to account for, but I did notice that your `actions-rs` steps have archived their actions in Oct 2023 so you may need to migrate away from those at some point.