### PR TITLE
add serde serialization to text chat types

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -393,7 +393,7 @@ checksum = "9ac0150caa2ae65ca5bd83f25c7de183dea78d4d366469f148435e2acfbad0da"
 [[package]]
 name = "candle-core"
 version = "0.8.0"
-source = "git+https://github.com/EricLBuehler/candle.git?rev=198f6dd#198f6ddacbba6714fcd28451241c74259324d344"
+source = "git+https://github.com/EricLBuehler/candle.git?rev=e97177b#e97177bd21215968d28073ff7b805e51321230e4"
 dependencies = [
  "accelerate-src",
  "byteorder",
@@ -424,7 +424,7 @@ dependencies = [
 [[package]]
 name = "candle-flash-attn"
 version = "0.8.0"
-source = "git+https://github.com/EricLBuehler/candle.git?rev=198f6dd#198f6ddacbba6714fcd28451241c74259324d344"
+source = "git+https://github.com/EricLBuehler/candle.git?rev=e97177b#e97177bd21215968d28073ff7b805e51321230e4"
 dependencies = [
  "anyhow",
  "bindgen_cuda 0.1.5",
@@ -435,7 +435,7 @@ dependencies = [
 [[package]]
 name = "candle-kernels"
 version = "0.8.0"
-source = "git+https://github.com/EricLBuehler/candle.git?rev=198f6dd#198f6ddacbba6714fcd28451241c74259324d344"
+source = "git+https://github.com/EricLBuehler/candle.git?rev=e97177b#e97177bd21215968d28073ff7b805e51321230e4"
 dependencies = [
  "bindgen_cuda 0.1.5",
 ]
@@ -443,7 +443,7 @@ dependencies = [
 [[package]]
 name = "candle-metal-kernels"
 version = "0.8.0"
-source = "git+https://github.com/EricLBuehler/candle.git?rev=198f6dd#198f6ddacbba6714fcd28451241c74259324d344"
+source = "git+https://github.com/EricLBuehler/candle.git?rev=e97177b#e97177bd21215968d28073ff7b805e51321230e4"
 dependencies = [
  "metal 0.27.0",
  "once_cell",
@@ -454,7 +454,7 @@ dependencies = [
 [[package]]
 name = "candle-nn"
 version = "0.8.0"
-source = "git+https://github.com/EricLBuehler/candle.git?rev=198f6dd#198f6ddacbba6714fcd28451241c74259324d344"
+source = "git+https://github.com/EricLBuehler/candle.git?rev=e97177b#e97177bd21215968d28073ff7b805e51321230e4"
 dependencies = [
  "accelerate-src",
  "candle-core",

--- a/mistralrs-core/src/response.rs
+++ b/mistralrs-core/src/response.rs
@@ -5,7 +5,7 @@ use std::{
 
 #[cfg(feature = "pyo3_macros")]
 use pyo3::{pyclass, pymethods};
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 
 use crate::{sampler::TopLogprob, tools::ToolCallResponse};
 
@@ -25,7 +25,7 @@ macro_rules! generate_repr {
 
 #[cfg_attr(feature = "pyo3_macros", pyclass)]
 #[cfg_attr(feature = "pyo3_macros", pyo3(get_all))]
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 /// Chat completion response message.
 pub struct ResponseMessage {
     pub content: Option<String>,
@@ -48,7 +48,7 @@ generate_repr!(Delta);
 
 #[cfg_attr(feature = "pyo3_macros", pyclass)]
 #[cfg_attr(feature = "pyo3_macros", pyo3(get_all))]
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 /// A logprob with the top logprobs for this token.
 pub struct ResponseLogprob {
     pub token: String,
@@ -61,7 +61,7 @@ generate_repr!(ResponseLogprob);
 
 #[cfg_attr(feature = "pyo3_macros", pyclass)]
 #[cfg_attr(feature = "pyo3_macros", pyo3(get_all))]
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 /// Logprobs per token.
 pub struct Logprobs {
     pub content: Option<Vec<ResponseLogprob>>,
@@ -71,7 +71,7 @@ generate_repr!(Logprobs);
 
 #[cfg_attr(feature = "pyo3_macros", pyclass)]
 #[cfg_attr(feature = "pyo3_macros", pyo3(get_all))]
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 /// Chat completion choice.
 pub struct Choice {
     pub finish_reason: String,
@@ -110,7 +110,7 @@ generate_repr!(CompletionChunkChoice);
 
 #[cfg_attr(feature = "pyo3_macros", pyclass)]
 #[cfg_attr(feature = "pyo3_macros", pyo3(get_all))]
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 /// OpenAI compatible (superset) usage during a request.
 pub struct Usage {
     pub completion_tokens: usize,
@@ -128,7 +128,7 @@ generate_repr!(Usage);
 
 #[cfg_attr(feature = "pyo3_macros", pyclass)]
 #[cfg_attr(feature = "pyo3_macros", pyo3(get_all))]
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 /// An OpenAI compatible chat completion response.
 pub struct ChatCompletionResponse {
     pub id: String,

--- a/mistralrs-core/src/sampler.rs
+++ b/mistralrs-core/src/sampler.rs
@@ -20,14 +20,14 @@ use tokenizers::Tokenizer;
 static DRY_SEQUENCE_BREAKERS: Lazy<Vec<String>> =
     Lazy::new(|| ["\n", ":", "\"", "*"].map(String::from).to_vec());
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 /// Stop sequences or ids.
 pub enum StopTokens {
     Seqs(Vec<String>),
     Ids(Vec<u32>),
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 /// Sampling params are used to control sampling.
 pub struct SamplingParams {
     pub temperature: Option<f64>,
@@ -67,7 +67,7 @@ impl SamplingParams {
     }
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct DrySamplingParams {
     pub sequence_breakers: Vec<String>,
     pub multiplier: f32,

--- a/mistralrs-core/src/tools/response.rs
+++ b/mistralrs-core/src/tools/response.rs
@@ -1,6 +1,6 @@
 #[cfg_attr(feature = "pyo3_macros", pyo3::pyclass(eq, eq_int))]
 #[cfg_attr(feature = "pyo3_macros", pyo3(get_all))]
-#[derive(Clone, Debug, serde::Serialize, PartialEq)]
+#[derive(Clone, Debug, serde::Serialize, serde::Deserialize, PartialEq)]
 #[serde(rename_all = "snake_case")]
 pub enum ToolCallType {
     Function,
@@ -24,7 +24,7 @@ pub struct CalledFunction {
 
 #[cfg_attr(feature = "pyo3_macros", pyo3::pyclass)]
 #[cfg_attr(feature = "pyo3_macros", pyo3(get_all))]
-#[derive(Clone, Debug, serde::Serialize)]
+#[derive(Clone, Debug, serde::Serialize, serde::Deserialize)]
 pub struct ToolCallResponse {
     pub id: String,
     #[serde(rename = "type")]

--- a/mistralrs/src/messages.rs
+++ b/mistralrs/src/messages.rs
@@ -4,8 +4,8 @@ use super::*;
 use either::Either;
 use image::DynamicImage;
 use indexmap::IndexMap;
-use serde_json::{json, Value};
 use serde::{Deserialize, Serialize};
+use serde_json::{json, Value};
 
 /// A type which can be used as a request.
 pub trait RequestLike {
@@ -28,6 +28,7 @@ pub trait RequestLike {
 pub struct TextMessages(Vec<IndexMap<String, MessageContent>>);
 
 /// A chat message role.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub enum TextMessageRole {
     User,
     Assistant,

--- a/mistralrs/src/messages.rs
+++ b/mistralrs/src/messages.rs
@@ -5,6 +5,7 @@ use either::Either;
 use image::DynamicImage;
 use indexmap::IndexMap;
 use serde_json::{json, Value};
+use serde::{Deserialize, Serialize};
 
 /// A type which can be used as a request.
 pub trait RequestLike {
@@ -18,7 +19,7 @@ pub trait RequestLike {
     fn take_sampling_params(&mut self) -> SamplingParams;
 }
 
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 /// Plain text (chat) messages.
 ///
 /// No constraints, logits processors, logprobs, tools, or adapters.


### PR DESCRIPTION
Adds serde serialization to some text chat types for some patterns where these need to be serialized and deserialized, like internal messaging systems, logs and event sourcing.