### PR TITLE
fix Half-Quadratic Quantization and Dequantization on CPU

### DIFF
--- a/mistralrs-quant/src/hqq/hqq_cpu.rs
+++ b/mistralrs-quant/src/hqq/hqq_cpu.rs
@@ -65,8 +65,9 @@ pub(crate) struct Dequant4Bit {
 }
 
 impl Dequant4Bit {
-    fn dequantize<T: WithDType>(&self, w: &[u8], s: &[T], z: &[T]) -> Vec<T> {
-        let mut out = Vec::with_capacity(w.len());
+    fn dequantize<T: WithDType + Default>(&self, w: &[u8], s: &[T], z: &[T]) -> Vec<T> {
+        let output_size = w.len() * 2;
+        let mut out = vec![T::default(); output_size];
         for (i, w) in w.iter().enumerate() {
             let j = i % self.w;
             let nrows = self.h * self.w;
@@ -125,8 +126,9 @@ pub(crate) struct Dequant2Bit {
 }
 
 impl Dequant2Bit {
-    fn dequantize<T: WithDType>(&self, w: &[u8], s: &[T], z: &[T]) -> Vec<T> {
-        let mut out = Vec::with_capacity(w.len());
+    fn dequantize<T: WithDType + Default>(&self, w: &[u8], s: &[T], z: &[T]) -> Vec<T> {
+        let output_size = w.len() * 4;
+        let mut out = vec![T::default(); output_size];
         for (i, w) in w.iter().enumerate() {
             let j = i % self.w;
             let nrows = self.h * self.w;
@@ -187,8 +189,9 @@ pub(crate) struct Dequant1Bit {
 }
 
 impl Dequant1Bit {
-    fn dequantize<T: WithDType>(&self, w: &[u8], s: &[T], z: &[T]) -> Vec<T> {
-        let mut out = Vec::with_capacity(w.len());
+    fn dequantize<T: WithDType + Default>(&self, w: &[u8], s: &[T], z: &[T]) -> Vec<T> {
+        let output_size = w.len() * 8;
+        let mut out = vec![T::default(); output_size];
         for (i, w) in w.iter().enumerate() {
             let j = i % self.w;
             let nrows = self.h * self.w;
@@ -253,8 +256,9 @@ pub(crate) struct Dequant3Bit {
 }
 
 impl Dequant3Bit {
-    fn dequantize<T: WithDType>(&self, w: &[i32], s: &[T], z: &[T]) -> Vec<T> {
-        let mut out = Vec::with_capacity(w.len());
+    fn dequantize<T: WithDType + Default>(&self, w: &[i32], s: &[T], z: &[T]) -> Vec<T> {
+        let output_size = w.len() * 10;
+        let mut out = vec![T::default(); output_size];
         for (i, w) in w.iter().enumerate() {
             let j = i % self.w;
             let nrows = self.h * self.w;

--- a/mistralrs-quant/src/utils/ops.rs
+++ b/mistralrs-quant/src/utils/ops.rs
@@ -52,7 +52,18 @@ impl CustomOp2 for BitWiseOr {
         }
         match s1 {
             CpuStorage::U8(vs1) => {
-                let vs2 = &s2.as_slice::<u8>().unwrap();
+                let vs1 = match l1.contiguous_offsets() {
+                    Some((start, end)) => &vs1[start..end],
+                    None => candle_core::bail!("Input tensor s1 must be contiguous"),
+                };
+                let vs2 = s2.as_slice::<u8>()?;
+                let vs2 = match l2.contiguous_offsets() {
+                    Some((start, end)) => &vs2[start..end],
+                    None => candle_core::bail!("Input tensor s2 must be contiguous"),
+                };
+                if vs1.len() != vs2.len() {
+                    candle_core::bail!("Input tensors must have the same number of elements");
+                };
                 let result = self.bitwise(vs1, vs2);
                 let result = CpuStorage::U8(result);
                 Ok((result, l1.shape().clone()))

--- a/mistralrs-quant/src/utils/ops.rs
+++ b/mistralrs-quant/src/utils/ops.rs
@@ -405,7 +405,7 @@ mod tests {
         use crate::HqqBits;
         use candle_core::{Device, Tensor};
         let bits = HqqBits::Eight;
-        let device = &Device::Cpu;
+        let device = Device::Cpu;
         let wq = Tensor::from_vec(vec![257_i32, 258, 259, 260, 511, 512], (3, 2), &device).unwrap();
         let c = bits.bitpack_type()(wq.clone())
             .unwrap()
@@ -438,7 +438,7 @@ mod tests {
         use crate::HqqBits;
         use candle_core::{Device, Tensor};
         let bits = HqqBits::Four;
-        let device = &Device::Cpu;
+        let device = Device::Cpu;
         let wq = Tensor::from_vec(vec![1_u8, 2, 3, 4, 5, 6], (3, 2), &device).unwrap();
         let c = bits.bitpack_type()(wq.clone())
             .unwrap()

--- a/mistralrs-quant/src/utils/ops.rs
+++ b/mistralrs-quant/src/utils/ops.rs
@@ -52,18 +52,7 @@ impl CustomOp2 for BitWiseOr {
         }
         match s1 {
             CpuStorage::U8(vs1) => {
-                let vs1 = match l1.contiguous_offsets() {
-                    Some((start, end)) => &vs1[start..end],
-                    None => candle_core::bail!("Input tensor s1 must be contiguous"),
-                };
-                let vs2 = s2.as_slice::<u8>()?;
-                let vs2 = match l2.contiguous_offsets() {
-                    Some((start, end)) => &vs2[start..end],
-                    None => candle_core::bail!("Input tensor s2 must be contiguous"),
-                };
-                if vs1.len() != vs2.len() {
-                    candle_core::bail!("Input tensors must have the same number of elements");
-                }
+                let vs2 = &s2.as_slice::<u8>().unwrap();
                 let result = self.bitwise(vs1, vs2);
                 let result = CpuStorage::U8(result);
                 Ok((result, l1.shape().clone()))

--- a/mistralrs-quant/src/utils/ops.rs
+++ b/mistralrs-quant/src/utils/ops.rs
@@ -52,7 +52,18 @@ impl CustomOp2 for BitWiseOr {
         }
         match s1 {
             CpuStorage::U8(vs1) => {
-                let vs2 = &s2.as_slice::<u8>().unwrap();
+                let vs1 = match l1.contiguous_offsets() {
+                    Some((start, end)) => &vs1[start..end],
+                    None => candle_core::bail!("Input tensor s1 must be contiguous"),
+                };
+                let vs2 = s2.as_slice::<u8>()?;
+                let vs2 = match l2.contiguous_offsets() {
+                    Some((start, end)) => &vs2[start..end],
+                    None => candle_core::bail!("Input tensor s2 must be contiguous"),
+                };
+                if vs1.len() != vs2.len() {
+                    candle_core::bail!("Input tensors must have the same number of elements");
+                }
                 let result = self.bitwise(vs1, vs2);
                 let result = CpuStorage::U8(result);
                 Ok((result, l1.shape().clone()))

--- a/mistralrs-quant/src/utils/ops.rs
+++ b/mistralrs-quant/src/utils/ops.rs
@@ -401,7 +401,40 @@ mod tests {
 
     #[cfg(not(feature = "cuda"))]
     #[test]
-    fn test_bitpack() {
+    fn test_bitpack_8bit() {
+        use crate::HqqBits;
+        use candle_core::{Device, Tensor};
+        let bits = HqqBits::Eight;
+        let device = &Device::Cpu;
+        let wq = Tensor::from_vec(vec![257_i32, 258, 259, 260, 511, 512], (3, 2), &device).unwrap();
+        let c = bits.bitpack_type()(wq.clone())
+            .unwrap()
+            .to_vec2::<u8>()
+            .unwrap();
+        assert_eq!(c, [[1, 2], [3, 4], [255, 0]]);
+    }
+
+    #[cfg(all(feature = "cuda"))]
+    #[test]
+    fn test_bitpack_8bit() {
+        use crate::HqqBits;
+        use candle_core::DType;
+        use candle_core::{Device, Tensor};
+        let bits = HqqBits::Eight;
+        let device = Device::new_cuda(0).unwrap();
+        let wq = Tensor::from_vec(vec![257_i32, 258, 259, 260, 511, 512], (3, 2), &device).unwrap();
+        let c = bits.bitpack_type()(wq.clone())
+            .unwrap()
+            .to_dtype(DType::U8)
+            .unwrap()
+            .to_vec2::<u8>()
+            .unwrap();
+        assert_eq!(c, [[1, 2], [3, 4], [255, 0]]);
+    }
+
+    #[cfg(not(feature = "cuda"))]
+    #[test]
+    fn test_bitpack_4bit() {
         use crate::HqqBits;
         use candle_core::{Device, Tensor};
         let bits = HqqBits::Four;
@@ -416,7 +449,7 @@ mod tests {
 
     #[cfg(all(feature = "cuda"))]
     #[test]
-    fn test_bitpack() {
+    fn test_bitpack_4bit() {
         use crate::HqqBits;
         use candle_core::{Device, Tensor};
         let bits = HqqBits::Four;

--- a/mistralrs-quant/src/utils/ops.rs
+++ b/mistralrs-quant/src/utils/ops.rs
@@ -414,7 +414,7 @@ mod tests {
         assert_eq!(c, [[1, 2], [3, 4], [255, 0]]);
     }
 
-    #[cfg(all(feature = "cuda"))]
+    #[cfg(feature = "cuda")]
     #[test]
     fn test_bitpack_8bit() {
         use crate::HqqBits;
@@ -447,7 +447,7 @@ mod tests {
         assert_eq!(c, [[19, 36]]);
     }
 
-    #[cfg(all(feature = "cuda"))]
+    #[cfg(feature = "cuda")]
     #[test]
     fn test_bitpack_4bit() {
         use crate::HqqBits;

--- a/mistralrs-quant/src/utils/ops.rs
+++ b/mistralrs-quant/src/utils/ops.rs
@@ -398,4 +398,34 @@ mod tests {
         assert_eq!(bv, [0b00001111]);
         assert_eq!(c, [0b11111111]);
     }
+
+    #[cfg(not(feature = "cuda"))]
+    #[test]
+    fn test_bitpack() {
+        use crate::HqqBits;
+        use candle_core::{Device, Tensor};
+        let bits = HqqBits::Four;
+        let device = &Device::Cpu;
+        let wq = Tensor::from_vec(vec![1_u8, 2, 3, 4, 5, 6], (3, 2), &device).unwrap();
+        let c = bits.bitpack_type()(wq.clone())
+            .unwrap()
+            .to_vec2::<u8>()
+            .unwrap();
+        assert_eq!(c, [[19, 36]]);
+    }
+
+    #[cfg(all(feature = "cuda"))]
+    #[test]
+    fn test_bitpack() {
+        use crate::HqqBits;
+        use candle_core::{Device, Tensor};
+        let bits = HqqBits::Four;
+        let device = Device::new_cuda(0).unwrap();
+        let wq = Tensor::from_vec(vec![1_u8, 2, 3, 4, 5, 6], (3, 2), &device).unwrap();
+        let c = bits.bitpack_type()(wq.clone())
+            .unwrap()
+            .to_vec2::<u8>()
+            .unwrap();
+        assert_eq!(c, [[19, 36]]);
+    }
 }


### PR DESCRIPTION
This confirms that `test_bitpack` is running solely on non-CPU hardware. To address this, we could implement a fix by ensuring contiguous data slices.