### PR TITLE
Implement Qwen 2.5 VL

### DIFF
--- a/mistralrs-core/src/pipeline/loaders/mod.rs
+++ b/mistralrs-core/src/pipeline/loaders/mod.rs
@@ -26,7 +26,7 @@ pub use normal_loaders::{
 use tracing::{info, warn};
 pub use vision_loaders::{
     Idefics2Loader, Idefics3Loader, LLaVALoader, LLaVANextLoader, MiniCpmOLoader, Phi3VLoader,
-    Qwen2VLLoader, VLlamaLoader, VisionLoaderType, VisionModel, VisionModelLoader,
+    Qwen2VLLoader, Qwen2_5VLLoader, VLlamaLoader, VisionLoaderType, VisionModel, VisionModelLoader,
 };
 
 pub use diffusion_loaders::{

--- a/mistralrs-core/src/pipeline/loaders/vision_loaders.rs
+++ b/mistralrs-core/src/pipeline/loaders/vision_loaders.rs
@@ -40,6 +40,10 @@ use crate::vision_models::phi3::{Config as Phi3Config, Model as Phi3, PHI3V_CLIP
 use crate::vision_models::phi3_inputs_processor::Phi3Processor;
 use crate::vision_models::preprocessor_config::PreProcessorConfig;
 use crate::vision_models::processor_config::ProcessorConfig;
+use crate::vision_models::qwen2_5_vl::{
+    Config as Qwen2_5VLConfig, Qwen2VLModel as Qwen2_5VLModel,
+    Qwen2VLProcessor as Qwen2_5VLProcessor,
+};
 use crate::vision_models::qwen2vl::{Config as Qwen2VLConfig, Qwen2VLModel, Qwen2VLProcessor};
 
 pub trait VisionModel: IsqModel + AnyMoeBaseModelMixin {
@@ -137,6 +141,8 @@ pub enum VisionLoaderType {
     Idefics3,
     #[serde(rename = "minicpmo")]
     MiniCpmO,
+    #[serde(rename = "qwen2_5vl")]
+    Qwen2_5VL,
 }
 
 impl FromStr for VisionLoaderType {
@@ -151,7 +157,8 @@ impl FromStr for VisionLoaderType {
             "qwen2vl" => Ok(Self::Qwen2VL),
             "idefics3" => Ok(Self::Idefics3),
             "minicpmo" => Ok(Self::MiniCpmO),
-            a => Err(format!("Unknown architecture `{a}`. Possible architectures: `phi3v`, `idefics2`, `llava_next`, `llava`, `vllama`, `qwen2vl`, `idefics3`, `minicpmo`.")),
+            "qwen2_5vl" => Ok(Self::Qwen2_5VL),
+            a => Err(format!("Unknown architecture `{a}`. Possible architectures: `phi3v`, `idefics2`, `llava_next`, `llava`, `vllama`, `qwen2vl`, `idefics3`, `minicpmo`, `qwen2_5vl`.")),
         }
     }
 }
@@ -2524,5 +2531,292 @@ impl DeviceMappedModelLoader for MiniCpmOLoader {
         };
 
         Ok(Box::new(cfg))
+    }
+}
+
+// ======================== Qwen2VL Loader
+
+/// [`VisionLoader`] for an Qwen2-VL model.
+///
+/// [`VisionLoader`]: https://ericlbuehler.github.io/mistral.rs/mistralrs/struct.VisionLoader.html
+pub struct Qwen2_5VLLoader;
+
+pub struct Qwen2_5VLPrefixer;
+
+impl VisionPromptPrefixer for Qwen2_5VLPrefixer {
+    fn prefix_image(&self, _image_index: usize, prompt: &str) -> String {
+        format!(
+            "{}{}{}{prompt}",
+            Qwen2_5VLProcessor::VISION_START,
+            Qwen2_5VLProcessor::IMAGE_PAD,
+            Qwen2_5VLProcessor::VISION_END
+        )
+    }
+}
+
+impl VisionModelLoader for Qwen2_5VLLoader {
+    fn load(
+        &self,
+        config: &str,
+        _use_flash_attn: bool,
+        vb: ShardedVarBuilder,
+        normal_loading_metadata: NormalLoadingMetadata,
+        attention_mechanism: AttentionImplementation,
+    ) -> Result<Box<dyn VisionModel + Send + Sync>> {
+        let config: Qwen2_5VLConfig = serde_json::from_str(config)?;
+        Ok(Box::new(Qwen2_5VLModel::new(
+            &config,
+            vb,
+            self.is_gptx(),
+            normal_loading_metadata,
+            attention_mechanism,
+        )?))
+    }
+    fn is_gptx(&self) -> bool {
+        true
+    }
+    fn get_config_repr(&self, config: &str, _use_flash_attn: bool) -> Result<Box<dyn Debug>> {
+        let config: Qwen2_5VLConfig = serde_json::from_str(config)?;
+        Ok(Box::new(config))
+    }
+    fn get_processor(
+        &self,
+        _model_config: &str,
+        _processor_config: Option<ProcessorConfig>,
+        _preprocessor_config: PreProcessorConfig,
+        max_edge: Option<u32>,
+    ) -> Arc<dyn Processor + Send + Sync> {
+        Arc::new(Qwen2_5VLProcessor::new(max_edge))
+    }
+    fn get_total_device_mapping_num_layers(&self, config: &str) -> Result<usize> {
+        let config: Qwen2_5VLConfig = serde_json::from_str(config)?;
+        // We only apply device mapping to text model
+        Ok(config.num_hidden_layers)
+    }
+    fn supports_paged_attention(&self) -> bool {
+        false
+    }
+    fn prefixer(&self) -> Arc<dyn VisionPromptPrefixer> {
+        Arc::new(Qwen2_5VLPrefixer)
+    }
+}
+
+impl IsqModelLoader for Qwen2_5VLLoader {
+    fn isq_layer_regexes(&self, _config: &str) -> Result<Vec<Regex>> {
+        Ok(vec![
+            Regex::new(r"lm_head\.(weight|bias)$")?,
+            // Attention
+            Regex::new(r"layers\.(\d+)\.self_attn\.q_proj\.(weight|bias)$")?,
+            Regex::new(r"layers\.(\d+)\.self_attn\.k_proj\.(weight|bias)$")?,
+            Regex::new(r"layers\.(\d+)\.self_attn\.v_proj\.(weight|bias)$")?,
+            Regex::new(r"layers\.(\d+)\.self_attn\.dense\.(weight|bias)$")?,
+            // MLP
+            Regex::new(r"layers\.(\d+)\.mlp\.gate_proj\.(weight|bias)$")?,
+            Regex::new(r"layers\.(\d+)\.mlp\.up_proj\.(weight|bias)$")?,
+            Regex::new(r"layers\.(\d+)\.mlp\.down_proj\.(weight|bias)$")?,
+        ])
+    }
+}
+
+impl DeviceMappedModelLoader for Qwen2_5VLLoader {
+    fn mapped_max_act_size_elems(
+        &self,
+        config: &str,
+        params: &AutoDeviceMapParams,
+        prompt_chunksize: usize,
+    ) -> Result<usize> {
+        let AutoDeviceMapParams::Vision {
+            max_seq_len: _,
+            max_batch_size,
+            max_image_shape,
+            max_num_images,
+        } = params
+        else {
+            anyhow::bail!("Expected vision AutoDeviceMapParams for this model!")
+        };
+
+        let cfg: Qwen2_5VLConfig = serde_json::from_str(config)?;
+
+        let img_seq_len = {
+            let cfg = &cfg.vision_config;
+            let grid_t = max_num_images / cfg.temporal_patch_size;
+            let grid_h = max_image_shape.0 / cfg.patch_size;
+            let grid_w = max_image_shape.1 / cfg.patch_size;
+            grid_t * grid_h * grid_w
+        };
+        let img_seq_len = img_seq_len * max_num_images;
+
+        let max_text_attn = {
+            // This model injects the vision information directly into the input embeddings
+            let max_seq_len = img_seq_len + prompt_chunksize;
+            max_batch_size * cfg.num_attention_heads * max_seq_len * max_seq_len
+        };
+
+        Ok(max_text_attn)
+    }
+
+    fn non_mapped_max_act_size_elems(
+        &self,
+        config: &str,
+        params: &AutoDeviceMapParams,
+    ) -> Result<usize> {
+        let AutoDeviceMapParams::Vision {
+            max_seq_len: _,
+            max_batch_size,
+            max_image_shape,
+            max_num_images,
+        } = params
+        else {
+            anyhow::bail!("Expected vision AutoDeviceMapParams for this model!")
+        };
+
+        let cfg: Qwen2_5VLConfig = serde_json::from_str(config)?;
+
+        let img_seq_len = {
+            let cfg = &cfg.vision_config;
+            let grid_t = max_num_images / cfg.temporal_patch_size;
+            let grid_h = max_image_shape.0 / cfg.patch_size;
+            let grid_w = max_image_shape.1 / cfg.patch_size;
+            grid_t * grid_h * grid_w
+        };
+
+        let max_vision_attn = {
+            let cfg = &cfg.vision_config;
+            (max_batch_size * max_num_images) * cfg.num_heads * img_seq_len * img_seq_len
+        };
+
+        Ok(max_vision_attn)
+    }
+
+    fn non_mapped_size_in_bytes(
+        &self,
+        config: &str,
+        dtype: DType,
+        weight_pack_factor: usize,
+    ) -> Result<usize> {
+        let cfg: Qwen2_5VLConfig = serde_json::from_str(config)?;
+        let text_elems = {
+            let embed_tokens = cfg.hidden_size * cfg.vocab_size / weight_pack_factor;
+            let lm_head = if !cfg.tie_word_embeddings {
+                cfg.hidden_size * cfg.vocab_size
+            } else {
+                0
+            };
+            let norm = cfg.hidden_size;
+            embed_tokens + lm_head + norm
+        };
+
+        let patch_merger = {
+            let cfg = &cfg.vision_config;
+            let hidden_size = cfg.hidden_size * cfg.spatial_merge_size.pow(2);
+
+            let mlp0 = hidden_size * hidden_size + hidden_size;
+            let mlp2 = hidden_size * cfg.hidden_size + cfg.hidden_size;
+
+            let ln_q = cfg.hidden_size + bias_if!(true, cfg.hidden_size);
+
+            mlp0 + mlp2 + ln_q
+        };
+
+        let patch_embed = {
+            let cfg = &cfg.vision_config;
+            let conv_cfg = Conv3dConfig {
+                stride: cfg.patch_size,
+                ..Default::default()
+            };
+            let kernel_sizes = [cfg.temporal_patch_size, cfg.patch_size, cfg.patch_size];
+            cfg.in_chans * cfg.hidden_size / conv_cfg.groups
+                * kernel_sizes[0]
+                * kernel_sizes[1]
+                * kernel_sizes[2]
+        };
+
+        let encoder_layer = {
+            let cfg = &cfg.vision_config;
+            let norm1 = cfg.hidden_size + bias_if!(true, cfg.hidden_size);
+            let norm2 = cfg.hidden_size + bias_if!(true, cfg.hidden_size);
+
+            #[allow(clippy::cast_possible_truncation, clippy::cast_precision_loss)]
+            let mlp_hidden_dim = (cfg.hidden_size as f64 * cfg.mlp_ratio) as usize;
+            let fc1 = cfg.hidden_size * mlp_hidden_dim + mlp_hidden_dim;
+            let fc2 = cfg.hidden_size * mlp_hidden_dim + cfg.hidden_size;
+
+            let qkv = cfg.hidden_size * cfg.hidden_size * 3 + cfg.hidden_size * 3;
+            let out = cfg.hidden_size * cfg.hidden_size + cfg.hidden_size;
+
+            norm1 + norm2 + fc1 + fc2 + qkv + out
+        };
+
+        let elems =
+            text_elems + patch_merger + patch_embed + encoder_layer * cfg.vision_config.depth;
+
+        Ok(elems * dtype.size_in_bytes())
+    }
+
+    fn layer_sizes_in_bytes(
+        &self,
+        config: &str,
+        dtype: DType,
+        weight_pack_factor: usize,
+    ) -> Result<Vec<usize>> {
+        let cfg: Qwen2_5VLConfig = serde_json::from_str(config)?;
+        let per_layer_elems = {
+            let input_layernorm = cfg.hidden_size;
+            let post_attention_layernorm = cfg.hidden_size;
+
+            let size_in = cfg.hidden_size;
+            let size_q = (cfg.hidden_size / cfg.num_attention_heads) * cfg.num_attention_heads;
+            let size_kv = (cfg.hidden_size / cfg.num_attention_heads) * cfg.num_key_value_heads;
+            let q_proj = size_in * size_q / weight_pack_factor + size_q;
+            let k_proj = size_in * size_kv / weight_pack_factor + size_kv;
+            let v_proj = size_in * size_kv / weight_pack_factor + size_kv;
+            let o_proj = size_q * size_in / weight_pack_factor;
+
+            let h_size = cfg.hidden_size;
+            let i_size = cfg.intermediate_size;
+            let gate_proj = h_size * i_size / weight_pack_factor;
+            let up_proj = h_size * i_size / weight_pack_factor;
+            let down_proj = i_size * h_size / weight_pack_factor;
+
+            input_layernorm
+                + post_attention_layernorm
+                + q_proj
+                + k_proj
+                + v_proj
+                + o_proj
+                + gate_proj
+                + up_proj
+                + down_proj
+        };
+        Ok(vec![
+            per_layer_elems * dtype.size_in_bytes();
+            cfg.num_hidden_layers
+        ])
+    }
+
+    fn num_layers(&self, config: &str) -> Result<usize> {
+        let cfg: Qwen2_5VLConfig = serde_json::from_str(config)?;
+        Ok(cfg.num_hidden_layers)
+    }
+
+    fn model_config(&self, config: &str) -> Result<Box<dyn ModelConfigLike>> {
+        let cfg: Qwen2_5VLConfig = serde_json::from_str(config)?;
+
+        let cfg = ModelConfigMetadata {
+            max_seq_len: cfg.max_position_embeddings,
+            num_layers: cfg.num_hidden_layers,
+            hidden_size: cfg.hidden_size,
+            num_kv_heads: cfg.num_key_value_heads,
+            num_attn_heads: cfg.num_attention_heads,
+            sliding_window: cfg.sliding_window,
+            k_head_dim: cfg.hidden_size / cfg.num_attention_heads,
+            v_head_dim: cfg.hidden_size / cfg.num_attention_heads,
+        };
+
+        Ok(Box::new(cfg))
+    }
+
+    fn non_mapped_sub_models(&self) -> Option<Vec<NonMappedSubModel>> {
+        Some(vec![NonMappedSubModel::Vision])
     }
 }

--- a/mistralrs-core/src/pipeline/loaders/vision_loaders.rs
+++ b/mistralrs-core/src/pipeline/loaders/vision_loaders.rs
@@ -2737,9 +2737,8 @@ impl DeviceMappedModelLoader for Qwen2_5VLLoader {
             let norm2 = cfg.hidden_size + bias_if!(true, cfg.hidden_size);
 
             #[allow(clippy::cast_possible_truncation, clippy::cast_precision_loss)]
-            let mlp_hidden_dim = (cfg.hidden_size as f64 * cfg.mlp_ratio) as usize;
-            let fc1 = cfg.hidden_size * mlp_hidden_dim + mlp_hidden_dim;
-            let fc2 = cfg.hidden_size * mlp_hidden_dim + cfg.hidden_size;
+            let fc1 = cfg.hidden_size * cfg.intermediate_size + cfg.intermediate_size;
+            let fc2 = cfg.hidden_size * cfg.intermediate_size + cfg.hidden_size;
 
             let qkv = cfg.hidden_size * cfg.hidden_size * 3 + cfg.hidden_size * 3;
             let out = cfg.hidden_size * cfg.hidden_size + cfg.hidden_size;

--- a/mistralrs-core/src/pipeline/mod.rs
+++ b/mistralrs-core/src/pipeline/mod.rs
@@ -37,8 +37,8 @@ pub use loaders::{
     LlamaLoader, Loader, LocalModelPaths, MiniCpmOLoader, MistralLoader, MixtralLoader, ModelKind,
     ModelPaths, NormalLoaderType, NormalLoadingMetadata, NormalModel, NormalModelLoader,
     Phi2Loader, Phi3Loader, Phi3VLoader, Phi3_5MoELoader, PrettyName, QuantizationKind,
-    Qwen2Loader, Qwen2VLLoader, Starcoder2Loader, TokenSource, VLlamaLoader, VisionLoaderType,
-    VisionModel, VisionModelLoader,
+    Qwen2Loader, Qwen2VLLoader, Qwen2_5VLLoader, Starcoder2Loader, TokenSource, VLlamaLoader,
+    VisionLoaderType, VisionModel, VisionModelLoader,
 };
 use mistralrs_quant::IsqType;
 pub use normal::{NormalLoader, NormalLoaderBuilder, NormalSpecificConfig};

--- a/mistralrs-core/src/pipeline/vision.rs
+++ b/mistralrs-core/src/pipeline/vision.rs
@@ -9,7 +9,8 @@ use super::{
     VisionPromptPrefixer, XLoraPaths,
 };
 use super::{
-    Idefics2Loader, Idefics3Loader, LLaVALoader, LLaVANextLoader, Phi3VLoader, VisionLoaderType,
+    Idefics2Loader, Idefics3Loader, LLaVALoader, LLaVANextLoader, Phi3VLoader, Qwen2_5VLLoader,
+    VisionLoaderType,
 };
 use crate::device_map::{self, DeviceMapper};
 use crate::paged_attention::{calculate_cache_config, AttentionImplementation, CacheEngine};
@@ -136,6 +137,7 @@ impl VisionLoaderBuilder {
             VisionLoaderType::Qwen2VL => Box::new(Qwen2VLLoader),
             VisionLoaderType::Idefics3 => Box::new(Idefics3Loader),
             VisionLoaderType::MiniCpmO => Box::new(MiniCpmOLoader),
+            VisionLoaderType::Qwen2_5VL => Box::new(Qwen2_5VLLoader),
         };
         Box::new(VisionLoader {
             inner: loader,

--- a/mistralrs-core/src/vision_models/mod.rs
+++ b/mistralrs-core/src/vision_models/mod.rs
@@ -12,6 +12,7 @@ pub(crate) mod phi3;
 pub(crate) use phi3::phi3_inputs_processor;
 pub(crate) mod preprocessor_config;
 pub(crate) mod processor_config;
+pub(crate) mod qwen2_5_vl;
 pub(crate) mod qwen2vl;
 pub(crate) use llava::llava15;
 pub(crate) use llava::llava_inputs_processor;

--- a/mistralrs-core/src/vision_models/qwen2_5_vl/config.rs
+++ b/mistralrs-core/src/vision_models/qwen2_5_vl/config.rs
@@ -1,0 +1,57 @@
+// https://github.com/huggingface/transformers/blob/f2c388e3f946862f657acc1e21b272ec946fc66c/src/transformers/models/qwen2_vl/configuration_qwen2_vl.py
+
+use mistralrs_quant::QuantizedConfig;
+
+use crate::layers::Activation;
+
+use crate::serde_default_fn;
+
+serde_default_fn!(Activation, default_vision_hidden_act, Activation::QuickGelu);
+serde_default_fn!(usize, default_in_channels, 3);
+
+#[derive(Debug, Clone, serde::Deserialize)]
+pub struct VisionConfig {
+    pub depth: usize,
+    pub hidden_size: usize,
+    pub out_hidden_size: usize,
+    #[serde(default = "default_vision_hidden_act")]
+    pub hidden_act: Activation,
+    pub mlp_ratio: f64,
+    pub num_heads: usize,
+    #[serde(default = "default_in_channels")]
+    pub in_chans: usize,
+    pub patch_size: usize,
+    pub spatial_merge_size: usize,
+    pub temporal_patch_size: usize,
+    pub window_size: usize,
+    pub fullatt_block_indexes: Vec<usize>,
+}
+
+#[derive(Debug, Clone, serde::Deserialize)]
+pub struct MRopeScaling {
+    pub mrope_section: Vec<usize>,
+}
+
+#[derive(Debug, Clone, serde::Deserialize)]
+pub struct Config {
+    pub vocab_size: usize,
+    pub hidden_size: usize,
+    pub intermediate_size: usize,
+    pub num_hidden_layers: usize,
+    pub num_attention_heads: usize,
+    pub num_key_value_heads: usize,
+    pub hidden_act: Activation,
+    pub max_position_embeddings: usize,
+    pub rms_norm_eps: f64,
+    pub tie_word_embeddings: bool,
+    pub rope_theta: f64,
+    pub use_sliding_window: bool,
+    pub sliding_window: Option<usize>,
+    pub vision_config: VisionConfig,
+    pub rope_scaling: MRopeScaling,
+    pub quantization_config: Option<QuantizedConfig>,
+    pub image_token_id: u32,
+    pub video_token_id: u32,
+    // pub vision_start_token_id: usize,
+    // pub max_window_layers: usize,
+}

--- a/mistralrs-core/src/vision_models/qwen2_5_vl/config.rs
+++ b/mistralrs-core/src/vision_models/qwen2_5_vl/config.rs
@@ -16,7 +16,7 @@ pub struct VisionConfig {
     pub out_hidden_size: usize,
     #[serde(default = "default_vision_hidden_act")]
     pub hidden_act: Activation,
-    pub mlp_ratio: f64,
+    pub intermediate_size: usize,
     pub num_heads: usize,
     #[serde(default = "default_in_channels")]
     pub in_chans: usize,

--- a/mistralrs-core/src/vision_models/qwen2_5_vl/inputs_processor.rs
+++ b/mistralrs-core/src/vision_models/qwen2_5_vl/inputs_processor.rs
@@ -1,0 +1,739 @@
+use std::{
+    any::Any,
+    num::NonZeroUsize,
+    sync::{Arc, RwLock},
+};
+
+use anyhow::Result;
+use candle_core::{Context, Device, IndexOp, Tensor};
+use image::{imageops::FilterType, DynamicImage, GenericImageView};
+use mistralrs_vision::{
+    ApplyTensorTransforms, ApplyTransforms, Normalize, TensorTransforms, ToTensor, Transforms,
+};
+use tokenizers::Tokenizer;
+use tracing::warn;
+
+use crate::{
+    device_map::DeviceMapper,
+    pipeline::{
+        text_models_inputs_processor::{
+            self, get_completion_input, get_prompt_input, PagedAttentionMeta,
+        },
+        InputProcessorOutput, InputsProcessor, InputsProcessorType, MessagesAction, Processor,
+    },
+    sequence::Sequence,
+    vision_models::{
+        image_processor::{ImagePreProcessor, PreprocessedImages},
+        preprocessor_config::{PreProcessorConfig, ToFilter},
+        ModelInputs,
+    },
+};
+
+use super::Qwen2VLVisionSpecificArgs;
+
+// Input processor
+struct Qwen2VLImageProcessor {
+    // To represent uninitialized, we do this. Should always be init by the time this is read.
+    merge_size: RwLock<Option<usize>>,
+    max_edge: Option<u32>,
+}
+// Processor
+pub struct Qwen2VLProcessor {
+    max_edge: Option<u32>,
+}
+
+impl Qwen2VLProcessor {
+    pub const VISION_START: &str = "<|vision_start|>";
+    pub const VISION_END: &str = "<|vision_end|>";
+    pub const IMAGE_PAD: &str = "<|image_pad|>";
+    pub const VIDEO_PAD: &str = "<|video_pad|>";
+    pub const PLACEHOLDER: &str = "<|placeholder|>";
+
+    pub fn new(max_edge: Option<u32>) -> Self {
+        Self { max_edge }
+    }
+}
+
+impl Processor for Qwen2VLProcessor {
+    fn inputs_processor(&self) -> Arc<dyn InputsProcessor> {
+        Arc::new(Qwen2VLImageProcessor {
+            merge_size: RwLock::new(None),
+            max_edge: self.max_edge,
+        })
+    }
+
+    fn get_special_tokens(&self) -> &[&'static str] {
+        &[Self::IMAGE_PAD, Self::VIDEO_PAD, Self::PLACEHOLDER]
+    }
+
+    fn template_action(&self) -> MessagesAction {
+        MessagesAction::FlattenOnlyText
+    }
+}
+
+fn replace_first_occurrence(text: &str, to_replace: &str, replacement: &str) -> String {
+    if let Some(pos) = text.find(to_replace) {
+        let mut result = text.to_string();
+        result.replace_range(pos..pos + to_replace.len(), replacement);
+        result
+    } else {
+        text.to_string()
+    }
+}
+
+fn find_sequences(nums: &[u32], needle: u32) -> Vec<(usize, usize)> {
+    let mut sequences = Vec::new();
+    let mut start = None;
+
+    for (i, &num) in nums.iter().enumerate() {
+        if num == needle {
+            if start.is_none() {
+                start = Some(i);
+            }
+        } else if let Some(s) = start {
+            sequences.push((s, i));
+            start = None;
+        }
+    }
+
+    if let Some(s) = start {
+        sequences.push((s, nums.len()));
+    }
+
+    sequences
+}
+
+// index + needle length
+fn find_substring_indices(haystack: &str, needle: &str) -> Vec<usize> {
+    let mut indices = Vec::new();
+    let mut start = 0;
+
+    while let Some(pos) = haystack[start..].find(needle) {
+        let index = start + pos;
+        indices.push(index + needle.len());
+        start = index + needle.len(); // Move past the last found occurrence
+    }
+
+    indices
+}
+
+impl InputsProcessor for Qwen2VLImageProcessor {
+    fn get_type(&self) -> InputsProcessorType {
+        InputsProcessorType::Vision
+    }
+    fn process_inputs(
+        &self,
+        tokenizer: Option<Arc<Tokenizer>>,
+        input_seqs: &mut [&mut Sequence],
+        is_prompt: bool,
+        is_xlora: bool,
+        device: &Device,
+        no_kv_cache: bool,
+        last_n_context_len: Option<(usize, usize)>,
+        return_raw_logits: bool,
+        other_config: Option<Arc<dyn Any>>,
+        mut paged_attn_metadata: Option<PagedAttentionMeta<'_>>,
+        prompt_chunksize: Option<NonZeroUsize>,
+        mapper: Option<&dyn DeviceMapper>,
+    ) -> Box<dyn Iterator<Item = Result<InputProcessorOutput>>> {
+        if is_xlora {
+            return Box::new(std::iter::once(Err(anyhow::Error::msg(
+                "Cannot make inputs for X-LoRA vision model.",
+            ))));
+        }
+        if no_kv_cache {
+            return Box::new(std::iter::once(Err(anyhow::Error::msg(
+                "Vision model must have kv cache.",
+            ))));
+        }
+        // TODO(EricLBuehler): support this? Would require some handling of image tokens.
+        if prompt_chunksize.is_some() {
+            warn!("`prompt_chunksize` is set. MLlama does not support prompt batching.");
+        }
+        if input_seqs.len() != 1 {
+            return Box::new(std::iter::once(Err(anyhow::Error::msg(
+                "Qwen2-VL only supports batch size = 1",
+            ))));
+        }
+        let Some(tokenizer) = tokenizer else {
+            return Box::new(std::iter::once(Err(anyhow::Error::msg(
+                "MLlamaInputProcessor requires a specified tokenizer.",
+            ))));
+        };
+
+        let text_models_inputs_processor::InnerInputProcessorOutput {
+            inputs:
+                text_models_inputs_processor::InputMetadata {
+                    input,
+                    positions,
+                    context_lens,
+                    position_ids,
+                    paged_attn_meta,
+                    flash_meta,
+                },
+            seq_indices,
+        } = if is_prompt {
+            get_prompt_input(
+                input_seqs
+                    .iter()
+                    .map(|seq| seq.get_toks().to_vec())
+                    .collect::<Vec<_>>(),
+                input_seqs,
+                device,
+                last_n_context_len,
+                return_raw_logits,
+                paged_attn_metadata.as_mut(),
+                None, // TODO: evaluate if it is possible to batch this
+                mapper,
+            )
+            .nth(0)
+            .unwrap()
+            .unwrap()
+        } else {
+            get_completion_input(
+                input_seqs
+                    .iter()
+                    .map(|seq| seq.get_toks().to_vec())
+                    .collect::<Vec<_>>(),
+                input_seqs,
+                device,
+                no_kv_cache,
+                last_n_context_len,
+                return_raw_logits,
+                paged_attn_metadata.as_mut(),
+                None, // TODO: evaluate if it is possible to batch this
+                mapper,
+            )
+            .nth(0)
+            .unwrap()
+            .unwrap()
+        };
+        let config = other_config.expect("Need a PreProcessorConfig config.");
+        let config: &PreProcessorConfig = config.downcast_ref().expect("Downcast failed.");
+
+        let has_images = input_seqs
+            .iter()
+            .all(|seq| seq.images().is_some_and(|images| !images.is_empty()));
+
+        let (
+            new_input,
+            pixel_values,
+            image_grid_thw,
+            video_grid_thw,
+            continuous_img_pad,
+            continuous_vid_pad,
+            input_ids_searching,
+            image_nums,
+            video_nums,
+        ) = if has_images {
+            let mut pixel_values_accum = Vec::new();
+            let mut image_grid_thw_accum = Vec::new();
+            let mut video_grid_thw_accum = Vec::new();
+
+            let mut detok_seqs = tokenizer
+                .decode_batch(
+                    &input_seqs
+                        .iter()
+                        .map(|seq| seq.get_toks())
+                        .collect::<Vec<_>>(),
+                    false,
+                )
+                .expect("Detokenization failed!");
+
+            for seq in input_seqs.iter_mut() {
+                let (pixel_values, image_grid_thw, video_grid_thw) =
+                    if let Some(cached_pixel_values) = &seq.cached_pixel_values {
+                        (
+                            cached_pixel_values.clone(),
+                            seq.cached_img_thw.clone(),
+                            seq.cached_vid_thw.clone(),
+                        )
+                    } else {
+                        let PreprocessedImages {
+                            pixel_values,
+                            pixel_attention_mask: _,
+                            image_sizes: _,
+                            num_img_tokens: _,
+                            aspect_ratio_ids: _,
+                            aspect_ratio_mask: _,
+                            num_tiles: _,
+                            image_grid_thw,
+                            video_grid_thw,
+                            rows: _,
+                            cols: _,
+                            pixel_values_list: _,
+                            tgt_sizes: _,
+                            image_sizes_all: _,
+                        } = self
+                            .preprocess(
+                                seq.clone_images()
+                                    .expect("Need to have images by this point."),
+                                vec![],
+                                config,
+                                device,
+                                (usize::MAX, usize::MAX), // Don't use it here...
+                            )
+                            .expect("Preprocessing failed");
+
+                        seq.cached_pixel_values = Some(pixel_values.clone());
+                        seq.cached_img_thw = image_grid_thw.clone();
+                        seq.cached_vid_thw = video_grid_thw.clone();
+                        (pixel_values, image_grid_thw, video_grid_thw)
+                    };
+
+                pixel_values_accum.push(pixel_values.unsqueeze(0).unwrap());
+                image_grid_thw_accum.push(image_grid_thw); //.map(|img| img.unsqueeze(0).unwrap()));
+                video_grid_thw_accum.push(video_grid_thw); //.map(|vid| vid.unsqueeze(0).unwrap()));
+            }
+
+            let image_grid_thw_accum = if image_grid_thw_accum.iter().any(|img| img.is_none()) {
+                None
+            } else {
+                Some(
+                    image_grid_thw_accum
+                        .into_iter()
+                        .map(|img| img.unwrap())
+                        .collect::<Vec<_>>(),
+                )
+            };
+
+            let video_grid_thw_accum = if video_grid_thw_accum.iter().any(|img| img.is_none()) {
+                None
+            } else {
+                Some(
+                    video_grid_thw_accum
+                        .into_iter()
+                        .map(|img| img.unwrap())
+                        .collect::<Vec<_>>(),
+                )
+            };
+
+            if is_prompt {
+                if let Some(ref image_grid_thw_accum) = image_grid_thw_accum {
+                    let merge_length = self.merge_size.read().unwrap().unwrap().pow(2);
+                    let mut index = 0;
+                    for (batch, text) in detok_seqs.iter_mut().enumerate() {
+                        while text.contains(Qwen2VLProcessor::IMAGE_PAD) {
+                            *text = replace_first_occurrence(
+                                text,
+                                Qwen2VLProcessor::IMAGE_PAD,
+                                &Qwen2VLProcessor::PLACEHOLDER.repeat(
+                                    image_grid_thw_accum[batch]
+                                        .i(index)
+                                        .unwrap()
+                                        .to_vec1::<u32>()
+                                        .unwrap()
+                                        .iter()
+                                        .product::<u32>()
+                                        as usize
+                                        / merge_length,
+                                ),
+                            );
+                            index += 1;
+                        }
+                        *text = text
+                            .replace(Qwen2VLProcessor::PLACEHOLDER, Qwen2VLProcessor::IMAGE_PAD);
+                    }
+                }
+
+                if let Some(ref video_grid_thw_accum) = video_grid_thw_accum {
+                    let merge_length = self.merge_size.read().unwrap().unwrap().pow(2);
+                    let mut index = 0;
+                    for (batch, text) in detok_seqs.iter_mut().enumerate() {
+                        while text.contains(Qwen2VLProcessor::VIDEO_PAD) {
+                            *text = replace_first_occurrence(
+                                text,
+                                Qwen2VLProcessor::VIDEO_PAD,
+                                &Qwen2VLProcessor::PLACEHOLDER.repeat(
+                                    video_grid_thw_accum[batch]
+                                        .i(index)
+                                        .unwrap()
+                                        .to_vec1::<u32>()
+                                        .unwrap()
+                                        .iter()
+                                        .product::<u32>()
+                                        as usize
+                                        / merge_length,
+                                ),
+                            );
+                            index += 1;
+                        }
+                        *text = text
+                            .replace(Qwen2VLProcessor::PLACEHOLDER, Qwen2VLProcessor::VIDEO_PAD);
+                    }
+                }
+            }
+
+            let mut all_ids = Vec::new();
+            let mut all_continuous_img_pad = Vec::new();
+            let mut all_continuous_vid_pad = Vec::new();
+            for (detok, seq) in detok_seqs.into_iter().zip(input_seqs.iter_mut()) {
+                seq.set_initial_prompt(detok.clone());
+
+                let toks = tokenizer
+                    .encode(detok, true)
+                    .expect("Detokenization failed!");
+
+                let ids = toks.get_ids().to_vec();
+                all_ids.push(ids.clone());
+
+                let img_pad = tokenizer
+                    .encode(Qwen2VLProcessor::IMAGE_PAD, false)
+                    .expect("Detokenization failed!")
+                    .get_ids()
+                    .to_vec();
+                let continuous_img_pad = find_sequences(&ids, img_pad[0]);
+                all_continuous_img_pad.push(continuous_img_pad);
+
+                let vid_pad = tokenizer
+                    .encode(Qwen2VLProcessor::VIDEO_PAD, false)
+                    .expect("Detokenization failed!")
+                    .get_ids()
+                    .to_vec();
+                let continuous_vid_pad = find_sequences(&ids, vid_pad[0]);
+                all_continuous_vid_pad.push(continuous_vid_pad);
+
+                seq.set_toks(ids);
+            }
+
+            let mut input_ids_searching = Vec::new();
+            let mut image_nums = Vec::new();
+            let mut video_nums = Vec::new();
+            for seq in input_seqs.iter() {
+                let prompt = seq.get_initial_prompt();
+                let match_indices = find_substring_indices(prompt, Qwen2VLProcessor::VISION_START);
+                image_nums.push(
+                    match_indices
+                        .iter()
+                        .filter(|&&idx| {
+                            prompt[idx..idx + Qwen2VLProcessor::IMAGE_PAD.len()]
+                                == *Qwen2VLProcessor::IMAGE_PAD
+                        })
+                        .count(),
+                );
+                video_nums.push(
+                    match_indices
+                        .iter()
+                        .filter(|&&idx| {
+                            prompt[idx..idx + Qwen2VLProcessor::VIDEO_PAD.len()]
+                                == *Qwen2VLProcessor::VIDEO_PAD
+                        })
+                        .count(),
+                );
+
+                let ids = tokenizer
+                    .encode(prompt, true)
+                    .expect("Tokenization failed!");
+
+                input_ids_searching.push(ids.get_ids().to_vec());
+            }
+
+            let mut all_ids_new = Vec::new();
+            let max_len = all_ids.iter().map(|ids| ids.len()).max().unwrap();
+            for ids in all_ids {
+                let pad = max_len - ids.len();
+                all_ids_new
+                    .push(Tensor::new([ids, vec![0; pad]].concat(), input.device()).unwrap());
+            }
+
+            (
+                Some(Tensor::stack(&all_ids_new, 0).unwrap()),
+                Some(Tensor::cat(&pixel_values_accum, 0).unwrap()),
+                image_grid_thw_accum.map(|img| Tensor::cat(&img, 0).unwrap()),
+                video_grid_thw_accum.map(|vid| Tensor::cat(&vid, 0).unwrap()),
+                all_continuous_img_pad,
+                all_continuous_vid_pad,
+                input_ids_searching,
+                image_nums,
+                video_nums,
+            )
+        } else {
+            (
+                None,
+                None,
+                None,
+                None,
+                vec![],
+                vec![],
+                vec![vec![]; input_seqs.len()],
+                vec![0; input_seqs.len()],
+                vec![0; input_seqs.len()],
+            )
+        };
+
+        let (input, input_ids_full) = match (new_input, is_prompt) {
+            (Some(new_input), true) => (new_input.clone(), new_input),
+            (Some(new_input), false) => (input, new_input),
+            (None, _) => (input.clone(), input.clone()),
+        };
+
+        let pixel_values = if is_prompt { pixel_values } else { None };
+
+        let seqlens = input_seqs
+            .iter()
+            .map(|seq| seq.prompt_tokens())
+            .collect::<Vec<_>>();
+
+        let inputs: Box<dyn Any> = Box::new(ModelInputs {
+            input_ids: input,
+            seqlen_offsets: positions,
+            context_lens,
+            position_ids,
+            pixel_values,
+            model_specific_args: Box::new(Qwen2VLVisionSpecificArgs {
+                input_ids_full,
+                image_grid_thw,
+                video_grid_thw,
+                seqlens,
+                continuous_img_pad,
+                continuous_vid_pad,
+                input_ids_searching,
+                image_nums,
+                video_nums,
+            }),
+            paged_attn_meta,
+            flash_meta,
+        });
+        Box::new(std::iter::once(Ok(InputProcessorOutput {
+            inputs,
+            seq_indices,
+        })))
+    }
+}
+
+impl Qwen2VLImageProcessor {
+    fn smart_resize(
+        &self,
+        height: usize,
+        width: usize,
+        factor: usize,
+        min_pixels: usize,
+        max_pixels: usize,
+    ) -> candle_core::Result<(usize, usize)> {
+        if height < factor || width < factor {
+            candle_core::bail!(
+                "height:{} or width:{} must be larger than factor:{}",
+                height,
+                width,
+                factor
+            );
+        } else if (height.max(width) as f64 / height.min(width) as f64) > 200.0 {
+            candle_core::bail!(
+                "absolute aspect ratio must be smaller than 200, got {:.2}",
+                height.max(width) as f64 / height.min(width) as f64
+            );
+        }
+
+        let mut h_bar = (height as f64 / factor as f64).round() as usize * factor;
+        let mut w_bar = (width as f64 / factor as f64).round() as usize * factor;
+
+        if h_bar * w_bar > max_pixels {
+            let beta = ((height * width) as f64 / max_pixels as f64).sqrt();
+            h_bar = ((height as f64 / beta / factor as f64).floor() as usize) * factor;
+            w_bar = ((width as f64 / beta / factor as f64).floor() as usize) * factor;
+        } else if h_bar * w_bar < min_pixels {
+            let beta = (min_pixels as f64 / (height * width) as f64).sqrt();
+            h_bar = ((height as f64 * beta / factor as f64).ceil() as usize) * factor;
+            w_bar = ((width as f64 * beta / factor as f64).ceil() as usize) * factor;
+        }
+
+        Ok((h_bar, w_bar))
+    }
+
+    // patches and t,h,w
+    fn preprocess_inner(
+        &self,
+        images: Vec<DynamicImage>,
+        config: &PreProcessorConfig,
+        device: &Device,
+        (mut height, mut width): (u32, u32),
+    ) -> candle_core::Result<(Tensor, (u32, u32, u32))> {
+        let mut processed_images = Vec::new();
+
+        for mut image in images {
+            image = image.resize_exact(
+                height,
+                width,
+                config
+                    .resampling
+                    .map(|resample| Some(resample).to_filter())
+                    .unwrap_or(Ok(FilterType::CatmullRom))?,
+            );
+            image = DynamicImage::ImageRgb8(image.to_rgb8());
+            if config.do_resize.is_none() || config.do_resize.is_some_and(|x| x) {
+                let (resized_height, resized_width) = self.smart_resize(
+                    height as usize,
+                    width as usize,
+                    config.patch_size.context("Require `patch_size`.")?
+                        * config.merge_size.context("Require `merge_size`")?,
+                    config.min_pixels.context("Require `min_pixels`")?,
+                    config.max_pixels.context("Require `max_pixels`")?,
+                )?;
+                height = resized_height as u32;
+                width = resized_width as u32;
+                image = image.resize_exact(
+                    resized_width as u32,
+                    resized_height as u32,
+                    config
+                        .resampling
+                        .map(|resample| Some(resample).to_filter())
+                        .unwrap_or(Ok(FilterType::CatmullRom))?,
+                );
+            }
+
+            let to_tensor_rescale = Transforms {
+                input: &ToTensor,
+                inner_transforms: &[],
+            };
+            let image = image.apply(to_tensor_rescale, device)?;
+
+            let transforms = TensorTransforms {
+                inner_transforms: &[&Normalize {
+                    mean: config.image_mean.unwrap_or(Self::DEFAULT_MEAN).to_vec(),
+                    std: config.image_std.unwrap_or(Self::DEFAULT_STD).to_vec(),
+                }],
+            };
+            let image = <Tensor as ApplyTensorTransforms>::apply(&image, transforms, device)?;
+
+            processed_images.push(image);
+        }
+
+        let mut patches = Tensor::stack(&processed_images, 0)?;
+        let temporal_patch_size = config
+            .temporal_patch_size
+            .context("Require `temporal_patch_size")?;
+        let patch_size = config.patch_size.context("Require `patch_size")?;
+        let merge_size = config.merge_size.context("Require `merge_size")?;
+        // Important to write it!
+        *self.merge_size.write().unwrap() = Some(merge_size);
+        // Image
+        if patches.dim(0)? == 1 {
+            patches = patches.repeat((temporal_patch_size, 1, 1, 1))?;
+        }
+        let channel = patches.dim(1)?;
+        let grid_t = patches.dim(0)? / temporal_patch_size;
+        let grid_h = height as usize / patch_size;
+        let grid_w = width as usize / patch_size;
+        patches = patches.reshape(&[
+            grid_t,
+            temporal_patch_size,
+            channel,
+            grid_h / merge_size,
+            merge_size,
+            patch_size,
+            grid_w / merge_size,
+            merge_size,
+            patch_size,
+        ])?;
+        patches = patches.permute([0, 3, 6, 4, 7, 2, 1, 5, 8])?;
+        let flattened_patches = patches.reshape((
+            grid_t * grid_h * grid_w,
+            channel * temporal_patch_size * patch_size * patch_size,
+        ))?;
+
+        Ok((
+            flattened_patches,
+            (grid_t as u32, grid_h as u32, grid_w as u32),
+        ))
+    }
+}
+
+impl ImagePreProcessor for Qwen2VLImageProcessor {
+    const DEFAULT_MEAN: [f64; 3] = [0.48145466, 0.4578275, 0.40821073];
+    const DEFAULT_STD: [f64; 3] = [0.26862954, 0.26130258, 0.27577711];
+
+    fn preprocess(
+        &self,
+        mut images: Vec<DynamicImage>,
+        videos: Vec<Vec<DynamicImage>>,
+        config: &PreProcessorConfig,
+        device: &Device,
+        (_, _): (usize, usize),
+    ) -> candle_core::Result<PreprocessedImages> {
+        let mut pixel_values = Vec::new();
+        let mut vision_grid_thw = Vec::new();
+
+        if !images.is_empty() {
+            if let Some(max_edge) = self.max_edge {
+                images = mistralrs_vision::pad_to_max_edge(&images, max_edge);
+            }
+
+            let mut height = 0;
+            let mut width = 0;
+            for image in &images {
+                let (w, h) = image.dimensions();
+                if w > width {
+                    width = w;
+                }
+                if h > height {
+                    height = h;
+                }
+            }
+
+            for image in images {
+                let (patches, (t, h, w)) =
+                    self.preprocess_inner(vec![image], config, device, (height, width))?;
+                pixel_values.push(patches);
+                vision_grid_thw.push(Tensor::new(&[t, h, w], &Device::Cpu)?);
+            }
+            let pixel_values = Tensor::stack(&pixel_values, 0)?;
+            let vision_grid_thw = Tensor::stack(&vision_grid_thw, 0)?;
+            return Ok(PreprocessedImages {
+                pixel_values,
+                pixel_attention_mask: None,
+                image_sizes: None,
+                num_img_tokens: None,
+                aspect_ratio_ids: None,
+                aspect_ratio_mask: None,
+                num_tiles: None,
+                image_grid_thw: Some(vision_grid_thw),
+                video_grid_thw: None,
+                rows: None,
+                cols: None,
+                pixel_values_list: None,
+                tgt_sizes: None,
+                image_sizes_all: None,
+            });
+        }
+
+        if !videos.is_empty() {
+            let mut height = 0;
+            let mut width = 0;
+            for image in &videos {
+                let (w, h) = image[0].dimensions();
+                if w > width {
+                    width = w;
+                }
+                if h > height {
+                    height = h;
+                }
+            }
+
+            for images in videos {
+                let (patches, (t, h, w)) =
+                    self.preprocess_inner(images, config, device, (height, width))?;
+                pixel_values.push(patches);
+                vision_grid_thw.push(Tensor::new(&[t, h, w], &Device::Cpu)?);
+            }
+            let pixel_values = Tensor::stack(&pixel_values, 0)?;
+            let vision_grid_thw = Tensor::stack(&vision_grid_thw, 0)?;
+            return Ok(PreprocessedImages {
+                pixel_values,
+                pixel_attention_mask: None,
+                image_sizes: None,
+                num_img_tokens: None,
+                aspect_ratio_ids: None,
+                aspect_ratio_mask: None,
+                num_tiles: None,
+                image_grid_thw: None,
+                video_grid_thw: Some(vision_grid_thw),
+                rows: None,
+                cols: None,
+                pixel_values_list: None,
+                tgt_sizes: None,
+                image_sizes_all: None,
+            });
+        }
+        unreachable!()
+    }
+}

--- a/mistralrs-core/src/vision_models/qwen2_5_vl/mod.rs
+++ b/mistralrs-core/src/vision_models/qwen2_5_vl/mod.rs
@@ -1,0 +1,518 @@
+#![allow(clippy::cast_possible_truncation, clippy::cast_precision_loss)]
+
+use std::{any::Any, sync::Arc};
+
+use candle_core::{Context, DType, Device, IndexOp, Result, Tensor, D};
+use mistralrs_quant::{QuantMethod, ShardedVarBuilder};
+use text::Qwen2VLTextModel;
+use vision::Qwen2VLVisionModel;
+
+use crate::{
+    amoe::AnyMoeBaseModelMixin,
+    device_map::DeviceMapper,
+    layers::CausalMasker,
+    layers_masker::{masked_fill, PastKvLenCache},
+    paged_attention::{AttentionImplementation, ModelConfigMetadata},
+    pipeline::{
+        text_models_inputs_processor::{FlashParams, PagedAttentionInputMetadata},
+        EitherCache, IsqModel, NormalLoadingMetadata, VisionModel,
+    },
+};
+
+mod config;
+mod inputs_processor;
+mod text;
+mod vision;
+
+pub(crate) use config::Config;
+pub(crate) use inputs_processor::Qwen2VLProcessor;
+
+pub struct Qwen2VLModel {
+    text: Qwen2VLTextModel,
+    vision: Qwen2VLVisionModel,
+    spatial_merge_size: usize,
+    image_token_id: u32,
+    video_token_id: u32,
+}
+
+impl Qwen2VLModel {
+    pub fn new(
+        cfg: &Config,
+        vb: ShardedVarBuilder,
+        is_gptx: bool,
+        normal_loading_metadata: NormalLoadingMetadata,
+        attention_mechanism: AttentionImplementation,
+    ) -> Result<Self> {
+        if cfg.use_sliding_window {
+            // TODO!
+            candle_core::bail!("Sliding window is unsupported for now!");
+        }
+        let vision = Qwen2VLVisionModel::new(
+            &cfg.vision_config,
+            vb.pp("visual")
+                .set_device(normal_loading_metadata.real_device.clone())
+                .set_dtype(DType::F32),
+        )?;
+        let text = Qwen2VLTextModel::new(
+            cfg,
+            vb.clone(),
+            is_gptx,
+            normal_loading_metadata,
+            attention_mechanism,
+        )?;
+        Ok(Self {
+            text,
+            vision,
+            spatial_merge_size: cfg.vision_config.spatial_merge_size,
+            image_token_id: cfg.image_token_id,
+            video_token_id: cfg.video_token_id,
+        })
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    /// (position_ids, mrope_position_deltas)
+    fn get_rope_index(
+        &self,
+        input_ids: &Tensor,
+        image_grid_thw: Option<&Tensor>,
+        video_grid_thw: Option<&Tensor>,
+        attention_mask: Option<&Tensor>,
+        attention_mask_indices: Option<&Tensor>,
+        input_ids_searching: Vec<Vec<u32>>,
+        image_nums: Vec<usize>,
+        video_nums: Vec<usize>,
+    ) -> Result<(Tensor, Tensor)> {
+        if image_grid_thw.is_some() || video_grid_thw.is_some() {
+            let total_input_ids = input_ids.clone();
+            let mut position_ids = Tensor::zeros(
+                (3, input_ids.dim(0)?, input_ids.dim(1)?),
+                DType::I64,
+                input_ids.device(),
+            )?;
+            let mut mrope_position_deltas = Vec::new();
+
+            let mut image_index = 0;
+            let mut video_index = 0;
+            for (i, mut input_ids) in total_input_ids
+                .chunk(input_ids.dim(0)?, 0)?
+                .into_iter()
+                .enumerate()
+            {
+                if let Some(attention_mask_indices) = attention_mask_indices {
+                    input_ids = input_ids
+                        .i(i)?
+                        .to_dtype(DType::F32)?
+                        .index_select(&attention_mask_indices.squeeze(0)?, 0)?
+                        .to_dtype(input_ids.dtype())?;
+                }
+                let image_nums = image_nums[i];
+                let vision_nums = video_nums[i];
+
+                let mut llm_pos_ids: Vec<Tensor> = Vec::new();
+                let mut max_last_llm_pos_ids = None;
+                let mut max_llm_pos_ids = 0;
+                let mut st = 0;
+                let (mut remain_images, mut remain_videos) = (image_nums, vision_nums);
+                for _ in 0..(image_nums + vision_nums) {
+                    let ed_image = if input_ids_searching[i].contains(&self.image_token_id)
+                        && remain_images > 0
+                    {
+                        input_ids_searching[i][st..]
+                            .iter()
+                            .position(|&t| t == self.image_token_id)
+                            .unwrap()
+                            + st
+                    } else {
+                        input_ids.dim(0)? + 1
+                    };
+                    let ed_video = if input_ids_searching[i].contains(&self.video_token_id)
+                        && remain_videos > 0
+                    {
+                        input_ids_searching[i][st..]
+                            .iter()
+                            .position(|&t| t == self.video_token_id)
+                            .unwrap()
+                            + st
+                    } else {
+                        input_ids.dim(0)? + 1
+                    };
+                    let (ed, llm_grid_t, h, w) = if ed_image < ed_video {
+                        let t = image_grid_thw.as_ref().unwrap().i((image_index, 0))?;
+                        let h = image_grid_thw.as_ref().unwrap().i((image_index, 1))?;
+                        let w = image_grid_thw.as_ref().unwrap().i((image_index, 2))?;
+                        image_index += 1;
+                        remain_images -= 1;
+                        (
+                            ed_image,
+                            t.to_scalar::<u32>()?,
+                            h.to_scalar::<u32>()?,
+                            w.to_scalar::<u32>()?,
+                        )
+                    } else {
+                        let t = video_grid_thw.as_ref().unwrap().i((video_index, 0))?;
+                        let h = video_grid_thw.as_ref().unwrap().i((video_index, 1))?;
+                        let w = video_grid_thw.as_ref().unwrap().i((video_index, 2))?;
+                        video_index += 1;
+                        remain_videos -= 1;
+                        (
+                            ed_video,
+                            t.to_scalar::<u32>()?,
+                            h.to_scalar::<u32>()?,
+                            w.to_scalar::<u32>()?,
+                        )
+                    };
+                    let llm_grid_h = h / self.spatial_merge_size as u32;
+                    let llm_grid_w = w / self.spatial_merge_size as u32;
+                    let text_len = ed - st;
+
+                    let st_idx = max_last_llm_pos_ids.unwrap_or(0);
+                    // max_last_llm_pos_ids = Some(text_len as i64 + st_idx);
+                    max_llm_pos_ids = max_llm_pos_ids.max(text_len as i64 + st_idx);
+                    llm_pos_ids.push(
+                        Tensor::arange(st_idx, text_len as i64 + st_idx, input_ids.device())?
+                            .unsqueeze(0)?
+                            .repeat((3, 1))?,
+                    );
+
+                    let t_idx = Tensor::arange(0, llm_grid_t as i64, input_ids.device())?
+                        .reshape(((), 1))?
+                        .repeat((1, llm_grid_h as usize * llm_grid_w as usize))?
+                        .flatten_all()?;
+                    let h_idx = Tensor::arange(0, llm_grid_h as i64, input_ids.device())?
+                        .reshape((1, (), 1))?
+                        .repeat((llm_grid_t as usize, 1, llm_grid_w as usize))?
+                        .flatten_all()?;
+                    let w_idx = Tensor::arange(0, llm_grid_w as i64, input_ids.device())?
+                        .reshape((1, 1, ()))?
+                        .repeat((llm_grid_t as usize, llm_grid_h as usize, 1))?
+                        .flatten_all()?;
+                    max_last_llm_pos_ids = Some(
+                        *[llm_grid_t, llm_grid_h, llm_grid_w].iter().max().unwrap() as i64
+                            + (text_len as i64 + st_idx),
+                    );
+                    max_llm_pos_ids = max_llm_pos_ids.max(max_last_llm_pos_ids.unwrap());
+                    llm_pos_ids.push(
+                        (Tensor::stack(&[t_idx, h_idx, w_idx], 0)?.to_dtype(DType::F32)?
+                            + (text_len + st_idx as usize) as f64)?
+                            .to_dtype(DType::I64)?,
+                    );
+                    st = ed + (llm_grid_t * llm_grid_h * llm_grid_w) as usize;
+                }
+
+                if st < input_ids.dim(0)? {
+                    let st_idx = max_last_llm_pos_ids.unwrap_or(0);
+                    let text_len = (input_ids.dim(0)? - st) as u32;
+                    // max_last_llm_pos_ids = Some(text_len as i64 + st_idx);
+                    max_llm_pos_ids = max_llm_pos_ids.max(text_len as i64 + st_idx);
+                    llm_pos_ids.push(
+                        Tensor::arange(st_idx, text_len as i64 + st_idx, input_ids.device())?
+                            .reshape((1, ()))?
+                            .repeat((3, 1))?,
+                    );
+                }
+
+                let llm_positions = Tensor::cat(&llm_pos_ids, 1)?.reshape((3, ()))?;
+                let positions_mask = attention_mask
+                    .as_ref()
+                    .unwrap()
+                    .i(i)?
+                    .eq(1f64)?
+                    .unsqueeze(0)?
+                    .repeat((3, 1))?;
+
+                position_ids = position_ids.slice_assign(
+                    &[&.., &i, &..],
+                    &positions_mask
+                        .where_cond(&llm_positions, &position_ids.i((.., i, ..))?)?
+                        .unsqueeze(1)?,
+                )?;
+                mrope_position_deltas
+                    .push(max_llm_pos_ids + 1 - total_input_ids.i(i)?.dim(0)? as i64);
+            }
+            let mrope_position_deltas_len = mrope_position_deltas.len();
+            let mrope_position_deltas = Tensor::from_vec(
+                mrope_position_deltas,
+                (mrope_position_deltas_len,),
+                input_ids.device(),
+            )?
+            .unsqueeze(1)?;
+            Ok((position_ids, mrope_position_deltas))
+        } else if let Some(attention_mask) = attention_mask {
+            let position_ids = (attention_mask.to_dtype(DType::F32)?.cumsum(D::Minus1)? - 1f64)?;
+            let position_ids = masked_fill(&position_ids, &attention_mask.eq(0f64)?, 1i64)?;
+            let position_ids = position_ids.unsqueeze(0)?.repeat((3, 1, 1))?;
+
+            let max_position_ids = position_ids.max(0)?.max_keepdim(D::Minus1)?;
+            let mrope_position_deltas =
+                ((max_position_ids + 1.)? - attention_mask.dim(D::Minus1)? as f64)?;
+
+            Ok((
+                position_ids.to_dtype(DType::I64)?,
+                mrope_position_deltas.to_dtype(DType::I64)?,
+            ))
+        } else {
+            let position_ids = Tensor::arange(0i64, input_ids.dim(1)? as i64, input_ids.device())?
+                .reshape((1, 1, ()))?
+                .repeat((3, input_ids.dim(0)?, 1))?;
+            let mrope_position_deltas =
+                Tensor::zeros((input_ids.dim(0)?, 1), DType::I64, input_ids.device())?;
+
+            Ok((position_ids, mrope_position_deltas))
+        }
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    pub fn forward(
+        &self,
+        input_ids: &Tensor,
+        input_ids_full: &Tensor,
+        pixel_values: Option<Tensor>,
+        pixel_values_videos: Option<Tensor>,
+        image_grid_thw: Option<Tensor>,
+        video_grid_thw: Option<Tensor>,
+        seqlens: Vec<usize>,
+        continuous_img_pad: Vec<Vec<(usize, usize)>>,
+        continuous_vid_pad: Vec<Vec<(usize, usize)>>,
+        input_ids_searching: Vec<Vec<u32>>,
+        image_nums: Vec<usize>,
+        video_nums: Vec<usize>,
+        seqlen_offsets: &[usize],
+        context_lens: Vec<(usize, usize)>,
+        flash_params: &FlashParams,
+    ) -> Result<Tensor> {
+        let attention_mask = CausalMasker.make_sliding_window_causal_mask_matrix(
+            input_ids,
+            &seqlen_offsets as &dyn PastKvLenCache,
+            self.text.cfg.sliding_window,
+            self.text.dtype,
+            self.text.cfg.num_attn_heads,
+        )?;
+
+        let input_embeds = if pixel_values.is_some() || pixel_values_videos.is_some() {
+            let mut xs = self.text.embed_tokens(input_ids)?;
+
+            if let Some(pixel_values) = pixel_values {
+                let image_embeds = self
+                    .vision
+                    .forward(
+                        &pixel_values,
+                        image_grid_thw
+                            .as_ref()
+                            .context("pixel_values require image_grid_thw")?,
+                    )?
+                    .to_dtype(self.text.dtype)?;
+
+                for (batch, batch_ids) in continuous_img_pad.into_iter().enumerate() {
+                    let mut last_end = 0;
+                    for (start, end) in batch_ids {
+                        xs = xs.slice_assign(
+                            &[&batch, &(start..end), &..],
+                            &image_embeds
+                                .i((last_end..last_end + (end - start), ..))?
+                                .unsqueeze(0)?,
+                        )?;
+                        last_end = end - start;
+                    }
+                }
+            }
+
+            if let Some(pixel_values_videos) = pixel_values_videos {
+                let video_embeds = self.vision.forward(
+                    &pixel_values_videos,
+                    video_grid_thw
+                        .as_ref()
+                        .context("pixel_values_videos require video_grid_thw")?,
+                )?;
+
+                for (batch, batch_ids) in continuous_vid_pad.into_iter().enumerate() {
+                    let mut last_end = 0;
+                    for (start, end) in batch_ids {
+                        xs = xs.slice_assign(
+                            &[&batch, &(start..end), &..],
+                            &video_embeds
+                                .i((last_end..last_end + (end - start), ..))?
+                                .unsqueeze(0)?,
+                        )?;
+                        last_end = end - start;
+                    }
+                }
+            }
+
+            xs
+        } else {
+            self.text.embed_tokens(input_ids)?
+        };
+
+        let mut ropeidx_attn_mask_bs = Vec::new();
+        let max_seqlens = *seqlens.iter().max().unwrap();
+        for len in &seqlens {
+            ropeidx_attn_mask_bs.push(Tensor::new(
+                [vec![1f32; *len], vec![0f32; max_seqlens - len]].concat(),
+                input_ids.device(),
+            )?);
+        }
+        let ropeidx_attn_mask = Tensor::stack(&ropeidx_attn_mask_bs, 0)?;
+        let mut ropeidx_attn_mask_indices_bs = Vec::new();
+        for len in seqlens {
+            ropeidx_attn_mask_indices_bs.push(Tensor::from_vec(
+                (0..len as i64).collect(),
+                (len,),
+                input_ids.device(),
+            )?);
+        }
+        let ropeidx_attn_mask_indices = Tensor::stack(&ropeidx_attn_mask_indices_bs, 0)?;
+
+        let ropeidx_input_ids = if attention_mask.is_some() {
+            input_ids
+        } else {
+            input_ids_full
+        };
+        let (position_ids, mrope_position_deltas) = self.get_rope_index(
+            ropeidx_input_ids,
+            image_grid_thw.as_ref(),
+            video_grid_thw.as_ref(),
+            Some(&ropeidx_attn_mask),
+            Some(&ropeidx_attn_mask_indices),
+            input_ids_searching,
+            image_nums,
+            video_nums,
+        )?;
+
+        let position_ids = if attention_mask.is_some() {
+            position_ids
+        } else {
+            let mut position_ids = Tensor::new(
+                seqlen_offsets.iter().map(|x| *x as i64).collect::<Vec<_>>(),
+                input_ids.device(),
+            )?
+            .reshape((1, (), 1))?
+            .repeat((3, 1, 1))?;
+
+            position_ids = position_ids.broadcast_add(&mrope_position_deltas.unsqueeze(0)?)?;
+
+            position_ids
+        };
+
+        let out = self.text.forward_embeds(
+            input_embeds,
+            attention_mask.as_ref(),
+            &position_ids,
+            context_lens,
+            flash_params,
+        )?;
+        Ok(out)
+    }
+}
+
+pub(crate) struct Qwen2VLVisionSpecificArgs {
+    input_ids_full: Tensor,
+    image_grid_thw: Option<Tensor>, // Some when pixel values are provided
+    video_grid_thw: Option<Tensor>, // Some when pixel values are provided
+    seqlens: Vec<usize>,
+    continuous_img_pad: Vec<Vec<(usize, usize)>>,
+    continuous_vid_pad: Vec<Vec<(usize, usize)>>,
+    input_ids_searching: Vec<Vec<u32>>,
+    image_nums: Vec<usize>,
+    video_nums: Vec<usize>,
+}
+
+impl VisionModel for Qwen2VLModel {
+    fn forward(
+        &self,
+        input_ids: &Tensor,
+        pixel_values: Option<Tensor>,
+        seqlen_offsets: &[usize],
+        context_lens: Vec<(usize, usize)>,
+        _position_ids: Vec<usize>,
+        model_specific_args: Box<dyn Any>,
+        _metadata: Option<(Vec<(Tensor, Tensor)>, &PagedAttentionInputMetadata)>,
+        flash_params: &FlashParams,
+    ) -> Result<Tensor> {
+        let Qwen2VLVisionSpecificArgs {
+            input_ids_full,
+            image_grid_thw,
+            video_grid_thw,
+            seqlens,
+            continuous_img_pad,
+            continuous_vid_pad,
+            input_ids_searching,
+            image_nums,
+            video_nums,
+        } = *model_specific_args
+            .downcast()
+            .expect("Cannot downcast into `Qwen2VLVisionSpecificArgs`");
+        let (pixel_values, pixel_values_video) = match (&image_grid_thw, &video_grid_thw) {
+            (Some(_), None) => (pixel_values, None),
+            (None, Some(_)) => (None, pixel_values),
+            (None, None) => (None, None),
+            (Some(_), Some(_)) => {
+                candle_core::bail!("Images and videos cannot be provided together.")
+            }
+        };
+        self.forward(
+            input_ids,
+            &input_ids_full,
+            pixel_values,
+            pixel_values_video,
+            image_grid_thw,
+            video_grid_thw,
+            seqlens,
+            continuous_img_pad,
+            continuous_vid_pad,
+            input_ids_searching,
+            image_nums,
+            video_nums,
+            seqlen_offsets,
+            context_lens,
+            flash_params,
+        )
+    }
+    fn cache(&self) -> &EitherCache {
+        &self.text.cache
+    }
+    fn cache_mut(&mut self) -> &mut EitherCache {
+        &mut self.text.cache
+    }
+    fn device(&self) -> &Device {
+        &self.text.device
+    }
+    fn max_seq_len(&self) -> usize {
+        self.text.max_seq_len
+    }
+    fn has_conv2d(&self) -> bool {
+        true
+    }
+    fn config(&self) -> &ModelConfigMetadata {
+        &self.text.cfg
+    }
+    fn default_model_specific_args(&self, input_ids: &Tensor) -> Box<dyn Any> {
+        assert_eq!(input_ids.dims()[0], 1);
+        Box::new(Qwen2VLVisionSpecificArgs {
+            input_ids_full: input_ids.clone(),
+            image_grid_thw: None,
+            video_grid_thw: None,
+            seqlens: vec![input_ids.dims()[1]],
+            continuous_img_pad: vec![],
+            continuous_vid_pad: vec![],
+            input_ids_searching: vec![vec![]; input_ids.dims()[0]],
+            image_nums: vec![0; input_ids.dims()[0]],
+            video_nums: vec![0; input_ids.dims()[0]],
+        })
+    }
+}
+
+impl IsqModel for Qwen2VLModel {
+    fn get_layers(
+        &mut self,
+    ) -> (
+        Vec<(&mut Arc<dyn QuantMethod>, Option<usize>)>,
+        &dyn DeviceMapper,
+    ) {
+        self.text.get_layers()
+    }
+    fn residual_tensors(&self) -> Vec<(String, Tensor)> {
+        self.text.residual_tensors()
+    }
+}
+
+impl AnyMoeBaseModelMixin for Qwen2VLModel {}

--- a/mistralrs-core/src/vision_models/qwen2_5_vl/text.rs
+++ b/mistralrs-core/src/vision_models/qwen2_5_vl/text.rs
@@ -1,0 +1,514 @@
+use std::{collections::HashMap, sync::Arc};
+
+use candle_core::{DType, Device, Result, Tensor};
+use candle_nn::{Embedding, Module};
+use mistralrs_quant::{
+    ColumnParallelLayer, QuantMethod, ReplicatedLayer, RowParallelLayer, ShardedVarBuilder,
+};
+
+use crate::{
+    attention::SdpaParams,
+    device_map::DeviceMapper,
+    layers::{self, Activation, F32RmsNorm, Qwen2VLRotaryEmbedding, Sdpa},
+    paged_attention::{AttentionImplementation, ModelConfigMetadata},
+    pipeline::{
+        extract_logits, text_models_inputs_processor::FlashParams, EitherCache, IsqModel, KvCache,
+        NormalCache, NormalLoadingMetadata,
+    },
+    utils::{progress::NiceProgressBar, unvarbuilder::UnVarBuilder},
+};
+
+use super::config::Config;
+
+struct Mlp {
+    gate_proj: Arc<dyn QuantMethod>,
+    up_proj: Arc<dyn QuantMethod>,
+    down_proj: Arc<dyn QuantMethod>,
+    act_fn: Activation,
+}
+
+impl Mlp {
+    fn new(cfg: &Config, vb: ShardedVarBuilder, comm: &Arc<mistralrs_quant::Comm>) -> Result<Self> {
+        let hidden_sz = cfg.hidden_size;
+        let intermediate_sz = cfg.intermediate_size;
+        let gate_proj = ColumnParallelLayer::new(
+            hidden_sz,
+            intermediate_sz,
+            &cfg.quantization_config,
+            false,
+            comm,
+            vb.pp("gate_proj"),
+        )?;
+        let up_proj = ColumnParallelLayer::new(
+            hidden_sz,
+            intermediate_sz,
+            &cfg.quantization_config,
+            false,
+            comm,
+            vb.pp("up_proj"),
+        )?;
+        let down_proj = RowParallelLayer::new(
+            intermediate_sz,
+            hidden_sz,
+            &cfg.quantization_config,
+            false,
+            comm,
+            vb.pp("down_proj"),
+        )?;
+        Ok(Self {
+            gate_proj,
+            up_proj,
+            down_proj,
+            act_fn: cfg.hidden_act,
+        })
+    }
+
+    fn forward(&self, xs: &Tensor) -> Result<Tensor> {
+        let original_dtype = xs.dtype();
+        let mut xs = xs.clone();
+        if let Some(t) = self.gate_proj.quantized_act_type() {
+            xs = xs.to_dtype(t)?;
+        }
+        let lhs = self.gate_proj.forward(&xs)?.apply(&self.act_fn)?;
+        let rhs = self.up_proj.forward(&xs)?;
+        self.down_proj
+            .forward(&(lhs * rhs)?)?
+            .to_dtype(original_dtype)
+    }
+}
+
+struct Attention {
+    q_proj: Arc<dyn QuantMethod>,
+    k_proj: Arc<dyn QuantMethod>,
+    v_proj: Arc<dyn QuantMethod>,
+    o_proj: Arc<dyn QuantMethod>,
+    num_heads: usize,
+    num_kv_heads: usize,
+    head_dim: usize,
+    rotary_emb: Arc<Qwen2VLRotaryEmbedding>,
+    sdpa_params: SdpaParams,
+}
+
+impl Attention {
+    fn new(
+        rotary_emb: Arc<Qwen2VLRotaryEmbedding>,
+        cfg: &Config,
+        vb: ShardedVarBuilder,
+        comm: &Arc<mistralrs_quant::Comm>,
+    ) -> Result<Self> {
+        let hidden_sz = cfg.hidden_size;
+        let num_heads = cfg.num_attention_heads;
+        let num_kv_heads = cfg.num_key_value_heads;
+        let head_dim = hidden_sz / num_heads;
+        let q_proj = ColumnParallelLayer::new(
+            hidden_sz,
+            num_heads * head_dim,
+            &cfg.quantization_config,
+            true,
+            comm,
+            vb.pp("q_proj"),
+        )?;
+        let kv_shard = mistralrs_quant::compute_kv_shard(
+            cfg.num_key_value_heads,
+            cfg.hidden_size / cfg.num_attention_heads,
+            comm,
+        );
+        let k_proj = ColumnParallelLayer::new_with_shard(
+            hidden_sz,
+            num_kv_heads * head_dim,
+            &cfg.quantization_config,
+            true,
+            comm,
+            kv_shard,
+            vb.pp("k_proj"),
+        )?;
+        let v_proj = ColumnParallelLayer::new_with_shard(
+            hidden_sz,
+            num_kv_heads * head_dim,
+            &cfg.quantization_config,
+            true,
+            comm,
+            kv_shard,
+            vb.pp("v_proj"),
+        )?;
+        let o_proj = RowParallelLayer::new(
+            num_heads * head_dim,
+            hidden_sz,
+            &cfg.quantization_config,
+            false,
+            comm,
+            vb.pp("o_proj"),
+        )?;
+        Ok(Self {
+            q_proj,
+            k_proj,
+            v_proj,
+            o_proj,
+            num_heads: num_heads / comm.world_size(),
+            num_kv_heads: (num_kv_heads / comm.world_size()).max(1),
+            head_dim,
+            rotary_emb,
+            sdpa_params: SdpaParams {
+                n_kv_groups: mistralrs_quant::compute_n_kv_groups(
+                    cfg.num_key_value_heads,
+                    cfg.num_attention_heads,
+                    comm,
+                ),
+                use_flash_attn: false,
+                softcap: None,
+                softmax_scale: 1.0 / (head_dim as f32).sqrt(),
+                sliding_window: None,
+            },
+        })
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn forward(
+        &self,
+        xs: &Tensor,
+        attention_mask: Option<&Tensor>,
+        cos_sin: &(Tensor, Tensor),
+        kv_cache: &mut KvCache,
+        flash_params: &FlashParams,
+    ) -> Result<Tensor> {
+        let (b_sz, q_len, _) = xs.dims3()?;
+
+        let original_dtype = xs.dtype();
+        let mut xs = xs.clone();
+        if let Some(t) = self.q_proj.quantized_act_type() {
+            xs = xs.to_dtype(t)?;
+        }
+        let mut q = self.q_proj.forward(&xs)?;
+        let mut k = self.k_proj.forward(&xs)?;
+        let mut v = self.v_proj.forward(&xs)?;
+        if self.q_proj.quantized_act_type().is_some() {
+            q = q.to_dtype(original_dtype)?;
+            k = k.to_dtype(original_dtype)?;
+            v = v.to_dtype(original_dtype)?;
+        }
+
+        let (mut q, mut k, v) = if q_len != 1 {
+            let q = q
+                .reshape((b_sz, q_len, self.num_heads, self.head_dim))?
+                .transpose(1, 2)?;
+            let k = k
+                .reshape((b_sz, q_len, self.num_kv_heads, self.head_dim))?
+                .transpose(1, 2)?;
+            let v = v
+                .reshape((b_sz, q_len, self.num_kv_heads, self.head_dim))?
+                .transpose(1, 2)?;
+            (q, k, v)
+        } else {
+            let q = q.reshape((b_sz, self.num_heads, q_len, self.head_dim))?;
+            let k = k.reshape((b_sz, self.num_kv_heads, q_len, self.head_dim))?;
+            let v = v.reshape((b_sz, self.num_kv_heads, q_len, self.head_dim))?;
+            (q, k, v)
+        };
+
+        self.rotary_emb.forward(cos_sin, &mut q, &mut k)?;
+
+        let mut attn_output = {
+            let (k, v) = kv_cache.append(&k, &v)?;
+
+            Sdpa.run_attention(
+                &q.contiguous()?.to_dtype(DType::F32)?,
+                &k.contiguous()?.to_dtype(DType::F32)?,
+                &v.contiguous()?.to_dtype(DType::F32)?,
+                attention_mask
+                    .map(|mask| mask.to_dtype(DType::F32).unwrap())
+                    .as_ref(),
+                Some(flash_params),
+                &self.sdpa_params,
+            )?
+            .to_dtype(q.dtype())?
+        };
+
+        if let Some(t) = self.q_proj.quantized_act_type() {
+            attn_output = attn_output.to_dtype(t)?;
+        }
+        attn_output = if attention_mask.is_some() {
+            attn_output.transpose(1, 2)?.reshape((b_sz, q_len, ()))?
+        } else {
+            attn_output.reshape((b_sz, q_len, ()))?
+        };
+        let mut res = self.o_proj.forward(&attn_output)?;
+        if self.q_proj.quantized_act_type().is_some() {
+            res = res.to_dtype(original_dtype)?;
+        }
+        Ok(res)
+    }
+}
+
+pub struct DecoderLayer {
+    self_attn: Attention,
+    mlp: Mlp,
+    input_layernorm: F32RmsNorm,
+    post_attention_layernorm: F32RmsNorm,
+}
+
+impl DecoderLayer {
+    fn new(
+        rotary_emb: Arc<Qwen2VLRotaryEmbedding>,
+        cfg: &Config,
+        vb: ShardedVarBuilder,
+        mapper: &dyn DeviceMapper,
+        layer_idx: usize,
+        loading_isq: bool,
+        comm: &Arc<mistralrs_quant::Comm>,
+    ) -> Result<Self> {
+        let self_attn = Attention::new(
+            rotary_emb,
+            cfg,
+            mapper.set_device(layer_idx, vb.pp("self_attn"), loading_isq),
+            comm,
+        )?;
+        let mlp = Mlp::new(
+            cfg,
+            mapper.set_device(layer_idx, vb.pp("mlp"), loading_isq),
+            comm,
+        )?;
+        let input_layernorm = F32RmsNorm::new(
+            cfg.hidden_size,
+            cfg.rms_norm_eps,
+            mapper.set_device(layer_idx, vb.pp("input_layernorm"), false),
+        )?;
+        let post_attention_layernorm = F32RmsNorm::new(
+            cfg.hidden_size,
+            cfg.rms_norm_eps,
+            mapper.set_device(layer_idx, vb.pp("post_attention_layernorm"), false),
+        )?;
+        Ok(Self {
+            self_attn,
+            mlp,
+            input_layernorm,
+            post_attention_layernorm,
+        })
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn forward(
+        &self,
+        xs: &Tensor,
+        attention_mask: Option<&Tensor>,
+        cos_sin: &(Tensor, Tensor),
+        kv_cache: &mut KvCache,
+        flash_params: &FlashParams,
+    ) -> Result<Tensor> {
+        let residual = xs;
+        let xs = self.input_layernorm.forward(xs)?;
+        let xs = self
+            .self_attn
+            .forward(&xs, attention_mask, cos_sin, kv_cache, flash_params)?;
+        let xs = (xs + residual)?;
+        let residual = &xs;
+        let xs = self
+            .mlp
+            .forward(&xs.apply(&self.post_attention_layernorm)?)?;
+        residual + xs
+    }
+}
+
+pub struct Qwen2VLTextModel {
+    embed_tokens: Embedding,
+    pub(super) norm: F32RmsNorm,
+    layers: Vec<DecoderLayer>,
+    mapper: Box<dyn DeviceMapper + Send + Sync>,
+    lm_head: Arc<dyn QuantMethod>,
+    pub(super) cache: EitherCache,
+    pub(super) cfg: ModelConfigMetadata,
+    pub(super) device: Device,
+    pub(super) dtype: DType,
+    pub(super) max_seq_len: usize,
+}
+
+impl Qwen2VLTextModel {
+    pub fn new(
+        cfg: &Config,
+        vb: ShardedVarBuilder,
+        _is_gptx: bool,
+        normal_loading_metadata: NormalLoadingMetadata,
+        attention_mechanism: AttentionImplementation,
+    ) -> Result<Self> {
+        if !matches!(attention_mechanism, AttentionImplementation::Eager) {
+            candle_core::bail!("Expected eager attention implementation");
+        }
+        let mapper = normal_loading_metadata.mapper;
+        let vb_m = vb.pp("model");
+
+        let embed_tokens = layers::embedding(
+            cfg.vocab_size,
+            cfg.hidden_size,
+            mapper.set_nm_device(vb_m.pp("embed_tokens"), false),
+        )?;
+        let mut layers = Vec::with_capacity(cfg.num_hidden_layers);
+        let head_dim = cfg.hidden_size / cfg.num_attention_heads;
+
+        let mut ropes = HashMap::new();
+        for layer_idx in 0..cfg.num_hidden_layers {
+            let device = mapper
+                .device_for(layer_idx, false)
+                .unwrap_or(&normal_loading_metadata.real_device);
+            ropes.insert(
+                device.location(),
+                Arc::new(Qwen2VLRotaryEmbedding::new(
+                    cfg.rope_theta as f32,
+                    head_dim,
+                    device,
+                    cfg.rope_scaling.mrope_section.clone(),
+                )?),
+            );
+        }
+
+        let vb_l = vb_m.pp("layers");
+        for layer_idx in NiceProgressBar::<_, 'b'>(
+            0..cfg.num_hidden_layers,
+            "Loading repeating layers",
+            &normal_loading_metadata.multi_progress,
+        ) {
+            let device = mapper
+                .device_for(layer_idx, false)
+                .unwrap_or(&normal_loading_metadata.real_device);
+            let rotary_emb = ropes
+                .get(&device.location())
+                .expect("No RoPE for device location!")
+                .clone();
+            let comm = mapper.get_comm_for(layer_idx)?;
+            let layer = DecoderLayer::new(
+                rotary_emb.clone(),
+                cfg,
+                vb_l.pp(layer_idx),
+                &*mapper,
+                layer_idx,
+                normal_loading_metadata.loading_isq,
+                &comm,
+            )?;
+            layers.push(layer)
+        }
+        let norm = F32RmsNorm::new(
+            cfg.hidden_size,
+            cfg.rms_norm_eps,
+            mapper.set_nm_device(vb_m.pp("norm"), false),
+        )?;
+        let lm_head = if !cfg.tie_word_embeddings {
+            ReplicatedLayer::new(
+                cfg.hidden_size,
+                cfg.vocab_size,
+                &None,
+                false,
+                mapper.set_nm_device(vb.pp("lm_head"), normal_loading_metadata.loading_isq),
+            )?
+        } else {
+            ReplicatedLayer::from_linear(candle_nn::Linear::new(
+                mapper.cast_nm_device(
+                    embed_tokens.embeddings(),
+                    normal_loading_metadata.loading_isq,
+                )?,
+                None,
+            ))?
+        };
+        Ok(Self {
+            embed_tokens,
+            norm,
+            layers,
+            lm_head,
+            cache: EitherCache::Normal(NormalCache::new(
+                cfg.num_hidden_layers,
+                cfg.max_position_embeddings,
+            )),
+            max_seq_len: cfg.max_position_embeddings,
+            cfg: ModelConfigMetadata {
+                max_seq_len: cfg.max_position_embeddings,
+                num_layers: cfg.num_hidden_layers,
+                hidden_size: cfg.hidden_size,
+                num_attn_heads: cfg.num_attention_heads / mapper.get_comm_for(0)?.world_size(),
+                num_kv_heads: (cfg.num_key_value_heads / mapper.get_comm_for(0)?.world_size())
+                    .max(1),
+                sliding_window: cfg.sliding_window,
+                k_head_dim: cfg.hidden_size / cfg.num_attention_heads,
+                v_head_dim: cfg.hidden_size / cfg.num_attention_heads,
+            },
+            device: normal_loading_metadata.real_device.clone(),
+            dtype: vb.dtype(),
+            mapper,
+        })
+    }
+
+    pub fn embed_tokens(&self, input_ids: &Tensor) -> Result<Tensor> {
+        self.embed_tokens.forward(input_ids)
+    }
+
+    pub fn forward_embeds(
+        &self,
+        mut xs: Tensor,
+        attention_mask: Option<&Tensor>,
+        position_ids: &Tensor,
+        context_lens: Vec<(usize, usize)>,
+        flash_params: &FlashParams,
+    ) -> Result<Tensor> {
+        let cache = &mut self.cache.normal().0;
+        let cos_sin = self.layers[0]
+            .self_attn
+            .rotary_emb
+            .compute_cos_sin(position_ids, xs.dtype())?;
+
+        for (i, layer) in self.layers.iter().enumerate() {
+            xs = self.mapper.map(xs, i)?;
+            xs = layer.forward(
+                &xs,
+                attention_mask
+                    .as_ref()
+                    .map(|m| m.to_device(xs.device()).unwrap())
+                    .as_ref(),
+                &cos_sin,
+                &mut cache[i],
+                flash_params,
+            )?
+        }
+        let xs = xs.to_device(&self.device)?;
+        let mut xs = xs.apply(&self.norm)?;
+        if let Some(t) = self.lm_head.quantized_act_type() {
+            xs = xs.to_dtype(t)?;
+        }
+        extract_logits(&self.lm_head.forward(&xs)?, context_lens)
+    }
+}
+
+impl IsqModel for Qwen2VLTextModel {
+    fn get_layers(
+        &mut self,
+    ) -> (
+        Vec<(&mut Arc<dyn QuantMethod>, Option<usize>)>,
+        &dyn DeviceMapper,
+    ) {
+        let mut tensors = Vec::new();
+        tensors.push((&mut self.lm_head, None));
+        for (i, layer) in self.layers.iter_mut().enumerate() {
+            tensors.push((&mut layer.self_attn.q_proj, Some(i)));
+            tensors.push((&mut layer.self_attn.k_proj, Some(i)));
+            tensors.push((&mut layer.self_attn.v_proj, Some(i)));
+            tensors.push((&mut layer.self_attn.o_proj, Some(i)));
+            tensors.push((&mut layer.mlp.gate_proj, Some(i)));
+            tensors.push((&mut layer.mlp.up_proj, Some(i)));
+            tensors.push((&mut layer.mlp.down_proj, Some(i)));
+        }
+        (tensors, &*self.mapper)
+    }
+
+    fn residual_tensors(&self) -> Vec<(String, Tensor)> {
+        let uvb = UnVarBuilder::new();
+
+        let uvb_m = uvb.pp("model");
+        uvb_m.pp("embed_tokens").add(&self.embed_tokens);
+        uvb_m.pp("norm").add(&self.norm);
+
+        for (layer_idx, layer) in self.layers.iter().enumerate() {
+            let uvb_l = uvb_m.pp("layers").pp(layer_idx);
+            uvb_l.pp("input_layernorm").add(&layer.input_layernorm);
+            uvb_l
+                .pp("post_attention_layernorm")
+                .add(&layer.post_attention_layernorm);
+        }
+
+        uvb.to_safetensors()
+    }
+}

--- a/mistralrs-core/src/vision_models/qwen2_5_vl/vision.rs
+++ b/mistralrs-core/src/vision_models/qwen2_5_vl/vision.rs
@@ -1,0 +1,485 @@
+use std::sync::Arc;
+
+use candle_core::{DType, Device, IndexOp, Result, Tensor, D};
+use candle_nn::{LayerNorm, Linear, Module};
+use mistralrs_quant::{QuantMethod, ShardedVarBuilder};
+
+use crate::{
+    layers::{self, layer_norm, Activation, Conv3dConfig, Conv3dNoBias, MatMul},
+    ops::RepeatInterleaveOp,
+};
+
+use super::config::VisionConfig;
+
+struct PatchEmbed {
+    proj: Conv3dNoBias,
+    in_channels: usize,
+    patch_size: usize,
+    temporal_patch_size: usize,
+    hidden_size: usize,
+}
+
+// https://github.com/huggingface/transformers/blob/f2c388e3f946862f657acc1e21b272ec946fc66c/src/transformers/models/qwen2_vl/modeling_qwen2_vl.py#L272
+impl PatchEmbed {
+    fn new(cfg: &VisionConfig, vb: ShardedVarBuilder) -> Result<Self> {
+        if cfg.temporal_patch_size != 2 {
+            candle_core::bail!("Only support temporal patch size of 2");
+        }
+        Ok(Self {
+            proj: Conv3dNoBias::new(
+                cfg.in_chans,
+                cfg.hidden_size,
+                [cfg.temporal_patch_size, cfg.patch_size, cfg.patch_size],
+                Conv3dConfig {
+                    stride: cfg.patch_size,
+                    ..Default::default()
+                },
+                vb.pp("proj"),
+            )?,
+            in_channels: cfg.in_chans,
+            patch_size: cfg.patch_size,
+            temporal_patch_size: cfg.temporal_patch_size,
+            hidden_size: cfg.hidden_size,
+        })
+    }
+
+    fn forward(&self, xs: &Tensor) -> Result<Tensor> {
+        let xs = xs.reshape((
+            (),
+            self.in_channels,
+            self.temporal_patch_size,
+            self.patch_size,
+            self.patch_size,
+        ))?;
+        xs.apply(&self.proj)?.reshape(((), self.hidden_size))
+    }
+}
+
+// https://github.com/huggingface/transformers/blob/a769ed45e17c44fd17b85c025863c4e4f2f73634/src/transformers/models/qwen2_vl/modeling_qwen2_vl.py#L314
+struct VisionMlp {
+    fc1: Arc<dyn QuantMethod>,
+    fc2: Arc<dyn QuantMethod>,
+    act: Activation,
+}
+
+impl VisionMlp {
+    fn new(dim: usize, hidden_dim: usize, act: Activation, vb: ShardedVarBuilder) -> Result<Self> {
+        Ok(Self {
+            fc1: mistralrs_quant::linear(dim, hidden_dim, &None, vb.pp("fc1"))?,
+            fc2: mistralrs_quant::linear(hidden_dim, dim, &None, vb.pp("fc2"))?,
+            act,
+        })
+    }
+
+    fn forward(&self, xs: &Tensor) -> Result<Tensor> {
+        let fc1 = self.act.forward(&self.fc1.forward(&xs.unsqueeze(0)?)?)?;
+        self.fc2.forward(&fc1)?.squeeze(0)
+    }
+}
+
+fn rotate_half(xs: &Tensor) -> Result<Tensor> {
+    let last_dim = xs.dim(D::Minus1)?;
+    let xs1 = xs.narrow(D::Minus1, 0, last_dim / 2)?;
+    let xs2 = xs.narrow(D::Minus1, last_dim / 2, last_dim - last_dim / 2)?;
+    Tensor::cat(&[&xs2.neg()?, &xs1], D::Minus1)
+}
+
+fn apply_rotary_pos_emb_vision(xs: &Tensor, freqs: &Tensor) -> Result<Tensor> {
+    let xs = xs.to_dtype(DType::F32)?;
+    let cos = freqs.cos()?;
+    let sin = freqs.sin()?;
+
+    xs.broadcast_mul(&cos)? + rotate_half(&xs)?.broadcast_mul(&sin)
+}
+
+// https://github.com/huggingface/transformers/blob/a769ed45e17c44fd17b85c025863c4e4f2f73634/src/transformers/models/qwen2_vl/modeling_qwen2_vl.py#L325
+struct VisionAttention {
+    qkv: Arc<dyn QuantMethod>,
+    proj: Arc<dyn QuantMethod>,
+    num_heads: usize,
+    head_dim: usize,
+}
+
+impl VisionAttention {
+    fn new(dim: usize, num_heads: usize, vb: ShardedVarBuilder) -> Result<Self> {
+        Ok(Self {
+            qkv: mistralrs_quant::linear(dim, dim * 3, &None, vb.pp("qkv"))?,
+            proj: mistralrs_quant::linear(dim, dim, &None, vb.pp("proj"))?,
+            num_heads,
+            head_dim: dim / num_heads,
+        })
+    }
+    fn forward(
+        &self,
+        xs: &Tensor,
+        attention_mask: Option<&Tensor>,
+        rotary_pos_emb: &Tensor,
+    ) -> Result<Tensor> {
+        let seq_len = xs.dim(0)?;
+        let (mut q, mut k, mut v) = {
+            let qkv = self
+                .qkv
+                .forward(&xs.unsqueeze(0)?)?
+                .reshape((seq_len, 3, self.num_heads, ()))?
+                .permute((1, 0, 2, 3))?
+                .chunk(3, 0)?;
+            (qkv[0].squeeze(0)?, qkv[1].squeeze(0)?, qkv[2].squeeze(0)?)
+        };
+
+        q = apply_rotary_pos_emb_vision(&q.unsqueeze(0)?, rotary_pos_emb)?
+            .squeeze(0)?
+            .to_dtype(q.dtype())?;
+        k = apply_rotary_pos_emb_vision(&k.unsqueeze(0)?, rotary_pos_emb)?
+            .squeeze(0)?
+            .to_dtype(q.dtype())?;
+
+        q = q.transpose(0, 1)?.contiguous()?;
+        k = k.transpose(0, 1)?.contiguous()?;
+        v = v.transpose(0, 1)?.contiguous()?;
+
+        let att = {
+            let mut att =
+                (MatMul.matmul(&q, &k.transpose(1, 2)?)? / (self.head_dim as f64).sqrt())?;
+            att = match attention_mask {
+                Some(m) => att.broadcast_add(m)?,
+                None => att,
+            };
+            att = candle_nn::ops::softmax_last_dim(&att)?;
+            MatMul
+                .matmul(&att, &v)?
+                .transpose(0, 1)?
+                .reshape((seq_len, ()))?
+                .to_dtype(xs.dtype())?
+        };
+
+        self.proj.forward(&att.unsqueeze(0)?)?.squeeze(0)
+    }
+}
+
+// https://github.com/huggingface/transformers/blob/f2c388e3f946862f657acc1e21b272ec946fc66c/src/transformers/models/qwen2_vl/modeling_qwen2_vl.py#L418
+struct VisionBlock {
+    norm1: LayerNorm,
+    norm2: LayerNorm,
+    mlp: VisionMlp,
+    attn: VisionAttention,
+}
+
+impl VisionBlock {
+    fn new(cfg: &VisionConfig, vb: ShardedVarBuilder) -> Result<Self> {
+        let norm1 = layer_norm(cfg.hidden_size, 1e-6, vb.pp("norm1"))?;
+        let norm2 = layer_norm(cfg.hidden_size, 1e-6, vb.pp("norm2"))?;
+
+        let mlp_hidden_dim = (cfg.hidden_size as f64 * cfg.mlp_ratio) as usize;
+        let mlp = VisionMlp::new(
+            cfg.hidden_size,
+            mlp_hidden_dim,
+            cfg.hidden_act,
+            vb.pp("mlp"),
+        )?;
+        let attn = VisionAttention::new(cfg.hidden_size, cfg.num_heads, vb.pp("attn"))?;
+
+        Ok(Self {
+            norm1,
+            norm2,
+            mlp,
+            attn,
+        })
+    }
+
+    fn forward(
+        &self,
+        xs: &Tensor,
+        attention_mask: Option<&Tensor>,
+        rotary_pos_emb: &Tensor,
+    ) -> Result<Tensor> {
+        let xs = (xs
+            + self
+                .attn
+                .forward(&self.norm1.forward(xs)?, attention_mask, rotary_pos_emb)?)?;
+        &xs + self.mlp.forward(&self.norm2.forward(&xs)?)?
+    }
+}
+
+struct PatchMerger {
+    ln_q: LayerNorm,
+    mlp0: Linear,
+    mlp2: Linear,
+    out_hidden_size: usize,
+}
+
+impl PatchMerger {
+    pub fn new(
+        dim: usize,
+        context_dim: usize,
+        spatial_merge_size: usize,
+        vb: ShardedVarBuilder,
+    ) -> Result<Self> {
+        let out_hidden_size = context_dim * spatial_merge_size.pow(2);
+        let mlp0 = layers::linear(out_hidden_size, out_hidden_size, vb.pp("mlp.0"))?;
+        let mlp2 = layers::linear(out_hidden_size, dim, vb.pp("mlp.2"))?;
+        Ok(Self {
+            ln_q: layer_norm(context_dim, 1e-6, vb.pp("ln_q"))?,
+            mlp0,
+            mlp2,
+            out_hidden_size,
+        })
+    }
+
+    fn forward(&self, xs: &Tensor) -> Result<Tensor> {
+        xs.unsqueeze(0)?
+            .apply(&self.ln_q)?
+            .reshape(((), self.out_hidden_size))?
+            .apply(&self.mlp0)?
+            .gelu()?
+            .apply(&self.mlp2)?
+            .squeeze(0)
+    }
+}
+
+struct VisionRotaryEmbedding {
+    inv_freq: Tensor,
+}
+
+impl VisionRotaryEmbedding {
+    const THETA: f32 = 10000.;
+
+    fn new(dim: usize, device: &Device) -> Result<Self> {
+        let inv_freq = (0..dim)
+            .step_by(2)
+            .map(|i| 1f32 / Self::THETA.powf(i as f32 / dim as f32))
+            .collect::<Vec<_>>();
+        let inv_freq_len = inv_freq.len();
+        Ok(Self {
+            inv_freq: Tensor::from_vec(inv_freq, (1, inv_freq_len), device)?,
+        })
+    }
+
+    fn make_embeds(&self, seqlen: usize) -> Result<Tensor> {
+        let seq =
+            Tensor::arange(0f32, seqlen as f32, self.inv_freq.device())?.unsqueeze(D::Minus1)?;
+        seq.broadcast_matmul(&self.inv_freq)
+    }
+}
+
+pub struct Qwen2VLVisionModel {
+    blocks: Vec<VisionBlock>,
+    patch_merger: PatchMerger,
+    patch_embed: PatchEmbed,
+    rotary_pos_emb: VisionRotaryEmbedding,
+    spatial_merge_size: usize,
+    spatial_merge_unit: usize,
+    window_size: usize,
+    patch_size: usize,
+    fullatt_block_indices: Vec<usize>,
+}
+
+impl Qwen2VLVisionModel {
+    pub fn new(cfg: &VisionConfig, vb: ShardedVarBuilder) -> Result<Self> {
+        let mut blocks = Vec::new();
+        for i in 0..cfg.depth {
+            blocks.push(VisionBlock::new(cfg, vb.pp(format!("blocks.{i}")))?);
+        }
+
+        let patch_merger = PatchMerger::new(
+            cfg.out_hidden_size,
+            cfg.hidden_size,
+            cfg.spatial_merge_size,
+            vb.pp("merger"),
+        )?;
+
+        let patch_embed = PatchEmbed::new(cfg, vb.pp("patch_embed"))?;
+
+        let head_dim = cfg.hidden_size / cfg.num_heads;
+        let rotary_pos_emb = VisionRotaryEmbedding::new(head_dim / 2, vb.device())?;
+
+        Ok(Self {
+            blocks,
+            patch_embed,
+            patch_merger,
+            rotary_pos_emb,
+            spatial_merge_size: cfg.spatial_merge_size,
+            spatial_merge_unit: cfg.spatial_merge_size * cfg.spatial_merge_size,
+            window_size: cfg.window_size,
+            patch_size: cfg.patch_size,
+            fullatt_block_indices: cfg.fullatt_block_indexes.clone(),
+        })
+    }
+
+    fn rot_pos_emb(&self, grid_thw: &Tensor, device: &Device) -> Result<Tensor> {
+        let mut pos_ids = Vec::new();
+        for i_thw in grid_thw.to_vec2::<u32>()? {
+            let (t, h, w) = (i_thw[0], i_thw[1], i_thw[2]);
+            let mut hpos_ids = Tensor::arange(0, h, device)?
+                .unsqueeze(1)?
+                .repeat((1, w as usize))?;
+            hpos_ids = hpos_ids.reshape((
+                h as usize / self.spatial_merge_size,
+                self.spatial_merge_size,
+                w as usize / self.spatial_merge_size,
+                self.spatial_merge_size,
+            ))?;
+            hpos_ids = hpos_ids.permute((0, 2, 1, 3))?;
+            hpos_ids = hpos_ids.flatten_all()?;
+
+            let mut wpos_ids = Tensor::arange(0, w, device)?
+                .unsqueeze(0)?
+                .repeat((h as usize, 1))?;
+            wpos_ids = wpos_ids.reshape((
+                h as usize / self.spatial_merge_size,
+                self.spatial_merge_size,
+                w as usize / self.spatial_merge_size,
+                self.spatial_merge_size,
+            ))?;
+            wpos_ids = wpos_ids.permute((0, 2, 1, 3))?;
+            wpos_ids = wpos_ids.flatten_all()?;
+
+            pos_ids.push(Tensor::stack(&[hpos_ids, wpos_ids], D::Minus1)?.repeat((t as usize, 1))?);
+        }
+        let pos_ids = Tensor::cat(&pos_ids, 0)?;
+        let max_grid_size = grid_thw.i((.., 1..))?.max(0)?.max(0)?.to_scalar::<u32>()?;
+        let rotary_pos_emb_full = self.rotary_pos_emb.make_embeds(max_grid_size as usize)?;
+
+        assert_eq!(pos_ids.rank(), 2);
+        rotary_pos_emb_full
+            .index_select(&pos_ids.flatten_all()?, 0)?
+            .reshape((pos_ids.dim(0)?, pos_ids.dim(1)?, ()))?
+            .flatten_from(1)
+    }
+
+    fn get_window_index(&self, grid_thw: &Tensor, device: &Device) -> Result<(Tensor, Vec<i32>)> {
+        let mut window_index = Vec::new();
+        let mut cu_window_seqlens = vec![0];
+        let mut window_index_id = 0;
+        let vit_merger_window_size = self.window_size / self.spatial_merge_size / self.patch_size;
+
+        for i_thw in grid_thw.to_vec2::<u32>()? {
+            let (t, h, w) = (i_thw[0] as usize, i_thw[1] as usize, i_thw[2] as usize);
+            let llm_grid_h = h / self.spatial_merge_size;
+            let llm_grid_w = w / self.spatial_merge_size;
+            let index = Tensor::arange(0i32, (t * llm_grid_h * llm_grid_w) as i32, &Device::Cpu)?
+                .reshape((t, llm_grid_h, llm_grid_w))?;
+            let pad_h = vit_merger_window_size - llm_grid_h % vit_merger_window_size;
+            let pad_w = vit_merger_window_size - llm_grid_w % vit_merger_window_size;
+            let num_windows_h = (llm_grid_h + pad_h) / vit_merger_window_size;
+            let num_windows_w = (llm_grid_w + pad_w) / vit_merger_window_size;
+            let index_padded = {
+                let h = Tensor::full(-100i32, (t, pad_h, llm_grid_w), &Device::Cpu)?;
+                let w = Tensor::full(-100i32, (t, pad_h + llm_grid_h, pad_w), &Device::Cpu)?;
+                let mut index = Tensor::cat(&[index, h], D::Minus2)?;
+                index = Tensor::cat(&[index, w], D::Minus1)?;
+                index = index.reshape((
+                    t,
+                    num_windows_h,
+                    vit_merger_window_size,
+                    num_windows_w,
+                    vit_merger_window_size,
+                ))?;
+                index = index.permute((0, 1, 3, 2, 4))?.reshape((
+                    t,
+                    num_windows_h * num_windows_w,
+                    vit_merger_window_size,
+                    vit_merger_window_size,
+                ))?;
+                index
+            };
+            let seqlens = index_padded.ne(-100.)?.sum((2, 3))?.flatten_all()?;
+            let index_new = index_padded
+                .flatten_all()?
+                .to_vec1::<i32>()?
+                .into_iter()
+                .filter(|x| *x != -100)
+                .collect::<Vec<_>>();
+            window_index.push(Tensor::new(
+                [index_new, vec![window_index_id]].concat(),
+                device,
+            )?);
+            let cu_seqlens_tmp = ((seqlens.cumsum(0)? * self.spatial_merge_unit as f64)?
+                + cu_window_seqlens[cu_window_seqlens.len() - 1] as f64)?;
+            cu_window_seqlens.extend(cu_seqlens_tmp.to_vec1::<i32>()?);
+            window_index_id += (t * llm_grid_h * llm_grid_w) as i32;
+        }
+
+        Ok((Tensor::cat(&window_index, 0)?, cu_window_seqlens))
+    }
+
+    pub fn forward(&self, xs: &Tensor, grid_thw: &Tensor) -> Result<Tensor> {
+        let xs = self
+            .patch_embed
+            .forward(&xs.to_dtype(self.patch_merger.mlp0.weight().dtype())?)?;
+        let rotary_pos_emb = self.rot_pos_emb(grid_thw, xs.device())?;
+        let (window_index, mut cu_window_seqlens) = self.get_window_index(grid_thw, xs.device())?;
+        cu_window_seqlens.dedup();
+
+        let seq_len = xs.dims2()?.0;
+        let mut xs = xs.reshape((
+            seq_len / self.spatial_merge_unit,
+            self.spatial_merge_unit,
+            (),
+        ))?;
+        xs = xs.index_select(&window_index, 0)?;
+        xs = xs.reshape((seq_len, ()))?;
+        let mut rotary_pos_emb = rotary_pos_emb.reshape((
+            seq_len / self.spatial_merge_unit,
+            self.spatial_merge_unit,
+            (),
+        ))?;
+        rotary_pos_emb = rotary_pos_emb.index_select(&window_index, 0)?;
+        rotary_pos_emb = rotary_pos_emb.reshape((seq_len, ()))?;
+
+        let grid_thw = grid_thw.to_device(&Device::Cpu)?;
+        let cu_seqlens = (grid_thw.i((.., 1))? * grid_thw.i((.., 2))?)?
+            .repeat_interleave_flat(grid_thw.i((.., 0))?.to_vec1::<u32>()?)?
+            .to_dtype(DType::F32)?
+            .cumsum(0)?
+            .to_dtype(DType::U32)?
+            .pad_with_zeros(0, 1, 0)?
+            .to_vec1::<u32>()?;
+
+        let seq_len = xs.dim(0)?;
+        let attention_mask_full = match &cu_seqlens[..] {
+            &[0, len] if len == seq_len as u32 => None,
+            cu_seqlens => {
+                let mut attention_mask =
+                    Tensor::full(f32::MIN, (1, seq_len, seq_len), xs.device())?
+                        .to_dtype(DType::F32)?;
+                for i in 1..cu_seqlens.len() {
+                    let a = cu_seqlens[i - 1] as usize;
+                    let b = cu_seqlens[i] as usize;
+                    attention_mask = attention_mask.slice_assign(
+                        &[&.., &(a..b), &(a..b)],
+                        &Tensor::zeros((1, b - a, b - a), DType::F32, xs.device())?,
+                    )?;
+                }
+                Some(attention_mask)
+            }
+        };
+        let attention_mask_window = match &cu_window_seqlens[..] {
+            &[0, len] if len == seq_len as i32 => None,
+            cu_seqlens => {
+                let mut attention_mask =
+                    Tensor::full(f32::MIN, (1, seq_len, seq_len), xs.device())?
+                        .to_dtype(DType::F32)?;
+                for i in 1..cu_seqlens.len() {
+                    let a = cu_seqlens[i - 1] as usize;
+                    let b = cu_seqlens[i] as usize;
+                    attention_mask = attention_mask.slice_assign(
+                        &[&.., &(a..b), &(a..b)],
+                        &Tensor::zeros((1, b - a, b - a), DType::F32, xs.device())?,
+                    )?;
+                }
+                Some(attention_mask)
+            }
+        };
+
+        for (i, blk) in self.blocks.iter().enumerate() {
+            let attention_mask = if self.fullatt_block_indices.contains(&i) {
+                attention_mask_full.as_ref()
+            } else {
+                attention_mask_window.as_ref()
+            };
+            xs = blk.forward(&xs, attention_mask, &rotary_pos_emb)?;
+        }
+
+        self.patch_merger.forward(&xs)
+    }
+}

--- a/mistralrs-core/src/vision_models/qwen2_5_vl/vision.rs
+++ b/mistralrs-core/src/vision_models/qwen2_5_vl/vision.rs
@@ -5,7 +5,7 @@ use candle_nn::{Linear, Module};
 use mistralrs_quant::{QuantMethod, ShardedVarBuilder};
 
 use crate::{
-    layers::{self, layer_norm, Activation, Conv3dConfig, Conv3dNoBias, MatMul, RmsNorm},
+    layers::{self, Activation, Conv3dConfig, Conv3dNoBias, MatMul, RmsNorm},
     ops::RepeatInterleaveOp,
 };
 

--- a/mistralrs-core/src/vision_models/qwen2_5_vl/vision.rs
+++ b/mistralrs-core/src/vision_models/qwen2_5_vl/vision.rs
@@ -480,6 +480,8 @@ impl Qwen2VLVisionModel {
             xs = blk.forward(&xs, attention_mask, &rotary_pos_emb)?;
         }
 
-        self.patch_merger.forward(&xs)
+        xs = self.patch_merger.forward(&xs)?;
+        let reverse_indices = window_index.arg_sort_last_dim(true)?;
+        xs.index_select(&reverse_indices, 0)
     }
 }

--- a/mistralrs-core/src/vision_models/qwen2_5_vl/vision.rs
+++ b/mistralrs-core/src/vision_models/qwen2_5_vl/vision.rs
@@ -169,10 +169,9 @@ impl VisionBlock {
         let norm1 = RmsNorm::new(cfg.hidden_size, 1e-6, vb.pp("norm1"))?;
         let norm2 = RmsNorm::new(cfg.hidden_size, 1e-6, vb.pp("norm2"))?;
 
-        let mlp_hidden_dim = (cfg.hidden_size as f64 * cfg.mlp_ratio) as usize;
         let mlp = VisionMlp::new(
             cfg.hidden_size,
-            mlp_hidden_dim,
+            cfg.intermediate_size,
             cfg.hidden_act,
             vb.pp("mlp"),
         )?;


### PR DESCRIPTION
Up-to-date status:

Architecture changes seem to be limited to the vision model and vision processing. This includes windowing attention in the vision model and using RmsNorm.

The video processing seems to be updated with some relatively minor changes, with the `tokens_per_second` parameter and other processing changes. These have not yet been implemented, but will be.