### PR TITLE
Partial Fix for Sliding Window Attention

### DIFF
--- a/mistralrs-core/src/pipeline/cache_manager.rs
+++ b/mistralrs-core/src/pipeline/cache_manager.rs
@@ -195,10 +195,6 @@ impl KvCache {
                 if let Some(mut mask) = mask.cloned() {
                     let mask_len = mask.dim(1)?;
                     mask = mask.narrow(1, mask_len - (sliding_window - 1), sliding_window - 1)?;
-                    mask = Tensor::cat(
-                        &[&mask, &mask.narrow(1, mask_len - 1, 1)?.ones_like()?],
-                        D::Minus1,
-                    )?;
                     return Ok((k, v, Some(mask)));
                 }
             }


### PR DESCRIPTION
Currently, in models like Phi3 and Mistral, with paged attention disabled, sliding window attention fails when the input sequence length exceeds the sliding window size, due to a "start > dim_len" error caused by the mask tensor being narrowed using its original length. 

An initial fix was updating the mask length after the first narrow operation, but this brings up another error where the mask's dimension was one higher than the corresponding dimension in the key and value tensors, leading to a shape mismatch in the `naive_sdpa` function.

The issue was resolved by removing the concatenation of the mask tensor, resulting in coherent outputs for non-flash attention, although flash attention remains non-functional. 

Any feedback or review of this change would be greatly appreciated!