### PR TITLE
Fix typo in documentation

### DIFF
--- a/mistralrs-core/src/lib.rs
+++ b/mistralrs-core/src/lib.rs
@@ -112,7 +112,7 @@ pub struct MistralRsConfig {
 }
 
 /// The MistralRs struct handles sending requests to the engine.
-/// It is the core multi-threaded component of mistral.rs, and uses `mspc`
+/// It is the core multi-threaded component of mistral.rs, and uses `mpsc`
 /// `Sender` and `Receiver` primitives to send and receive requests to the
 /// engine.
 pub struct MistralRs {

--- a/mistralrs-core/src/request.rs
+++ b/mistralrs-core/src/request.rs
@@ -112,7 +112,7 @@ impl NormalRequest {
 
 #[derive(Clone)]
 /// A request to the Engine, encapsulating the various parameters as well as
-/// the `mspc` response `Sender` used to return the [`Response`].
+/// the `mpsc` response `Sender` used to return the [`Response`].
 pub enum Request {
     Normal(NormalRequest),
     ReIsq(IsqType),


### PR DESCRIPTION
Fixed 'mspc' to 'mpsc' in rustdoc comments.
