### PR TITLE
Typo in error of model architecture enum

### DIFF
--- a/mistralrs-core/src/pipeline/loaders/vision_loaders.rs
+++ b/mistralrs-core/src/pipeline/loaders/vision_loaders.rs
@@ -100,7 +100,7 @@ impl FromStr for VisionLoaderType {
             "llava_next" => Ok(Self::LLaVANext),
             "llava" => Ok(Self::LLaVA),
             "vllama" => Ok(Self::VLlama),
-            a => Err(format!("Unknown architecture `{a}`. Possible architectures: `phi3v`, `idefics2`, `llava_next`, `llava`, `vsllama`.")),
+            a => Err(format!("Unknown architecture `{a}`. Possible architectures: `phi3v`, `idefics2`, `llava_next`, `llava`, `vllama`.")),
         }
     }
 }


### PR DESCRIPTION
saw this in [cpu-0.3.1](ghcr.io/ericlbuehler/mistral.rs:cpu-sha-1caf83a@sha256:b7acce1fa5cbc8595f5d973b7c6c643ff2d7bb678583d747c2ac1fc4f90950e6)

<img width="1170" alt="image" src="https://github.com/user-attachments/assets/7a99e9bc-e4af-47d3-82df-07efe20547c0">
