### PR TITLE
Remove has_conv2d from vision model API

### DIFF
--- a/mistralrs-core/src/pipeline/loaders/vision_loaders.rs
+++ b/mistralrs-core/src/pipeline/loaders/vision_loaders.rs
@@ -74,7 +74,6 @@ pub trait VisionModel: IsqModel + AnyMoeBaseModelMixin {
     fn cache(&self) -> &EitherCache;
     fn cache_mut(&mut self) -> &mut EitherCache;
     fn max_seq_len(&self) -> usize;
-    fn has_conv2d(&self) -> bool;
     fn config(&self) -> &ModelConfigMetadata;
     /// For a prompt without images. Requires batch size of 1!
     fn default_model_specific_args(&self, input_ids: &Tensor) -> Box<dyn Any>;

--- a/mistralrs-core/src/pipeline/mod.rs
+++ b/mistralrs-core/src/pipeline/mod.rs
@@ -215,7 +215,6 @@ pub trait AnyMoePipelineMixin {
 pub enum ModelCategory {
     Text,
     Vision {
-        has_conv2d: bool,
         prefixer: Arc<dyn VisionPromptPrefixer>,
     },
     Diffusion,

--- a/mistralrs-core/src/pipeline/vision.rs
+++ b/mistralrs-core/src/pipeline/vision.rs
@@ -872,9 +872,7 @@ impl Pipeline for VisionPipeline {
         sample_and_add_toks(self, seqs, logits, prefix_cacher, disable_eos_stop, rng).await
     }
     fn category(&self) -> ModelCategory {
-        let has_conv2d = self.model.has_conv2d();
         ModelCategory::Vision {
-            has_conv2d,
             prefixer: self.prefixer.clone(),
         }
     }

--- a/mistralrs-core/src/vision_models/gemma3/mod.rs
+++ b/mistralrs-core/src/vision_models/gemma3/mod.rs
@@ -222,10 +222,6 @@ impl VisionModel for Gemma3Model {
     fn config(&self) -> &ModelConfigMetadata {
         self.language_model.config()
     }
-    fn has_conv2d(&self) -> bool {
-        // TODO
-        false
-    }
 }
 
 impl AnyMoeBaseModelMixin for Gemma3Model {

--- a/mistralrs-core/src/vision_models/gemma3/text.rs
+++ b/mistralrs-core/src/vision_models/gemma3/text.rs
@@ -723,9 +723,6 @@ impl VisionModel for TextModel {
     fn config(&self) -> &ModelConfigMetadata {
         &self.cfg
     }
-    fn has_conv2d(&self) -> bool {
-        unreachable!()
-    }
 }
 
 impl AnyMoeBaseModelMixin for TextModel {

--- a/mistralrs-core/src/vision_models/idefics2/mod.rs
+++ b/mistralrs-core/src/vision_models/idefics2/mod.rs
@@ -1296,9 +1296,6 @@ impl VisionModel for Idefics2 {
     fn max_seq_len(&self) -> usize {
         self.text_model.max_seq_len()
     }
-    fn has_conv2d(&self) -> bool {
-        true
-    }
     fn config(&self) -> &ModelConfigMetadata {
         self.text_model.config()
     }

--- a/mistralrs-core/src/vision_models/idefics3/mod.rs
+++ b/mistralrs-core/src/vision_models/idefics3/mod.rs
@@ -330,9 +330,6 @@ impl VisionModel for Idefics3Model {
     fn max_seq_len(&self) -> usize {
         self.text_model.max_seq_len()
     }
-    fn has_conv2d(&self) -> bool {
-        true
-    }
     fn config(&self) -> &ModelConfigMetadata {
         self.text_model.config()
     }

--- a/mistralrs-core/src/vision_models/llama4/mod.rs
+++ b/mistralrs-core/src/vision_models/llama4/mod.rs
@@ -261,9 +261,6 @@ impl VisionModel for Llama4Model {
     fn config(&self) -> &ModelConfigMetadata {
         self.language_model.config()
     }
-    fn has_conv2d(&self) -> bool {
-        false
-    }
     fn device(&self) -> &Device {
         self.language_model.device()
     }

--- a/mistralrs-core/src/vision_models/llava/llava15.rs
+++ b/mistralrs-core/src/vision_models/llava/llava15.rs
@@ -333,10 +333,6 @@ impl VisionModel for Model {
         self.config.text_config.max_length
     }
 
-    fn has_conv2d(&self) -> bool {
-        true
-    }
-
     fn config(&self) -> &ModelConfigMetadata {
         self.llm.config()
     }

--- a/mistralrs-core/src/vision_models/llava/llava_next.rs
+++ b/mistralrs-core/src/vision_models/llava/llava_next.rs
@@ -425,10 +425,6 @@ impl VisionModel for Model {
         self.config.text_config.max_length
     }
 
-    fn has_conv2d(&self) -> bool {
-        true
-    }
-
     fn config(&self) -> &ModelConfigMetadata {
         self.llm.config()
     }

--- a/mistralrs-core/src/vision_models/minicpmo/mod.rs
+++ b/mistralrs-core/src/vision_models/minicpmo/mod.rs
@@ -258,9 +258,6 @@ impl VisionModel for MiniCpmOModel {
     fn device(&self) -> &Device {
         self.llm.device()
     }
-    fn has_conv2d(&self) -> bool {
-        true
-    }
     fn max_seq_len(&self) -> usize {
         self.llm.max_seq_len()
     }

--- a/mistralrs-core/src/vision_models/mistral3/mod.rs
+++ b/mistralrs-core/src/vision_models/mistral3/mod.rs
@@ -342,9 +342,6 @@ impl VisionModel for Mistral3Model {
     fn config(&self) -> &ModelConfigMetadata {
         self.text_model.config()
     }
-    fn has_conv2d(&self) -> bool {
-        true
-    }
 }
 
 impl AnyMoeBaseModelMixin for Mistral3Model {

--- a/mistralrs-core/src/vision_models/mllama/mod.rs
+++ b/mistralrs-core/src/vision_models/mllama/mod.rs
@@ -187,9 +187,6 @@ impl VisionModel for MLlamaModel {
     fn device(&self) -> &Device {
         &self.language_model.device
     }
-    fn has_conv2d(&self) -> bool {
-        true
-    }
     fn max_seq_len(&self) -> usize {
         self.language_model.max_position_embeddings
     }

--- a/mistralrs-core/src/vision_models/phi3/mod.rs
+++ b/mistralrs-core/src/vision_models/phi3/mod.rs
@@ -1225,9 +1225,6 @@ impl VisionModel for Model {
     fn max_seq_len(&self) -> usize {
         self.max_seq_len
     }
-    fn has_conv2d(&self) -> bool {
-        true
-    }
     fn config(&self) -> &ModelConfigMetadata {
         &self.cfg
     }

--- a/mistralrs-core/src/vision_models/phi4/mod.rs
+++ b/mistralrs-core/src/vision_models/phi4/mod.rs
@@ -577,9 +577,6 @@ impl VisionModel for Phi4MMModel {
     fn max_seq_len(&self) -> usize {
         self.max_seq_len
     }
-    fn has_conv2d(&self) -> bool {
-        true
-    }
     fn config(&self) -> &ModelConfigMetadata {
         &self.cfg
     }

--- a/mistralrs-core/src/vision_models/qwen2_5_vl/mod.rs
+++ b/mistralrs-core/src/vision_models/qwen2_5_vl/mod.rs
@@ -479,9 +479,6 @@ impl VisionModel for Qwen2_5VLModel {
     fn max_seq_len(&self) -> usize {
         self.text.max_seq_len
     }
-    fn has_conv2d(&self) -> bool {
-        true
-    }
     fn config(&self) -> &ModelConfigMetadata {
         &self.text.cfg
     }

--- a/mistralrs-core/src/vision_models/qwen2vl/mod.rs
+++ b/mistralrs-core/src/vision_models/qwen2vl/mod.rs
@@ -479,9 +479,6 @@ impl VisionModel for Qwen2VLModel {
     fn max_seq_len(&self) -> usize {
         self.text.max_seq_len
     }
-    fn has_conv2d(&self) -> bool {
-        true
-    }
     fn config(&self) -> &ModelConfigMetadata {
         &self.text.cfg
     }

--- a/mistralrs-server/src/interactive_mode.rs
+++ b/mistralrs-server/src/interactive_mode.rs
@@ -339,10 +339,7 @@ async fn vision_interactive_mode(
     let mut images = Vec::new();
 
     let prefixer = match &mistralrs.config().category {
-        ModelCategory::Vision {
-            has_conv2d: _,
-            prefixer,
-        } => prefixer,
+        ModelCategory::Vision { prefixer } => prefixer,
         _ => {
             panic!("`add_image_message` expects a vision model.")
         }

--- a/mistralrs/src/messages.rs
+++ b/mistralrs/src/messages.rs
@@ -159,10 +159,7 @@ impl VisionMessages {
         model: &Model,
     ) -> anyhow::Result<Self> {
         let prefixer = match &model.config().category {
-            ModelCategory::Vision {
-                has_conv2d: _,
-                prefixer,
-            } => prefixer,
+            ModelCategory::Vision { prefixer } => prefixer,
             _ => {
                 anyhow::bail!("`add_image_message` expects a vision model.")
             }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Simplified the interface for vision models by removing the requirement to specify convolutional layer support.
	- Streamlined related logic and pattern matching for improved maintainability.
- **Chores**
	- Cleaned up unused fields and methods associated with vision model capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->