### PR TITLE
#1008: Working <|image|> injection

### DIFF
--- a/mistralrs-server/src/chat_completion.rs
+++ b/mistralrs-server/src/chat_completion.rs
@@ -217,10 +217,15 @@ async fn parse_request(
                             if image_messages[text_idx]["text"].is_right() {
                                 anyhow::bail!("Expected string value in `text`.");
                             }
-                            let content = image_messages[text_idx]["text"]
+                            let content_original = image_messages[text_idx]["text"]
                                 .as_ref()
                                 .unwrap_left()
                                 .clone();
+                            let content = if content_original.contains("<|image|>") {
+                                content_original
+                            } else {
+                                format!("<|image|> {}", content_original)
+                            };
                             if image_messages[url_idx]["image_url"].is_left()
                                 || !image_messages[url_idx]["image_url"]
                                     .as_ref()


### PR DESCRIPTION
I had trouble getting the latest `master` to work, so I branched off `b38c72c` since that was the last published Docker image. I was able to get image payloads working without needing to include `<|image|>` in the text part. I seem to run out of CUDA memory if I try a second image, but this will work for my single-image payload needs for now. I suspect I am wasting memory by duplicating the content per message, so some pointers on optimal rust would be appreciated or feel free to tweak this as needed.

I know mllama expects the `<|image|>` token in there. If any backends DONT expect the token in there, you might need to move this into the mllama backend itself to take care of its own need for such a token. Either way, I will be using this branch on my fork for myself, but I hope you can find it useful for #1008 if you the use case and approach is compelling. Thanks!