### PR TITLE
Improve error handling

### DIFF
--- a/mistralrs-core/src/pipeline/ggml.rs
+++ b/mistralrs-core/src/pipeline/ggml.rs
@@ -346,9 +346,10 @@ impl Loader for GGMLLoader {
         };
 
         let tokenizer = get_tokenizer(paths.get_tokenizer_filename(), None)?;
-        let gen_conf: Option<GenerationConfig> = paths
-            .get_gen_conf_filename()
-            .map(|f| serde_json::from_str(&fs::read_to_string(f).unwrap()).unwrap());
+        let gen_conf: Option<GenerationConfig> = paths.get_gen_conf_filename().map(|f| {
+            serde_json::from_str(&fs::read_to_string(f).unwrap())
+                .expect("bos_token_id/eos_token_id missing in generation_config.json")
+        });
         let chat_template = get_chat_template(
             paths,
             &paths

--- a/mistralrs-core/src/pipeline/gguf.rs
+++ b/mistralrs-core/src/pipeline/gguf.rs
@@ -469,9 +469,10 @@ impl Loader for GGUFLoader {
             (None, None)
         };
 
-        let gen_conf: Option<GenerationConfig> = paths
-            .get_gen_conf_filename()
-            .map(|f| serde_json::from_str(&fs::read_to_string(f).unwrap()).unwrap());
+        let gen_conf: Option<GenerationConfig> = paths.get_gen_conf_filename().map(|f| {
+            serde_json::from_str(&fs::read_to_string(f).unwrap())
+                .expect("bos_token_id/eos_token_id missing in generation_config.json")
+        });
         let mut chat_template = get_chat_template(
             paths,
             &paths

--- a/mistralrs-core/src/pipeline/normal.rs
+++ b/mistralrs-core/src/pipeline/normal.rs
@@ -386,7 +386,11 @@ impl Loader for NormalLoader {
         let tokenizer = get_tokenizer(paths.get_tokenizer_filename(), None)?;
         let gen_conf: Option<GenerationConfig> = paths
             .get_gen_conf_filename()
-            .map(|f| serde_json::from_str(&fs::read_to_string(f).unwrap()).unwrap());
+            .map(|f| {
+                serde_json::from_str(&fs::read_to_string(f).unwrap())
+                    .expect("bos_token_id/eos_token_id missing in generation_config.json")
+            });
+
         let chat_template = get_chat_template(
             paths,
             &paths

--- a/mistralrs-core/src/pipeline/normal.rs
+++ b/mistralrs-core/src/pipeline/normal.rs
@@ -384,12 +384,10 @@ impl Loader for NormalLoader {
         };
 
         let tokenizer = get_tokenizer(paths.get_tokenizer_filename(), None)?;
-        let gen_conf: Option<GenerationConfig> = paths
-            .get_gen_conf_filename()
-            .map(|f| {
-                serde_json::from_str(&fs::read_to_string(f).unwrap())
-                    .expect("bos_token_id/eos_token_id missing in generation_config.json")
-            });
+        let gen_conf: Option<GenerationConfig> = paths.get_gen_conf_filename().map(|f| {
+            serde_json::from_str(&fs::read_to_string(f).unwrap())
+                .expect("bos_token_id/eos_token_id missing in generation_config.json")
+        });
 
         let chat_template = get_chat_template(
             paths,

--- a/mistralrs-core/src/pipeline/vision.rs
+++ b/mistralrs-core/src/pipeline/vision.rs
@@ -303,9 +303,10 @@ impl Loader for VisionLoader {
             Some(processor.get_special_tokens()),
         )?;
 
-        let gen_conf: Option<GenerationConfig> = paths
-            .get_gen_conf_filename()
-            .map(|f| serde_json::from_str(&fs::read_to_string(f).unwrap()).unwrap());
+        let gen_conf: Option<GenerationConfig> = paths.get_gen_conf_filename().map(|f| {
+            serde_json::from_str(&fs::read_to_string(f).unwrap())
+                .expect("bos_token_id/eos_token_id missing in generation_config.json")
+        });
         let chat_template = get_chat_template(
             paths,
             &paths


### PR DESCRIPTION
Currently, when the `bos_token_id` or `eos_token_id` field is missing from `generation_config.json`, the error message is "Error(`missing field `bos_token_id`", line: 4, column: 1)", which does not provide clear context about the source of the issue.

This change indicates the problem is in the `generation_config.json` file.