### PR TITLE
Fix example gguf_locally to match chat template requirements

### DIFF
--- a/mistralrs/examples/gguf_locally/main.rs
+++ b/mistralrs/examples/gguf_locally/main.rs
@@ -18,15 +18,10 @@ async fn main() -> Result<()> {
     .build()
     .await?;
 
-    let messages = TextMessages::new()
-        .add_message(
-            TextMessageRole::System,
-            "You are an AI agent with a specialty in programming.",
-        )
-        .add_message(
-            TextMessageRole::User,
-            "Hello! How are you? Please write generic binary search function in Rust.",
-        );
+    let messages = TextMessages::new().add_message(
+        TextMessageRole::User,
+        "Hello! How are you? Please write generic binary search function in Rust.",
+    );
 
     let response = model.send_chat_request(messages).await?;
 


### PR DESCRIPTION
The `gguf_locally` example was failing due to a mismatch between the chat template (chat_templates/mistral.json) and the example code. The chat template only supports 'user' and 'assistant' roles, but the example code included a 'system' role message.

When running the example, I encountered the following error:

```
Error: invalid operation: Conversation roles must alternate user/assistant/user/assistant/... (in chat_template:1)
```

This PR removes the 'system' role message from the example code to allow it to run successfully.