### PR TITLE
Fix `--cpu` on cuda

### DIFF
--- a/mistralrs-server/src/main.rs
+++ b/mistralrs-server/src/main.rs
@@ -485,7 +485,8 @@ async fn main() -> Result<()> {
         .with_opt_log(args.log)
         .with_truncate_sequence(args.truncate_sequence)
         .with_no_kv_cache(args.no_kv_cache)
-        .with_prefix_cache_n(args.prefix_cache_n);
+        .with_prefix_cache_n(args.prefix_cache_n)
+        .with_gemm_full_precision_f16(args.cpu);
 
     if args.interactive_mode {
         interactive_mode(builder.build(), args.throughput_log).await;


### PR DESCRIPTION
First mentioned [here](https://github.com/EricLBuehler/mistral.rs/pull/997#issuecomment-2556723000).

2 error cases occur when `--cpu` is used with a CUDA build:
1. If no CUDA device exists:
```
thread 'main' panicked at mistralrs-core/src/lib.rs:253:69:
called `Result::unwrap()` on an `Err` value: WithBacktrace { inner: Cuda(Cuda(DriverError(CUDA_ERROR_NO_DEVICE, "no CUDA-capable device is detected"))), backtrace: Backtrace [{ fn: "candle_core::error::Error::bt" }, { fn: "<candle_core::cuda_backend::device::CudaDevice as candle_core::backend::BackendDevice>::new" }, { fn: "candle_core::device::Device::new_cuda" }, { fn: "mistralrs_core::MistralRsBuilder::build" }, { fn: "mistralrs_server::main::{{closure}}" }, { fn: "tokio::runtime::park::CachedParkThread::block_on" }, { fn: "mistralrs_server::main" }, { fn: "std::sys::backtrace::__rust_begin_short_backtrace" }, { fn: "std::rt::lang_start::{{closure}}" }, { fn: "std::rt::lang_start_internal" }, { fn: "main" }, { fn: "__libc_start_main" }, { fn: "_start" }] }
```
2. If a CUDA device exists but has very little free memory:
```
thread 'main' panicked at mistralrs-core/src/lib.rs:266:68:
called `Result::unwrap()` on an `Err` value: WithBacktrace { inner: Cuda(Cublas(CublasError(CUBLAS_STATUS_ALLOC_FAILED))), backtrace: Backtrace [{ fn: "candle_core::error::Error::bt" }, { fn: "<candle_core::cuda_backend::device::CudaDevice as candle_core::backend::BackendDevice>::new" }, { fn: "candle_core::device::Device::new_cuda" }, { fn: "mistralrs_core::MistralRsBuilder::build" }, { fn: "mistralrs_server::main::{{closure}}" }, { fn: "tokio::runtime::park::CachedParkThread::block_on" }, { fn: "mistralrs_server::main" }, { fn: "std::sys::backtrace::__rust_begin_short_backtrace" }, { fn: "std::rt::lang_start::{{closure}}" }, { fn: "std::rt::lang_start_internal" }, { fn: "main" }, { fn: "__libc_start_main" }, { fn: "_start" }] }
```

This PR resolves both issues by disabling GEMM when running solely on CPU.