### PR TITLE
build fix for arm.

### DIFF
--- a/mistralrs-core/src/daemon.rs
+++ b/mistralrs-core/src/daemon.rs
@@ -1,3 +1,4 @@
+use core::ffi::c_char;
 use interprocess::local_socket::{GenericNamespaced, Name, ToNsName};
 use serde::{Deserialize, Serialize};
 use serde_big_array::BigArray;
@@ -10,11 +11,14 @@ pub(crate) fn is_daemon() -> bool {
 
 #[derive(Serialize, Deserialize, Debug)]
 #[serde(transparent)]
-pub(crate) struct BigI8Array(#[serde(with = "BigArray")] pub(crate) [i8; 128]);
+pub(crate) struct BigCCharArray(#[serde(with = "BigArray")] pub(crate) [c_char; 128]);
 
 #[derive(Serialize, Deserialize, Debug)]
 pub(crate) enum WorkerTransferData {
-    Init { id: BigI8Array, worker_rank: usize },
+    Init {
+        id: BigCCharArray,
+        worker_rank: usize,
+    },
 }
 
 pub(crate) fn ipc_name() -> anyhow::Result<Name<'static>> {

--- a/mistralrs-core/src/pipeline/normal.rs
+++ b/mistralrs-core/src/pipeline/normal.rs
@@ -18,7 +18,7 @@ use super::{
     Qwen2Loader, Starcoder2Loader,
 };
 use crate::amoe::AnyMoeExpertType;
-use crate::daemon::{self, BigI8Array, WorkerTransferData};
+use crate::daemon::{self, BigCCharArray, WorkerTransferData};
 use crate::device_map::{self, DeviceMapper};
 use crate::lora::Ordering;
 use crate::paged_attention::{calculate_cache_config, AttentionImplementation, CacheEngine};
@@ -523,7 +523,7 @@ impl Loader for NormalLoader {
                     cmd.args(&args[1..]);
 
                     let data = WorkerTransferData::Init {
-                        id: BigI8Array(*id.internal()),
+                        id: BigCCharArray(*id.internal()),
                         worker_rank,
                     };
 

--- a/mistralrs-quant/src/distributed/socket.rs
+++ b/mistralrs-quant/src/distributed/socket.rs
@@ -121,9 +121,9 @@ impl Client {
         let mut buffer = [0u8; 128];
         stream.read_exact(&mut buffer)?;
 
-        let mut id_bytes = [0i8; 128];
+        let mut id_bytes: [core::ffi::c_char; 128] = [0; 128];
         for (i, &b) in buffer.iter().enumerate() {
-            id_bytes[i] = b as i8;
+            id_bytes[i] = b as core::ffi::c_char;
         }
         Ok(Id::uninit(id_bytes))
     }


### PR DESCRIPTION
core::ffi::c_char is defined as u8 instead of i8 in some platforms, so cannot use i8 as type in some codes.
fix https://github.com/EricLBuehler/mistral.rs/issues/1162