### PR TITLE
update to llguidance 0.7.16

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -928,9 +928,9 @@ dependencies = [
 
 [[package]]
 name = "derivre"
-version = "0.3.1"
+version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a3c2606b3ffc46f91fd62d954d55659ba9fb391bb673311b70f50daf9c15e49"
+checksum = "4a605f30e6a1460a323cc4de7bc62dea81df1d9d67eb92194d3a983a8a9601c4"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -1097,9 +1097,6 @@ name = "esaxx-rs"
 version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d817e038c30374a4bcb22f94d0a8a0e216958d4c3dcde369b1439fec4bdda6e6"
-dependencies = [
- "cc",
-]
 
 [[package]]
 name = "exr"
@@ -2124,8 +2121,9 @@ checksum = "23fb14cb19457329c82206317a5663005a4d404783dc74f4252769b0d5f42856"
 
 [[package]]
 name = "llguidance"
-version = "0.7.0"
-source = "git+https://github.com/EricLBuehler/llguidance?rev=8d71957#8d7195774a209038ddfbb0d1a5348ed17b387386"
+version = "0.7.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5e83eefc7b98a59c1d46f7e50ec9d3b05865a0085961acf55a7cac9d17be6dc"
 dependencies = [
  "anyhow",
  "derivre",
@@ -4320,7 +4318,6 @@ dependencies = [
  "derive_builder",
  "esaxx-rs",
  "getrandom 0.2.15",
- "indicatif",
  "itertools 0.13.0",
  "lazy_static",
  "log",
@@ -4406,8 +4403,9 @@ dependencies = [
 
 [[package]]
 name = "toktrie"
-version = "0.7.0"
-source = "git+https://github.com/EricLBuehler/llguidance?rev=8d71957#8d7195774a209038ddfbb0d1a5348ed17b387386"
+version = "0.7.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "032073ff474d0701e31fdc7bfec2e1d3e772472e0bd3809f9a6e327a3c62b84f"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -4418,8 +4416,9 @@ dependencies = [
 
 [[package]]
 name = "toktrie_hf_tokenizers"
-version = "0.7.0"
-source = "git+https://github.com/EricLBuehler/llguidance?rev=8d71957#8d7195774a209038ddfbb0d1a5348ed17b387386"
+version = "0.7.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "54351f50b331d38928d25b61747b70c5a78b19dba6d333e3b856ce5aa0d6b62c"
 dependencies = [
  "anyhow",
  "log",

--- a/examples/python/lark.py
+++ b/examples/python/lark.py
@@ -8,7 +8,7 @@ runner = Runner(
     num_device_layers=["500"],
 )
 
-# see llguidance.py for a better way of dealing with JSON and Lark together
+# see lark_llg.py for a better way of dealing with JSON and Lark together
 
 json_lark = r"""
 start: object # we only want objects

--- a/examples/python/lark_llg.py
+++ b/examples/python/lark_llg.py
@@ -8,27 +8,20 @@ runner = Runner(
     num_device_layers=["500"],
 )
 
-# In fact, JSON object can be also defined in the grammar itself, see
-# lark_llg.py and https://github.com/guidance-ai/llguidance/blob/main/docs/syntax.md#inline-json-schemas
+# see https://github.com/guidance-ai/llguidance/blob/main/docs/syntax.md for docs on syntax
 
-# @myobj will reference the JSON schema defined below (see grammars = [ ... ])
 top_lark = r"""
-start: "Reasoning: " /.+/ "\nJSON: " @myobj
-"""
-
-answer_schema = {
+start: "Reasoning: " /.+/ "\nJSON: " answer
+answer: %json {
     "type": "object",
     "properties": {
-        "answer": {"type": "string", "enum": ["Yes", "No"]},
+        "answer": {"type": "string", "enum": ["Yes", "No"]}
     },
     "required": ["answer"],
-    "additionalProperties": False,
+    "additionalProperties": false
 }
+"""
 
-grammars = [
-    {"lark_grammar": top_lark},
-    {"name": "myobj", "json_schema": answer_schema},
-]
 
 res = runner.send_chat_completion_request(
     ChatCompletionRequest(
@@ -41,8 +34,8 @@ res = runner.send_chat_completion_request(
         ],
         max_tokens=30,
         temperature=0.1,
-        grammar_type="llguidance",
-        grammar=dumps({"grammars": grammars}),
+        grammar_type="lark",
+        grammar=top_lark,
     )
 )
 print(res.choices[0].message.content)

--- a/examples/python/lark_llg.py
+++ b/examples/python/lark_llg.py
@@ -32,7 +32,7 @@ res = runner.send_chat_completion_request(
                 "content": "If all dogs are mammals, and all mammals are animals, are dogs animals?",
             }
         ],
-        max_tokens=30,
+        max_tokens=100,
         temperature=0.1,
         grammar_type="lark",
         grammar=top_lark,

--- a/mistralrs-core/Cargo.toml
+++ b/mistralrs-core/Cargo.toml
@@ -77,8 +77,8 @@ regex.workspace = true
 serde_plain = "1.0.2"
 as-any = "0.3.1"
 float8.workspace = true
-llguidance = { git = "https://github.com/EricLBuehler/llguidance", rev = "8d71957", default-features = false, features = ["lark"] }
-toktrie_hf_tokenizers = { git = "https://github.com/EricLBuehler/llguidance", rev = "8d71957" }
+llguidance = { version = "0.7.16", default-features = false, features = ["lark"] }
+toktrie_hf_tokenizers = "0.7.16"
 objc = { version = "0.2.7", optional = true }
 metal = { workspace = true, optional = true }
 candle-flash-attn-v3 = { workspace = true, optional = true }

--- a/mistralrs-core/src/engine/add_request.rs
+++ b/mistralrs-core/src/engine/add_request.rs
@@ -394,7 +394,7 @@ impl Engine {
             Some(StopTokens::Ids(ref i)) => {
                 let tok_env = {
                     let pipeline = get_mut_arcmutex!(self.pipeline);
-                    pipeline.get_metadata().tok_env.clone()
+                    pipeline.get_metadata().tok_env()
                 };
                 for id in i {
                     // We can't use ` ` (space) as a stop token because other tokens like ` moon` start with a space.
@@ -420,7 +420,7 @@ impl Engine {
 
                 let (tok_env, tokenizer) = {
                     let pipeline = get_mut_arcmutex!(self.pipeline);
-                    let tok_env = pipeline.get_metadata().tok_env.clone();
+                    let tok_env = pipeline.get_metadata().tok_env();
                     let tokenizer = pipeline.tokenizer();
                     (tok_env, tokenizer)
                 };
@@ -496,11 +496,11 @@ impl Engine {
 
         // Add sequences
         for response_index in 0..request.sampling_params.n_choices {
-            let trie = get_mut_arcmutex!(self.pipeline)
+            let factory = get_mut_arcmutex!(self.pipeline)
                 .get_metadata()
-                .tok_env
+                .llg_factory
                 .clone();
-            let recognizer = match Self::build_sequence_recognizer(&trie, &request.constraint) {
+            let recognizer = match Self::build_sequence_recognizer(&factory, &request.constraint) {
                 Ok(recognizer) => recognizer,
                 Err(err) => {
                     request

--- a/mistralrs-core/src/engine/mod.rs
+++ b/mistralrs-core/src/engine/mod.rs
@@ -13,7 +13,7 @@ use crate::{
     CompletionResponse, SchedulerConfig, DEBUG,
 };
 use interprocess::local_socket::{traits::Listener, ListenerOptions};
-use llguidance::toktrie::TokEnv;
+use llguidance::ParserFactory;
 use logger::IntervalLogger;
 use once_cell::sync::Lazy;
 use rand::SeedableRng;
@@ -463,14 +463,14 @@ impl Engine {
     }
 
     fn build_sequence_recognizer(
-        tok_env: &Option<TokEnv>,
+        factory: &Option<Arc<ParserFactory>>,
         constraint: &Constraint,
     ) -> anyhow::Result<SequenceRecognizer> {
         if let Some(grm) = llg_grammar_from_constraint(constraint)? {
-            let tok_env = tok_env
+            let factory = factory
                 .as_ref()
-                .ok_or_else(|| anyhow::anyhow!("No token environment found."))?;
-            let llg = constraint_from_llg_grammar(tok_env.clone(), grm)?;
+                .ok_or_else(|| anyhow::anyhow!("No token environment (llg_factory) found."))?;
+            let llg = constraint_from_llg_grammar(factory, grm)?;
             Ok(SequenceRecognizer::Llguidance(Box::new(llg)))
         } else {
             Ok(SequenceRecognizer::None)

--- a/mistralrs-core/src/pipeline/diffusion.rs
+++ b/mistralrs-core/src/pipeline/diffusion.rs
@@ -215,7 +215,7 @@ impl Loader for DiffusionLoader {
             model_id: self.model_id.clone(),
             metadata: Arc::new(GeneralMetadata {
                 max_seq_len,
-                tok_env: None,
+                llg_factory: None,
                 is_xlora: false,
                 no_prefix_cache: false,
                 num_hidden_layers: 1, // FIXME(EricLBuehler): we know this is only for caching, so its OK.

--- a/mistralrs-core/src/pipeline/ggml.rs
+++ b/mistralrs-core/src/pipeline/ggml.rs
@@ -363,7 +363,7 @@ impl Loader for GGMLLoader {
             Model::Llama(ref l) => l.max_seq_len,
             Model::XLoraLlama(ref xl) => xl.max_seq_len,
         };
-        let llg_factory = build_llg_factory(tokenizer.clone());
+        let llg_factory = build_llg_factory(tokenizer.clone())?;
         let num_hidden_layers = match model {
             Model::Llama(ref model) => model.cache.normal().0.len(),
             Model::XLoraLlama(ref model) => model.cache.full().lock().len(),

--- a/mistralrs-core/src/pipeline/ggml.rs
+++ b/mistralrs-core/src/pipeline/ggml.rs
@@ -1,5 +1,5 @@
 use super::cache_manager::FullCacheManager;
-use super::llg::build_tok_env;
+use super::llg::build_llg_factory;
 use super::{
     get_model_paths, get_xlora_paths, text_models_inputs_processor::ModelInputs, AdapterKind,
     CacheManager, GeneralMetadata, Loader, ModelKind, ModelPaths, QuantizationKind, TokenSource,
@@ -363,7 +363,7 @@ impl Loader for GGMLLoader {
             Model::Llama(ref l) => l.max_seq_len,
             Model::XLoraLlama(ref xl) => xl.max_seq_len,
         };
-        let tok_env = build_tok_env(tokenizer.clone());
+        let llg_factory = build_llg_factory(tokenizer.clone());
         let num_hidden_layers = match model {
             Model::Llama(ref model) => model.cache.normal().0.len(),
             Model::XLoraLlama(ref model) => model.cache.full().lock().len(),
@@ -383,7 +383,7 @@ impl Loader for GGMLLoader {
             }),
             metadata: Arc::new(GeneralMetadata {
                 max_seq_len,
-                tok_env: Some(tok_env),
+                llg_factory: Some(llg_factory),
                 no_kv_cache: self.no_kv_cache,
                 no_prefix_cache: false,
                 num_hidden_layers,

--- a/mistralrs-core/src/pipeline/gguf.rs
+++ b/mistralrs-core/src/pipeline/gguf.rs
@@ -511,7 +511,7 @@ impl Loader for GGUFLoader {
             Model::Starcoder2(ref p) => p.max_seq_len,
             Model::Qwen2(ref p) => p.max_seq_len,
         };
-        let llg_factory = build_llg_factory(tokenizer.clone());
+        let llg_factory = build_llg_factory(tokenizer.clone())?;
         let num_hidden_layers = match model {
             Model::Llama(ref model) => model.cache.normal().0.len(),
             Model::Phi2(ref model) => model.cache.normal().0.len(),

--- a/mistralrs-core/src/pipeline/gguf.rs
+++ b/mistralrs-core/src/pipeline/gguf.rs
@@ -1,5 +1,5 @@
 use super::cache_manager::{FullCacheManager, NormalCacheManager};
-use super::llg::build_tok_env;
+use super::llg::build_llg_factory;
 use super::{
     get_model_paths, get_xlora_paths, text_models_inputs_processor::ModelInputs, AdapterKind,
     CacheManager, GeneralMetadata, Loader, ModelKind, ModelPaths, PrettyName, QuantizationKind,
@@ -511,7 +511,7 @@ impl Loader for GGUFLoader {
             Model::Starcoder2(ref p) => p.max_seq_len,
             Model::Qwen2(ref p) => p.max_seq_len,
         };
-        let tok_env = build_tok_env(tokenizer.clone());
+        let llg_factory = build_llg_factory(tokenizer.clone());
         let num_hidden_layers = match model {
             Model::Llama(ref model) => model.cache.normal().0.len(),
             Model::Phi2(ref model) => model.cache.normal().0.len(),
@@ -550,7 +550,7 @@ impl Loader for GGUFLoader {
             }),
             metadata: Arc::new(GeneralMetadata {
                 max_seq_len,
-                tok_env: Some(tok_env),
+                llg_factory: Some(llg_factory),
                 no_kv_cache: self.no_kv_cache,
                 no_prefix_cache: false,
                 num_hidden_layers,

--- a/mistralrs-core/src/pipeline/llg.rs
+++ b/mistralrs-core/src/pipeline/llg.rs
@@ -1,21 +1,18 @@
 use std::sync::Arc;
 
 use anyhow::Result;
-use llguidance::{
-    api::{ParserLimits, TopLevelGrammar},
-    toktrie::{InferenceCapabilities, TokEnv},
-    TokenParser,
-};
+use llguidance::{api::TopLevelGrammar, ParserFactory};
 use tokenizers::Tokenizer;
 
 use crate::Constraint;
 
-pub fn build_tok_env(tokenizer: Tokenizer) -> TokEnv {
-    let bt = toktrie_hf_tokenizers::ByteTokenizer::from_tokenizer(tokenizer)
-        .expect("Failed to create ByteTokenizer from Tokenizer");
-    let env = toktrie_hf_tokenizers::ByteTokenizerEnv::new(bt, None)
+pub fn build_llg_factory(tokenizer: Tokenizer) -> Arc<ParserFactory> {
+    let env = toktrie_hf_tokenizers::ByteTokenizer::from_tokenizer(tokenizer)
+        .expect("Failed to create ByteTokenizer from Tokenizer")
+        .into_tok_env(None)
         .expect("Failed to create ByteTokenizerEnv");
-    Arc::new(env)
+    let factory = ParserFactory::new_simple(&env).expect("Failed to create ParserFactory");
+    Arc::new(factory)
 }
 
 pub fn llg_grammar_from_constraint(constraint: &Constraint) -> Result<Option<TopLevelGrammar>> {
@@ -30,18 +27,9 @@ pub fn llg_grammar_from_constraint(constraint: &Constraint) -> Result<Option<Top
 }
 
 pub fn constraint_from_llg_grammar(
-    tok_env: TokEnv,
+    factory: &ParserFactory,
     grm: TopLevelGrammar,
 ) -> Result<llguidance::Constraint> {
-    let parser = TokenParser::from_grammar(
-        tok_env,
-        grm,
-        llguidance::Logger::new(0, 1),
-        InferenceCapabilities {
-            ..Default::default()
-        },
-        ParserLimits::default(),
-        vec![],
-    )?;
+    let parser = factory.create_parser(grm)?;
     Ok(llguidance::Constraint::new(parser))
 }

--- a/mistralrs-core/src/pipeline/llg.rs
+++ b/mistralrs-core/src/pipeline/llg.rs
@@ -29,7 +29,7 @@ pub fn llg_grammar_from_constraint(constraint: &Constraint) -> Result<Option<Top
 pub fn constraint_from_llg_grammar(
     factory: &ParserFactory,
     grm: TopLevelGrammar,
-) -> Result<llguidance::Constraint> {
+) -> Result<llguidance::Matcher> {
     let parser = factory.create_parser(grm)?;
-    Ok(llguidance::Constraint::new(parser))
+    Ok(llguidance::Matcher::new(Ok(parser)))
 }

--- a/mistralrs-core/src/pipeline/llg.rs
+++ b/mistralrs-core/src/pipeline/llg.rs
@@ -6,13 +6,11 @@ use tokenizers::Tokenizer;
 
 use crate::Constraint;
 
-pub fn build_llg_factory(tokenizer: Tokenizer) -> Arc<ParserFactory> {
-    let env = toktrie_hf_tokenizers::ByteTokenizer::from_tokenizer(tokenizer)
-        .expect("Failed to create ByteTokenizer from Tokenizer")
-        .into_tok_env(None)
-        .expect("Failed to create ByteTokenizerEnv");
-    let factory = ParserFactory::new_simple(&env).expect("Failed to create ParserFactory");
-    Arc::new(factory)
+pub fn build_llg_factory(tokenizer: Tokenizer) -> Result<Arc<ParserFactory>> {
+    let env =
+        toktrie_hf_tokenizers::ByteTokenizer::from_tokenizer(tokenizer)?.into_tok_env(None)?;
+    let factory = ParserFactory::new_simple(&env)?;
+    Ok(Arc::new(factory))
 }
 
 pub fn llg_grammar_from_constraint(constraint: &Constraint) -> Result<Option<TopLevelGrammar>> {

--- a/mistralrs-core/src/pipeline/mod.rs
+++ b/mistralrs-core/src/pipeline/mod.rs
@@ -31,6 +31,7 @@ use image::DynamicImage;
 pub use inputs_processor::InputProcessorOutput;
 pub(crate) use isq::IsqModelLoader;
 pub use isq::{parse_isq_value, IsqModel, IsqOrganization, UQFF_MULTI_FILE_DELIMITER};
+use llguidance::toktrie::TokEnv;
 pub use loaders::{
     AdapterKind, AutoDeviceMapParams, AutoLoader, DeepSeekV2Loader, DeepSeekV3Loader,
     DeviceMappedModelLoader, DiffusionLoaderType, DiffusionModel, DiffusionModelLoader, FluxLoader,
@@ -76,8 +77,8 @@ use self::text_models_inputs_processor::PagedAttentionMeta;
 
 pub struct GeneralMetadata {
     pub max_seq_len: usize,
-    /// Only None if it doesnt make sense for the model
-    pub tok_env: Option<llguidance::toktrie::TokEnv>,
+    /// Only None if it doesn't make sense for the model
+    pub llg_factory: Option<Arc<llguidance::ParserFactory>>,
     pub no_kv_cache: bool,
     pub no_prefix_cache: bool,
     pub num_hidden_layers: usize,
@@ -92,6 +93,12 @@ pub struct GeneralMetadata {
     pub cache_engine: Option<CacheEngine>,
     pub prompt_chunksize: Option<NonZeroUsize>,
     pub model_metadata: Option<Arc<dyn ModelConfigLike + Send + Sync>>,
+}
+
+impl GeneralMetadata {
+    pub fn tok_env(&self) -> Option<TokEnv> {
+        self.llg_factory.as_ref().map(|f| f.tok_env().clone())
+    }
 }
 
 pub enum CacheInstruction {

--- a/mistralrs-core/src/pipeline/normal.rs
+++ b/mistralrs-core/src/pipeline/normal.rs
@@ -1,7 +1,7 @@
 use super::cache_manager::{FullCacheManager, NormalCacheManager};
 use super::inputs_processor::DEFAULT_PROMPT_CHUNK_SIZE;
 use super::isq::ImatrixDataSource;
-use super::llg::build_tok_env;
+use super::llg::build_llg_factory;
 use super::{
     get_model_paths, get_xlora_paths, text_models_inputs_processor::ModelInputs, AdapterKind,
     CacheManager, GeneralMetadata, Loader, ModelKind, ModelPaths, NormalModel, NormalModelLoader,
@@ -809,7 +809,7 @@ impl Loader for NormalLoader {
         };
 
         let max_seq_len = model.max_seq_len();
-        let tok_env = build_tok_env(tokenizer.clone());
+        let llg_factory = build_llg_factory(tokenizer.clone());
         let num_hidden_layers = match model.cache() {
             EitherCache::Full(full) => full.lock().len(),
             EitherCache::Normal(normal) => normal.lock().unwrap().0.len(),
@@ -832,7 +832,7 @@ impl Loader for NormalLoader {
             model_id: self.model_id.clone(),
             metadata: Arc::new(GeneralMetadata {
                 max_seq_len,
-                tok_env: Some(tok_env),
+                llg_factory: Some(llg_factory),
                 no_kv_cache: self.no_kv_cache,
                 no_prefix_cache: is_xlora,
                 num_hidden_layers,

--- a/mistralrs-core/src/pipeline/normal.rs
+++ b/mistralrs-core/src/pipeline/normal.rs
@@ -809,7 +809,7 @@ impl Loader for NormalLoader {
         };
 
         let max_seq_len = model.max_seq_len();
-        let llg_factory = build_llg_factory(tokenizer.clone());
+        let llg_factory = build_llg_factory(tokenizer.clone())?;
         let num_hidden_layers = match model.cache() {
             EitherCache::Full(full) => full.lock().len(),
             EitherCache::Normal(normal) => normal.lock().unwrap().0.len(),

--- a/mistralrs-core/src/pipeline/sampling.rs
+++ b/mistralrs-core/src/pipeline/sampling.rs
@@ -316,7 +316,6 @@ pub async fn sample_and_add_toks(
                 return_logprobs,
                 rng.clone(),
                 use_async_pool,
-                true, // Append result to trie
                 false,
             )
         })
@@ -347,7 +346,6 @@ pub async fn sample_sequence(
     return_logprobs: bool,
     rng: Arc<std::sync::Mutex<Isaac64Rng>>,
     use_async_pool: bool,
-    add_to_trie: bool,
     sample_speculative: bool,
 ) -> Result<Logprobs> {
     let logits = logits.squeeze(0)?.squeeze(0)?.to_dtype(DType::F32)?;
@@ -379,18 +377,27 @@ pub async fn sample_sequence(
 
     let bias_if_not_allowed = match &mut seq.recognizer {
         SequenceRecognizer::Llguidance(ref mut llg) => {
-            let mask = llg.compute_mask_or_eos().map_err(candle_core::Error::msg)?;
-            if mask.is_allowed(first_lobprobs_response.token) {
+            if llg
+                .validate_tokens(&[first_lobprobs_response.token])
+                .unwrap_or(0)
+                == 1
+            {
                 None
             } else {
-                let mut acc = vec![-f32::INFINITY; logits.shape().dims1().unwrap()];
-                mask.iter_set_entries(|idx| {
-                    if idx < acc.len() {
-                        acc[idx] = 0.0;
-                    }
-                });
+                let mask = llg.compute_mask_or_eos().map_err(candle_core::Error::msg)?;
+                if mask.is_allowed(first_lobprobs_response.token) {
+                    // shouldn't really happen, except for EOS
+                    None
+                } else {
+                    let mut acc = vec![-f32::INFINITY; logits.shape().dims1().unwrap()];
+                    mask.iter_set_entries(|idx| {
+                        if idx < acc.len() {
+                            acc[idx] = 0.0;
+                        }
+                    });
 
-                Some(acc)
+                    Some(acc)
+                }
             }
         }
         SequenceRecognizer::None => None,
@@ -426,17 +433,16 @@ pub async fn sample_sequence(
         None => first_lobprobs_response,
     };
 
-    if add_to_trie {
-        match seq.recognizer {
-            SequenceRecognizer::Llguidance(ref mut llg) => {
-                if !llg.is_stopped() {
-                    llg.consume_token(second_logprobs_response.token)
-                        .map_err(candle_core::Error::msg)?;
-                }
+    match seq.recognizer {
+        SequenceRecognizer::Llguidance(ref mut llg) => {
+            if !llg.is_stopped() {
+                llg.consume_token(second_logprobs_response.token)
+                    .map_err(candle_core::Error::msg)?;
             }
-            SequenceRecognizer::None => {}
         }
+        SequenceRecognizer::None => {}
     }
+
     Ok(second_logprobs_response)
 }
 
@@ -445,7 +451,7 @@ pub struct SpeculativeSample {
     pub sample: Logprobs,
 }
 
-/// Async sample without modifying sequence.
+/// Async sample without modifying sequence (except for the constraint).
 pub async fn sample_target_sequence_speculative(
     logits: Tensor,
     seq: &mut Sequence,
@@ -453,6 +459,14 @@ pub async fn sample_target_sequence_speculative(
     rng: Arc<std::sync::Mutex<Isaac64Rng>>,
     n_toks: usize,
 ) -> Result<Vec<SpeculativeSample>> {
+    // first, rollback the llg
+    match &mut seq.recognizer {
+        SequenceRecognizer::Llguidance(ref mut llg) => {
+            llg.rollback(n_toks).map_err(candle_core::Error::msg)?;
+        }
+        SequenceRecognizer::None => {}
+    }
+
     let mut sampled = Vec::new();
     for chunk in logits.chunk(n_toks, 1)? {
         sampled.push(SpeculativeSample {
@@ -461,8 +475,7 @@ pub async fn sample_target_sequence_speculative(
                 seq,
                 return_logprobs,
                 rng.clone(),
-                true,  // TODO(EricLBuehler): does this hurt perf?
-                false, // Do not append to trie (yet)
+                true, // TODO(EricLBuehler): does this hurt perf?
                 true,
             )
             .await?,

--- a/mistralrs-core/src/pipeline/sampling.rs
+++ b/mistralrs-core/src/pipeline/sampling.rs
@@ -36,8 +36,7 @@ pub(crate) async fn finish_or_add_toks_to_seq(
     seq.add_token(
         logprobs.clone(),
         this.get_metadata()
-            .tok_env
-            .as_ref()
+            .tok_env()
             .ok_or(candle_core::Error::Msg(
                 "`finish_or_add_toks_to_seq` requires the pipeline to have a token trie"
                     .to_string(),

--- a/mistralrs-core/src/pipeline/sampling.rs
+++ b/mistralrs-core/src/pipeline/sampling.rs
@@ -377,10 +377,11 @@ pub async fn sample_sequence(
 
     let bias_if_not_allowed = match &mut seq.recognizer {
         SequenceRecognizer::Llguidance(ref mut llg) => {
-            if llg
-                .validate_tokens(&[first_lobprobs_response.token])
-                .unwrap_or(0)
-                == 1
+            if !llg.is_stopped()
+                && llg
+                    .validate_tokens(&[first_lobprobs_response.token])
+                    .unwrap_or(0)
+                    == 1
             {
                 None
             } else {

--- a/mistralrs-core/src/pipeline/sampling.rs
+++ b/mistralrs-core/src/pipeline/sampling.rs
@@ -458,7 +458,7 @@ pub async fn sample_target_sequence_speculative(
     seq: &mut Sequence,
     return_logprobs: bool,
     rng: Arc<std::sync::Mutex<Isaac64Rng>>,
-    draft_samples: &Vec<SpeculativeSample>,
+    draft_samples: &[SpeculativeSample],
 ) -> Result<Vec<SpeculativeSample>> {
     let n_toks = draft_samples.len();
 

--- a/mistralrs-core/src/pipeline/speculative.rs
+++ b/mistralrs-core/src/pipeline/speculative.rs
@@ -18,7 +18,7 @@ use crate::{
         finish_or_add_toks_to_seq, sample_sequence, sample_target_sequence_speculative,
     },
     prefix_cacher::PrefixCacheManagerV2,
-    sequence::{Sequence, SequenceRecognizer},
+    sequence::Sequence,
     DeviceMapSetting, Loader, ModelKind, PagedAttentionConfig, Pipeline, TokenSource, TryIntoDType,
 };
 

--- a/mistralrs-core/src/pipeline/speculative.rs
+++ b/mistralrs-core/src/pipeline/speculative.rs
@@ -1,6 +1,5 @@
 use std::{
     any::Any,
-    iter::zip,
     sync::{Arc, Mutex},
     time::{Duration, Instant},
 };
@@ -479,18 +478,11 @@ impl Pipeline for SpeculativePipeline {
                     seq,
                     seq.return_logprobs(),
                     rng.clone(),
-                    self.gamma,
+                    &draft_samples,
                 )
                 .await?;
 
-                let mut accepted_tokens = Vec::new();
-                for (target_sample, draft_sample) in zip(samples, draft_samples) {
-                    let tok = target_sample.sample.token;
-                    accepted_tokens.push(target_sample.sample);
-                    if draft_sample.sample.token != tok {
-                        break;
-                    }
-                }
+                let accepted_tokens = samples.into_iter().map(|s| s.sample).collect::<Vec<_>>();
 
                 // ======================= Narrow caches to account for rejections ============================
                 let n_not_accepted = self.gamma - accepted_tokens.len();

--- a/mistralrs-core/src/pipeline/vision.rs
+++ b/mistralrs-core/src/pipeline/vision.rs
@@ -16,7 +16,7 @@ use crate::device_map::{self, DeviceMapper};
 use crate::distributed::{self, WorkerTransferData};
 use crate::paged_attention::{calculate_cache_config, AttentionImplementation, CacheEngine};
 use crate::pipeline::chat_template::{calculate_eos_tokens, GenerationConfig};
-use crate::pipeline::llg::build_tok_env;
+use crate::pipeline::llg::build_llg_factory;
 use crate::pipeline::sampling::sample_and_add_toks;
 use crate::pipeline::text_models_inputs_processor::make_prompt_chunk;
 use crate::pipeline::{get_chat_template, ChatTemplate, IsqOrganization, LocalModelPaths};
@@ -655,7 +655,7 @@ impl Loader for VisionLoader {
         };
 
         let max_seq_len = model.max_seq_len();
-        let tok_env = build_tok_env(tokenizer.clone());
+        let llg_factory = build_llg_factory(tokenizer.clone());
         let num_hidden_layers = match model.cache() {
             EitherCache::Full(full) => full.lock().len(),
             EitherCache::Normal(normal) => normal.lock().unwrap().0.len(),
@@ -670,7 +670,7 @@ impl Loader for VisionLoader {
             model_id: self.model_id.clone(),
             metadata: Arc::new(GeneralMetadata {
                 max_seq_len,
-                tok_env: Some(tok_env),
+                llg_factory: Some(llg_factory),
                 is_xlora: false,
                 num_hidden_layers,
                 eos_tok: eos,

--- a/mistralrs-core/src/pipeline/vision.rs
+++ b/mistralrs-core/src/pipeline/vision.rs
@@ -655,7 +655,7 @@ impl Loader for VisionLoader {
         };
 
         let max_seq_len = model.max_seq_len();
-        let llg_factory = build_llg_factory(tokenizer.clone());
+        let llg_factory = build_llg_factory(tokenizer.clone())?;
         let num_hidden_layers = match model.cache() {
             EitherCache::Full(full) => full.lock().len(),
             EitherCache::Normal(normal) => normal.lock().unwrap().0.len(),

--- a/mistralrs-core/src/sequence.rs
+++ b/mistralrs-core/src/sequence.rs
@@ -65,7 +65,7 @@ pub enum SequenceState {
 }
 
 pub enum SequenceRecognizer {
-    Llguidance(Box<llguidance::Constraint>),
+    Llguidance(Box<llguidance::Matcher>),
     None,
 }
 


### PR DESCRIPTION
- this updates llguidance to 0.7.16 from crates.io - the openssl dep is now gone from `toktrie_hf_tokenizers`
- use `llguidance::Matcher` instead of Constraint - it has additional APIs and is generally cleaner
- use ParserFactory for building Matchers - this enables [slicer optimization](https://github.com/guidance-ai/llguidance/blob/main/docs/optimizations.md#slicer-optimization) and is anyway the only way to do it now
- use Matcher.validate_tokens() first, so we can often skip computing masks
- rework the spec-decoding code a bit

@EricLBuehler I need comments on the last bit (the rest should be uncontroversial) - I changed `sample_target_sequence_speculative()` to take draft tokens and stop sampling once it diverges, instead of sampling everything first and only dropping tokens later - it saves some sampling and simplifies handling of constraints, but if it's a problem I can revert

I tested the various `*.py` scripts that deal with constrained decoding, but didn't really test the spec-decoding yet (I'm pretty sure spec-decoding + constrained-decoding isn't working now (before this PR) judging from the code)