### PR TITLE
Paged attention support for multi gpu

### DIFF
--- a/mistralrs-core/src/dummy_paged_attention/config.rs
+++ b/mistralrs-core/src/dummy_paged_attention/config.rs
@@ -1,4 +1,5 @@
 pub trait ModelConfigLike {
+    fn max_seq_len(&self) -> usize;
     fn num_layers(&self) -> usize;
     fn hidden_size(&self) -> usize;
     fn num_kv_heads(&self) -> usize;
@@ -13,6 +14,7 @@ pub trait ModelConfigLike {
 
 #[derive(Clone)]
 pub struct ModelConfigMetadata {
+    pub max_seq_len: usize,
     pub num_layers: usize,
     pub hidden_size: usize,
     pub num_kv_heads: usize,
@@ -23,6 +25,9 @@ pub struct ModelConfigMetadata {
 }
 
 impl ModelConfigLike for ModelConfigMetadata {
+    fn max_seq_len(&self) -> usize {
+        self.max_seq_len
+    }
     fn hidden_size(&self) -> usize {
         self.hidden_size
     }

--- a/mistralrs-core/src/dummy_paged_attention/mod.rs
+++ b/mistralrs-core/src/dummy_paged_attention/mod.rs
@@ -21,9 +21,6 @@ pub use scheduler::{
     PagedAttentionScheduler, PagedAttentionSchedulerConfig, PagedAttentionSchedulerOutput,
 };
 
-use crate::MemoryUsage;
-use tracing::info;
-
 /// All memory counts in MB. Default for block size is 32.
 #[derive(Clone, Copy)]
 pub struct PagedAttentionConfig {
@@ -55,73 +52,15 @@ pub enum MemoryGpuConfig {
     ContextSize(usize),
 }
 
-// See `pagedattention.cu` CALL_V1_LAUNCHER_BLOCK_SIZE
-const SUPPORTED_BLOCK_SIZE: &[usize] = &[8, 16, 32];
-
-const SIZE_IN_MB: usize = 1024 * 1024;
-
-macro_rules! mb_to_blocks {
-    ($mb_size:expr, $dtype_size:expr, $block_size:expr, $config:expr) => {
-        $mb_size
-            / $dtype_size
-            / $block_size
-            / $config.num_kv_heads()
-            / ($config.hidden_size() / $config.num_attn_heads())
-            / $config.num_layers()
-            / 2
-    };
-}
-
-macro_rules! ctxt_to_blocks {
-    ($context_len:expr, $dtype_size:expr, $block_size:expr, $config:expr) => {
-        $context_len
-            * $dtype_size
-            * $config.num_kv_heads()
-            * ($config.hidden_size() / $config.num_attn_heads())
-            * $config.num_layers()
-            * 2
-    };
-}
-
 /// Memory values are in MBs or a percentage in [0,1]. Specify block size or the default is 32.
 pub fn calculate_cache_config(
-    mem_gpu: MemoryGpuConfig,
-    mem_cpu: usize,
-    block_size: Option<usize>,
-    dtype: DType,
-    config: &dyn ModelConfigLike,
-    device: &Device,
+    _mem_gpu: MemoryGpuConfig,
+    _mem_cpu: usize,
+    _block_size: Option<usize>,
+    _dtype: DType,
+    _config: &dyn ModelConfigLike,
+    _device: &Device,
+    _layer_devices: &[Option<Device>],
 ) -> anyhow::Result<CacheConfig> {
-    let block_size = block_size.unwrap_or(32);
-    if !SUPPORTED_BLOCK_SIZE.contains(&block_size) {
-        anyhow::bail!("Block size must be in {SUPPORTED_BLOCK_SIZE:?}, got {block_size}");
-    }
-    let dtype_size = dtype.size_in_bytes();
-
-    #[allow(clippy::cast_possible_truncation, clippy::cast_precision_loss)]
-    let mem_gpu = match mem_gpu {
-        MemoryGpuConfig::MbAmount(v) => v,
-        MemoryGpuConfig::Utilization(f) => {
-            let free = MemoryUsage.get_memory_available(device)? as f32 / SIZE_IN_MB as f32;
-            let total = MemoryUsage.get_total_memory(device)? as f32 / SIZE_IN_MB as f32;
-            let used = total - free;
-            (total * f - used) as usize
-        }
-        MemoryGpuConfig::ContextSize(toks) => {
-            ctxt_to_blocks!(toks, dtype_size, block_size, config) / SIZE_IN_MB
-        }
-    };
-    info!("Allocating {mem_gpu} MB for PagedAttention KV cache");
-
-    let num_gpu_blocks = mb_to_blocks!(mem_gpu * SIZE_IN_MB, dtype_size, block_size, config);
-    let num_cpu_blocks = mb_to_blocks!(mem_cpu * SIZE_IN_MB, dtype_size, block_size, config);
-    if num_gpu_blocks == 0 {
-        anyhow::bail!("Num GPU blocks is 0. This means there is not enough memory. Either reduce the memory amount/utilization/context size or disable PagedAttention.");
-    }
-    info!("Using PagedAttention with block size {block_size} and {num_gpu_blocks} GPU blocks: available context length is {} tokens", num_gpu_blocks*block_size);
-    Ok(CacheConfig {
-        block_size,
-        num_gpu_blocks,
-        num_cpu_blocks,
-    })
+    anyhow::bail!("Cannot calculate cache config when not using PagedAttention.")
 }

--- a/mistralrs-core/src/models/deepseek2.rs
+++ b/mistralrs-core/src/models/deepseek2.rs
@@ -804,6 +804,7 @@ impl DeepSeekV2 {
             device: normal_loading_metadata.real_device.clone(),
             max_seq_len: cfg.max_position_embeddings,
             cfg: ModelConfigMetadata {
+                max_seq_len: cfg.max_position_embeddings,
                 num_layers: cfg.num_hidden_layers,
                 hidden_size: cfg.hidden_size,
                 num_kv_heads: cfg.num_attention_heads,

--- a/mistralrs-core/src/models/gemma.rs
+++ b/mistralrs-core/src/models/gemma.rs
@@ -552,6 +552,7 @@ impl Model {
             max_seq_len: default_max_position_embeddings(),
             mapper,
             cfg: ModelConfigMetadata {
+                max_seq_len: cfg.max_position_embeddings,
                 num_layers: cfg.num_hidden_layers,
                 hidden_size: cfg.hidden_size,
                 num_kv_heads: cfg.num_key_value_heads,

--- a/mistralrs-core/src/models/gemma2.rs
+++ b/mistralrs-core/src/models/gemma2.rs
@@ -600,6 +600,7 @@ impl Model {
             sliding_window: cfg.sliding_window,
             final_logit_softcapping: cfg.final_logit_softcapping,
             cfg: ModelConfigMetadata {
+                max_seq_len: cfg.max_position_embeddings,
                 num_layers: cfg.num_hidden_layers,
                 hidden_size: cfg.hidden_size,
                 num_kv_heads: cfg.num_key_value_heads,

--- a/mistralrs-core/src/models/llama.rs
+++ b/mistralrs-core/src/models/llama.rs
@@ -542,6 +542,7 @@ impl Llama {
             device: normal_loading_metadata.real_device,
             mapper,
             cfg: ModelConfigMetadata {
+                max_seq_len: cfg.max_position_embeddings,
                 num_layers: cfg.num_hidden_layers,
                 hidden_size: cfg.hidden_size,
                 num_kv_heads: cfg.num_key_value_heads,

--- a/mistralrs-core/src/models/mistral.rs
+++ b/mistralrs-core/src/models/mistral.rs
@@ -564,6 +564,7 @@ impl Model {
             max_seq_len: cfg.max_position_embeddings,
             mapper,
             cfg: ModelConfigMetadata {
+                max_seq_len: cfg.max_position_embeddings,
                 num_layers: cfg.num_hidden_layers,
                 hidden_size: cfg.hidden_size,
                 num_kv_heads: cfg.num_key_value_heads,

--- a/mistralrs-core/src/models/mixtral.rs
+++ b/mistralrs-core/src/models/mixtral.rs
@@ -596,6 +596,7 @@ impl Model {
             max_seq_len: cfg.max_position_embeddings,
             mapper,
             cfg: ModelConfigMetadata {
+                max_seq_len: cfg.max_position_embeddings,
                 num_layers: cfg.num_hidden_layers,
                 hidden_size: cfg.hidden_size,
                 num_kv_heads: cfg.num_key_value_heads,

--- a/mistralrs-core/src/models/phi2.rs
+++ b/mistralrs-core/src/models/phi2.rs
@@ -527,6 +527,7 @@ impl Model {
             max_seq_len: cfg.max_position_embeddings,
             mapper,
             cfg: ModelConfigMetadata {
+                max_seq_len: cfg.max_position_embeddings,
                 num_layers: cfg.num_hidden_layers,
                 hidden_size: cfg.hidden_size,
                 num_kv_heads: cfg.num_key_value_heads(),

--- a/mistralrs-core/src/models/phi3.rs
+++ b/mistralrs-core/src/models/phi3.rs
@@ -529,6 +529,7 @@ impl Model {
             mapper,
             sliding_window: cfg.sliding_window,
             cfg: ModelConfigMetadata {
+                max_seq_len: cfg.max_position_embeddings,
                 num_layers: cfg.num_hidden_layers,
                 hidden_size: cfg.hidden_size,
                 num_kv_heads: cfg.num_key_value_heads,

--- a/mistralrs-core/src/models/phi3_5_moe.rs
+++ b/mistralrs-core/src/models/phi3_5_moe.rs
@@ -651,6 +651,7 @@ impl Model {
             mapper,
             sliding_window: cfg.sliding_window,
             cfg: ModelConfigMetadata {
+                max_seq_len: cfg.max_position_embeddings,
                 num_layers: cfg.num_hidden_layers,
                 hidden_size: cfg.hidden_size,
                 num_kv_heads: cfg.num_key_value_heads,

--- a/mistralrs-core/src/models/qwen2.rs
+++ b/mistralrs-core/src/models/qwen2.rs
@@ -536,6 +536,7 @@ impl Model {
             max_seq_len: cfg.max_position_embeddings,
             mapper,
             cfg: ModelConfigMetadata {
+                max_seq_len: cfg.max_position_embeddings,
                 num_layers: cfg.num_hidden_layers,
                 hidden_size: cfg.hidden_size,
                 num_kv_heads: cfg.num_key_value_heads,

--- a/mistralrs-core/src/models/starcoder2.rs
+++ b/mistralrs-core/src/models/starcoder2.rs
@@ -517,6 +517,7 @@ impl Model {
             max_seq_len: cfg.max_position_embeddings,
             mapper,
             cfg: ModelConfigMetadata {
+                max_seq_len: cfg.max_position_embeddings,
                 num_layers: cfg.num_hidden_layers,
                 hidden_size: cfg.hidden_size,
                 num_kv_heads: cfg.num_key_value_heads,

--- a/mistralrs-core/src/paged_attention/config.rs
+++ b/mistralrs-core/src/paged_attention/config.rs
@@ -1,4 +1,5 @@
 pub trait ModelConfigLike {
+    fn max_seq_len(&self) -> usize;
     fn num_layers(&self) -> usize;
     fn hidden_size(&self) -> usize;
     fn num_kv_heads(&self) -> usize;
@@ -13,6 +14,7 @@ pub trait ModelConfigLike {
 
 #[derive(Clone)]
 pub struct ModelConfigMetadata {
+    pub max_seq_len: usize,
     pub num_layers: usize,
     pub hidden_size: usize,
     pub num_kv_heads: usize,
@@ -23,6 +25,9 @@ pub struct ModelConfigMetadata {
 }
 
 impl ModelConfigLike for ModelConfigMetadata {
+    fn max_seq_len(&self) -> usize {
+        self.max_seq_len
+    }
     fn hidden_size(&self) -> usize {
         self.hidden_size
     }

--- a/mistralrs-core/src/pipeline/gguf.rs
+++ b/mistralrs-core/src/pipeline/gguf.rs
@@ -252,6 +252,7 @@ impl GGUFLoader {
 }
 
 struct ContentConfig {
+    max_seq_len: usize,
     hidden_size: usize,
     num_attn_heads: usize,
     num_kv_heads: usize,
@@ -264,6 +265,9 @@ impl<'a, R: std::io::Seek + std::io::Read> From<&Content<'a, R>> for ContentConf
         let metadata = value.get_metadata();
         let arch = metadata["general.architecture"].to_string().unwrap();
         Self {
+            max_seq_len: metadata[&format!("{arch}.context_length")]
+                .to_u64()
+                .unwrap() as usize,
             hidden_size: metadata[&format!("{arch}.embedding_length")]
                 .to_u64()
                 .unwrap() as usize,
@@ -279,6 +283,9 @@ impl<'a, R: std::io::Seek + std::io::Read> From<&Content<'a, R>> for ContentConf
 }
 
 impl ModelConfigLike for ContentConfig {
+    fn max_seq_len(&self) -> usize {
+        self.max_seq_len
+    }
     fn hidden_size(&self) -> usize {
         self.hidden_size
     }
@@ -484,6 +491,7 @@ impl Loader for GGUFLoader {
                 internal_dtype,
                 model_config,
                 device,
+                &layer_devices,
             )?;
             let cache_engine = CacheEngine::new(
                 model_config,

--- a/mistralrs-core/src/pipeline/normal.rs
+++ b/mistralrs-core/src/pipeline/normal.rs
@@ -609,6 +609,7 @@ impl Loader for NormalLoader {
                 dtype,
                 model.config(),
                 device,
+                &layer_devices,
             )?;
             let cache_engine =
                 CacheEngine::new(model.config(), &cache_config, dtype, device, layer_devices)?;

--- a/mistralrs-core/src/pipeline/vision.rs
+++ b/mistralrs-core/src/pipeline/vision.rs
@@ -508,6 +508,7 @@ impl Loader for VisionLoader {
                 dtype,
                 model.config(),
                 device,
+                &layer_devices,
             )?;
             let cache_engine =
                 CacheEngine::new(model.config(), &cache_config, dtype, device, layer_devices)?;

--- a/mistralrs-core/src/utils/memory_usage.rs
+++ b/mistralrs-core/src/utils/memory_usage.rs
@@ -1,67 +1,5 @@
-use std::process::Command;
-
 use candle_core::{Device, Result};
 use sysinfo::System;
-
-fn get_available_memory_vm_stat() -> Result<usize> {
-    // Execute the `vm_stat` command
-    let output = Command::new("vm_stat")
-        .output()
-        .map_err(|e| candle_core::Error::msg(format!("Failed to execute vm_stat: {}", e)))?;
-
-    // Convert output to a string
-    let output_str = String::from_utf8(output.stdout)
-        .map_err(|e| candle_core::Error::msg(format!("Failed to parse output: {}", e)))?;
-
-    // Initialize variables
-    let mut free_pages = 0;
-    let mut inactive_pages = 0;
-    let mut page_size = 0; // Default page size in bytes for macOS
-
-    // Parse the output line by line
-    for line in output_str.lines() {
-        if line.starts_with("Pages free:") {
-            if let Some(value) = line.split_whitespace().nth(2) {
-                free_pages = value.trim_end_matches('.').parse::<usize>().unwrap();
-            }
-        } else if line.starts_with("Pages inactive:") {
-            if let Some(value) = line.split_whitespace().nth(2) {
-                inactive_pages = value.trim_end_matches('.').parse::<usize>().unwrap();
-            }
-        } else if line.starts_with("Mach Virtual Memory Statistics:") {
-            if let Some(start) = line.find("of ") {
-                if let Some(end) = line.find(" bytes)") {
-                    page_size = (line[start + "of ".len()..end].to_string())
-                        .parse::<usize>()
-                        .unwrap();
-                }
-            }
-        }
-    }
-
-    // Calculate available memory
-    let available_memory = (free_pages + inactive_pages) * page_size;
-
-    Ok(available_memory)
-}
-
-fn get_total_memory_vm_stat() -> Result<usize> {
-    // Execute the `vm_stat` command
-    let output = Command::new("sysctl")
-        .arg("hw.memsize")
-        .output()
-        .map_err(|e| candle_core::Error::msg(format!("Failed to execute sysctl: {}", e)))?;
-
-    // Convert output to a string
-    let output_str = String::from_utf8(output.stdout)
-        .map_err(|e| candle_core::Error::msg(format!("Failed to parse output: {}", e)))?;
-
-    Ok(output_str
-        .trim_start_matches("hw.memsize: ")
-        .trim()
-        .parse::<usize>()
-        .unwrap())
-}
 
 pub struct MemoryUsage;
 
@@ -110,7 +48,18 @@ impl MemoryUsage {
             Device::Cuda(_) => {
                 candle_core::bail!("Cannot get memory available for CUDA device")
             }
-            Device::Metal(_) => get_available_memory_vm_stat(),
+            #[cfg(feature = "metal")]
+            Device::Metal(dev) => {
+                let max = dev.recommended_max_working_set_size();
+                let alloc = dev.current_allocated_size();
+                let avail = max - alloc;
+
+                Ok(avail as usize)
+            }
+            #[cfg(not(feature = "metal"))]
+            Device::Metal(_) => {
+                candle_core::bail!("Cannot get memory available for Metal device")
+            }
         }
     }
 
@@ -158,7 +107,12 @@ impl MemoryUsage {
             Device::Cuda(_) => {
                 candle_core::bail!("Cannot get total memory for CUDA device")
             }
-            Device::Metal(_) => get_total_memory_vm_stat(),
+            #[cfg(feature = "metal")]
+            Device::Metal(dev) => Ok(dev.recommended_max_working_set_size() as usize),
+            #[cfg(not(feature = "metal"))]
+            Device::Metal(_) => {
+                candle_core::bail!("Cannot get memory available for Metal device")
+            }
         }
     }
 }

--- a/mistralrs-core/src/vision_models/llava/llava_llm/llama.rs
+++ b/mistralrs-core/src/vision_models/llava/llava_llm/llama.rs
@@ -471,6 +471,7 @@ impl Llama {
             mapper,
             rope_parameters,
             cfg: ModelConfigMetadata {
+                max_seq_len: cfg.max_position_embeddings,
                 num_layers: cfg.num_hidden_layers,
                 hidden_size: cfg.hidden_size,
                 num_kv_heads: cfg.num_key_value_heads,

--- a/mistralrs-core/src/vision_models/llava/llava_llm/mistral.rs
+++ b/mistralrs-core/src/vision_models/llava/llava_llm/mistral.rs
@@ -479,6 +479,7 @@ impl Model {
             mapper,
             rope_parameters,
             cfg: ModelConfigMetadata {
+                max_seq_len: cfg.max_position_embeddings,
                 num_layers: cfg.num_hidden_layers,
                 hidden_size: cfg.hidden_size,
                 num_kv_heads: cfg.num_key_value_heads,

--- a/mistralrs-core/src/vision_models/mllama/text.rs
+++ b/mistralrs-core/src/vision_models/mllama/text.rs
@@ -609,6 +609,7 @@ impl MLlamaTextModel {
             norm,
             lm_head,
             cfg: ModelConfigMetadata {
+                max_seq_len: cfg.max_position_embeddings,
                 num_layers: cfg.num_hidden_layers,
                 hidden_size: cfg.hidden_size,
                 num_kv_heads: cfg.num_key_value_heads,

--- a/mistralrs-core/src/vision_models/phi3/mod.rs
+++ b/mistralrs-core/src/vision_models/phi3/mod.rs
@@ -1056,6 +1056,7 @@ impl Model {
             sliding_window: cfg.sliding_window,
             embed_tokens,
             cfg: ModelConfigMetadata {
+                max_seq_len: cfg.max_position_embeddings,
                 num_layers: cfg.num_hidden_layers,
                 hidden_size: cfg.hidden_size,
                 num_kv_heads: cfg.num_key_value_heads,

--- a/mistralrs-core/src/vision_models/qwen2vl/text.rs
+++ b/mistralrs-core/src/vision_models/qwen2vl/text.rs
@@ -378,6 +378,7 @@ impl Qwen2VLTextModel {
             max_seq_len: cfg.max_position_embeddings,
             mapper,
             cfg: ModelConfigMetadata {
+                max_seq_len: cfg.max_position_embeddings,
                 num_layers: cfg.num_hidden_layers,
                 hidden_size: cfg.hidden_size,
                 num_kv_heads: cfg.num_key_value_heads,

--- a/mistralrs-core/src/xlora_models/gemma.rs
+++ b/mistralrs-core/src/xlora_models/gemma.rs
@@ -586,6 +586,7 @@ impl XLoraModel {
             }),
             mapper,
             cfg: ModelConfigMetadata {
+                max_seq_len: cfg.max_position_embeddings,
                 num_layers: cfg.num_hidden_layers,
                 hidden_size: cfg.hidden_size,
                 num_kv_heads: cfg.num_key_value_heads,

--- a/mistralrs-core/src/xlora_models/gemma2.rs
+++ b/mistralrs-core/src/xlora_models/gemma2.rs
@@ -630,6 +630,7 @@ impl Model {
                 XLoraClassifier::new(xlora_config, count, lora_config.len(), vb, false).unwrap()
             }),
             cfg: ModelConfigMetadata {
+                max_seq_len: cfg.max_position_embeddings,
                 num_layers: cfg.num_hidden_layers,
                 hidden_size: cfg.hidden_size,
                 num_kv_heads: cfg.num_key_value_heads,

--- a/mistralrs-core/src/xlora_models/llama.rs
+++ b/mistralrs-core/src/xlora_models/llama.rs
@@ -712,6 +712,7 @@ impl XLoraLlama {
             dtype,
             mapper,
             cfg: ModelConfigMetadata {
+                max_seq_len: cfg.max_position_embeddings,
                 num_layers: cfg.num_hidden_layers,
                 hidden_size: cfg.hidden_size,
                 num_kv_heads: cfg.num_key_value_heads,

--- a/mistralrs-core/src/xlora_models/mistral.rs
+++ b/mistralrs-core/src/xlora_models/mistral.rs
@@ -581,6 +581,7 @@ impl XLoraModel {
             }),
             mapper,
             cfg: ModelConfigMetadata {
+                max_seq_len: cfg.max_position_embeddings,
                 num_layers: cfg.num_hidden_layers,
                 hidden_size: cfg.hidden_size,
                 num_kv_heads: cfg.num_key_value_heads,

--- a/mistralrs-core/src/xlora_models/mixtral.rs
+++ b/mistralrs-core/src/xlora_models/mixtral.rs
@@ -722,6 +722,7 @@ impl XLoraModel {
             }),
             mapper,
             cfg: ModelConfigMetadata {
+                max_seq_len: cfg.max_position_embeddings,
                 num_layers: cfg.num_hidden_layers,
                 hidden_size: cfg.hidden_size,
                 num_kv_heads: cfg.num_key_value_heads,

--- a/mistralrs-core/src/xlora_models/phi2.rs
+++ b/mistralrs-core/src/xlora_models/phi2.rs
@@ -546,6 +546,7 @@ impl Model {
             }),
             mapper,
             cfg: ModelConfigMetadata {
+                max_seq_len: cfg.max_position_embeddings,
                 num_layers: cfg.num_hidden_layers,
                 hidden_size: cfg.hidden_size,
                 num_kv_heads: cfg.num_key_value_heads(),

--- a/mistralrs-core/src/xlora_models/phi3.rs
+++ b/mistralrs-core/src/xlora_models/phi3.rs
@@ -510,6 +510,7 @@ impl Model {
             }),
             sliding_window: cfg.sliding_window,
             cfg: ModelConfigMetadata {
+                max_seq_len: cfg.max_position_embeddings,
                 num_layers: cfg.num_hidden_layers,
                 hidden_size: cfg.hidden_size,
                 num_kv_heads: cfg.num_key_value_heads,

--- a/mistralrs-core/src/xlora_models/starcoder2.rs
+++ b/mistralrs-core/src/xlora_models/starcoder2.rs
@@ -563,6 +563,7 @@ impl Model {
                 XLoraClassifier::new(xlora_config, count, lora_config.len(), vb, false).unwrap()
             }),
             cfg: ModelConfigMetadata {
+                max_seq_len: cfg.max_position_embeddings,
                 num_layers: cfg.num_hidden_layers,
                 hidden_size: cfg.hidden_size,
                 num_kv_heads: cfg.num_key_value_heads,


### PR DESCRIPTION
- Maximum PA. GPU allocation is now equivalent of the model max. seq length (should this not be included for the case of multiple requests?)
- Handle different GPUs with different memory availability and therefore a lower max kv cache size for the model
- Better measure memory on Metal devices