### PR TITLE
Fix bug for kernel cache & Phi3 inference

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2492,6 +2492,7 @@ dependencies = [
  "float8",
  "half",
  "metal 0.27.0",
+ "once_cell",
  "thiserror 1.0.69",
 ]
 

--- a/mistralrs-core/src/lib.rs
+++ b/mistralrs-core/src/lib.rs
@@ -1,5 +1,4 @@
 #![deny(clippy::cast_possible_truncation, clippy::cast_precision_loss)]
-#![feature(is_none_or)]
 use candle_core::Device;
 use cublaslt::setup_cublas_lt_wrapper;
 use engine::Engine;

--- a/mistralrs-core/src/lib.rs
+++ b/mistralrs-core/src/lib.rs
@@ -1,5 +1,5 @@
 #![deny(clippy::cast_possible_truncation, clippy::cast_precision_loss)]
-
+#![feature(is_none_or)]
 use candle_core::Device;
 use cublaslt::setup_cublas_lt_wrapper;
 use engine::Engine;

--- a/mistralrs-core/src/models/quantized_phi3.rs
+++ b/mistralrs-core/src/models/quantized_phi3.rs
@@ -104,7 +104,7 @@ impl LayerWeights {
             let v = v
                 .reshape((b_sz, seq_len, self.n_kv_head, self.head_dim))?
                 .transpose(1, 2)?;
-            (q, k, v)
+            (q, k, v.contiguous()?)
         } else {
             let q = q.reshape((b_sz, self.n_head, seq_len, self.head_dim))?;
             let k = k.reshape((b_sz, self.n_kv_head, seq_len, self.head_dim))?;

--- a/mistralrs-paged-attn/Cargo.toml
+++ b/mistralrs-paged-attn/Cargo.toml
@@ -17,6 +17,7 @@ half.workspace = true
 float8.workspace = true
 metal = { workspace = true, optional = true }
 thiserror = "1"
+once_cell = "1.20.2"
 
 [build-dependencies]
 bindgen_cuda = {git = "https://github.com/guoqingbao/bindgen_cuda.git", version = "0.1.6", optional = true}

--- a/mistralrs-paged-attn/src/metal/backend/cache.rs
+++ b/mistralrs-paged-attn/src/metal/backend/cache.rs
@@ -74,7 +74,7 @@ pub fn copy_blocks(
         kernels::call_copy_blocks(
             dev.device(),
             &command_buffer,
-            &kernels::Kernels::new(),
+            &kernels::Kernels::default(),
             key_cache.dtype(),
             key_storage.buffer(),
             key_offset * key_storage.dtype().size_in_bytes(),

--- a/mistralrs-paged-attn/src/metal/backend/paged_attention.rs
+++ b/mistralrs-paged-attn/src/metal/backend/paged_attention.rs
@@ -167,7 +167,7 @@ impl candle_core::CustomOp1 for PagedAttention {
             kernels::call_paged_attention_v1(
                 dev.device(),
                 &command_buffer,
-                &kernels::Kernels::new(),
+                kernels::Kernels::default(),
                 internal_type,
                 q.buffer(),
                 q_l.start_offset() * q.dtype().size_in_bytes(),
@@ -214,7 +214,7 @@ impl candle_core::CustomOp1 for PagedAttention {
             kernels::call_paged_attention_v2(
                 dev.device(),
                 &command_buffer,
-                &kernels::Kernels::new(),
+                kernels::Kernels::default(),
                 internal_type,
                 &exp_sums,
                 &max_logits,
@@ -420,7 +420,7 @@ pub fn reshape_and_cache(
     kernels::call_reshape_and_cache(
         dev.device(),
         &command_buffer,
-        &kernels::Kernels::new(),
+        kernels::Kernels::default(),
         internal_type,
         k.buffer(),
         k_l.start_offset() * key.dtype().size_in_bytes(),


### PR DESCRIPTION
The metal kernels need to be loaded with load_source in each of the function callls in the current implementation because there is no global kernel cache, this PR fix the problem.