### PR TITLE
Fix CPU hogging in interactive mode

### DIFF
--- a/mistralrs-core/src/engine/logger.rs
+++ b/mistralrs-core/src/engine/logger.rs
@@ -27,12 +27,12 @@ impl IntervalLogger {
         let t_total_new_seqs = total_new_seqs.clone();
         let t_enable_logging = enable_logging.clone();
         thread::spawn(move || {
-            // Wait
-            while !t_enable_logging.load(Ordering::Relaxed) {}
-
             // Start the actual logging
             loop {
                 thread::sleep(interval);
+                if !t_enable_logging.load(Ordering::Relaxed) {
+                    continue;
+                }
 
                 let total_new_seqs = t_total_new_seqs.load(Ordering::Relaxed);
                 let prefix_cache_hits = t_prefix_cache_hits.load(Ordering::Relaxed);


### PR DESCRIPTION
The log enabler should be checked after the sleep instead of a busy
loop checking.

Since the interactive mode always disables the token speed logger, 100%
CPU was taken by this loop always.

(There is another busy loop problem which will be fixed in another PR.)
