### PR TITLE
Fix paged attention for vision models on multiple devices

### DIFF
--- a/mistralrs-core/src/vision_models/idefics2/idefics2_input_processor.rs
+++ b/mistralrs-core/src/vision_models/idefics2/idefics2_input_processor.rs
@@ -142,7 +142,7 @@ impl InputsProcessor for Idefics2ImageProcessor {
         other_config: Option<Arc<dyn Any>>,
         mut paged_attn_metadata: Option<PagedAttentionMeta<'_>>,
         prompt_batchsize: Option<NonZeroUsize>,
-        _mapper: Option<&dyn DeviceMapper>,
+        mapper: Option<&dyn DeviceMapper>,
     ) -> Box<dyn Iterator<Item = anyhow::Result<InputProcessorOutput>>> {
         if is_xlora {
             return Box::new(std::iter::once(Err(anyhow::Error::msg(
@@ -183,7 +183,7 @@ impl InputsProcessor for Idefics2ImageProcessor {
                 return_raw_logits,
                 paged_attn_metadata.as_mut(),
                 None, // TODO: evaluate if it is possible to batch this
-                None,
+                mapper,
             )
             .nth(0)
             .unwrap()
@@ -201,7 +201,7 @@ impl InputsProcessor for Idefics2ImageProcessor {
                 return_raw_logits,
                 paged_attn_metadata.as_mut(),
                 None, // TODO: evaluate if it is possible to batch this
-                None,
+                mapper,
             )
             .nth(0)
             .unwrap()

--- a/mistralrs-core/src/vision_models/idefics3/inputs_processor.rs
+++ b/mistralrs-core/src/vision_models/idefics3/inputs_processor.rs
@@ -113,7 +113,7 @@ impl InputsProcessor for Idefics3ImageProcessor {
         other_config: Option<Arc<dyn Any>>,
         mut paged_attn_metadata: Option<PagedAttentionMeta<'_>>,
         prompt_batchsize: Option<NonZeroUsize>,
-        _mapper: Option<&dyn DeviceMapper>,
+        mapper: Option<&dyn DeviceMapper>,
     ) -> Box<dyn Iterator<Item = anyhow::Result<InputProcessorOutput>>> {
         if is_xlora {
             return Box::new(std::iter::once(Err(anyhow::Error::msg(
@@ -159,7 +159,7 @@ impl InputsProcessor for Idefics3ImageProcessor {
                 return_raw_logits,
                 paged_attn_metadata.as_mut(),
                 None, // TODO: evaluate if it is possible to batch this
-                None,
+                mapper,
             )
             .nth(0)
             .unwrap()
@@ -177,7 +177,7 @@ impl InputsProcessor for Idefics3ImageProcessor {
                 return_raw_logits,
                 paged_attn_metadata.as_mut(),
                 None, // TODO: evaluate if it is possible to batch this
-                None,
+                mapper,
             )
             .nth(0)
             .unwrap()

--- a/mistralrs-core/src/vision_models/llava/llava_inputs_processor.rs
+++ b/mistralrs-core/src/vision_models/llava/llava_inputs_processor.rs
@@ -88,7 +88,7 @@ impl InputsProcessor for LLaVAInputProcessor {
         other_config: Option<Arc<dyn Any>>,
         mut paged_attn_metadata: Option<PagedAttentionMeta<'_>>,
         prompt_batchsize: Option<NonZeroUsize>,
-        _mapper: Option<&dyn DeviceMapper>,
+        mapper: Option<&dyn DeviceMapper>,
     ) -> Box<dyn Iterator<Item = anyhow::Result<InputProcessorOutput>>> {
         if is_xlora {
             return Box::new(std::iter::once(Err(anyhow::Error::msg(
@@ -169,7 +169,7 @@ impl InputsProcessor for LLaVAInputProcessor {
                         other_config,
                         paged_attn_metadata,
                         None, // TODO
-                        None,
+                        mapper,
                     )
                     .map(|metadata| {
                         let InputProcessorOutput {
@@ -286,7 +286,7 @@ impl InputsProcessor for LLaVAInputProcessor {
                 return_raw_logits,
                 paged_attn_metadata.as_mut(),
                 None, // TODO: evaluate if it is possible to batch this
-                None,
+                mapper,
             )
         } else {
             get_completion_input(
@@ -298,7 +298,7 @@ impl InputsProcessor for LLaVAInputProcessor {
                 return_raw_logits,
                 paged_attn_metadata.as_mut(),
                 None, // TODO: evaluate if it is possible to batch this
-                None,
+                mapper,
             )
         };
 

--- a/mistralrs-core/src/vision_models/llava/llava_next_inputs_processor.rs
+++ b/mistralrs-core/src/vision_models/llava/llava_next_inputs_processor.rs
@@ -95,7 +95,7 @@ impl InputsProcessor for LLaVANextInputProcessor {
         other_config: Option<Arc<dyn Any>>,
         mut paged_attn_metadata: Option<PagedAttentionMeta<'_>>,
         prompt_batchsize: Option<NonZeroUsize>,
-        _mapper: Option<&dyn DeviceMapper>,
+        mapper: Option<&dyn DeviceMapper>,
     ) -> Box<dyn Iterator<Item = anyhow::Result<InputProcessorOutput>>> {
         if is_xlora {
             return Box::new(std::iter::once(Err(anyhow::Error::msg(
@@ -195,7 +195,7 @@ impl InputsProcessor for LLaVANextInputProcessor {
                         other_config,
                         paged_attn_metadata,
                         None, // TODO
-                        None,
+                        mapper,
                     )
                     .map(|metadata| {
                         let InputProcessorOutput {
@@ -330,7 +330,7 @@ impl InputsProcessor for LLaVANextInputProcessor {
                 return_raw_logits,
                 paged_attn_metadata.as_mut(),
                 None, // TODO: evaluate if it is possible to batch this
-                None,
+                mapper,
             )
         } else {
             get_completion_input(
@@ -342,7 +342,7 @@ impl InputsProcessor for LLaVANextInputProcessor {
                 return_raw_logits,
                 paged_attn_metadata.as_mut(),
                 None, // TODO: evaluate if it is possible to batch this
-                None,
+                mapper,
             )
         };
 

--- a/mistralrs-core/src/vision_models/mllama/inputs_processor.rs
+++ b/mistralrs-core/src/vision_models/mllama/inputs_processor.rs
@@ -182,7 +182,7 @@ impl InputsProcessor for MLlamaImageProcessor {
         other_config: Option<Arc<dyn Any>>,
         mut paged_attn_metadata: Option<PagedAttentionMeta<'_>>,
         prompt_batchsize: Option<NonZeroUsize>,
-        _mapper: Option<&dyn DeviceMapper>,
+        mapper: Option<&dyn DeviceMapper>,
     ) -> Box<dyn Iterator<Item = anyhow::Result<InputProcessorOutput>>> {
         if is_xlora {
             return Box::new(std::iter::once(Err(anyhow::Error::msg(
@@ -228,7 +228,7 @@ impl InputsProcessor for MLlamaImageProcessor {
                 return_raw_logits,
                 paged_attn_metadata.as_mut(),
                 None, // TODO: evaluate if it is possible to batch this
-                None,
+                mapper,
             )
             .nth(0)
             .unwrap()
@@ -246,7 +246,7 @@ impl InputsProcessor for MLlamaImageProcessor {
                 return_raw_logits,
                 paged_attn_metadata.as_mut(),
                 None, // TODO: evaluate if it is possible to batch this
-                None,
+                mapper,
             )
             .nth(0)
             .unwrap()

--- a/mistralrs-core/src/vision_models/phi3/phi3_inputs_processor.rs
+++ b/mistralrs-core/src/vision_models/phi3/phi3_inputs_processor.rs
@@ -82,7 +82,7 @@ impl InputsProcessor for Phi3InputsProcessor {
         other_config: Option<Arc<dyn Any>>,
         mut paged_attn_metadata: Option<PagedAttentionMeta<'_>>,
         prompt_batchsize: Option<NonZeroUsize>,
-        _mapper: Option<&dyn DeviceMapper>,
+        mapper: Option<&dyn DeviceMapper>,
     ) -> Box<dyn Iterator<Item = anyhow::Result<InputProcessorOutput>>> {
         if is_xlora {
             return Box::new(std::iter::once(Err(anyhow::Error::msg(
@@ -171,7 +171,7 @@ impl InputsProcessor for Phi3InputsProcessor {
                         other_config,
                         paged_attn_metadata,
                         None, // TODO
-                        None,
+                        mapper,
                     )
                     .map(|metadata| {
                         let InputProcessorOutput {
@@ -323,7 +323,7 @@ impl InputsProcessor for Phi3InputsProcessor {
                 return_raw_logits,
                 paged_attn_metadata.as_mut(),
                 None, // TODO: evaluate if it is possible to batch this
-                None,
+                mapper,
             )
         } else {
             get_completion_input(
@@ -335,7 +335,7 @@ impl InputsProcessor for Phi3InputsProcessor {
                 return_raw_logits,
                 paged_attn_metadata.as_mut(),
                 None, // TODO: evaluate if it is possible to batch this
-                None,
+                mapper,
             )
         };
 

--- a/mistralrs-core/src/vision_models/qwen2vl/inputs_processor.rs
+++ b/mistralrs-core/src/vision_models/qwen2vl/inputs_processor.rs
@@ -134,7 +134,7 @@ impl InputsProcessor for Qwen2VLImageProcessor {
         other_config: Option<Arc<dyn Any>>,
         mut paged_attn_metadata: Option<PagedAttentionMeta<'_>>,
         prompt_batchsize: Option<NonZeroUsize>,
-        _mapper: Option<&dyn DeviceMapper>,
+        mapper: Option<&dyn DeviceMapper>,
     ) -> Box<dyn Iterator<Item = Result<InputProcessorOutput>>> {
         if is_xlora {
             return Box::new(std::iter::once(Err(anyhow::Error::msg(
@@ -185,7 +185,7 @@ impl InputsProcessor for Qwen2VLImageProcessor {
                 return_raw_logits,
                 paged_attn_metadata.as_mut(),
                 None, // TODO: evaluate if it is possible to batch this
-                None,
+                mapper,
             )
             .nth(0)
             .unwrap()
@@ -203,7 +203,7 @@ impl InputsProcessor for Qwen2VLImageProcessor {
                 return_raw_logits,
                 paged_attn_metadata.as_mut(),
                 None, // TODO: evaluate if it is possible to batch this
-                None,
+                mapper,
             )
             .nth(0)
             .unwrap()


### PR DESCRIPTION
The `DeviceMapper` was set to `None` for vision models before, now it's being passed properly. Tested working on Phi3V.