### PR TITLE
Faster CUDA prompt speeds

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -393,7 +393,7 @@ checksum = "9ac0150caa2ae65ca5bd83f25c7de183dea78d4d366469f148435e2acfbad0da"
 [[package]]
 name = "candle-core"
 version = "0.8.0"
-source = "git+https://github.com/EricLBuehler/candle.git?rev=198f6dd#198f6ddacbba6714fcd28451241c74259324d344"
+source = "git+https://github.com/EricLBuehler/candle.git?rev=e97177b#e97177bd21215968d28073ff7b805e51321230e4"
 dependencies = [
  "accelerate-src",
  "byteorder",
@@ -424,7 +424,7 @@ dependencies = [
 [[package]]
 name = "candle-flash-attn"
 version = "0.8.0"
-source = "git+https://github.com/EricLBuehler/candle.git?rev=198f6dd#198f6ddacbba6714fcd28451241c74259324d344"
+source = "git+https://github.com/EricLBuehler/candle.git?rev=e97177b#e97177bd21215968d28073ff7b805e51321230e4"
 dependencies = [
  "anyhow",
  "bindgen_cuda 0.1.5",
@@ -435,7 +435,7 @@ dependencies = [
 [[package]]
 name = "candle-kernels"
 version = "0.8.0"
-source = "git+https://github.com/EricLBuehler/candle.git?rev=198f6dd#198f6ddacbba6714fcd28451241c74259324d344"
+source = "git+https://github.com/EricLBuehler/candle.git?rev=e97177b#e97177bd21215968d28073ff7b805e51321230e4"
 dependencies = [
  "bindgen_cuda 0.1.5",
 ]
@@ -443,7 +443,7 @@ dependencies = [
 [[package]]
 name = "candle-metal-kernels"
 version = "0.8.0"
-source = "git+https://github.com/EricLBuehler/candle.git?rev=198f6dd#198f6ddacbba6714fcd28451241c74259324d344"
+source = "git+https://github.com/EricLBuehler/candle.git?rev=e97177b#e97177bd21215968d28073ff7b805e51321230e4"
 dependencies = [
  "metal 0.27.0",
  "once_cell",
@@ -454,7 +454,7 @@ dependencies = [
 [[package]]
 name = "candle-nn"
 version = "0.8.0"
-source = "git+https://github.com/EricLBuehler/candle.git?rev=198f6dd#198f6ddacbba6714fcd28451241c74259324d344"
+source = "git+https://github.com/EricLBuehler/candle.git?rev=e97177b#e97177bd21215968d28073ff7b805e51321230e4"
 dependencies = [
  "accelerate-src",
  "candle-core",

--- a/mistralrs-core/src/attention.rs
+++ b/mistralrs-core/src/attention.rs
@@ -180,7 +180,10 @@ impl Sdpa {
                     let k = k.flatten(0, 1)?;
                     let q = q.flatten(0, 1)?;
                     let v = v.flatten(0, 1)?;
-                    let attention_bias = mask.map(|mask| mask.flatten(0, 1)).transpose()?;
+                    let attention_bias = match mask {
+                        Some(mask) => Some(mask.unsqueeze(0)?.repeat((n_attn_heads, 1, 1))?),
+                        None => None,
+                    };
 
                     // If attention_bias is set, we fuse the add by giving it as the output matrix
                     // and setting beta to 1.0


### PR DESCRIPTION
I measure +4% PP for Llama 3.2 3b (807 T/s -> 840 T/s, 42 prompt tokens).