### PR TITLE
Optimized CUDA RoPE kernels

### DIFF
--- a/mistralrs-core/src/models/llama.rs
+++ b/mistralrs-core/src/models/llama.rs
@@ -111,9 +111,7 @@ impl CausalSelfAttention {
             (q, k, v)
         };
 
-        dbg!(&q, &k, &v);
         let (q, k) = self.rotary_emb.forward(&q, &k, seqlen_offsets)?;
-        dbg!(&q, &k, &v);
 
         let mut y = match &self.paged_attn {
             Some(paged_attn) => match metadata {

--- a/mistralrs-core/src/models/llama.rs
+++ b/mistralrs-core/src/models/llama.rs
@@ -111,7 +111,9 @@ impl CausalSelfAttention {
             (q, k, v)
         };
 
+        dbg!(&q, &k, &v);
         let (q, k) = self.rotary_emb.forward(&q, &k, seqlen_offsets)?;
+        dbg!(&q, &k, &v);
 
         let mut y = match &self.paged_attn {
             Some(paged_attn) => match metadata {

--- a/mistralrs-quant/build.rs
+++ b/mistralrs-quant/build.rs
@@ -85,6 +85,7 @@ fn main() {
             "kernels/hqq/hqq.cu",
             "kernels/ops/ops.cu",
             "kernels/bitsandbytes/dequant.cu",
+            "kernels/rotary/rotary.cu",
         ];
         if cc_over_800 {
             lib_files.push("kernels/marlin/marlin_kernel.cu");

--- a/mistralrs-quant/kernels/rotary/cuda_compat.h
+++ b/mistralrs-quant/kernels/rotary/cuda_compat.h
@@ -1,0 +1,27 @@
+#pragma once
+
+#ifndef USE_ROCM
+  #define VLLM_LDG(arg) __ldg(arg)
+#else
+  #define VLLM_LDG(arg) *(arg)
+#endif
+
+#ifndef USE_ROCM
+  #define VLLM_SHFL_XOR_SYNC(var, lane_mask) __shfl_xor_sync(uint32_t(-1), var, lane_mask)
+#else
+  #define VLLM_SHFL_XOR_SYNC(var, lane_mask) __shfl_xor(var, lane_mask)
+#endif
+
+#ifndef USE_ROCM
+  #define VLLM_SHFL_SYNC(var, src_lane) __shfl_sync(uint32_t(-1), var, src_lane)
+#else
+  #define VLLM_SHFL_SYNC(var, src_lane) __shfl(var, src_lane)
+#endif
+
+#ifndef USE_ROCM
+  #define VLLM_DevFuncAttribute_SET_MaxDynamicSharedMemorySize(FUNC, VAL) \
+    cudaFuncSetAttribute(FUNC, cudaFuncAttributeMaxDynamicSharedMemorySize, VAL)
+#else
+  #define VLLM_DevFuncAttribute_SET_MaxDynamicSharedMemorySize(FUNC, VAL) \
+    hipFuncSetAttribute(FUNC, hipFuncAttributeMaxDynamicSharedMemorySize, VAL)
+#endif

--- a/mistralrs-quant/kernels/rotary/rotary.cu
+++ b/mistralrs-quant/kernels/rotary/rotary.cu
@@ -1,0 +1,131 @@
+#include <cuda_fp16.h>
+#include <cuda_bf16.h>
+#include <stdint.h>
+
+#include "cuda_compat.h"
+
+namespace vllm {
+
+template<typename scalar_t, bool IS_NEOX>
+inline __device__ void apply_rotary_embedding(
+  scalar_t* __restrict__ arr,
+  const scalar_t* __restrict__ cos_ptr,
+  const scalar_t* __restrict__ sin_ptr,
+  int rot_offset,
+  int rot_dim)
+{
+  int x_index, y_index;
+  scalar_t cos, sin;
+  if (IS_NEOX) {
+    // GPT-NeoX style rotary embedding.
+    x_index = rot_offset;
+    y_index = rot_dim + rot_offset;
+    cos = VLLM_LDG(cos_ptr + x_index);
+    sin = VLLM_LDG(sin_ptr + x_index);
+  } else {
+    // GPT-J style rotary embedding.
+    x_index = 2 * rot_offset;
+    y_index = 2 * rot_offset + 1;
+    cos = VLLM_LDG(cos_ptr + x_index / 2);
+    sin = VLLM_LDG(sin_ptr + x_index / 2);
+  }
+
+  const scalar_t x = arr[x_index];
+  const scalar_t y = arr[y_index];
+  arr[x_index] = x * cos - y * sin;
+  arr[y_index] = y * cos + x * sin;
+}
+
+template<typename scalar_t, bool IS_NEOX>
+__global__ void rotary_embedding_kernel(
+  scalar_t* __restrict__ query,                    // [num_tokens, num_heads, head_size]
+  scalar_t* __restrict__ key,                      // [num_tokens, num_heads, head_size]
+  const scalar_t* __restrict__ cos_cache,          // [num_tokens, rot_dim]
+  const scalar_t* __restrict__ sin_cache,          // [num_tokens, rot_dim]
+  const int rot_dim,
+  const int64_t query_stride,
+  const int64_t key_stride,
+  const int num_heads,
+  const int num_kv_heads,
+  const int head_size) {
+  // Each thread block is responsible for one token.
+  const int token_idx = blockIdx.x;
+
+  const scalar_t* cos_ptr = cos_cache + token_idx * rot_dim;
+  const scalar_t* sin_ptr = sin_cache + token_idx * rot_dim;
+
+  const int nq = num_heads * rot_dim;
+  for (int i = threadIdx.x; i < nq; i += blockDim.x) {
+    const int head_idx = i / rot_dim;
+    const int64_t token_head = token_idx * query_stride + head_idx * head_size;
+    const int rot_offset = i % rot_dim;
+    apply_rotary_embedding<scalar_t, IS_NEOX>(query + token_head, cos_ptr,
+                                              sin_ptr, rot_offset, rot_dim);
+  }
+
+  const int nk = num_kv_heads * rot_dim;
+  for (int i = threadIdx.x; i < nk; i += blockDim.x) {
+    const int head_idx = i / rot_dim;
+    const int64_t token_head = token_idx * key_stride + head_idx * head_size;
+    const int rot_offset = i % rot_dim;
+    apply_rotary_embedding<scalar_t, IS_NEOX>(key + token_head, cos_ptr,
+                                              sin_ptr, rot_offset, rot_dim);
+  }
+}
+
+} // namespace vllm
+
+#define CALL_ROTARY(T, IS_NEOX)                                               \
+  vllm::rotary_embedding_kernel<T, IS_NEOX><<<grid, block, 0, stream>>>(      \
+    reinterpret_cast<T*>(query),                                              \
+    reinterpret_cast<T*>(key),                                                \
+    reinterpret_cast<T*>(cos_cache),                                          \
+    reinterpret_cast<T*>(sin_cache),                                          \
+    rot_dim,                                                                  \
+    query_stride,                                                             \
+    key_stride,                                                               \
+    num_heads,                                                                \
+    num_kv_heads,                                                             \
+    head_size);
+
+extern "C" void rotary_embedding(
+  void *query,             // [num_tokens, num_heads, head_size]
+  void *key,               // [num_tokens, num_kv_heads, head_size]
+  void *cos_cache,         // [num_tokens, rot_dim]
+  void *sin_cache,         // [num_tokens, rot_dim]
+  int32_t is_neox,
+
+  int32_t head_size,
+  int64_t num_tokens,
+  int32_t rot_dim,
+  int32_t num_heads,
+  int32_t num_kv_heads,
+  int64_t query_stride,
+  int64_t key_stride,
+
+  uint32_t dtype // 0 => f16; 1 => bf16; 2 => f32
+  ) {
+
+  dim3 grid(num_tokens);
+  dim3 block(std::min(num_heads * rot_dim, 512));
+  const cudaStream_t stream = 0;
+  const bool is_neox_bool = is_neox;
+
+  if (is_neox_bool) {
+    if (dtype == 0){
+      CALL_ROTARY(half, true);
+    } else if (dtype == 1) {
+      CALL_ROTARY(__nv_bfloat16, true);
+    } else if (dtype == 2) {
+      CALL_ROTARY(float, true);
+    }
+  } else {
+    if (dtype == 0){
+      CALL_ROTARY(half, false);
+    } else if (dtype == 1) {
+      CALL_ROTARY(__nv_bfloat16, false);
+    } else if (dtype == 2) {
+      CALL_ROTARY(float, false);
+    }
+  }
+}

--- a/mistralrs-quant/src/lib.rs
+++ b/mistralrs-quant/src/lib.rs
@@ -24,6 +24,7 @@ mod gguf;
 mod gptq;
 mod hqq;
 mod imatrix;
+pub mod rotary;
 pub mod safetensors;
 mod static_lora;
 mod unquantized;

--- a/mistralrs-quant/src/rotary/ffi.rs
+++ b/mistralrs-quant/src/rotary/ffi.rs
@@ -1,0 +1,22 @@
+use core::ffi::{c_int, c_long, c_void};
+
+extern "C" {
+    pub(crate) fn rotary_embedding(
+        query: *const c_void,
+        key: *const c_void,
+        cos_cache: *const c_void,
+        sin_cache: *const c_void,
+
+        is_neox: c_int,
+
+        head_size: c_int,
+        num_tokens: c_long,
+        rot_dim: c_int,
+        num_heads: c_int,
+        num_kv_heads: c_int,
+        query_stride: c_long,
+        key_stride: c_long,
+
+        dtype: u32,
+    );
+}

--- a/mistralrs-quant/src/rotary/mod.rs
+++ b/mistralrs-quant/src/rotary/mod.rs
@@ -1,0 +1,177 @@
+mod ffi;
+
+use candle_core::cuda_backend::cudarc::driver::DevicePtr;
+use candle_core::{DType, Device, Result, Storage, Tensor};
+use half::{bf16, f16};
+use std::ffi::{c_int, c_long};
+
+fn apply_rotary_<
+    T: candle_core::cuda_backend::CudaDType + candle_core::cuda_backend::cudarc::driver::DeviceRepr,
+>(
+    query: &Tensor,
+    key: &Tensor,
+    cos_cache: &Tensor,
+    sin_cache: &Tensor,
+    is_neox: bool,
+) -> Result<()> {
+    let dtype = query.dtype();
+    if key.dtype() != dtype || cos_cache.dtype() != dtype || sin_cache.dtype() != dtype {
+        candle_core::bail!("apply-rotary expects all tensors to have the same dtype");
+    }
+
+    let internal_type = match dtype {
+        DType::F16 => 0,
+        DType::BF16 => 1,
+        DType::F32 => 2,
+        dtype => candle_core::bail!("dtype {dtype:?} is not supported"),
+    };
+
+    let (q, q_l) = query.storage_and_layout();
+    let q = match &*q {
+        Storage::Cuda(q) => q,
+        _ => candle_core::bail!("query must be a cuda tensor"),
+    };
+
+    let (k, k_l) = key.storage_and_layout();
+    let k = match &*k {
+        Storage::Cuda(k) => k,
+        _ => candle_core::bail!("key must be a cuda tensor"),
+    };
+
+    let (cc, cc_l) = cos_cache.storage_and_layout();
+    let cc = match &*cc {
+        Storage::Cuda(cc) => cc,
+        _ => candle_core::bail!("cos_cache must be a cuda tensor"),
+    };
+
+    let (sc, sc_l) = sin_cache.storage_and_layout();
+    let sc = match &*sc {
+        Storage::Cuda(sc) => sc,
+        _ => candle_core::bail!("sin_cache must be a cuda tensor"),
+    };
+
+    let q_rank = q_l.stride().len();
+    let k_rank = k_l.stride().len();
+    let cc_rank = cc_l.stride().len();
+    let sc_rank = sc_l.stride().len();
+
+    if q_rank != 3 || k_rank != 3 {
+        candle_core::bail!("apply-rotary expects input tensors of rank 3 (k: {q_l:?}, v: {k_l:?})")
+    }
+
+    if cc_rank != 2 || sc_rank != 2 {
+        candle_core::bail!(
+            "apply-rotary expects cache tensors of rank 2 (k: {cc_l:?}, v: {sc_l:?})"
+        )
+    }
+
+    // Get cuda slices for all tensors
+    let q = q.as_cuda_slice::<T>()?;
+    let k = k.as_cuda_slice::<T>()?;
+    let cc = cc.as_cuda_slice::<T>()?;
+    let sc = sc.as_cuda_slice::<T>()?;
+
+    // Get cuda views for all tensors
+    let q = q.slice(q_l.start_offset()..);
+    let k = k.slice(k_l.start_offset()..);
+    let cc = cc.slice(cc_l.start_offset()..);
+    let sc = sc.slice(sc_l.start_offset()..);
+
+    let (num_tokens, num_heads, head_size) = q_l.shape().dims3()?;
+    let (num_tokens_kv, num_kv_heads, head_size_kv) = k_l.shape().dims3()?;
+
+    if (num_tokens, head_size) != (num_tokens_kv, head_size_kv) {
+        candle_core::bail!("shape mismatch q {:?} and k {:?}", q_l.shape(), k_l.shape())
+    }
+
+    let rot_dim = cc_l.dims()[1];
+    if (num_tokens, rot_dim) != cc_l.shape().dims2()? {
+        candle_core::bail!(
+            "shape mismatch cos_cache {:?}, expected {:?}",
+            cc_l.shape(),
+            (num_tokens, rot_dim)
+        )
+    }
+
+    if (num_tokens, rot_dim) != sc_l.shape().dims2()? {
+        candle_core::bail!(
+            "shape mismatch sin_cache {:?}, expected {:?}",
+            sc_l.shape(),
+            (num_tokens, rot_dim)
+        )
+    }
+
+    let query_stride = q_l.stride()[0];
+    let key_stride = k_l.stride()[0];
+
+    let q_ptr = *q.device_ptr() as *const core::ffi::c_void;
+    let k_ptr = *k.device_ptr() as *const core::ffi::c_void;
+    let cc_ptr = *cc.device_ptr() as *const core::ffi::c_void;
+    let sc_ptr = *sc.device_ptr() as *const core::ffi::c_void;
+
+    let neox = if is_neox { 1 } else { 0 };
+
+    unsafe {
+        ffi::rotary_embedding(
+            q_ptr,
+            k_ptr,
+            cc_ptr,
+            sc_ptr,
+            neox,
+            head_size as c_int,
+            num_tokens as c_long,
+            rot_dim as c_int,
+            num_heads as c_int,
+            num_kv_heads as c_int,
+            query_stride as c_long,
+            key_stride as c_long,
+            internal_type,
+        )
+    }
+    Ok(())
+}
+
+pub fn inv_freqs(dim: usize, base: f32, device: &Device) -> Result<Tensor> {
+    let inv_freq: Vec<_> = (0..dim)
+        .step_by(2)
+        .map(|i| 1f32 / base.powf(i as f32 / dim as f32))
+        .collect();
+    let inv_freq_len = inv_freq.len();
+    Tensor::from_vec(inv_freq, (1, inv_freq_len), device)
+}
+
+pub fn cos_sin(length: usize, inv_freqs: &Tensor, dtype: DType) -> Result<(Tensor, Tensor)> {
+    let t = Tensor::arange(0u32, length as u32, inv_freqs.device())?
+        .to_dtype(DType::F32)?
+        .reshape((length, 1))?;
+    let freqs = t.matmul(&inv_freqs)?;
+    let cos = freqs.cos()?.to_dtype(dtype)?;
+    let sin = freqs.sin()?.to_dtype(dtype)?;
+    Ok((cos, sin))
+}
+
+/// Apply Rotary position encoding inplace
+///
+/// # Arguments
+///
+/// * `query` - Query tensor of shape `(num_tokens, num_heads, head_size)`.
+/// * `key` - Key tensor of shape `(num_tokens, num_kv_heads, head_size)`.
+/// * `cos_cache` - Aligned cache of shape `(num_tokens, rot_dim)`
+/// * `sin_cache` - Aligned cache of shape `(num_tokens, rot_dim)`
+/// * `is_neox` - Use neox encoding instead of gpt-j style rotary
+pub fn apply_rotary_inplace(
+    query: &Tensor,
+    key: &Tensor,
+    cos_cache: &Tensor,
+    sin_cache: &Tensor,
+    is_neox: bool,
+) -> Result<()> {
+    match key.dtype() {
+        DType::F16 => apply_rotary_::<f16>(query, key, cos_cache, sin_cache, is_neox),
+        DType::BF16 => apply_rotary_::<bf16>(query, key, cos_cache, sin_cache, is_neox),
+        DType::F32 => apply_rotary_::<f32>(query, key, cos_cache, sin_cache, is_neox),
+        dt => {
+            candle_core::bail!("apply_rotary is only supported for f32, f16 and bf16 ({dt:?})")
+        }
+    }
+}

--- a/mistralrs-quant/src/rotary/mod.rs
+++ b/mistralrs-quant/src/rotary/mod.rs
@@ -1,154 +1,171 @@
+#[cfg(feature = "cuda")]
 mod ffi;
 
-use candle_core::cuda_backend::cudarc::driver::DevicePtr;
-use candle_core::{DType, Device, Result, Storage, Tensor};
-use half::{bf16, f16};
-use std::ffi::{c_int, c_long};
+#[cfg(feature = "cuda")]
+mod cuda {
+    use candle_core::cuda_backend::cudarc::driver::DevicePtr;
+    use candle_core::{DType, Result, Storage, Tensor};
+    use half::{bf16, f16};
+    use std::ffi::{c_int, c_long};
 
-fn apply_rotary_<
-    T: candle_core::cuda_backend::CudaDType + candle_core::cuda_backend::cudarc::driver::DeviceRepr,
->(
-    query: &Tensor,
-    key: &Tensor,
-    cos_cache: &Tensor,
-    sin_cache: &Tensor,
-    is_neox: bool,
-) -> Result<()> {
-    let dtype = query.dtype();
-    if key.dtype() != dtype || cos_cache.dtype() != dtype || sin_cache.dtype() != dtype {
-        candle_core::bail!("apply-rotary expects all tensors to have the same dtype");
+    fn apply_rotary_<
+        T: candle_core::cuda_backend::CudaDType
+            + candle_core::cuda_backend::cudarc::driver::DeviceRepr,
+    >(
+        query: &Tensor,
+        key: &Tensor,
+        cos_cache: &Tensor,
+        sin_cache: &Tensor,
+        is_neox: bool,
+    ) -> Result<()> {
+        let dtype = query.dtype();
+        if key.dtype() != dtype || cos_cache.dtype() != dtype || sin_cache.dtype() != dtype {
+            candle_core::bail!("apply-rotary expects all tensors to have the same dtype");
+        }
+
+        let internal_type = match dtype {
+            DType::F16 => 0,
+            DType::BF16 => 1,
+            DType::F32 => 2,
+            dtype => candle_core::bail!("dtype {dtype:?} is not supported"),
+        };
+
+        let (q, q_l) = query.storage_and_layout();
+        let q = match &*q {
+            Storage::Cuda(q) => q,
+            _ => candle_core::bail!("query must be a cuda tensor"),
+        };
+
+        let (k, k_l) = key.storage_and_layout();
+        let k = match &*k {
+            Storage::Cuda(k) => k,
+            _ => candle_core::bail!("key must be a cuda tensor"),
+        };
+
+        let (cc, cc_l) = cos_cache.storage_and_layout();
+        let cc = match &*cc {
+            Storage::Cuda(cc) => cc,
+            _ => candle_core::bail!("cos_cache must be a cuda tensor"),
+        };
+
+        let (sc, sc_l) = sin_cache.storage_and_layout();
+        let sc = match &*sc {
+            Storage::Cuda(sc) => sc,
+            _ => candle_core::bail!("sin_cache must be a cuda tensor"),
+        };
+
+        let q_rank = q_l.stride().len();
+        let k_rank = k_l.stride().len();
+        let cc_rank = cc_l.stride().len();
+        let sc_rank = sc_l.stride().len();
+
+        if q_rank != 3 || k_rank != 3 {
+            candle_core::bail!(
+                "apply-rotary expects input tensors of rank 3 (k: {q_l:?}, v: {k_l:?})"
+            )
+        }
+
+        if cc_rank != 2 || sc_rank != 2 {
+            candle_core::bail!(
+                "apply-rotary expects cache tensors of rank 2 (k: {cc_l:?}, v: {sc_l:?})"
+            )
+        }
+
+        // Get cuda slices for all tensors
+        let q = q.as_cuda_slice::<T>()?;
+        let k = k.as_cuda_slice::<T>()?;
+        let cc = cc.as_cuda_slice::<T>()?;
+        let sc = sc.as_cuda_slice::<T>()?;
+
+        // Get cuda views for all tensors
+        let q = q.slice(q_l.start_offset()..);
+        let k = k.slice(k_l.start_offset()..);
+        let cc = cc.slice(cc_l.start_offset()..);
+        let sc = sc.slice(sc_l.start_offset()..);
+
+        let (num_tokens, num_heads, head_size) = q_l.shape().dims3()?;
+        let (num_tokens_kv, num_kv_heads, head_size_kv) = k_l.shape().dims3()?;
+
+        if (num_tokens, head_size) != (num_tokens_kv, head_size_kv) {
+            candle_core::bail!("shape mismatch q {:?} and k {:?}", q_l.shape(), k_l.shape())
+        }
+
+        let rot_dim = cc_l.dims()[1];
+        if (num_tokens, rot_dim) != cc_l.shape().dims2()? {
+            candle_core::bail!(
+                "shape mismatch cos_cache {:?}, expected {:?}",
+                cc_l.shape(),
+                (num_tokens, rot_dim)
+            )
+        }
+
+        if (num_tokens, rot_dim) != sc_l.shape().dims2()? {
+            candle_core::bail!(
+                "shape mismatch sin_cache {:?}, expected {:?}",
+                sc_l.shape(),
+                (num_tokens, rot_dim)
+            )
+        }
+
+        let query_stride = q_l.stride()[0];
+        let key_stride = k_l.stride()[0];
+
+        let q_ptr = *q.device_ptr() as *const core::ffi::c_void;
+        let k_ptr = *k.device_ptr() as *const core::ffi::c_void;
+        let cc_ptr = *cc.device_ptr() as *const core::ffi::c_void;
+        let sc_ptr = *sc.device_ptr() as *const core::ffi::c_void;
+
+        let neox = if is_neox { 1 } else { 0 };
+
+        unsafe {
+            super::ffi::rotary_embedding(
+                q_ptr,
+                k_ptr,
+                cc_ptr,
+                sc_ptr,
+                neox,
+                head_size as c_int,
+                num_tokens as c_long,
+                rot_dim as c_int,
+                num_heads as c_int,
+                num_kv_heads as c_int,
+                query_stride as c_long,
+                key_stride as c_long,
+                internal_type,
+            )
+        }
+        Ok(())
     }
 
-    let internal_type = match dtype {
-        DType::F16 => 0,
-        DType::BF16 => 1,
-        DType::F32 => 2,
-        dtype => candle_core::bail!("dtype {dtype:?} is not supported"),
-    };
-
-    let (q, q_l) = query.storage_and_layout();
-    let q = match &*q {
-        Storage::Cuda(q) => q,
-        _ => candle_core::bail!("query must be a cuda tensor"),
-    };
-
-    let (k, k_l) = key.storage_and_layout();
-    let k = match &*k {
-        Storage::Cuda(k) => k,
-        _ => candle_core::bail!("key must be a cuda tensor"),
-    };
-
-    let (cc, cc_l) = cos_cache.storage_and_layout();
-    let cc = match &*cc {
-        Storage::Cuda(cc) => cc,
-        _ => candle_core::bail!("cos_cache must be a cuda tensor"),
-    };
-
-    let (sc, sc_l) = sin_cache.storage_and_layout();
-    let sc = match &*sc {
-        Storage::Cuda(sc) => sc,
-        _ => candle_core::bail!("sin_cache must be a cuda tensor"),
-    };
-
-    let q_rank = q_l.stride().len();
-    let k_rank = k_l.stride().len();
-    let cc_rank = cc_l.stride().len();
-    let sc_rank = sc_l.stride().len();
-
-    if q_rank != 3 || k_rank != 3 {
-        candle_core::bail!("apply-rotary expects input tensors of rank 3 (k: {q_l:?}, v: {k_l:?})")
+    /// Apply Rotary position encoding inplace
+    ///
+    /// # Arguments
+    ///
+    /// * `query` - Query tensor of shape `(num_tokens, num_heads, head_size)`.
+    /// * `key` - Key tensor of shape `(num_tokens, num_kv_heads, head_size)`.
+    /// * `cos_cache` - Aligned cache of shape `(num_tokens, rot_dim)`
+    /// * `sin_cache` - Aligned cache of shape `(num_tokens, rot_dim)`
+    /// * `is_neox` - Use neox encoding instead of gpt-j style rotary
+    pub fn apply_rotary_inplace(
+        query: &Tensor,
+        key: &Tensor,
+        cos_cache: &Tensor,
+        sin_cache: &Tensor,
+        is_neox: bool,
+    ) -> Result<()> {
+        match key.dtype() {
+            DType::F16 => apply_rotary_::<f16>(query, key, cos_cache, sin_cache, is_neox),
+            DType::BF16 => apply_rotary_::<bf16>(query, key, cos_cache, sin_cache, is_neox),
+            DType::F32 => apply_rotary_::<f32>(query, key, cos_cache, sin_cache, is_neox),
+            dt => {
+                candle_core::bail!("apply_rotary is only supported for f32, f16 and bf16 ({dt:?})")
+            }
+        }
     }
-
-    if cc_rank != 2 || sc_rank != 2 {
-        candle_core::bail!(
-            "apply-rotary expects cache tensors of rank 2 (k: {cc_l:?}, v: {sc_l:?})"
-        )
-    }
-
-    // Get cuda slices for all tensors
-    let q = q.as_cuda_slice::<T>()?;
-    let k = k.as_cuda_slice::<T>()?;
-    let cc = cc.as_cuda_slice::<T>()?;
-    let sc = sc.as_cuda_slice::<T>()?;
-
-    // Get cuda views for all tensors
-    let q = q.slice(q_l.start_offset()..);
-    let k = k.slice(k_l.start_offset()..);
-    let cc = cc.slice(cc_l.start_offset()..);
-    let sc = sc.slice(sc_l.start_offset()..);
-
-    let (num_tokens, num_heads, head_size) = q_l.shape().dims3()?;
-    let (num_tokens_kv, num_kv_heads, head_size_kv) = k_l.shape().dims3()?;
-
-    if (num_tokens, head_size) != (num_tokens_kv, head_size_kv) {
-        candle_core::bail!("shape mismatch q {:?} and k {:?}", q_l.shape(), k_l.shape())
-    }
-
-    let rot_dim = cc_l.dims()[1];
-    if (num_tokens, rot_dim) != cc_l.shape().dims2()? {
-        candle_core::bail!(
-            "shape mismatch cos_cache {:?}, expected {:?}",
-            cc_l.shape(),
-            (num_tokens, rot_dim)
-        )
-    }
-
-    if (num_tokens, rot_dim) != sc_l.shape().dims2()? {
-        candle_core::bail!(
-            "shape mismatch sin_cache {:?}, expected {:?}",
-            sc_l.shape(),
-            (num_tokens, rot_dim)
-        )
-    }
-
-    let query_stride = q_l.stride()[0];
-    let key_stride = k_l.stride()[0];
-
-    let q_ptr = *q.device_ptr() as *const core::ffi::c_void;
-    let k_ptr = *k.device_ptr() as *const core::ffi::c_void;
-    let cc_ptr = *cc.device_ptr() as *const core::ffi::c_void;
-    let sc_ptr = *sc.device_ptr() as *const core::ffi::c_void;
-
-    let neox = if is_neox { 1 } else { 0 };
-
-    unsafe {
-        ffi::rotary_embedding(
-            q_ptr,
-            k_ptr,
-            cc_ptr,
-            sc_ptr,
-            neox,
-            head_size as c_int,
-            num_tokens as c_long,
-            rot_dim as c_int,
-            num_heads as c_int,
-            num_kv_heads as c_int,
-            query_stride as c_long,
-            key_stride as c_long,
-            internal_type,
-        )
-    }
-    Ok(())
 }
 
-pub fn inv_freqs(dim: usize, base: f32, device: &Device) -> Result<Tensor> {
-    let inv_freq: Vec<_> = (0..dim)
-        .step_by(2)
-        .map(|i| 1f32 / base.powf(i as f32 / dim as f32))
-        .collect();
-    let inv_freq_len = inv_freq.len();
-    Tensor::from_vec(inv_freq, (1, inv_freq_len), device)
-}
-
-pub fn cos_sin(length: usize, inv_freqs: &Tensor, dtype: DType) -> Result<(Tensor, Tensor)> {
-    let t = Tensor::arange(0u32, length as u32, inv_freqs.device())?
-        .to_dtype(DType::F32)?
-        .reshape((length, 1))?;
-    let freqs = t.matmul(&inv_freqs)?;
-    let cos = freqs.cos()?.to_dtype(dtype)?;
-    let sin = freqs.sin()?.to_dtype(dtype)?;
-    Ok((cos, sin))
-}
+#[cfg(feature = "cuda")]
+pub use cuda::*;
 
 /// Apply Rotary position encoding inplace
 ///
@@ -159,19 +176,13 @@ pub fn cos_sin(length: usize, inv_freqs: &Tensor, dtype: DType) -> Result<(Tenso
 /// * `cos_cache` - Aligned cache of shape `(num_tokens, rot_dim)`
 /// * `sin_cache` - Aligned cache of shape `(num_tokens, rot_dim)`
 /// * `is_neox` - Use neox encoding instead of gpt-j style rotary
+#[cfg(not(feature = "cuda"))]
 pub fn apply_rotary_inplace(
-    query: &Tensor,
-    key: &Tensor,
-    cos_cache: &Tensor,
-    sin_cache: &Tensor,
-    is_neox: bool,
+    _query: &Tensor,
+    _key: &Tensor,
+    _cos_cache: &Tensor,
+    _sin_cache: &Tensor,
+    _is_neox: bool,
 ) -> Result<()> {
-    match key.dtype() {
-        DType::F16 => apply_rotary_::<f16>(query, key, cos_cache, sin_cache, is_neox),
-        DType::BF16 => apply_rotary_::<bf16>(query, key, cos_cache, sin_cache, is_neox),
-        DType::F32 => apply_rotary_::<f32>(query, key, cos_cache, sin_cache, is_neox),
-        dt => {
-            candle_core::bail!("apply_rotary is only supported for f32, f16 and bf16 ({dt:?})")
-        }
-    }
+    candle_core::bail!("apply_rotary is only supported for cuda");
 }

--- a/mistralrs-quant/src/rotary/mod.rs
+++ b/mistralrs-quant/src/rotary/mod.rs
@@ -178,11 +178,11 @@ pub use cuda::*;
 /// * `is_neox` - Use neox encoding instead of gpt-j style rotary
 #[cfg(not(feature = "cuda"))]
 pub fn apply_rotary_inplace(
-    _query: &Tensor,
-    _key: &Tensor,
-    _cos_cache: &Tensor,
-    _sin_cache: &Tensor,
+    _query: &candle_core::Tensor,
+    _key: &candle_core::Tensor,
+    _cos_cache: &candle_core::Tensor,
+    _sin_cache: &candle_core::Tensor,
     _is_neox: bool,
-) -> Result<()> {
+) -> candle_core::Result<()> {
     candle_core::bail!("apply_rotary is only supported for cuda");
 }


### PR DESCRIPTION
Now applied for both Q and K, also no .contiguous necessary when flash-attn.