### PR TITLE
Add None check to prevent panic in evict_all_to_cpu in prefix_cacher.rs

### DIFF
--- a/mistralrs-core/src/prefix_cacher.rs
+++ b/mistralrs-core/src/prefix_cacher.rs
@@ -147,6 +147,10 @@ impl PrefixCacheManager {
         }
         // Intentionally evict the first ones first, as they are the oldest
         for (cache, xlora_cache) in &self.eviction_cache_ptrs {
+            if get_mut_arcmutex!(cache.as_ref())[0].is_none() {
+                // TODO: add support for normal cache
+                continue;
+            }
             if !matches!(
                 get_mut_arcmutex!(cache.as_ref())[0]
                     .as_ref()


### PR DESCRIPTION
This check is already present in the `evict_to_cpu` function and was missing in `evict_all_to_cpu`.

Note: I'm not entirely sure if the comment is relevant here, I just copied it from the `evict_to_cpu` function - still getting familiar with the code