### PR TITLE
set minimum rustc version to 1.82

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ repository = "https://github.com/EricLBuehler/mistral.rs"
 keywords = ["machine-learning"]
 categories = ["science"]
 license = "MIT"
+rust-version = "1.82"
 
 [workspace.dependencies]
 anyhow = "1.0.80"


### PR DESCRIPTION
The `is_none_or` function was introduced in 1.82. 

BTW, maybe we need 1.83?