### PR TITLE
Support BF16 kvcache, rope and attentions for inference of GGUF/GGML models

### DIFF
--- a/README.md
+++ b/README.md
@@ -393,7 +393,7 @@ Mistral.rs uses subcommands to control the model type. They are generally of for
 
 ### Architecture for plain models
 
-> Note: for plain models, you can specify the data type to load and run in. This must be one of `f32`, `f16`, `bf16` or `auto` to choose based on the device. This is specified in the `--dype`/`-d` parameter after the model architecture (`plain`).
+> Note: for plain models, you can specify the data type to load and run in. This must be one of `f32`, `f16`, `bf16` or `auto` to choose based on the device. This is specified in the `--dype`/`-d` parameter after the model architecture (`plain`). For quantized models (gguf/ggml), you may specify data type of `f32` or `bf16` (`f16` is not recommended due to its lower precision in quantized inference).
 
 If you do not specify the architecture, an attempt will be made to use the model's config. If this fails, please raise an issue.
 
@@ -453,6 +453,13 @@ And even diffusion models:
 
 ```bash
 ./mistralrs-server -i diffusion-plain -m black-forest-labs/FLUX.1-schnell -a flux
+```
+
+On Apple Silicon (`Metal`), run with throughput log, settings of paged attention (maximum usage of 4GB for kv cache) and dtype (bf16 for kv cache and attention)
+
+```bash
+cargo build --release --features metal
+./target/release/mistralrs-server -i --throughput --paged-attn --pa-gpu-mem 4096 gguf --dtype bf16 -m /Users/Downloads/ -f Phi-3.5-mini-instruct-Q4_K_M.gguf
 ```
 
 ### OpenAI HTTP server

