### PR TITLE
Patch prefix caching to fix incorrect outputs

### DIFF
--- a/mistralrs-core/src/engine/mod.rs
+++ b/mistralrs-core/src/engine/mod.rs
@@ -82,12 +82,12 @@ impl Engine {
         no_kv_cache |= get_mut_arcmutex!(pipeline).get_metadata().no_kv_cache;
 
         // TODO: We need a nice fix, when prefix caching is enabled setting the non-PA pre op to
+        // Nothing makes it work but breaks all other cases. This requires more investigation!!
         // no_prefix_cache |= get_mut_arcmutex!(pipeline).get_metadata().no_prefix_cache;
         // TODO: Prefix caching is always disabled if using PagedAttention for now.
         // let no_prefix_cache = matches!(config, SchedulerConfig::PagedAttentionMeta { .. })
         //     || no_prefix_cache
         //     || no_kv_cache;
-        // Nothing makes it work but breaks all other cases. This requires more investigation!!
         let no_prefix_cache = true;
         Self {
             rx,


### PR DESCRIPTION
We need a nice fix, this just disables the prefix cacher when prefix caching is enabled, setting the non-PA pre op to `Nothing` makes it work but breaks many other cases as reported in #1026 and actually even #1025. This requires more investigation!!

Reverts #1019.