### PR TITLE
Improve memory efficency of vllama

### DIFF
--- a/mistralrs-core/src/attention.rs
+++ b/mistralrs-core/src/attention.rs
@@ -100,7 +100,7 @@ fn naive_sdpa(
             att = (att * softcap as f64)?;
         }
 
-        let att = candle_nn::ops::attn_softmax_last_dim(
+        att = candle_nn::ops::attn_softmax_last_dim(
             &att,
             mask.unwrap(),
             1. / (head_dim as f32).sqrt(),
@@ -114,11 +114,11 @@ fn naive_sdpa(
             att = (att * softcap as f64)?;
         }
 
-        let att = match mask {
+        att = match mask {
             Some(m) => att.broadcast_add(m)?,
             None => att,
         };
-        let att = candle_nn::ops::softmax_last_dim(&att)?;
+        att = candle_nn::ops::softmax_last_dim(&att)?;
         MatMul.matmul(&att, v)
     }
 }

--- a/mistralrs-core/src/vision_models/mllama/vision.rs
+++ b/mistralrs-core/src/vision_models/mllama/vision.rs
@@ -383,10 +383,11 @@ impl MLlamaVisionEncoder {
         let mut hidden_state = hidden_state.clone();
         let mut hidden_states = Vec::new();
         for (i, layer) in self.layers.iter().enumerate() {
-            if intermediate_layers_indices.is_some_and(|indices| indices.contains(&i)) {
+            if intermediate_layers_indices.is_some_and(|indices: &[usize]| indices.contains(&i)) {
                 hidden_states.push(hidden_state.clone());
             }
             hidden_state = layer.forward(&hidden_state, attention_mask)?;
+            hidden_state.device().synchronize()?;
         }
         Ok((hidden_state, hidden_states))
     }


### PR DESCRIPTION
\image https://www.nhmagazine.com/content/uploads/2019/05/mtwashingtonFranconia-2-19-18-108-Edit-Edit.jpg What is this?

After PR:
+ ~8GB

Before PR:
+ ~30GB

Improved usage by 22GB!