--- a/mistralrs-core/src/model_loader.rs
+++ b/mistralrs-core/src/model_loader.rs
@@ -89,8 +89,9 @@ pub fn get_model_dtype(model: &ModelSelected) -> anyhow::Result<ModelDType> {
         | ModelSelected::GGML { dtype, .. }
         | ModelSelected::GGUF { dtype, .. }
         | ModelSelected::XLoraGGUF { dtype, .. }
-        | ModelSelected::XLoraGGML { dtype, .. } => Ok(*dtype),
-        ModelSelected::LoraGGUF { .. } | ModelSelected::LoraGGML { .. } => Ok(ModelDType::Auto),
+        | ModelSelected::XLoraGGML { dtype, .. }
+        | ModelSelected::LoraGGUF { dtype, .. }
+        | ModelSelected::LoraGGML { dtype, .. } => Ok(*dtype),
         ModelSelected::Toml { file } => {
             let selector: TomlSelector = toml::from_str(
                 &fs::read_to_string(file.clone())
@@ -276,6 +277,7 @@ fn loader_from_model_selected(args: LoaderBuilder) -> anyhow::Result<Box<dyn Loa
             adapters_model_id,
             order,
             topology,
+            ..
         } => GGUFLoaderBuilder::new(
             args.chat_template,
             tok_model_id,
@@ -363,6 +365,7 @@ fn loader_from_model_selected(args: LoaderBuilder) -> anyhow::Result<Box<dyn Loa
             order,
             gqa,
             topology,
+            ..
         } => GGMLLoaderBuilder::new(
             GGMLSpecificConfig {
                 gqa,

--- a/mistralrs-core/src/model_loader.rs
+++ b/mistralrs-core/src/model_loader.rs
@@ -87,11 +87,10 @@ pub fn get_model_dtype(model: &ModelSelected) -> anyhow::Result<ModelDType> {
         | ModelSelected::VisionPlain { dtype, .. }
         | ModelSelected::DiffusionPlain { dtype, .. }
         | ModelSelected::GGML { dtype, .. }
-        | ModelSelected::GGUF { dtype, .. } => Ok(*dtype),
-        ModelSelected::LoraGGUF { .. }
-        | ModelSelected::LoraGGML { .. }
-        | ModelSelected::XLoraGGUF { .. }
-        | ModelSelected::XLoraGGML { .. } => Ok(ModelDType::Auto),
+        | ModelSelected::GGUF { dtype, .. }
+        | ModelSelected::XLoraGGUF { dtype, .. }
+        | ModelSelected::XLoraGGML { dtype, .. } => Ok(*dtype),
+        ModelSelected::LoraGGUF { .. } | ModelSelected::LoraGGML { .. } => Ok(ModelDType::Auto),
         ModelSelected::Toml { file } => {
             let selector: TomlSelector = toml::from_str(
                 &fs::read_to_string(file.clone())
@@ -245,6 +244,7 @@ fn loader_from_model_selected(args: LoaderBuilder) -> anyhow::Result<Box<dyn Loa
             order,
             tgt_non_granular_index,
             topology,
+            ..
         } => GGUFLoaderBuilder::new(
             args.chat_template,
             tok_model_id,
@@ -330,6 +330,7 @@ fn loader_from_model_selected(args: LoaderBuilder) -> anyhow::Result<Box<dyn Loa
             tgt_non_granular_index,
             gqa,
             topology,
+            ..
         } => GGMLLoaderBuilder::new(
             GGMLSpecificConfig {
                 gqa,

--- a/mistralrs-core/src/model_loader.rs
+++ b/mistralrs-core/src/model_loader.rs
@@ -85,10 +85,10 @@ pub fn get_model_dtype(model: &ModelSelected) -> anyhow::Result<ModelDType> {
         | ModelSelected::Lora { dtype, .. }
         | ModelSelected::XLora { dtype, .. }
         | ModelSelected::VisionPlain { dtype, .. }
-        | ModelSelected::DiffusionPlain { dtype, .. } => Ok(*dtype),
-        ModelSelected::GGUF { .. }
-        | ModelSelected::LoraGGUF { .. }
-        | ModelSelected::GGML { .. }
+        | ModelSelected::DiffusionPlain { dtype, .. }
+        | ModelSelected::GGML { dtype, .. }
+        | ModelSelected::GGUF { dtype, .. } => Ok(*dtype),
+        ModelSelected::LoraGGUF { .. }
         | ModelSelected::LoraGGML { .. }
         | ModelSelected::XLoraGGUF { .. }
         | ModelSelected::XLoraGGML { .. } => Ok(ModelDType::Auto),
@@ -222,6 +222,7 @@ fn loader_from_model_selected(args: LoaderBuilder) -> anyhow::Result<Box<dyn Loa
             quantized_model_id,
             quantized_filename,
             topology,
+            ..
         } => GGUFLoaderBuilder::new(
             args.chat_template,
             tok_model_id,
@@ -304,6 +305,7 @@ fn loader_from_model_selected(args: LoaderBuilder) -> anyhow::Result<Box<dyn Loa
             quantized_filename,
             gqa,
             topology,
+            ..
         } => GGMLLoaderBuilder::new(
             GGMLSpecificConfig {
                 gqa,

--- a/mistralrs-core/src/model_selected.rs
+++ b/mistralrs-core/src/model_selected.rs
@@ -254,6 +254,10 @@ pub enum ModelSelected {
         #[arg(short, long)]
         order: String,
 
+        /// Model data type. Defaults to `auto`.
+        #[arg(short, long, default_value_t = ModelDType::Auto, value_parser = parse_model_dtype)]
+        dtype: ModelDType,
+
         /// Path to a topology YAML file.
         #[arg(long)]
         topology: Option<String>,
@@ -366,6 +370,10 @@ pub enum ModelSelected {
         /// GQA value
         #[arg(short, long, default_value_t = 1)]
         gqa: usize,
+
+        /// Model data type. Defaults to `auto`.
+        #[arg(short, long, default_value_t = ModelDType::Auto, value_parser = parse_model_dtype)]
+        dtype: ModelDType,
 
         /// Path to a topology YAML file.
         #[arg(long)]

--- a/mistralrs-core/src/model_selected.rs
+++ b/mistralrs-core/src/model_selected.rs
@@ -179,6 +179,10 @@ pub enum ModelSelected {
         #[arg(short = 'f', long)]
         quantized_filename: String,
 
+        /// Model data type. Defaults to `auto`.
+        #[arg(short, long, default_value_t = ModelDType::Auto, value_parser = parse_model_dtype)]
+        dtype: ModelDType,
+
         /// Path to a topology YAML file.
         #[arg(long)]
         topology: Option<String>,
@@ -273,6 +277,10 @@ pub enum ModelSelected {
         /// GQA value
         #[arg(short, long, default_value_t = 1)]
         gqa: usize,
+
+        /// Model data type. Defaults to `auto`.
+        #[arg(short, long, default_value_t = ModelDType::Auto, value_parser = parse_model_dtype)]
+        dtype: ModelDType,
 
         /// Path to a topology YAML file.
         #[arg(long)]

--- a/mistralrs-core/src/model_selected.rs
+++ b/mistralrs-core/src/model_selected.rs
@@ -219,6 +219,10 @@ pub enum ModelSelected {
         #[arg(long)]
         tgt_non_granular_index: Option<usize>,
 
+        /// Model data type. Defaults to `auto`.
+        #[arg(short, long, default_value_t = ModelDType::Auto, value_parser = parse_model_dtype)]
+        dtype: ModelDType,
+
         /// Path to a topology YAML file.
         #[arg(long)]
         topology: Option<String>,
@@ -322,6 +326,10 @@ pub enum ModelSelected {
         /// GQA value
         #[arg(short, long, default_value_t = 1)]
         gqa: usize,
+
+        /// Model data type. Defaults to `auto`.
+        #[arg(short, long, default_value_t = ModelDType::Auto, value_parser = parse_model_dtype)]
+        dtype: ModelDType,
 
         /// Path to a topology YAML file.
         #[arg(long)]

--- a/mistralrs-core/src/models/quantized_phi2.rs
+++ b/mistralrs-core/src/models/quantized_phi2.rs
@@ -56,6 +56,7 @@ struct LayerWeights {
     rope_dim: usize,
     paged_attn: Option<PagedAttention>,
     sdpa_params: SdpaParams,
+    dtype: DType,
 }
 
 impl LayerWeights {
@@ -83,10 +84,11 @@ impl LayerWeights {
         metadata: Option<((Tensor, Tensor), &mut PagedAttentionInputMetadata)>,
     ) -> Result<Tensor> {
         let (b_sz, seq_len, n_embd) = x.dims3()?;
-        let qkv =
-            self.attn_qkv
-                .forward(x)?
-                .reshape((b_sz, seq_len, 3, self.n_head, self.head_dim))?;
+        let qkv = self
+            .attn_qkv
+            .forward(x)?
+            .reshape((b_sz, seq_len, 3, self.n_head, self.head_dim))?
+            .to_dtype(self.dtype)?;
 
         let q = qkv.i((.., .., 0))?.transpose(1, 2)?;
         let k = qkv.i((.., .., 1))?.transpose(1, 2)?;
@@ -125,7 +127,7 @@ impl LayerWeights {
         } else {
             y.reshape(&[b_sz, seq_len, n_embd])?
         };
-        let y = self.attn_output.forward(&y)?;
+        let y = self.attn_output.forward(&y.to_dtype(x.dtype())?)?;
         Ok(y)
     }
 }
@@ -139,6 +141,7 @@ pub struct ModelWeights {
     pub cache: EitherCache,
     pub max_seq_len: usize,
     mapper: Box<dyn DeviceMapper + Send + Sync>,
+    dtype: DType,
 }
 
 fn precomput_freqs_cis(
@@ -146,6 +149,7 @@ fn precomput_freqs_cis(
     freq_base: f32,
     device: &Device,
     max_seq_len: usize,
+    dtype: DType,
 ) -> Result<(Tensor, Tensor)> {
     let theta: Vec<_> = (0..head_dim)
         .step_by(2)
@@ -156,8 +160,8 @@ fn precomput_freqs_cis(
         .to_dtype(DType::F32)?
         .reshape((max_seq_len, 1))?
         .matmul(&theta.reshape((1, theta.elem_count()))?)?;
-    let cos = idx_theta.cos()?;
-    let sin = idx_theta.sin()?;
+    let cos = idx_theta.cos()?.to_dtype(dtype)?;
+    let sin = idx_theta.sin()?.to_dtype(dtype)?;
     Ok((cos, sin))
 }
 
@@ -224,6 +228,7 @@ impl ModelConfig::FromGGUF for ModelWeights {
         mapper: DeviceMapMetadata,
         topology: Option<&'_ Topology>,
         attention_mechanism: AttentionImplementation,
+        dtype: DType,
     ) -> Result<Self> {
         // Parameter extraction from metadata.
         let metadata = ContentMetadata {
@@ -240,7 +245,7 @@ impl ModelConfig::FromGGUF for ModelWeights {
             max_seq_len,
         } = PropsGGUF::try_from(metadata).or_else(|err| candle_core::bail!("{err}"))?;
 
-        let (cos, sin) = precomput_freqs_cis(rope_dim, 10_000., device, max_seq_len)?;
+        let (cos, sin) = precomput_freqs_cis(rope_dim, 10_000., device, max_seq_len, dtype)?;
 
         let tok_embeddings = ct.tensor("token_embd.weight", device)?;
         let tok_embeddings = tok_embeddings.dequantize(device)?;
@@ -326,6 +331,7 @@ impl ModelConfig::FromGGUF for ModelWeights {
                     softmax_scale: 1.0 / (head_dim as f32).sqrt(),
                     sliding_window: None,
                 },
+                dtype,
             })
         }
         Ok(Self {
@@ -337,6 +343,7 @@ impl ModelConfig::FromGGUF for ModelWeights {
             cache: EitherCache::Normal(NormalCache::new(block_count, max_seq_len)),
             max_seq_len,
             mapper,
+            dtype,
         })
     }
 }
@@ -357,7 +364,7 @@ impl ModelWeights {
                 .as_ref()
                 .map(|(_, _)| &seqlen_offsets as &dyn PastKvLenCache)
                 .unwrap_or(cache as &dyn PastKvLenCache),
-            DType::F32,
+            self.dtype,
             self.layers[0].n_head,
         )?;
         for (i, layer) in self.layers.iter().enumerate() {

--- a/mistralrs-core/src/models/quantized_phi3.rs
+++ b/mistralrs-core/src/models/quantized_phi3.rs
@@ -57,6 +57,7 @@ struct LayerWeights {
     sliding_window: usize,
     paged_attn: Option<PagedAttention>,
     sdpa_params: SdpaParams,
+    dtype: DType,
 }
 
 impl LayerWeights {
@@ -84,7 +85,9 @@ impl LayerWeights {
         metadata: Option<((Tensor, Tensor), &mut PagedAttentionInputMetadata)>,
     ) -> Result<Tensor> {
         let (b_sz, seq_len, n_embd) = x.dims3()?;
-        let qkv = MatMul.qmethod_matmul(x, &*self.attn_qkv)?;
+        let qkv = MatMul
+            .qmethod_matmul(x, &*self.attn_qkv)?
+            .to_dtype(self.dtype)?;
         let query_pos = self.n_head * self.head_dim;
         let q = qkv.narrow(D::Minus1, 0, query_pos)?;
         let k = qkv.narrow(D::Minus1, query_pos, self.n_kv_head * self.head_dim)?;
@@ -112,9 +115,8 @@ impl LayerWeights {
             (q, k, v)
         };
 
-        let q = self.apply_rotary_emb(&q, seqlen_offsets)?.contiguous()?;
+        let q = self.apply_rotary_emb(&q, seqlen_offsets)?;
         let k = self.apply_rotary_emb(&k, seqlen_offsets)?;
-
         let y = match &self.paged_attn {
             Some(paged_attn) => {
                 let ((key_cache, value_cache), input_metadata) = metadata.unwrap();
@@ -142,7 +144,7 @@ impl LayerWeights {
         } else {
             y.reshape(&[b_sz, seq_len, n_embd])?
         };
-        let y = MatMul.qmethod_matmul(&y, &*self.attn_output)?;
+        let y = MatMul.qmethod_matmul(&y.to_dtype(x.dtype())?, &*self.attn_output)?;
         Ok(y)
     }
 }
@@ -156,6 +158,7 @@ pub struct ModelWeights {
     pub device: Device,
     pub cache: EitherCache,
     pub max_seq_len: usize,
+    dtype: DType,
 }
 
 fn precomput_freqs_cis(
@@ -163,6 +166,7 @@ fn precomput_freqs_cis(
     freq_base: f32,
     device: &Device,
     context_window: usize,
+    dtype: DType,
 ) -> Result<(Tensor, Tensor)> {
     let theta: Vec<_> = (0..head_dim)
         .step_by(2)
@@ -173,8 +177,8 @@ fn precomput_freqs_cis(
         .to_dtype(DType::F32)?
         .reshape((context_window, 1))?
         .matmul(&theta.reshape((1, theta.elem_count()))?)?;
-    let cos = idx_theta.cos()?;
-    let sin = idx_theta.sin()?;
+    let cos = idx_theta.cos()?.to_dtype(dtype)?;
+    let sin = idx_theta.sin()?.to_dtype(dtype)?;
     Ok((cos, sin))
 }
 
@@ -234,6 +238,7 @@ impl ModelConfig::FromGGUF for ModelWeights {
         mapper: DeviceMapMetadata,
         topology: Option<&'_ Topology>,
         attention_mechanism: AttentionImplementation,
+        dtype: DType,
     ) -> Result<Self> {
         // Parameter extraction from metadata.
         let metadata = ContentMetadata {
@@ -251,7 +256,7 @@ impl ModelConfig::FromGGUF for ModelWeights {
             context_window,
         } = PropsGGUF::try_from(metadata).or_else(|err| candle_core::bail!("{err}"))?;
 
-        let (cos, sin) = precomput_freqs_cis(rope_dim, 10_000., device, context_window)?;
+        let (cos, sin) = precomput_freqs_cis(rope_dim, 10_000., device, context_window, dtype)?;
 
         let tok_embeddings = ct.tensor("token_embd.weight", device)?;
         let tok_embeddings = tok_embeddings.dequantize(device)?;
@@ -342,6 +347,7 @@ impl ModelConfig::FromGGUF for ModelWeights {
                     softmax_scale: 1.0 / (head_dim as f32).sqrt(),
                     sliding_window: Some(context_window),
                 },
+                dtype,
             })
         }
         Ok(Self {
@@ -353,6 +359,7 @@ impl ModelConfig::FromGGUF for ModelWeights {
             device: device.clone(),
             cache: EitherCache::Normal(NormalCache::new(block_count, context_window)),
             max_seq_len: context_window,
+            dtype,
         })
     }
 }
@@ -374,7 +381,7 @@ impl ModelWeights {
                 .map(|(_, _)| &seqlen_offsets as &dyn PastKvLenCache)
                 .unwrap_or(cache as &dyn PastKvLenCache),
             Some(self.max_seq_len),
-            DType::F32,
+            self.dtype,
             self.layers[0].n_head,
         )?;
         for (i, layer) in self.layers.iter().enumerate() {
@@ -400,7 +407,6 @@ impl ModelWeights {
             let ys = layer.mlp.forward(&ys)?;
             xs = (ys + residual)?
         }
-        let xs = xs.to_device(&self.device)?;
         let xs = xs.apply(&self.output_norm)?.i((.., seq_len - 1, ..))?;
         MatMul.qmatmul(&xs, &self.output)
     }

--- a/mistralrs-core/src/models/quantized_qwen2.rs
+++ b/mistralrs-core/src/models/quantized_qwen2.rs
@@ -51,6 +51,7 @@ struct LayerWeights {
     rotary: Arc<RotaryEmbedding>,
     paged_attn: Option<PagedAttention>,
     sdpa_params: SdpaParams,
+    dtype: DType,
 }
 
 impl LayerWeights {
@@ -65,9 +66,15 @@ impl LayerWeights {
     ) -> Result<Tensor> {
         let (b_sz, seq_len, n_embd) = x.dims3()?;
 
-        let q = MatMul.qmethod_matmul(x, &*self.attention_wq)?;
-        let k = MatMul.qmethod_matmul(x, &*self.attention_wk)?;
-        let v = MatMul.qmethod_matmul(x, &*self.attention_wv)?;
+        let q = MatMul
+            .qmethod_matmul(x, &*self.attention_wq)?
+            .to_dtype(self.dtype)?;
+        let k = MatMul
+            .qmethod_matmul(x, &*self.attention_wk)?
+            .to_dtype(self.dtype)?;
+        let v = MatMul
+            .qmethod_matmul(x, &*self.attention_wv)?
+            .to_dtype(self.dtype)?;
 
         let mut q = q.reshape((b_sz * seq_len, self.n_head, self.head_dim))?;
         let mut k = k.reshape((b_sz * seq_len, self.n_kv_head, self.head_dim))?;
@@ -128,7 +135,7 @@ impl LayerWeights {
             y.reshape(&[b_sz, seq_len, n_embd])?
         };
 
-        let y = MatMul.qmethod_matmul(&y, &*self.attention_wo)?;
+        let y = MatMul.qmethod_matmul(&y.to_dtype(x.dtype())?, &*self.attention_wo)?;
         Ok(y)
     }
 }
@@ -142,6 +149,7 @@ pub struct ModelWeights {
     pub cache: EitherCache,
     pub max_seq_len: usize,
     mapper: Option<Box<dyn DeviceMapper + Send + Sync>>,
+    dtype: DType,
 }
 
 // qwen2 `llm` fields:
@@ -214,6 +222,7 @@ impl ModelConfig::FromGGUF for ModelWeights {
         mapper: DeviceMapMetadata,
         topology: Option<&'_ Topology>,
         attention_mechanism: AttentionImplementation,
+        dtype: DType,
     ) -> Result<Self> {
         // Parameter extraction from metadata.
         let metadata = ContentMetadata {
@@ -262,7 +271,7 @@ impl ModelConfig::FromGGUF for ModelWeights {
                     max_seq_len,
                     device,
                     false,
-                    DType::F32,
+                    dtype,
                 )?),
             );
         }
@@ -353,6 +362,7 @@ impl ModelConfig::FromGGUF for ModelWeights {
                     softmax_scale: 1.0 / (head_dim as f32).sqrt(),
                     sliding_window: None,
                 },
+                dtype,
             })
         }
         Ok(Self {
@@ -367,6 +377,7 @@ impl ModelConfig::FromGGUF for ModelWeights {
             cache: EitherCache::Normal(NormalCache::new(block_count, max_seq_len)),
             max_seq_len,
             mapper: Some(mapper),
+            dtype,
         })
     }
 }
@@ -388,7 +399,7 @@ impl ModelWeights {
                 .as_ref()
                 .map(|(_, _)| &start_offsets as &dyn PastKvLenCache)
                 .unwrap_or(cache as &dyn PastKvLenCache),
-            DType::F32,
+            self.dtype,
             self.layers[0].n_head,
         )?;
         for (i, layer) in self.layers.iter().enumerate() {
@@ -419,7 +430,6 @@ impl ModelWeights {
             let x = (x + residual)?;
             layer_in = x;
         }
-        let layer_in = layer_in.to_device(&self.device)?;
         let x = self.norm.forward(&layer_in)?;
         extract_logits(
             &MatMul.qmethod_matmul(&x.contiguous()?, &*self.output)?,

--- a/mistralrs-core/src/models/quantized_starcoder2.rs
+++ b/mistralrs-core/src/models/quantized_starcoder2.rs
@@ -59,6 +59,7 @@ struct LayerWeights {
     rotary_emb: Arc<RotaryEmbedding>,
     paged_attn: Option<PagedAttention>,
     sdpa_params: SdpaParams,
+    dtype: DType,
 }
 
 impl LayerWeights {
@@ -73,9 +74,15 @@ impl LayerWeights {
     ) -> Result<Tensor> {
         let (b_sz, q_len, hidden_size) = x.dims3()?;
 
-        let q = MatMul.qmethod_matmul(x, &*self.attn_q)?;
-        let k = MatMul.qmethod_matmul(x, &*self.attn_k)?;
-        let v = MatMul.qmethod_matmul(x, &*self.attn_v)?;
+        let q = MatMul
+            .qmethod_matmul(x, &*self.attn_q)?
+            .to_dtype(self.dtype)?;
+        let k = MatMul
+            .qmethod_matmul(x, &*self.attn_k)?
+            .to_dtype(self.dtype)?;
+        let v = MatMul
+            .qmethod_matmul(x, &*self.attn_v)?
+            .to_dtype(self.dtype)?;
 
         let mut q = q.reshape((b_sz * q_len, self.n_head, self.head_dim))?;
         let mut k = k.reshape((b_sz * q_len, self.n_kv_head, self.head_dim))?;
@@ -136,7 +143,7 @@ impl LayerWeights {
             y.reshape(&[b_sz, q_len, hidden_size])?
         };
 
-        MatMul.qmethod_matmul(&y, &*self.attn_output)
+        MatMul.qmethod_matmul(&y.to_dtype(x.dtype())?, &*self.attn_output)
     }
 }
 
@@ -149,6 +156,7 @@ pub struct ModelWeights {
     pub device: Device,
     pub cache: EitherCache,
     pub max_seq_len: usize,
+    dtype: DType,
 }
 
 // starcoder2 `llm` fields:
@@ -202,6 +210,7 @@ impl ModelConfig::FromGGUF for ModelWeights {
         mapper: DeviceMapMetadata,
         topology: Option<&'_ Topology>,
         attention_mechanism: AttentionImplementation,
+        dtype: DType,
     ) -> Result<Self> {
         // Parameter extraction from metadata.
         let metadata = ContentMetadata {
@@ -242,7 +251,7 @@ impl ModelConfig::FromGGUF for ModelWeights {
                     context_window,
                     device,
                     true,
-                    DType::F32,
+                    dtype,
                 )?),
             );
         }
@@ -343,6 +352,7 @@ impl ModelConfig::FromGGUF for ModelWeights {
                     softmax_scale: 1.0 / (head_dim as f32).sqrt(),
                     sliding_window: None,
                 },
+                dtype,
             })
         }
         Ok(Self {
@@ -354,6 +364,7 @@ impl ModelConfig::FromGGUF for ModelWeights {
             device: device.clone(),
             cache: EitherCache::Normal(NormalCache::new(block_count, context_window)),
             max_seq_len: context_window,
+            dtype,
         })
     }
 }
@@ -375,7 +386,7 @@ impl ModelWeights {
                 .as_ref()
                 .map(|(_, _)| &seqlen_offsets as &dyn PastKvLenCache)
                 .unwrap_or(cache as &dyn PastKvLenCache),
-            DType::F32,
+            self.dtype,
             self.layers[0].n_head,
         )?;
         for (i, layer) in self.layers.iter().enumerate() {
@@ -402,7 +413,6 @@ impl ModelWeights {
             let ys = layer.mlp.forward(&ys)?;
             xs = (ys + residual)?
         }
-        let xs = xs.to_device(&self.device)?;
         let xs = xs.apply(&self.output_norm)?.i((.., seq_len - 1, ..))?;
         MatMul.qmatmul(&xs, &self.output)
     }

--- a/mistralrs-core/src/pipeline/gguf.rs
+++ b/mistralrs-core/src/pipeline/gguf.rs
@@ -41,7 +41,7 @@ use crate::{
     xlora_models::{XLoraQLlama, XLoraQPhi3},
 };
 use anyhow::{bail, Result};
-use candle_core::{DType, Device, Tensor};
+use candle_core::{Device, Tensor};
 use either::Either;
 use hf_hub::{api::sync::ApiBuilder, Repo, RepoType};
 use mistralrs_quant::IsqType;
@@ -327,7 +327,7 @@ impl Loader for GGUFLoader {
     fn load_model_from_path(
         &self,
         paths: &Box<dyn ModelPaths>,
-        _: &dyn TryIntoDType,
+        dtype: &dyn TryIntoDType,
         device: &Device,
         silent: bool,
         mapper: DeviceMapMetadata,
@@ -403,6 +403,7 @@ impl Loader for GGUFLoader {
         };
 
         let model_config_metadata: ContentConfig = (&model).into();
+        let internal_dtype = dtype.try_into_dtype(&[device]).unwrap();
 
         let model_config = {
             // Base config (quantization only):
@@ -414,6 +415,7 @@ impl Loader for GGUFLoader {
                 } else {
                     AttentionImplementation::Eager
                 },
+                internal_dtype,
             );
 
             // With optional adapter config:
@@ -459,11 +461,12 @@ impl Loader for GGUFLoader {
                 paged_attn_config.mem_gpu,
                 paged_attn_config.mem_cpu,
                 paged_attn_config.block_size,
-                DType::F32,
+                internal_dtype,
                 model_config,
                 device,
             )?;
-            let cache_engine = CacheEngine::new(model_config, &cache_config, DType::F32, device)?;
+            let cache_engine =
+                CacheEngine::new(model_config, &cache_config, internal_dtype, device)?;
             (Some(cache_config), Some(cache_engine))
         } else {
             (None, None)
@@ -538,7 +541,7 @@ impl Loader for GGUFLoader {
                 eos_tok: eos,
                 kind: self.kind.clone(),
                 is_xlora,
-                activation_dtype: DType::F32,
+                activation_dtype: internal_dtype,
                 sliding_window: None,
                 cache_config,
                 cache_engine,

--- a/mistralrs-core/src/pipeline/paths.rs
+++ b/mistralrs-core/src/pipeline/paths.rs
@@ -387,9 +387,9 @@ pub(crate) fn get_chat_template(
             // In this case the override chat template is being used. The user must add the bos/eos/unk toks themselves.
             info!("Using literal chat template.");
             let mut template = ChatTemplate::default();
-            if chat_template.find("<|end|>").is_some() {
+            if chat_template.contains("<|end|>") {
                 template.eos_token = Some(BeginEndUnkTok(Either::Left("<|end|>".to_string())));
-            } else if chat_template.find("<|endoftext|>").is_some() {
+            } else if chat_template.contains("<|endoftext|>") {
                 template.eos_token =
                     Some(BeginEndUnkTok(Either::Left("<|endoftext|>".to_string())));
             }

--- a/mistralrs-core/src/pipeline/paths.rs
+++ b/mistralrs-core/src/pipeline/paths.rs
@@ -14,7 +14,6 @@ use regex_automata::meta::Regex;
 use serde_json::Value;
 use tracing::{info, warn};
 
-use super::chat_template::BeginEndUnkTok;
 use crate::{
     api_dir_list, api_get_file,
     lora::LoraConfig,
@@ -387,12 +386,6 @@ pub(crate) fn get_chat_template(
             // In this case the override chat template is being used. The user must add the bos/eos/unk toks themselves.
             info!("Using literal chat template.");
             let mut template = ChatTemplate::default();
-            if chat_template.contains("<|end|>") {
-                template.eos_token = Some(BeginEndUnkTok(Either::Left("<|end|>".to_string())));
-            } else if chat_template.contains("<|endoftext|>") {
-                template.eos_token =
-                    Some(BeginEndUnkTok(Either::Left("<|endoftext|>".to_string())));
-            }
             template.chat_template = Some(ChatTemplateValue(Either::Left(chat_template)));
             template
         }

--- a/mistralrs-core/src/toml_selector.rs
+++ b/mistralrs-core/src/toml_selector.rs
@@ -134,6 +134,10 @@ pub enum TomlModelSelected {
         /// May be a single filename, or use a delimiter of " " (a single space) for multiple files.
         quantized_filename: String,
 
+        /// Model data type. Defaults to `auto`.
+        #[serde(default = "default_dtype")]
+        dtype: ModelDType,
+
         /// Path to a topology YAML file.
         topology: Option<String>,
     },
@@ -208,6 +212,10 @@ pub enum TomlModelSelected {
         /// GQA value
         #[serde(default = "default_one")]
         gqa: usize,
+
+        /// Model data type. Defaults to `auto`.
+        #[serde(default = "default_dtype")]
+        dtype: ModelDType,
 
         /// Path to a topology YAML file.
         topology: Option<String>,
@@ -366,10 +374,10 @@ pub fn get_toml_selected_model_dtype(model: &TomlSelector) -> ModelDType {
         TomlModelSelected::Plain { dtype, .. }
         | TomlModelSelected::Lora { dtype, .. }
         | TomlModelSelected::XLora { dtype, .. }
-        | TomlModelSelected::VisionPlain { dtype, .. } => dtype,
-        TomlModelSelected::GGUF { .. }
-        | TomlModelSelected::LoraGGUF { .. }
-        | TomlModelSelected::GGML { .. }
+        | TomlModelSelected::VisionPlain { dtype, .. }
+        | TomlModelSelected::GGUF { dtype, .. }
+        | TomlModelSelected::GGML { dtype, .. } => dtype,
+        TomlModelSelected::LoraGGUF { .. }
         | TomlModelSelected::LoraGGML { .. }
         | TomlModelSelected::XLoraGGUF { .. }
         | TomlModelSelected::XLoraGGML { .. } => ModelDType::Auto,
@@ -480,6 +488,7 @@ fn loader_from_selected(
             quantized_model_id,
             quantized_filename,
             topology,
+            dtype: _,
         } => GGUFLoaderBuilder::new(
             args.chat_template,
             Some(tok_model_id),
@@ -559,6 +568,7 @@ fn loader_from_selected(
             quantized_filename,
             gqa,
             topology,
+            dtype: _,
         } => GGMLLoaderBuilder::new(
             GGMLSpecificConfig {
                 gqa,

--- a/mistralrs-core/src/toml_selector.rs
+++ b/mistralrs-core/src/toml_selector.rs
@@ -167,6 +167,10 @@ pub enum TomlModelSelected {
         /// This makes the maximum running sequences 1.
         tgt_non_granular_index: Option<usize>,
 
+        /// Model data type. Defaults to `auto`.
+        #[serde(default = "default_dtype")]
+        dtype: ModelDType,
+
         /// Path to a topology YAML file.
         topology: Option<String>,
     },
@@ -246,6 +250,10 @@ pub enum TomlModelSelected {
         /// GQA value
         #[serde(default = "default_one")]
         gqa: usize,
+
+        /// Model data type. Defaults to `auto`.
+        #[serde(default = "default_dtype")]
+        dtype: ModelDType,
 
         /// Path to a topology YAML file.
         topology: Option<String>,
@@ -376,11 +384,10 @@ pub fn get_toml_selected_model_dtype(model: &TomlSelector) -> ModelDType {
         | TomlModelSelected::XLora { dtype, .. }
         | TomlModelSelected::VisionPlain { dtype, .. }
         | TomlModelSelected::GGUF { dtype, .. }
-        | TomlModelSelected::GGML { dtype, .. } => dtype,
-        TomlModelSelected::LoraGGUF { .. }
-        | TomlModelSelected::LoraGGML { .. }
-        | TomlModelSelected::XLoraGGUF { .. }
-        | TomlModelSelected::XLoraGGML { .. } => ModelDType::Auto,
+        | TomlModelSelected::GGML { dtype, .. }
+        | TomlModelSelected::XLoraGGUF { dtype, .. }
+        | TomlModelSelected::XLoraGGML { dtype, .. } => dtype,
+        TomlModelSelected::LoraGGUF { .. } | TomlModelSelected::LoraGGML { .. } => ModelDType::Auto,
     }
 }
 
@@ -511,6 +518,7 @@ fn loader_from_selected(
             order,
             tgt_non_granular_index,
             topology,
+            ..
         } => GGUFLoaderBuilder::new(
             args.chat_template,
             tok_model_id,
@@ -591,6 +599,7 @@ fn loader_from_selected(
             tgt_non_granular_index,
             gqa,
             topology,
+            ..
         } => GGMLLoaderBuilder::new(
             GGMLSpecificConfig {
                 gqa,

--- a/mistralrs-core/src/toml_selector.rs
+++ b/mistralrs-core/src/toml_selector.rs
@@ -196,6 +196,10 @@ pub enum TomlModelSelected {
         /// Ordering JSON file
         order: String,
 
+        /// Model data type. Defaults to `auto`.
+        #[serde(default = "default_dtype")]
+        dtype: ModelDType,
+
         /// Path to a topology YAML file.
         topology: Option<String>,
     },
@@ -280,6 +284,10 @@ pub enum TomlModelSelected {
         /// GQA value
         #[serde(default = "default_one")]
         gqa: usize,
+
+        /// Model data type. Defaults to `auto`.
+        #[serde(default = "default_dtype")]
+        dtype: ModelDType,
 
         /// Path to a topology YAML file.
         topology: Option<String>,
@@ -386,8 +394,9 @@ pub fn get_toml_selected_model_dtype(model: &TomlSelector) -> ModelDType {
         | TomlModelSelected::GGUF { dtype, .. }
         | TomlModelSelected::GGML { dtype, .. }
         | TomlModelSelected::XLoraGGUF { dtype, .. }
-        | TomlModelSelected::XLoraGGML { dtype, .. } => dtype,
-        TomlModelSelected::LoraGGUF { .. } | TomlModelSelected::LoraGGML { .. } => ModelDType::Auto,
+        | TomlModelSelected::XLoraGGML { dtype, .. }
+        | TomlModelSelected::LoraGGUF { dtype, .. }
+        | TomlModelSelected::LoraGGML { dtype, .. } => dtype,
     }
 }
 
@@ -549,6 +558,7 @@ fn loader_from_selected(
             adapters_model_id,
             order,
             topology,
+            ..
         } => GGUFLoaderBuilder::new(
             args.chat_template,
             tok_model_id,
@@ -630,6 +640,7 @@ fn loader_from_selected(
             order,
             gqa,
             topology,
+            ..
         } => GGMLLoaderBuilder::new(
             GGMLSpecificConfig {
                 gqa,

--- a/mistralrs-core/src/utils/model_config.rs
+++ b/mistralrs-core/src/utils/model_config.rs
@@ -1,6 +1,6 @@
 use super::varbuilder_utils::{from_mmaped_safetensors, load_preload_adapters};
 use anyhow::Result;
-use candle_core::quantized::ggml_file;
+use candle_core::{quantized::ggml_file, DType};
 use candle_nn::VarBuilder;
 use std::{collections::HashMap, path::PathBuf};
 
@@ -17,6 +17,7 @@ use crate::{
 pub struct FileGGML {
     pub ct: ggml_file::Content,
     pub gqa: usize,
+    pub dtype: DType,
 }
 
 #[derive(derive_more::From)]
@@ -97,6 +98,7 @@ pub struct ParamsGGUF<'a, R: std::io::Seek + std::io::Read>(
     pub Content<'a, R>,
     pub Device<'a>,
     pub AttentionImplementation,
+    pub DType,
 );
 
 // A `None` type vs the `Some` type (`Adapter<'a>`)
@@ -151,7 +153,11 @@ impl<'a, Q: QuantParams> ModelParams<'a, Q> {
 // Traits for the existing methods used across various model types to impl `from_ggml()` / `from_gguf()`
 // Basic:
 pub trait FromGGML {
-    fn from_ggml(ct: ggml_file::Content, gqa: usize) -> Result<Self, candle_core::Error>
+    fn from_ggml(
+        ct: ggml_file::Content,
+        gqa: usize,
+        dtype: DType,
+    ) -> Result<Self, candle_core::Error>
     where
         Self: Sized;
 }
@@ -163,6 +169,7 @@ pub trait FromGGUF {
         mapper: DeviceMapMetadata,
         topology: Option<&Topology>,
         attention_mechanism: AttentionImplementation,
+        dtype: DType,
     ) -> Result<Self, candle_core::Error>
     where
         Self: Sized;
@@ -178,6 +185,7 @@ pub trait FromAdapterGGML {
         ordering: &Ordering,
         xlora_config: Option<XLoraConfig>,
         preload_adapters: &Option<HashMap<String, (VarBuilder, LoraConfig)>>,
+        dtype: DType,
     ) -> Result<Self, candle_core::Error>
     where
         Self: Sized;
@@ -194,6 +202,7 @@ pub trait FromAdapterGGUF {
         mapper: DeviceMapMetadata,
         topology: Option<&Topology>,
         preload_adapters: &Option<HashMap<String, (VarBuilder, LoraConfig)>>,
+        dtype: DType,
     ) -> Result<Self, candle_core::Error>
     where
         Self: Sized;
@@ -203,17 +212,17 @@ pub trait FromAdapterGGUF {
 impl Config<ParamsGGML, NoAdapter> {
     pub fn try_into_model<T: FromGGML>(self) -> Result<T, candle_core::Error> {
         // Destructure props:
-        let ParamsGGML(FileGGML { ct, gqa }) = self.quant;
+        let ParamsGGML(FileGGML { ct, gqa, dtype }) = self.quant;
 
         // Forwards all structured fields above into the required flattened param sequence:
-        T::from_ggml(ct, gqa)
+        T::from_ggml(ct, gqa, dtype)
     }
 }
 
 impl Config<ParamsGGML, Adapter<'_>> {
     pub fn try_into_model<T: FromAdapterGGML>(self) -> Result<T, candle_core::Error> {
         // Destructure props:
-        let ParamsGGML(FileGGML { ct, gqa }) = self.quant;
+        let ParamsGGML(FileGGML { ct, gqa, dtype }) = self.quant;
 
         let Adapter {
             xlora_config,
@@ -232,6 +241,7 @@ impl Config<ParamsGGML, Adapter<'_>> {
             ordering,
             xlora_config,
             &preload_adapters,
+            dtype,
         )
     }
 }
@@ -247,10 +257,18 @@ impl<R: std::io::Seek + std::io::Read> Config<ParamsGGUF<'_, R>, NoAdapter> {
                 topology,
             },
             attention_implementation,
+            dtype,
         ) = self.quant;
 
         // Forwards all structured fields above into the required flattened param sequence:
-        T::from_gguf(ct, device, mapper, topology, attention_implementation)
+        T::from_gguf(
+            ct,
+            device,
+            mapper,
+            topology,
+            attention_implementation,
+            dtype,
+        )
     }
 }
 
@@ -265,6 +283,7 @@ impl<R: std::io::Seek + std::io::Read> Config<ParamsGGUF<'_, R>, Adapter<'_>> {
                 topology,
             },
             _attention_implementation,
+            dtype,
         ) = self.quant;
 
         let Adapter {
@@ -286,6 +305,7 @@ impl<R: std::io::Seek + std::io::Read> Config<ParamsGGUF<'_, R>, Adapter<'_>> {
             mapper,
             topology,
             &preload_adapters,
+            dtype,
         )
     }
 }

--- a/mistralrs-core/src/utils/model_config.rs
+++ b/mistralrs-core/src/utils/model_config.rs
@@ -177,6 +177,7 @@ pub trait FromGGUF {
 
 // Extended variants:
 pub trait FromAdapterGGML {
+    #[allow(clippy::too_many_arguments)]
     fn from_ggml(
         ct: ggml_file::Content,
         gqa: usize,

--- a/mistralrs-core/src/xlora_models/quantized_phi3.rs
+++ b/mistralrs-core/src/xlora_models/quantized_phi3.rs
@@ -95,6 +95,7 @@ struct LayerWeights {
     sin: Tensor,
     sliding_window: usize,
     sdpa_params: SdpaParams,
+    dtype: DType,
 }
 
 impl LayerWeights {
@@ -126,12 +127,10 @@ impl LayerWeights {
         flash_params: &FlashParams,
     ) -> Result<Tensor> {
         let (b_sz, seq_len, n_embd) = x.dims3()?;
-        let qkv = self.attn_qkv.lora_forward(
-            x,
-            scalings.clone(),
-            global_scaling_weight,
-            is_scaling_pass,
-        )?;
+        let qkv = self
+            .attn_qkv
+            .lora_forward(x, scalings.clone(), global_scaling_weight, is_scaling_pass)?
+            .to_dtype(self.dtype)?;
 
         let query_pos = self.n_head * self.head_dim;
         let q = qkv.narrow(D::Minus1, 0, query_pos)?;
@@ -182,9 +181,12 @@ impl LayerWeights {
         )?;
 
         let y = y.transpose(1, 2)?.reshape(&[b_sz, seq_len, n_embd])?;
-        let y =
-            self.attn_output
-                .lora_forward(&y, scalings, global_scaling_weight, is_scaling_pass)?;
+        let y = self.attn_output.lora_forward(
+            &y.to_dtype(x.dtype())?,
+            scalings,
+            global_scaling_weight,
+            is_scaling_pass,
+        )?;
         Ok(y)
     }
 }
@@ -199,6 +201,7 @@ pub struct ModelWeights {
     pub cache: EitherCache,
     pub max_seq_len: usize,
     xlora_classifier: Option<XLoraClassifier>,
+    dtype: DType,
 }
 
 fn precomput_freqs_cis(
@@ -206,6 +209,7 @@ fn precomput_freqs_cis(
     freq_base: f32,
     device: &Device,
     context_window: usize,
+    dtype: DType,
 ) -> Result<(Tensor, Tensor)> {
     let theta: Vec<_> = (0..head_dim)
         .step_by(2)
@@ -216,8 +220,8 @@ fn precomput_freqs_cis(
         .to_dtype(DType::F32)?
         .reshape((context_window, 1))?
         .matmul(&theta.reshape((1, theta.elem_count()))?)?;
-    let cos = idx_theta.cos()?;
-    let sin = idx_theta.sin()?;
+    let cos = idx_theta.cos()?.to_dtype(dtype)?;
+    let sin = idx_theta.sin()?.to_dtype(dtype)?;
     Ok((cos, sin))
 }
 
@@ -233,6 +237,7 @@ impl ModelConfig::FromAdapterGGUF for ModelWeights {
         mapper: DeviceMapMetadata,
         topology: Option<&'_ Topology>,
         preload_adapters: &Option<HashMap<String, (VarBuilder, LoraConfig)>>,
+        dtype: DType,
     ) -> Result<Self> {
         verify_sanity_adapters(ordering, &SUPPORTED_LAYERS)?;
 
@@ -252,7 +257,7 @@ impl ModelConfig::FromAdapterGGUF for ModelWeights {
             context_window,
         } = PropsGGUF::try_from(metadata).or_else(|err| candle_core::bail!("{err}"))?;
 
-        let (cos, sin) = precomput_freqs_cis(rope_dim, 10_000., device, context_window)?;
+        let (cos, sin) = precomput_freqs_cis(rope_dim, 10_000., device, context_window, dtype)?;
 
         let tok_embeddings = ct.tensor("token_embd.weight", device)?;
         let tok_embeddings = tok_embeddings.dequantize(device)?;
@@ -343,6 +348,7 @@ impl ModelConfig::FromAdapterGGUF for ModelWeights {
                     softmax_scale: 1.0 / (head_dim as f32).sqrt(),
                     sliding_window: Some(context_window),
                 },
+                dtype,
             })
         }
         if xlora_config.is_none() {
@@ -383,6 +389,7 @@ impl ModelConfig::FromAdapterGGUF for ModelWeights {
                 XLoraClassifier::new(xlora_config, count, lora_config.len(), vb.clone(), true)
                     .unwrap()
             }),
+            dtype,
         })
     }
 }
@@ -431,7 +438,7 @@ impl ModelWeights {
             input_ids,
             &*cache,
             Some(self.max_seq_len),
-            DType::F32,
+            self.dtype,
             self.layers[0].n_head,
         )?;
         for (i, layer) in self.layers.iter().enumerate() {

--- a/mistralrs-server/src/main.rs
+++ b/mistralrs-server/src/main.rs
@@ -143,7 +143,7 @@ struct Args {
     no_paged_attn: bool,
 
     /// Enable PagedAttention on Metal. Because PagedAttention is already enabled on CUDA, this is only applicable on Metal.
-    #[arg(long = "no-paged-attn", default_value_t = false)]
+    #[arg(long = "paged-attn", default_value_t = false)]
     paged_attn: bool,
 
     /// Enable server throughput logging, supported in the server and with interactive mode


### PR DESCRIPTION
The current approach for inference of GGUF/GGML models requires the input data type to be `F32` due to limitations in kernel implementations for quantized matmul, which necessitate an `F32` input and quantized weights. This limitation causes side effects, making attention mechanisms (including SDPA, paged attention, and flash attention) and the KV cache also to be `F32`.  

This PR addresses the issue by allowing the data type to be specified for GGUF/GGML models and casting the `F32` results of quantized matmuls to `BF16`. This casting applies to subsequent attention operations, rotary embeddings, and KV cache storage. As a result, KV cache usage is reduced by half, and inference performance is improved due to the use of `BF16` for matmuls and attentions.

### Example

On Apple Silicon (`Metal`), run the following example with throughput logging enabled, paged attention settings (limiting KV cache to a maximum of 4GB), and data type set to `BF16` (for KV cache, rotary embeddings, and attentions):

```bash
cargo build --release --features metal
./target/release/mistralrs-server -i --throughput --paged-attn --pa-gpu-mem 4096 gguf --dtype bf16 -m /Users/Downloads/ -f Phi-3.5-mini-instruct-Q4_K_M.gguf
```

You may also run without paged attention:
```bash
./target/release/mistralrs-server -i --throughput gguf --dtype bf16 -m /Users/Downloads/ -f Phi-3.5-mini-instruct-Q4_K_M.gguf
```

### Notes

- For quantized GGUF/GGML models, you may specify the data type as either `f32` or `bf16`. 
- The use of `f16` is not recommended due to its lower precision, which can adversely impact the precision of quantized inference.
