### PR TITLE
Add `Audio` and `Speech` model categories

### DIFF
--- a/mistralrs-core/src/pipeline/mod.rs
+++ b/mistralrs-core/src/pipeline/mod.rs
@@ -218,6 +218,7 @@ pub enum ModelCategory {
         has_conv2d: bool,
         prefixer: Arc<dyn VisionPromptPrefixer>,
     },
+    Audio,
     Diffusion,
 }
 
@@ -226,10 +227,9 @@ impl PartialEq for ModelCategory {
         match (self, other) {
             (Self::Text, Self::Text) => true,
             (Self::Vision { .. }, Self::Vision { .. }) => true,
+            (Self::Audio, Self::Audio) => true,
             (Self::Diffusion, Self::Diffusion) => true,
-            (Self::Text, _) => false,
-            (Self::Vision { .. }, _) => false,
-            (Self::Diffusion, _) => false,
+            (_, _) => false,
         }
     }
 }

--- a/mistralrs-core/src/pipeline/mod.rs
+++ b/mistralrs-core/src/pipeline/mod.rs
@@ -231,7 +231,10 @@ impl PartialEq for ModelCategory {
             (Self::Audio, Self::Audio) => true,
             (Self::Speech, Self::Speech) => true,
             (Self::Diffusion, Self::Diffusion) => true,
-            (_, _) => false,
+            (
+                Self::Text | Self::Vision { .. } | Self::Diffusion | Self::Audio | Self::Speech,
+                _,
+            ) => false,
         }
     }
 }

--- a/mistralrs-core/src/pipeline/mod.rs
+++ b/mistralrs-core/src/pipeline/mod.rs
@@ -218,8 +218,9 @@ pub enum ModelCategory {
         has_conv2d: bool,
         prefixer: Arc<dyn VisionPromptPrefixer>,
     },
-    Audio,
     Diffusion,
+    Audio,
+    Speech,
 }
 
 impl PartialEq for ModelCategory {
@@ -228,6 +229,7 @@ impl PartialEq for ModelCategory {
             (Self::Text, Self::Text) => true,
             (Self::Vision { .. }, Self::Vision { .. }) => true,
             (Self::Audio, Self::Audio) => true,
+            (Self::Speech, Self::Speech) => true,
             (Self::Diffusion, Self::Diffusion) => true,
             (_, _) => false,
         }

--- a/mistralrs-server/src/interactive_mode.rs
+++ b/mistralrs-server/src/interactive_mode.rs
@@ -61,7 +61,7 @@ fn read_line<H: Helper, I: History>(editor: &mut Editor<H, I>) -> String {
 
         Err(e) => {
             editor.save_history(&history_file_path()).unwrap();
-            eprintln!("Error reading input: {:?}", e);
+            eprintln!("Error reading input: {e:?}");
             std::process::exit(1);
         }
         Ok(prompt) => {
@@ -84,8 +84,9 @@ pub async fn interactive_mode(
         ModelCategory::Vision { .. } => {
             vision_interactive_mode(mistralrs, do_search, enable_thinking).await
         }
-        ModelCategory::Audio => audio_interactive_mode(mistralrs, do_search, enable_thinking).await,
         ModelCategory::Diffusion => diffusion_interactive_mode(mistralrs, do_search).await,
+        ModelCategory::Audio => audio_interactive_mode(mistralrs, do_search, enable_thinking).await,
+        ModelCategory::Speech => speech_interactive_mode(mistralrs, do_search).await,
     }
 }
 
@@ -258,7 +259,7 @@ async fn text_interactive_mode(
                     } = &chunk.choices[0]
                     {
                         assistant_output.push_str(content);
-                        print!("{}", content);
+                        print!("{content}");
                         io::stdout().flush().unwrap();
                         if finish_reason.is_some() {
                             if matches!(finish_reason.as_ref().unwrap().as_str(), "length") {
@@ -499,7 +500,7 @@ async fn vision_interactive_mode(
                     } = &chunk.choices[0]
                     {
                         assistant_output.push_str(content);
-                        print!("{}", content);
+                        print!("{content}");
                         io::stdout().flush().unwrap();
                         if finish_reason.is_some() {
                             if matches!(finish_reason.as_ref().unwrap().as_str(), "length") {
@@ -559,7 +560,11 @@ async fn audio_interactive_mode(
     _do_search: bool,
     _enable_thinking: Option<bool>,
 ) {
-    unimplemented!("Using audio models interactively isn't supported yet")
+    unimplemented!("Using audio models isn't supported yet")
+}
+
+async fn speech_interactive_mode(_mistralrs: Arc<MistralRs>, _do_search: bool) {
+    unimplemented!("Using speech models isn't supported yet")
 }
 
 async fn diffusion_interactive_mode(mistralrs: Arc<MistralRs>, do_search: bool) {

--- a/mistralrs/src/messages.rs
+++ b/mistralrs/src/messages.rs
@@ -159,7 +159,7 @@ impl VisionMessages {
         model: &Model,
     ) -> anyhow::Result<Self> {
         let prefixer = match &model.config().category {
-            ModelCategory::Text | ModelCategory::Diffusion => {
+            ModelCategory::Text | ModelCategory::Audio | ModelCategory::Diffusion => {
                 anyhow::bail!("`add_image_message` expects a vision model.")
             }
             ModelCategory::Vision {

--- a/mistralrs/src/messages.rs
+++ b/mistralrs/src/messages.rs
@@ -159,13 +159,13 @@ impl VisionMessages {
         model: &Model,
     ) -> anyhow::Result<Self> {
         let prefixer = match &model.config().category {
-            ModelCategory::Text | ModelCategory::Audio | ModelCategory::Diffusion => {
-                anyhow::bail!("`add_image_message` expects a vision model.")
-            }
             ModelCategory::Vision {
                 has_conv2d: _,
                 prefixer,
             } => prefixer,
+            _ => {
+                anyhow::bail!("`add_image_message` expects a vision model.")
+            }
         };
         self.images.push(image);
         self.messages.push(IndexMap::from([


### PR DESCRIPTION
* Add `Audio` and `Speech` model categories!
* Some refactoring to the mistral-server's interactive functions to reduce code duplication once the speech and audio variants are implemented 

I want to add audio input support so I figured I'd dice this out to reduce PR conflicts.

# Testing

Tested text model:
```bash
cargo run --release --features=cuda -p mistralrs-server -- --interactive-mode plain --model-id microsoft/Phi-4-mini-instruct --arch phi3
```

Tested vision model:
```
cargo run --release --features=cuda -p mistralrs-server -- --interactive-mode vision-plain --model-id microsoft/Phi-4-multimodal-instruct --arch phi4mm
```

phi4mm crashes with ```Msg("`c` end offset must be 33554432")``` on master and in my branch when an image input is given, so no change there

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for two new model categories: Audio and Speech.
  - Introduced interactive mode stubs for Audio and Speech models.

- **Improvements**
  - Unified sampling parameter usage across interactive modes.
  - Enhanced help messages in interactive modes for better user guidance.
  - Generalized file parsing to support more flexible input handling.
  - Updated output formatting for improved readability.

- **Bug Fixes**
  - Simplified and consolidated error handling in vision message processing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->