### PR TITLE
add marlin as cargo feature

### DIFF
--- a/mistralrs-quant/Cargo.toml
+++ b/mistralrs-quant/Cargo.toml
@@ -27,6 +27,7 @@ once_cell.workspace = true
 [features]
 cuda = ["candle-core/cuda", "candle-nn/cuda", "dep:bindgen_cuda"]
 metal = ["candle-core/metal", "candle-nn/metal"]
+marlin = []
 
 [build-dependencies]
 bindgen_cuda = { version = "0.1.5", optional = true }

--- a/mistralrs-quant/build.rs
+++ b/mistralrs-quant/build.rs
@@ -11,8 +11,12 @@ fn main() {
             "kernels/gptq/q_gemm.cu",
             "kernels/hqq/hqq.cu",
             "kernels/ops/ops.cu",
-            "kernels/marlin/marlin_kernel.cu",
         ];
+        #[cfg(feature = "marlin")]
+        {
+            lib_files.push("kernels/marlin/marlin_kernel.cu");
+        }
+
         for lib_file in lib_files.iter() {
             println!("cargo:rerun-if-changed={lib_file}");
         }


### PR DESCRIPTION
This ensures broader accessibility to Mistral.rs across different hardware configurations by enabling its use even on systems with a CUDA compute capability less than 8.0.