### PR TITLE
Improve performance of deepseek models

### DIFF
--- a/mistralrs-core/src/models/deepseek2.rs
+++ b/mistralrs-core/src/models/deepseek2.rs
@@ -19,7 +19,7 @@ use crate::{
         DeepSeekV2RotaryEmbedding, Mlp, RmsNorm, Sdpa,
     },
     layers_masker::{masked_fill, PastKvLenCache},
-    ops::{BincountOp, NonZeroOp, SplitOp, TopKLastDimOp, TopKOutput},
+    ops::{NonZeroOp, SplitOp, TopKLastDimOp, TopKOutput},
     paged_attention::{AttentionImplementation, ModelConfigMetadata, PagedAttention},
     pipeline::{
         extract_logits,
@@ -29,7 +29,8 @@ use crate::{
     serde_default_fn,
     utils::{progress::NiceProgressBar, unvarbuilder::UnVarBuilder},
 };
-
+use std::collections::HashSet;
+use std::iter::FromIterator;
 serde_default_fn!(f64, routed_scaling_factor, 1.0);
 serde_default_fn!(TopkMethod, topk_method, TopkMethod::Greedy);
 serde_default_fn!(usize, moe_layer_freq, 1);
@@ -587,16 +588,15 @@ impl Moe {
 
     fn moe_infer(&self, xs: &Tensor, topk_ids: &Tensor, topk_weight: &Tensor) -> Result<Tensor> {
         let mut y = xs.zeros_like()?;
-        let counts = topk_ids
-            .flatten_all()?
-            .bincount(self.experts.len() as u32)?;
-        for (i, count) in counts
-            .iter()
-            .enumerate()
-            .take(self.experts_end_idx)
-            .skip(self.experts_start_idx)
-        {
-            if *count == 0 {
+        let topk_weight = if topk_weight.dtype() != xs.dtype() {
+            topk_weight.to_dtype(xs.dtype())?
+        } else {
+            topk_weight.to_owned()
+        };
+        let unique_ids: HashSet<u32> =
+            HashSet::from_iter(topk_ids.to_device(&Device::Cpu)?.flatten_all()?.to_vec1()?);
+        for i in self.experts_start_idx..self.experts_end_idx {
+            if !unique_ids.contains(&(i as u32)) {
                 continue;
             }
             let idx_top = topk_ids.eq(i as f64)?.nonzero()?.t()?;
@@ -614,8 +614,7 @@ impl Moe {
                         .index_select(idx, 0)?
                         .gather(&top.unsqueeze(1)?, 1)?
                         .squeeze(1)?
-                        .unsqueeze(D::Minus1)?
-                        .to_dtype(xs.dtype())?,
+                        .unsqueeze(D::Minus1)?,
                 )?,
                 0,
             )?;

--- a/mistralrs-core/src/models/deepseek3.rs
+++ b/mistralrs-core/src/models/deepseek3.rs
@@ -19,7 +19,7 @@ use crate::{
         DeepSeekV2RotaryEmbedding, Mlp, RmsNorm, Sdpa,
     },
     layers_masker::{masked_fill, PastKvLenCache},
-    ops::{BincountOp, NonZeroOp, SplitOp, TopKLastDimOp, TopKOutput},
+    ops::{NonZeroOp, SplitOp, TopKLastDimOp, TopKOutput},
     paged_attention::{AttentionImplementation, ModelConfigMetadata, PagedAttention},
     pipeline::{
         extract_logits,
@@ -29,7 +29,8 @@ use crate::{
     serde_default_fn,
     utils::{progress::NiceProgressBar, unvarbuilder::UnVarBuilder},
 };
-
+use std::collections::HashSet;
+use std::iter::FromIterator;
 serde_default_fn!(f64, routed_scaling_factor, 1.0);
 serde_default_fn!(TopkMethod, topk_method, TopkMethod::Greedy);
 serde_default_fn!(usize, moe_layer_freq, 1);
@@ -640,16 +641,15 @@ impl Moe {
 
     fn moe_infer(&self, xs: &Tensor, topk_ids: &Tensor, topk_weight: &Tensor) -> Result<Tensor> {
         let mut y = xs.zeros_like()?;
-        let counts = topk_ids
-            .flatten_all()?
-            .bincount(self.experts.len() as u32)?;
-        for (i, count) in counts
-            .iter()
-            .enumerate()
-            .take(self.experts_end_idx)
-            .skip(self.experts_start_idx)
-        {
-            if *count == 0 {
+        let topk_weight = if topk_weight.dtype() != xs.dtype() {
+            topk_weight.to_dtype(xs.dtype())?
+        } else {
+            topk_weight.to_owned()
+        };
+        let unique_ids: HashSet<u32> =
+            HashSet::from_iter(topk_ids.to_device(&Device::Cpu)?.flatten_all()?.to_vec1()?);
+        for i in self.experts_start_idx..self.experts_end_idx {
+            if !unique_ids.contains(&(i as u32)) {
                 continue;
             }
             let idx_top = topk_ids.eq(i as f64)?.nonzero()?.t()?;
@@ -667,8 +667,7 @@ impl Moe {
                         .index_select(idx, 0)?
                         .gather(&top.unsqueeze(1)?, 1)?
                         .squeeze(1)?
-                        .unsqueeze(D::Minus1)?
-                        .to_dtype(xs.dtype())?,
+                        .unsqueeze(D::Minus1)?,
                 )?,
                 0,
             )?;

--- a/mistralrs-core/src/ops.rs
+++ b/mistralrs-core/src/ops.rs
@@ -839,10 +839,12 @@ impl SplitOp for Tensor {
     }
 }
 
+#[allow(dead_code)]
 pub trait BincountOp {
     fn bincount(&self, minlength: u32) -> Result<Vec<u32>>;
 }
 
+#[allow(dead_code)]
 fn bincount(values: &[u32], minlength: u32) -> Vec<u32> {
     // let max_val = values.iter().max().copied().unwrap_or(0);
     // let result_len = (max_val + 1).max(minlength);
@@ -899,6 +901,7 @@ fn bincount(values: &[u32], minlength: u32) -> Vec<u32> {
         )
 }
 
+#[allow(dead_code)]
 impl BincountOp for Tensor {
     fn bincount(&self, minlength: u32) -> Result<Vec<u32>> {
         let values = self.to_vec1::<u32>()?;

--- a/mistralrs-quant/src/afq/ops.rs
+++ b/mistralrs-quant/src/afq/ops.rs
@@ -307,7 +307,7 @@ pub(crate) fn afq_mm_op(
             if lhs_indices.dtype() != DType::U32 || rhs_indices.dtype() != DType::U32 {
                 candle_core::bail!("lhs and rhs indices must be u32.")
             }
-            // Broadcase the indices if applicable.
+            // Broadcast the indices if applicable.
             {
                 let mut shape = lhs_indices.shape().clone();
                 shape = rhs_indices


### PR DESCRIPTION
Hi Eric,

I’d like to merge a recent PR made in [candle-vllm](https://github.com/EricLBuehler/candle-vllm/pull/124) into mistral.rs.

---
_Here are the comments from the original PR for your reference:_

The bincount operation takes a significant amount of time, especially with large token context sizes, leading to a slower moe_infer process. This PR replaces bincount with a Rust HashSet for counting expert appearances in topk_ids (produced by the Top-K operation or MoE gating), resulting in an overall inference performance improvement of over 20% for DeepSeek models.

Tested case (DeepSeek-V2-Chat)

Before:

```shell
Prompt "<｜begin▁of▁sentence｜>User: Talk about China.\n\nAssistant:"
Request cmpl-c934f6d3-02ac-48a5-bad3-e9d562ab92f1 with length 11 added to sequence group.
2025-04-10 05:55:13 WARN candle_vllm::openai::pipelines::llm_engine Sending 1 tasks to 1 subprocesses
Request cmpl-c934f6d3-02ac-48a5-bad3-e9d562ab92f1 decoding 404 tokens finished in 17 seconds
2025-04-10 05:55:31 WARN candle_vllm::openai::pipelines::llm_engine generate_once: no unfinished_sequences, break
2025-04-10 05:55:31 WARN candle_vllm::openai::pipelines::llm_engine Sending finish message to subprocesses
2025-04-10 05:55:31 WARN candle_vllm::openai::pipelines::llm_engine generate_once: finished generation

 [1 requests] Prefilling: 11 prompt tokens processed in 0 seconds

 [1 requests] Decoding: 404 tokens processed in 17 seconds (22 tokens/s)
```

After:

```shell
Prompt "<｜begin▁of▁sentence｜>User: Talk about China.\n\nAssistant:"
Request cmpl-f8224dbd-ba1c-4b1f-b92a-12806ac8ea2e with length 11 added to sequence group.
2025-04-10 05:52:31 WARN candle_vllm::openai::pipelines::llm_engine Sending 1 tasks to 1 subprocesses
Request cmpl-f8224dbd-ba1c-4b1f-b92a-12806ac8ea2e decoding 404 tokens finished in 11 seconds
2025-04-10 05:52:43 WARN candle_vllm::openai::pipelines::llm_engine generate_once: no unfinished_sequences, break
2025-04-10 05:52:43 WARN candle_vllm::openai::pipelines::llm_engine Sending finish message to subprocesses
2025-04-10 05:52:43 WARN candle_vllm::openai::pipelines::llm_engine generate_once: finished generation

 [1 requests] Prefilling: 11 prompt tokens processed in 0 seconds

 [1 requests] Decoding: 404 tokens processed in 11 seconds (34 tokens/s)
```