### PR TITLE
Remove unexpected cp behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -290,11 +290,11 @@ Enabling features is done by passing `--features ...` to the build system. When 
         ```bash
         cargo install --path mistralrs-server --features cuda
         ```
-6) The build process will output a binary `mistralrs-server` at `./target/release/mistralrs-server` which may be copied into the working directory with the following command:
-    
+6) The build process will output a binary `mistralrs-server` at `./target/release/mistralrs-server`. We can switch to that directory so that the binary can be accessed as `./mistralrs-server` with the following command:
+
     *Example on Ubuntu:*
     ```
-    cp ./target/release/mistralrs-server ./mistralrs-server
+    cd target/release
     ```
 
 7) Use our APIs and integrations: 


### PR DESCRIPTION
There's currently an issue in the readme in this section:

> The build process will output a binary mistralrs-server at ./target/release/mistralrs-server which may be copied into the working directory with the following command:
>
> Example on Ubuntu:
> 
> cp ./target/release/mistralrs-server ./mistralrs-server

The intent here is to copy the `mistralrs-server` binary into the current working directory. Unfortunately, this doesn't work properly, as the repository already includes a directory with this name. The cp command copies the binary into that directory. Running subsequent examples fails because `./mistralrs-server` is a directory rather than the binary.

This PR updates the readme to suggest the user `cd` into `target/release` in order to access the binary.