### PR TITLE
Typo fix (add_speial_tokens to add_special_tokens)

### DIFF
--- a/mistralrs-pyo3/mistralrs.pyi
+++ b/mistralrs-pyo3/mistralrs.pyi
@@ -382,7 +382,7 @@ class Runner:
         Tokenize some text, returning raw tokens.
         """
 
-    def detokenize_text(self, tokens: list[int], add_special_tokens: bool) -> str:
+    def detokenize_text(self, tokens: list[int], skip_special_tokens: bool) -> str:
         """
         Detokenize some tokens, returning text.
         """

--- a/mistralrs-pyo3/mistralrs.pyi
+++ b/mistralrs-pyo3/mistralrs.pyi
@@ -377,12 +377,12 @@ class Runner:
         Send a request to make the specified adapters the active adapters for the model.
         """
 
-    def tokenize_text(self, text: str, add_speial_tokens: bool) -> list[int]:
+    def tokenize_text(self, text: str, add_special_tokens: bool) -> list[int]:
         """
         Tokenize some text, returning raw tokens.
         """
 
-    def detokenize_text(self, tokens: list[int], skip_speial_tokens: bool) -> str:
+    def detokenize_text(self, tokens: list[int], add_special_tokens: bool) -> str:
         """
         Detokenize some tokens, returning text.
         """


### PR DESCRIPTION
Fix typo in argument name: `add_speial_tokens` to `add_special_tokens`  

`got an unexpected keyword argument 'add_speial_tokens'`