### PR TITLE
Always cast image to rgb8 for qwenvl2

### DIFF
--- a/mistralrs-core/src/vision_models/qwen2vl/inputs_processor.rs
+++ b/mistralrs-core/src/vision_models/qwen2vl/inputs_processor.rs
@@ -552,6 +552,7 @@ impl Qwen2VLImageProcessor {
                     .map(|resample| Some(resample).to_filter())
                     .unwrap_or(Ok(FilterType::CatmullRom))?,
             );
+            image = DynamicImage::ImageRgb8(image.to_rgb8());
             if config.do_resize.is_none() || config.do_resize.is_some_and(|x| x) {
                 let (resized_height, resized_width) = self.smart_resize(
                     height as usize,

--- a/mistralrs-vision/src/transforms.rs
+++ b/mistralrs-vision/src/transforms.rs
@@ -85,7 +85,12 @@ impl ImageTransform for Normalize {
     fn map(&self, x: &Self::Input, _: &Device) -> Result<Self::Output> {
         let num_channels = x.dim(0)?;
         if self.mean.len() != num_channels || self.std.len() != num_channels {
-            candle_core::bail!("Num channels must match number of mean and std.");
+            candle_core::bail!(
+                "Num channels ({}) must match number of mean ({}) and std ({}).",
+                num_channels,
+                self.mean.len(),
+                self.std.len()
+            );
         }
         let mut accum = Vec::new();
         for (i, channel) in x.chunk(num_channels, 0)?.iter().enumerate() {


### PR DESCRIPTION
Also, better error message. See #935.