### PR TITLE
Trim whitespace (such as carriage returns) from nvidia-smi output.

### DIFF
--- a/mistralrs-quant/build.rs
+++ b/mistralrs-quant/build.rs
@@ -16,7 +16,7 @@ fn main() {
                     .stdout,
             )
             .expect("Output of nvidia-smi was not utf8.");
-            (output.split('\n').nth(1).unwrap().parse::<f32>().unwrap() * 100.) as usize
+            (output.split('\n').nth(1).unwrap().trim().parse::<f32>().unwrap() * 100.) as usize
         };
 
         // ======== Handle optional marlin kernel compilation

--- a/mistralrs-quant/build.rs
+++ b/mistralrs-quant/build.rs
@@ -16,7 +16,14 @@ fn main() {
                     .stdout,
             )
             .expect("Output of nvidia-smi was not utf8.");
-            (output.split('\n').nth(1).unwrap().trim().parse::<f32>().unwrap() * 100.) as usize
+            (output
+                .split('\n')
+                .nth(1)
+                .unwrap()
+                .trim()
+                .parse::<f32>()
+                .unwrap()
+                * 100.) as usize
         };
 
         // ======== Handle optional marlin kernel compilation


### PR DESCRIPTION
Hello,

I'm encountering a build error from the latest `master` (`7a67ddaf`) on Windows 11.

It appears to be due to `nvidia-smi`'s line endings being CR LF. This fix just trims whitespace from the compute cap, allowing it to be parsed correctly.

My build environment, for reference:
```
rustc 1.82.0 (f6e511eec 2024-10-15)

Microsoft (R) C/C++ Optimizing Compiler Version 19.41.34123 for x64

nvcc: NVIDIA (R) Cuda compiler driver
Copyright (c) 2005-2024 NVIDIA Corporation
Built on Thu_Mar_28_02:30:10_Pacific_Daylight_Time_2024
Cuda compilation tools, release 12.4, V12.4.131
Build cuda_12.4.r12.4/compiler.34097967_0
```