### PR TITLE
Engine ID fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 *.a
 .DS_Store
 .idea
+/gguf_models

--- a/mistralrs-core/src/engine/mod.rs
+++ b/mistralrs-core/src/engine/mod.rs
@@ -27,7 +27,7 @@ use crate::{
     scheduler::{Scheduler, SchedulerOutput},
     sequence::{SeqStepType, StopReason},
     tools::{ToolCallingMatcher, ToolChoice},
-    CompletionResponse, RequestMessage, Response, SchedulerConfig, DEBUG,
+    CompletionResponse, RequestMessage, Response, SchedulerConfig, DEBUG, ENGINE_ID,
 };
 use rand::SeedableRng;
 use rand_isaac::Isaac64Rng;
@@ -91,7 +91,7 @@ impl Engine {
             rx,
             pipeline,
             scheduler: config.into_scheduler(),
-            id: 0,
+            id: ENGINE_ID.fetch_add(1, Ordering::SeqCst) + 1,
             truncate_sequence,
             no_kv_cache,
             prefix_cacher: PrefixCacheManagerV2::new(prefix_cache_n, no_prefix_cache),
@@ -968,7 +968,7 @@ impl Engine {
             } else {
                 seq
             };
-            self.id += 1;
+            self.id = ENGINE_ID.fetch_add(1, Ordering::SeqCst) + 1;
             self.scheduler.add_seq(seq);
         }
     }

--- a/mistralrs/examples/gguf_locally/main.rs
+++ b/mistralrs/examples/gguf_locally/main.rs
@@ -2,30 +2,42 @@ use anyhow::Result;
 use mistralrs::{
     GgufModelBuilder, PagedAttentionMetaBuilder, RequestBuilder, TextMessageRole, TextMessages,
 };
+use serde_json::json;
 
 #[tokio::main]
 async fn main() -> Result<()> {
     // We do not use any files from remote servers here, and instead load the
     // chat template from the specified file, and the tokenizer and model from a
     // local GGUF file at the path specified.
-    let model = GgufModelBuilder::new(
-        "gguf_models/mistral_v0.1/",
-        vec!["mistral-7b-instruct-v0.1.Q4_K_M.gguf"],
-    )
-    .with_chat_template("chat_templates/mistral.json")
-    .with_logging()
-    .with_paged_attn(|| PagedAttentionMetaBuilder::default().build())?
-    .build()
-    .await?;
+    let model = GgufModelBuilder::new("gguf_models/", vec!["Llama-3.2-3B-Instruct-Q4_K_M.gguf"])
+        // .with_chat_template("chat_templates/llama3.json")
+        .with_logging()
+        // .with_paged_attn(|| PagedAttentionMetaBuilder::default().build())?
+        .build()
+        .await?;
 
-    let messages = TextMessages::new().add_message(
-        TextMessageRole::User,
-        "Hello! How are you? Please write generic binary search function in Rust.",
+    let request = RequestBuilder::new()
+        .set_constraint(mistralrs::Constraint::JsonSchema(json!(
+            {
+                "type": "object",
+                "properties": {
+                    "street": {"type": "string"},
+                    "city": {"type": "string"},
+                    "state": {"type": "string", "pattern": "^[A-Z]{2}$"},
+                },
+                "required": ["street", "city", "state"],
+                "additionalProperties": false,
+            }
+        )))
+        .set_sampler_max_len(100)
+        .add_message(TextMessageRole::User, "A sample address please.");
+
+    let response = model.send_chat_request(request).await?;
+
+    println!(
+        "{}",
+        response.choices[0].message.content.as_ref().unwrap().trim()
     );
-
-    let response = model.send_chat_request(messages).await?;
-
-    println!("{}", response.choices[0].message.content.as_ref().unwrap());
     dbg!(
         response.usage.avg_prompt_tok_per_sec,
         response.usage.avg_compl_tok_per_sec

--- a/mistralrs/examples/grammar/main.rs
+++ b/mistralrs/examples/grammar/main.rs
@@ -8,7 +8,7 @@ async fn main() -> Result<()> {
     let model = TextModelBuilder::new("microsoft/Phi-3.5-mini-instruct")
         .with_isq(IsqType::Q4K)
         .with_logging()
-        .with_paged_attn(|| PagedAttentionMetaBuilder::default().build())?
+        // .with_paged_attn(|| PagedAttentionMetaBuilder::default().build())?
         .build()
         .await?;
 

--- a/mistralrs/examples/llguidance/main.rs
+++ b/mistralrs/examples/llguidance/main.rs
@@ -1,7 +1,7 @@
 use anyhow::Result;
 use mistralrs::{
-    llguidance::api::GrammarWithLexer, IsqType, LlguidanceGrammar, PagedAttentionMetaBuilder,
-    RequestBuilder, TextMessageRole, TextModelBuilder,
+    llguidance::api::GrammarWithLexer, GgufModelBuilder, IsqType, LlguidanceGrammar,
+    PagedAttentionMetaBuilder, RequestBuilder, TextMessageRole, TextModelBuilder,
 };
 use serde_json::json;
 
@@ -14,32 +14,44 @@ async fn main() -> Result<()> {
         .build()
         .await?;
 
-    let top =
-        GrammarWithLexer::from_lark(r#"start: "Reasoning: " /.+/ "\nJSON: " @myobj"#.to_string());
+    // let model = GgufModelBuilder::new(
+    //     "gguf_models/",
+    //     vec!["Llama-3.2-3B-Instruct-uncensored-Q4_K_M.gguf"],
+    // )
+    // // .with_chat_template("chat_templates/llama3.json")
+    // .with_logging()
+    // // .with_paged_attn(|| PagedAttentionMetaBuilder::default().build())?
+    // .build()
+    // .await?;
+
+    let top = GrammarWithLexer::from_lark(r#"@myobj"#.to_string());
     let schema = GrammarWithLexer {
         name: Some("myobj".to_string()),
-        json_schema: Some(json!({
-            "type": "object",
-            "properties": {
-                "answer": {"type": "string", "enum": ["Yes", "No"]},
-            },
-            "required": ["answer"],
-            "additionalProperties": false,
-        })),
+        json_schema: Some(json!(
+        {
+        "type": "object",
+        "properties": {
+        "street": {"type": "string"},
+        "city": {"type": "string"},
+        "state": {"type": "string", "pattern": "^[A-Z]{2}$"},
+        "zip": {"type": "integer", "minimum": 10000, "maximum": 99999},
+        },
+        "required": ["street", "city", "state", "zip"],
+        "additionalProperties": false,
+        }
+        )),
         ..Default::default()
     };
 
     let request = RequestBuilder::new()
         .set_constraint(mistralrs::Constraint::Llguidance(LlguidanceGrammar {
-            grammars: vec![top, schema],
+            grammars: vec![schema],
             max_tokens: None,
             test_trace: false,
         }))
+        .set_sampler_n_choices(1)
         .set_sampler_max_len(100)
-        .add_message(
-            TextMessageRole::User,
-            "If all dogs are mammals, and all mammals are animals, are dogs animals?",
-        );
+        .add_message(TextMessageRole::User, "A sample address please.");
 
     let response = model.send_chat_request(request).await?;
 


### PR DESCRIPTION
When dropping MistralRs, it does not emit the correct ENGINE_ID to Terminate the engine. 

Currently if you try to drop a MistralRs instance, and start a new instance. The old engine is still running, and a new engine is created. 

This PR fixes the error described in this issue:
https://github.com/EricLBuehler/mistral.rs/issues/865#issue-2598762587