### PR TITLE
Unified/automatic flash attention enabler

### DIFF
--- a/mistralrs-core/src/attention.rs
+++ b/mistralrs-core/src/attention.rs
@@ -282,7 +282,7 @@ impl Sdpa {
     /// - v: (b_sz, n_kv_heads, q_len, head_dim)
     ///
     /// The attention implementation is dispatched as follows:
-    /// 1) If `use_flash_attn == true` (CUDA), use a flash attention V2 kernel
+    /// 1) If using flash attn (CUDA), use a flash attention V2/V3 kernel
     /// 2) If decoding and using a Metal device, use a fused kkernel
     /// 2) Otherwise, use the "naive" SDPA implementation (with optimized mask+softmax+scale application)
     #[allow(unused_variables, clippy::too_many_arguments)]

--- a/mistralrs-core/src/attention.rs
+++ b/mistralrs-core/src/attention.rs
@@ -266,7 +266,6 @@ fn naive_sdpa(
 
 pub struct SdpaParams {
     pub n_kv_groups: usize,
-    pub use_flash_attn: bool,
     pub softcap: Option<f32>,
     pub softmax_scale: f32,
     pub sliding_window: Option<usize>,
@@ -299,7 +298,7 @@ impl Sdpa {
         let (b_sz, n_attn_heads, seq_len, head_dim) = q.dims4()?;
         let (_, _, _, k_head_dim) = k.dims4()?;
         let (_, _, _, v_head_dim) = v.dims4()?;
-        if sdpa_params.use_flash_attn && q.device().is_cuda() {
+        if crate::using_flash_attn() && q.device().is_cuda() {
             // flash-attn expects (b_sz, seq_len, nheads, head_dim)
             let q = q.transpose(1, 2)?;
             let k = k.transpose(1, 2)?;

--- a/mistralrs-core/src/lib.rs
+++ b/mistralrs-core/src/lib.rs
@@ -86,14 +86,14 @@ pub use paged_attention::{MemoryGpuConfig, PagedAttentionConfig};
 pub use pipeline::{
     chat_template::ChatTemplate, parse_isq_value, AdapterPaths, AnyMoeLoader, AnyMoePipeline,
     AutoDeviceMapParams, DiffusionGenerationParams, DiffusionLoader, DiffusionLoaderBuilder,
-    DiffusionLoaderType, DiffusionSpecificConfig, GGMLLoader, GGMLLoaderBuilder,
-    GGMLSpecificConfig, GGUFLoader, GGUFLoaderBuilder, GGUFSpecificConfig, GemmaLoader,
-    Idefics2Loader, IsqOrganization, LLaVALoader, LLaVANextLoader, LlamaLoader, Loader,
-    LocalModelPaths, LoraAdapterPaths, MistralLoader, MixtralLoader, ModelKind, ModelPaths,
-    NormalLoader, NormalLoaderBuilder, NormalLoaderType, NormalSpecificConfig, Phi2Loader,
-    Phi3Loader, Phi3VLoader, Qwen2Loader, SpeculativeConfig, SpeculativeLoader,
-    SpeculativePipeline, Starcoder2Loader, TokenSource, VisionLoader, VisionLoaderBuilder,
-    VisionLoaderType, VisionPromptPrefixer, VisionSpecificConfig, UQFF_MULTI_FILE_DELIMITER,
+    DiffusionLoaderType, GGMLLoader, GGMLLoaderBuilder, GGMLSpecificConfig, GGUFLoader,
+    GGUFLoaderBuilder, GGUFSpecificConfig, GemmaLoader, Idefics2Loader, IsqOrganization,
+    LLaVALoader, LLaVANextLoader, LlamaLoader, Loader, LocalModelPaths, LoraAdapterPaths,
+    MistralLoader, MixtralLoader, ModelKind, ModelPaths, NormalLoader, NormalLoaderBuilder,
+    NormalLoaderType, NormalSpecificConfig, Phi2Loader, Phi3Loader, Phi3VLoader, Qwen2Loader,
+    SpeculativeConfig, SpeculativeLoader, SpeculativePipeline, Starcoder2Loader, TokenSource,
+    VisionLoader, VisionLoaderBuilder, VisionLoaderType, VisionPromptPrefixer,
+    VisionSpecificConfig, UQFF_MULTI_FILE_DELIMITER,
 };
 pub use request::{
     ApproximateUserLocation, Constraint, DetokenizationRequest, ImageGenerationResponseFormat,

--- a/mistralrs-core/src/models/deepseek2.rs
+++ b/mistralrs-core/src/models/deepseek2.rs
@@ -244,7 +244,6 @@ impl Attention {
             num_attention_heads: cfg.num_attention_heads / comm.world_size(),
             sdpa_params: SdpaParams {
                 n_kv_groups: 1,
-                use_flash_attn: cfg.use_flash_attn,
                 softcap: None,
                 softmax_scale: cfg.softmax_scale(),
                 sliding_window: None,

--- a/mistralrs-core/src/models/deepseek2.rs
+++ b/mistralrs-core/src/models/deepseek2.rs
@@ -39,7 +39,6 @@ serde_default_fn!(bool, norm_topk_prob, false);
 serde_default_fn!(ScoringFunc, scoring_func, ScoringFunc::Softmax);
 serde_default_fn!(Activation, hidden_act, Activation::Silu);
 serde_default_fn!(bool, tie_word_embeddings, false);
-serde_default_fn!(bool, use_flash_attn_default, false);
 
 #[derive(Deserialize, Clone, Debug)]
 enum TopkMethod {

--- a/mistralrs-core/src/models/deepseek2.rs
+++ b/mistralrs-core/src/models/deepseek2.rs
@@ -93,8 +93,6 @@ pub struct DeepSeekV2Config {
     pub(crate) kv_lora_rank: usize,
     pub(crate) v_head_dim: usize,
     pub(crate) qk_nope_head_dim: usize,
-    #[serde(default = "use_flash_attn_default")]
-    pub(crate) use_flash_attn: bool,
     pub(crate) quantization_config: Option<QuantizedConfig>,
     pub(crate) n_group: usize,
     pub(crate) topk_group: usize,

--- a/mistralrs-core/src/models/deepseek3.rs
+++ b/mistralrs-core/src/models/deepseek3.rs
@@ -244,7 +244,6 @@ impl Attention {
             num_attention_heads: cfg.num_attention_heads / comm.world_size(),
             sdpa_params: SdpaParams {
                 n_kv_groups: 1,
-                use_flash_attn: cfg.use_flash_attn,
                 softcap: None,
                 softmax_scale: cfg.softmax_scale(),
                 sliding_window: None,

--- a/mistralrs-core/src/models/deepseek3.rs
+++ b/mistralrs-core/src/models/deepseek3.rs
@@ -93,8 +93,6 @@ pub struct DeepSeekV3Config {
     pub(crate) kv_lora_rank: usize,
     pub(crate) v_head_dim: usize,
     pub(crate) qk_nope_head_dim: usize,
-    #[serde(default = "use_flash_attn_default")]
-    pub(crate) use_flash_attn: bool,
     pub(crate) quantization_config: Option<QuantizedConfig>,
     pub(crate) n_group: usize,
     pub(crate) topk_group: usize,

--- a/mistralrs-core/src/models/deepseek3.rs
+++ b/mistralrs-core/src/models/deepseek3.rs
@@ -38,7 +38,6 @@ serde_default_fn!(usize, first_k_dense_replace, 0);
 serde_default_fn!(ScoringFunc, scoring_func, ScoringFunc::Softmax);
 serde_default_fn!(Activation, hidden_act, Activation::Silu);
 serde_default_fn!(bool, tie_word_embeddings, false);
-serde_default_fn!(bool, use_flash_attn_default, false);
 
 #[derive(Deserialize, Clone, Debug)]
 enum TopkMethod {

--- a/mistralrs-core/src/models/gemma.rs
+++ b/mistralrs-core/src/models/gemma.rs
@@ -150,7 +150,6 @@ impl Attention {
                     cfg.num_attention_heads,
                     comm,
                 ),
-                use_flash_attn: cfg.use_flash_attn,
                 softcap: None,
                 softmax_scale: 1.0 / (head_dim as f32).sqrt(),
                 sliding_window: None,

--- a/mistralrs-core/src/models/gemma.rs
+++ b/mistralrs-core/src/models/gemma.rs
@@ -50,7 +50,6 @@ pub struct Config {
 
     #[serde(default = "default_max_position_embeddings")]
     pub max_position_embeddings: usize,
-    pub use_flash_attn: bool,
     pub quantization_config: Option<QuantizedConfig>,
     #[serde(default = "word_emb_default")]
     #[allow(dead_code)]

--- a/mistralrs-core/src/models/gemma2.rs
+++ b/mistralrs-core/src/models/gemma2.rs
@@ -152,7 +152,6 @@ impl Attention {
                     cfg.num_attention_heads,
                     comm,
                 ),
-                use_flash_attn: cfg.use_flash_attn,
                 softcap: cfg.attn_logit_softcapping.map(|x| x as f32),
                 softmax_scale: 1.0 / (cfg.query_pre_attn_scalar as f32).sqrt(),
                 sliding_window,

--- a/mistralrs-core/src/models/gemma2.rs
+++ b/mistralrs-core/src/models/gemma2.rs
@@ -24,7 +24,7 @@ use crate::{
     utils::{progress::NiceProgressBar, unvarbuilder::UnVarBuilder},
 };
 
-#[derive(Debug, Clone, Default, serde::Serialize)]
+#[derive(Debug, Clone, Default, serde::Deserialize)]
 pub struct Config {
     pub attention_bias: bool,
     pub head_dim: usize,
@@ -45,7 +45,6 @@ pub struct Config {
     pub query_pre_attn_scalar: usize,
     pub max_position_embeddings: usize,
     pub quantization_config: Option<QuantizedConfig>,
-    pub use_flash_attn: bool,
     #[allow(dead_code)]
     pub tie_word_embeddings: bool,
 }

--- a/mistralrs-core/src/models/llama.rs
+++ b/mistralrs-core/src/models/llama.rs
@@ -30,7 +30,6 @@ use crate::{
 };
 
 serde_default_fn!(bool, word_emb_default, false);
-serde_default_fn!(bool, use_flash_attn_default, false);
 
 #[derive(Debug, Clone, Deserialize, Serialize, Default)]
 pub struct Config {

--- a/mistralrs-core/src/models/llama.rs
+++ b/mistralrs-core/src/models/llama.rs
@@ -240,7 +240,6 @@ impl CausalSelfAttention {
                     cfg.num_attention_heads,
                     comm,
                 ),
-                use_flash_attn: cfg.use_flash_attn,
                 softcap: None,
                 softmax_scale: 1.0 / ((cfg.hidden_size / cfg.num_attention_heads) as f32).sqrt(),
                 sliding_window: None,

--- a/mistralrs-core/src/models/llama.rs
+++ b/mistralrs-core/src/models/llama.rs
@@ -41,8 +41,6 @@ pub struct Config {
     pub num_hidden_layers: usize,
     pub num_attention_heads: usize,
     pub num_key_value_heads: usize,
-    #[serde(default = "use_flash_attn_default")]
-    pub use_flash_attn: bool,
     pub rms_norm_eps: f64,
     pub rope_theta: f32,
     pub max_position_embeddings: usize,

--- a/mistralrs-core/src/models/mistral.rs
+++ b/mistralrs-core/src/models/mistral.rs
@@ -137,7 +137,6 @@ impl Attention {
                     cfg.num_attention_heads,
                     comm,
                 ),
-                use_flash_attn: cfg.use_flash_attn,
                 softcap: None,
                 softmax_scale: 1.0 / (head_dim as f32).sqrt(),
                 sliding_window: cfg.sliding_window,

--- a/mistralrs-core/src/models/mistral.rs
+++ b/mistralrs-core/src/models/mistral.rs
@@ -26,7 +26,6 @@ use crate::{
     utils::{progress::NiceProgressBar, unvarbuilder::UnVarBuilder},
 };
 
-serde_default_fn!(bool, use_flash_attn, false);
 serde_default_fn!(bool, tie_word_embeddings, false);
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]

--- a/mistralrs-core/src/models/mistral.rs
+++ b/mistralrs-core/src/models/mistral.rs
@@ -42,8 +42,6 @@ pub struct Config {
     pub(crate) rms_norm_eps: f64,
     pub(crate) rope_theta: f64,
     pub(crate) sliding_window: Option<usize>,
-    #[serde(default = "use_flash_attn")]
-    pub(crate) use_flash_attn: bool,
     pub(crate) head_dim: Option<usize>,
     pub(crate) quantization_config: Option<QuantizedConfig>,
     #[serde(default = "tie_word_embeddings")]

--- a/mistralrs-core/src/models/mixtral.rs
+++ b/mistralrs-core/src/models/mixtral.rs
@@ -45,7 +45,6 @@ pub struct Config {
     pub(crate) sliding_window: Option<usize>,
     pub(crate) num_experts_per_tok: usize,
     pub(crate) num_local_experts: usize,
-    pub(crate) use_flash_attn: bool,
     pub(crate) quantization_config: Option<QuantizedConfig>,
     #[serde(default = "word_emb_default")]
     pub(crate) tie_word_embeddings: bool,

--- a/mistralrs-core/src/models/mixtral.rs
+++ b/mistralrs-core/src/models/mixtral.rs
@@ -131,7 +131,6 @@ impl Attention {
                     cfg.num_attention_heads,
                     comm,
                 ),
-                use_flash_attn: cfg.use_flash_attn,
                 softcap: None,
                 softmax_scale: 1.0 / (head_dim as f32).sqrt(),
                 sliding_window: cfg.sliding_window,

--- a/mistralrs-core/src/models/phi2.rs
+++ b/mistralrs-core/src/models/phi2.rs
@@ -51,7 +51,6 @@ pub struct Config {
     pub(crate) rope_theta: f32,
     pub(crate) partial_rotary_factor: f64,
     pub(crate) qk_layernorm: bool,
-    pub(crate) use_flash_attn: bool,
     pub(crate) quantization_config: Option<QuantizedConfig>,
     #[serde(default = "word_emb_default")]
     pub(crate) tie_word_embeddings: bool,

--- a/mistralrs-core/src/models/phi2.rs
+++ b/mistralrs-core/src/models/phi2.rs
@@ -251,7 +251,6 @@ impl Attention {
                     cfg.num_attention_heads,
                     comm,
                 ),
-                use_flash_attn: cfg.use_flash_attn,
                 softcap: None,
                 softmax_scale: 1.0 / (head_dim as f32).sqrt(),
                 sliding_window: None,

--- a/mistralrs-core/src/models/phi3.rs
+++ b/mistralrs-core/src/models/phi3.rs
@@ -123,7 +123,6 @@ impl Attention {
             paged_attn,
             sdpa_params: SdpaParams {
                 n_kv_groups: num_heads / num_kv_heads,
-                use_flash_attn: cfg.use_flash_attn,
                 softcap: None,
                 softmax_scale: 1.0 / (head_dim as f32).sqrt(),
                 sliding_window: cfg.sliding_window,

--- a/mistralrs-core/src/models/phi3.rs
+++ b/mistralrs-core/src/models/phi3.rs
@@ -47,7 +47,6 @@ pub struct Config {
     pub eos_token_id: Option<u32>,
     pub rope_scaling: Option<PhiRopeScalingConfig>,
     pub max_position_embeddings: usize,
-    pub use_flash_attn: bool,
     pub sliding_window: Option<usize>,
     pub original_max_position_embeddings: usize,
     pub quantization_config: Option<QuantizedConfig>,

--- a/mistralrs-core/src/models/phi3_5_moe.rs
+++ b/mistralrs-core/src/models/phi3_5_moe.rs
@@ -43,7 +43,6 @@ pub struct Config {
     pub(crate) rope_theta: f64,
     pub(crate) rope_scaling: Option<PhiRopeScalingConfig>,
     pub(crate) max_position_embeddings: usize,
-    pub(crate) use_flash_attn: bool,
     pub(crate) sliding_window: Option<usize>,
     pub(crate) original_max_position_embeddings: usize,
     pub(crate) quantization_config: Option<QuantizedConfig>,

--- a/mistralrs-core/src/models/phi3_5_moe.rs
+++ b/mistralrs-core/src/models/phi3_5_moe.rs
@@ -155,7 +155,6 @@ impl Attention {
                     cfg.num_attention_heads,
                     comm,
                 ),
-                use_flash_attn: cfg.use_flash_attn,
                 softcap: None,
                 softmax_scale: 1.0 / (head_dim as f32).sqrt(),
                 sliding_window: cfg.sliding_window,

--- a/mistralrs-core/src/models/quantized_llama.rs
+++ b/mistralrs-core/src/models/quantized_llama.rs
@@ -298,7 +298,6 @@ impl ModelConfig::FromGGML for ModelWeights {
                 paged_attn: None, // TODO
                 sdpa_params: SdpaParams {
                     n_kv_groups: ct.hparams.n_head as usize / n_kv_head,
-                    use_flash_attn: false,
                     softcap: None,
                     softmax_scale: 1.0 / (head_dim as f32).sqrt(),
                     sliding_window: None,
@@ -621,7 +620,6 @@ impl ModelConfig::FromGGUF for ModelWeights {
                 paged_attn,
                 sdpa_params: SdpaParams {
                     n_kv_groups: head_count / head_count_kv,
-                    use_flash_attn: false,
                     softcap: None,
                     softmax_scale: 1.0 / (head_dim as f32).sqrt(),
                     sliding_window: None,

--- a/mistralrs-core/src/models/quantized_phi2.rs
+++ b/mistralrs-core/src/models/quantized_phi2.rs
@@ -321,7 +321,6 @@ impl ModelConfig::FromGGUF for ModelWeights {
                 paged_attn,
                 sdpa_params: SdpaParams {
                     n_kv_groups: head_count / head_count_kv,
-                    use_flash_attn: false,
                     softcap: None,
                     softmax_scale: 1.0 / (head_dim as f32).sqrt(),
                     sliding_window: None,

--- a/mistralrs-core/src/models/quantized_phi3.rs
+++ b/mistralrs-core/src/models/quantized_phi3.rs
@@ -335,7 +335,6 @@ impl ModelConfig::FromGGUF for ModelWeights {
                 paged_attn,
                 sdpa_params: SdpaParams {
                     n_kv_groups: head_count / head_count_kv,
-                    use_flash_attn: false,
                     softcap: None,
                     softmax_scale: 1.0 / (head_dim as f32).sqrt(),
                     sliding_window: Some(context_window),

--- a/mistralrs-core/src/models/quantized_qwen2.rs
+++ b/mistralrs-core/src/models/quantized_qwen2.rs
@@ -339,7 +339,6 @@ impl ModelConfig::FromGGUF for ModelWeights {
                 paged_attn,
                 sdpa_params: SdpaParams {
                     n_kv_groups: head_count / head_count_kv,
-                    use_flash_attn: false,
                     softcap: None,
                     softmax_scale: 1.0 / (head_dim as f32).sqrt(),
                     sliding_window: None,

--- a/mistralrs-core/src/models/quantized_starcoder2.rs
+++ b/mistralrs-core/src/models/quantized_starcoder2.rs
@@ -330,7 +330,6 @@ impl ModelConfig::FromGGUF for ModelWeights {
                 paged_attn,
                 sdpa_params: SdpaParams {
                     n_kv_groups: head_count / head_count_kv,
-                    use_flash_attn: false,
                     softcap: None,
                     softmax_scale: 1.0 / (head_dim as f32).sqrt(),
                     sliding_window: None,

--- a/mistralrs-core/src/models/qwen2.rs
+++ b/mistralrs-core/src/models/qwen2.rs
@@ -127,7 +127,6 @@ impl Attention {
                     cfg.num_attention_heads,
                     comm,
                 ),
-                use_flash_attn: cfg.use_flash_attn,
                 softcap: None,
                 softmax_scale: 1.0 / (head_dim as f32).sqrt(),
                 sliding_window: cfg.sliding_window,

--- a/mistralrs-core/src/models/qwen2.rs
+++ b/mistralrs-core/src/models/qwen2.rs
@@ -40,8 +40,6 @@ pub struct Config {
     pub rope_theta: f64,
     pub rms_norm_eps: f64,
     pub hidden_act: Activation,
-    #[serde(default = "use_flash_attn")]
-    pub use_flash_attn: bool,
     pub quantization_config: Option<QuantizedConfig>,
     #[serde(default = "word_emb_default")]
     pub tie_word_embeddings: bool,

--- a/mistralrs-core/src/models/qwen2.rs
+++ b/mistralrs-core/src/models/qwen2.rs
@@ -25,7 +25,6 @@ use crate::{
 };
 
 serde_default_fn!(bool, word_emb_default, false);
-serde_default_fn!(bool, use_flash_attn, false);
 
 #[derive(Debug, Clone, serde::Deserialize, Default, serde::Serialize)]
 pub struct Config {

--- a/mistralrs-core/src/models/qwen3.rs
+++ b/mistralrs-core/src/models/qwen3.rs
@@ -40,7 +40,6 @@ macro_rules! sliding_window {
     };
 }
 
-serde_default_fn!(bool, use_flash_attn, false);
 serde_default_fn!(bool, tie_word_embeddings, false);
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]

--- a/mistralrs-core/src/models/qwen3.rs
+++ b/mistralrs-core/src/models/qwen3.rs
@@ -56,8 +56,6 @@ pub struct Config {
     pub(crate) rms_norm_eps: f64,
     pub(crate) rope_theta: f64,
     pub(crate) sliding_window: Option<usize>,
-    #[serde(default = "use_flash_attn")]
-    pub(crate) use_flash_attn: bool,
     pub(crate) head_dim: Option<usize>,
     pub(crate) quantization_config: Option<QuantizedConfig>,
     #[serde(default = "tie_word_embeddings")]

--- a/mistralrs-core/src/models/qwen3.rs
+++ b/mistralrs-core/src/models/qwen3.rs
@@ -172,7 +172,6 @@ impl Attention {
                     cfg.num_attention_heads,
                     comm,
                 ),
-                use_flash_attn: cfg.use_flash_attn,
                 softcap: None,
                 softmax_scale: 1.0 / (head_dim as f32).sqrt(),
                 sliding_window,

--- a/mistralrs-core/src/models/qwen3_moe.rs
+++ b/mistralrs-core/src/models/qwen3_moe.rs
@@ -176,7 +176,6 @@ impl Attention {
                     cfg.num_attention_heads,
                     comm,
                 ),
-                use_flash_attn: cfg.use_flash_attn,
                 softcap: None,
                 softmax_scale: 1.0 / (head_dim as f32).sqrt(),
                 sliding_window,

--- a/mistralrs-core/src/models/qwen3_moe.rs
+++ b/mistralrs-core/src/models/qwen3_moe.rs
@@ -38,7 +38,6 @@ macro_rules! sliding_window {
     };
 }
 
-serde_default_fn!(bool, use_flash_attn, false);
 serde_default_fn!(bool, tie_word_embeddings, false);
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]

--- a/mistralrs-core/src/models/qwen3_moe.rs
+++ b/mistralrs-core/src/models/qwen3_moe.rs
@@ -54,8 +54,6 @@ pub struct Config {
     pub(crate) rms_norm_eps: f64,
     pub(crate) rope_theta: f64,
     pub(crate) sliding_window: Option<usize>,
-    #[serde(default = "use_flash_attn")]
-    pub(crate) use_flash_attn: bool,
     pub(crate) head_dim: Option<usize>,
     pub(crate) quantization_config: Option<QuantizedConfig>,
     #[serde(default = "tie_word_embeddings")]

--- a/mistralrs-core/src/models/starcoder2.rs
+++ b/mistralrs-core/src/models/starcoder2.rs
@@ -223,7 +223,6 @@ impl Attention {
                     cfg.num_attention_heads,
                     comm,
                 ),
-                use_flash_attn: cfg.use_flash_attn,
                 softcap: None,
                 softmax_scale: 1.0 / (head_dim as f32).sqrt(),
                 sliding_window: cfg.sliding_window,

--- a/mistralrs-core/src/models/starcoder2.rs
+++ b/mistralrs-core/src/models/starcoder2.rs
@@ -42,7 +42,6 @@ pub struct Config {
     pub(crate) rope_theta: f64,
     pub(crate) use_bias: bool,
     pub(crate) sliding_window: Option<usize>,
-    pub(crate) use_flash_attn: bool,
     pub(crate) quantization_config: Option<QuantizedConfig>,
     #[serde(default = "word_emb_default")]
     #[allow(dead_code)]

--- a/mistralrs-core/src/pipeline/diffusion.rs
+++ b/mistralrs-core/src/pipeline/diffusion.rs
@@ -147,7 +147,7 @@ impl Loader for DiffusionLoader {
         }
 
         if crate::using_flash_attn() {
-            once_log_info(format!("FlashAttention is enabled."));
+            once_log_info("FlashAttention is enabled.");
         }
 
         let configs = paths

--- a/mistralrs-core/src/pipeline/diffusion.rs
+++ b/mistralrs-core/src/pipeline/diffusion.rs
@@ -39,7 +39,6 @@ pub struct DiffusionPipeline {
 pub struct DiffusionLoader {
     inner: Box<dyn DiffusionModelLoader>,
     model_id: String,
-    config: DiffusionSpecificConfig,
     kind: ModelKind,
 }
 
@@ -47,20 +46,12 @@ pub struct DiffusionLoader {
 /// A builder for a loader for a vision (non-quantized) model.
 pub struct DiffusionLoaderBuilder {
     model_id: Option<String>,
-    config: DiffusionSpecificConfig,
     kind: ModelKind,
 }
 
-#[derive(Clone, Default)]
-/// Config specific to loading a vision model.
-pub struct DiffusionSpecificConfig {
-    pub use_flash_attn: bool,
-}
-
 impl DiffusionLoaderBuilder {
-    pub fn new(config: DiffusionSpecificConfig, model_id: Option<String>) -> Self {
+    pub fn new(model_id: Option<String>) -> Self {
         Self {
-            config,
             model_id,
             kind: ModelKind::Normal,
         }
@@ -74,7 +65,6 @@ impl DiffusionLoaderBuilder {
         Box::new(DiffusionLoader {
             inner: loader,
             model_id: self.model_id.unwrap(),
-            config: self.config,
             kind: self.kind,
         })
     }
@@ -194,7 +184,6 @@ impl Loader for DiffusionLoader {
 
                 self.inner.load(
                     configs,
-                    self.config.use_flash_attn,
                     vbs,
                     crate::pipeline::NormalLoadingMetadata {
                         mapper,

--- a/mistralrs-core/src/pipeline/diffusion.rs
+++ b/mistralrs-core/src/pipeline/diffusion.rs
@@ -11,6 +11,7 @@ use crate::paged_attention::AttentionImplementation;
 use crate::pipeline::ChatTemplate;
 use crate::prefix_cacher::PrefixCacheManagerV2;
 use crate::sequence::Sequence;
+use crate::utils::log::once_log_info;
 use crate::utils::varbuilder_utils::DeviceForLoadTensor;
 use crate::utils::{tokens::get_token, varbuilder_utils::from_mmaped_safetensors};
 use crate::{DeviceMapSetting, PagedAttentionConfig, Pipeline, TryIntoDType};
@@ -143,6 +144,10 @@ impl Loader for DiffusionLoader {
             warn!("PagedAttention is not supported for Diffusion models, disabling it.");
 
             paged_attn_config = None;
+        }
+
+        if crate::using_flash_attn() {
+            once_log_info(format!("FlashAttention is enabled."));
         }
 
         let configs = paths

--- a/mistralrs-core/src/pipeline/loaders/diffusion_loaders.rs
+++ b/mistralrs-core/src/pipeline/loaders/diffusion_loaders.rs
@@ -52,7 +52,6 @@ pub trait DiffusionModelLoader: Send + Sync {
     fn load(
         &self,
         configs: Vec<String>,
-        use_flash_attn: bool,
         vbs: Vec<ShardedVarBuilder>,
         normal_loading_metadata: NormalLoadingMetadata,
         attention_mechanism: AttentionImplementation,
@@ -157,7 +156,6 @@ impl DiffusionModelLoader for FluxLoader {
     fn load(
         &self,
         mut configs: Vec<String>,
-        _use_flash_attn: bool,
         mut vbs: Vec<ShardedVarBuilder>,
         normal_loading_metadata: NormalLoadingMetadata,
         _attention_mechanism: AttentionImplementation,

--- a/mistralrs-core/src/pipeline/loaders/vision_loaders.rs
+++ b/mistralrs-core/src/pipeline/loaders/vision_loaders.rs
@@ -266,10 +266,9 @@ impl VisionModelLoader for Phi3VLoader {
         normal_loading_metadata: NormalLoadingMetadata,
         attention_mechanism: AttentionImplementation,
     ) -> Result<Box<dyn VisionModel + Send + Sync>> {
-        let mut config: Phi3Config = serde_json::from_str(config)?;
-        config.use_flash_attn = use_flash_attn;
+        let cfg: crate::vision_models::phi3::Config = serde_json::from_str(config)?;
         Ok(Box::new(Phi3::new(
-            &config,
+            &cfg,
             vb,
             self.is_gptx(),
             normal_loading_metadata,
@@ -280,9 +279,8 @@ impl VisionModelLoader for Phi3VLoader {
         true
     }
     fn get_config_repr(&self, config: &str, use_flash_attn: bool) -> Result<Box<dyn Debug>> {
-        let mut config: Phi3Config = serde_json::from_str(config)?;
-        config.use_flash_attn = use_flash_attn;
-        Ok(Box::new(config))
+        let cfg: crate::vision_models::phi3::Config = serde_json::from_str(config)?;
+        Ok(Box::new(cfg))
     }
     fn get_processor(
         &self,
@@ -529,10 +527,9 @@ impl VisionModelLoader for Idefics2Loader {
         normal_loading_metadata: NormalLoadingMetadata,
         attention_mechanism: AttentionImplementation,
     ) -> Result<Box<dyn VisionModel + Send + Sync>> {
-        let mut config: Idefics2Config = serde_json::from_str(config)?;
-        config.text_config.use_flash_attn = use_flash_attn;
+        let cfg: crate::vision_models::idefics2::Config = serde_json::from_str(config)?;
         Ok(Box::new(Idefics2::new(
-            &config,
+            &cfg,
             vb,
             self.is_gptx(),
             normal_loading_metadata,
@@ -543,9 +540,8 @@ impl VisionModelLoader for Idefics2Loader {
         true
     }
     fn get_config_repr(&self, config: &str, use_flash_attn: bool) -> Result<Box<dyn Debug>> {
-        let mut config: Idefics2Config = serde_json::from_str(config)?;
-        config.text_config.use_flash_attn = use_flash_attn;
-        Ok(Box::new(config))
+        let cfg: crate::vision_models::idefics2::Config = serde_json::from_str(config)?;
+        Ok(Box::new(cfg))
     }
     fn get_processor(
         &self,
@@ -857,10 +853,9 @@ impl VisionModelLoader for LLaVANextLoader {
         normal_loading_metadata: NormalLoadingMetadata,
         attention_mechanism: AttentionImplementation,
     ) -> Result<Box<dyn VisionModel + Send + Sync>> {
-        let mut config: LLaVAConfig = serde_json::from_str(config)?;
-        config.use_flash_attn = use_flash_attn;
+        let cfg: crate::vision_models::llava::config::Config = serde_json::from_str(config)?;
         Ok(Box::new(LLaVANext::new(
-            &config,
+            &cfg,
             vb,
             self.is_gptx(),
             normal_loading_metadata,
@@ -871,9 +866,8 @@ impl VisionModelLoader for LLaVANextLoader {
         false
     }
     fn get_config_repr(&self, config: &str, use_flash_attn: bool) -> Result<Box<dyn Debug>> {
-        let mut config: LLaVAConfig = serde_json::from_str(config)?;
-        config.use_flash_attn = use_flash_attn;
-        Ok(Box::new(config))
+        let cfg: crate::vision_models::llava::config::Config = serde_json::from_str(config)?;
+        Ok(Box::new(cfg))
     }
     fn get_processor(
         &self,
@@ -1105,10 +1099,9 @@ impl VisionModelLoader for LLaVALoader {
         normal_loading_metadata: NormalLoadingMetadata,
         attention_mechanism: AttentionImplementation,
     ) -> Result<Box<dyn VisionModel + Send + Sync>> {
-        let mut config: LLaVAConfig = serde_json::from_str(config)?;
-        config.use_flash_attn = use_flash_attn;
+        let cfg: crate::vision_models::llava::config::Config = serde_json::from_str(config)?;
         Ok(Box::new(LLaVA::new(
-            &config,
+            &cfg,
             vb,
             self.is_gptx(),
             normal_loading_metadata,
@@ -1119,9 +1112,8 @@ impl VisionModelLoader for LLaVALoader {
         false
     }
     fn get_config_repr(&self, config: &str, use_flash_attn: bool) -> Result<Box<dyn Debug>> {
-        let mut config: LLaVAConfig = serde_json::from_str(config)?;
-        config.use_flash_attn = use_flash_attn;
-        Ok(Box::new(config))
+        let cfg: crate::vision_models::llava::config::Config = serde_json::from_str(config)?;
+        Ok(Box::new(cfg))
     }
     fn get_processor(
         &self,
@@ -1345,10 +1337,9 @@ impl VisionModelLoader for VLlamaLoader {
         normal_loading_metadata: NormalLoadingMetadata,
         attention_mechanism: AttentionImplementation,
     ) -> Result<Box<dyn VisionModel + Send + Sync>> {
-        let mut config: MLlamaConfig = serde_json::from_str(config)?;
-        config.text_config.use_flash_attn = use_flash_attn;
+        let cfg: crate::vision_models::mllama::MLlamaConfig = serde_json::from_str(config)?;
         Ok(Box::new(MLlamaModel::new(
-            &config,
+            &cfg,
             vb,
             self.is_gptx(),
             normal_loading_metadata,
@@ -1359,9 +1350,8 @@ impl VisionModelLoader for VLlamaLoader {
         true
     }
     fn get_config_repr(&self, config: &str, use_flash_attn: bool) -> Result<Box<dyn Debug>> {
-        let mut config: MLlamaConfig = serde_json::from_str(config)?;
-        config.text_config.use_flash_attn = use_flash_attn;
-        Ok(Box::new(config))
+        let cfg: crate::vision_models::mllama::MLlamaConfig = serde_json::from_str(config)?;
+        Ok(Box::new(cfg))
     }
     fn get_processor(
         &self,
@@ -2006,10 +1996,9 @@ impl VisionModelLoader for Idefics3Loader {
         normal_loading_metadata: NormalLoadingMetadata,
         attention_mechanism: AttentionImplementation,
     ) -> Result<Box<dyn VisionModel + Send + Sync>> {
-        let mut config: Idefics3Config = serde_json::from_str(config)?;
-        config.text_config.use_flash_attn = use_flash_attn;
+        let cfg: crate::vision_models::idefics3::Idefics3Config = serde_json::from_str(config)?;
         Ok(Box::new(Idefics3Model::new(
-            &config,
+            &cfg,
             vb,
             self.is_gptx(),
             normal_loading_metadata,
@@ -2020,9 +2009,8 @@ impl VisionModelLoader for Idefics3Loader {
         true
     }
     fn get_config_repr(&self, config: &str, use_flash_attn: bool) -> Result<Box<dyn Debug>> {
-        let mut config: Idefics3Config = serde_json::from_str(config)?;
-        config.text_config.use_flash_attn = use_flash_attn;
-        Ok(Box::new(config))
+        let cfg: crate::vision_models::idefics3::Idefics3Config = serde_json::from_str(config)?;
+        Ok(Box::new(cfg))
     }
     fn get_processor(
         &self,
@@ -2288,10 +2276,9 @@ impl VisionModelLoader for MiniCpmOLoader {
         normal_loading_metadata: NormalLoadingMetadata,
         attention_mechanism: AttentionImplementation,
     ) -> Result<Box<dyn VisionModel + Send + Sync>> {
-        let mut config: MiniCpmOConfig = serde_json::from_str(config)?;
-        config.text_config.use_flash_attn = use_flash_attn;
+        let cfg: crate::vision_models::minicpmo::MiniCpmOConfig = serde_json::from_str(config)?;
         Ok(Box::new(MiniCpmOModel::new(
-            &config,
+            &cfg,
             vb,
             self.is_gptx(),
             normal_loading_metadata,
@@ -2302,9 +2289,8 @@ impl VisionModelLoader for MiniCpmOLoader {
         true
     }
     fn get_config_repr(&self, config: &str, use_flash_attn: bool) -> Result<Box<dyn Debug>> {
-        let mut config: MiniCpmOConfig = serde_json::from_str(config)?;
-        config.text_config.use_flash_attn = use_flash_attn;
-        Ok(Box::new(config))
+        let cfg: crate::vision_models::minicpmo::MiniCpmOConfig = serde_json::from_str(config)?;
+        Ok(Box::new(cfg))
     }
     fn get_processor(
         &self,
@@ -2564,10 +2550,9 @@ impl VisionModelLoader for Phi4MMLoader {
         normal_loading_metadata: NormalLoadingMetadata,
         attention_mechanism: AttentionImplementation,
     ) -> Result<Box<dyn VisionModel + Send + Sync>> {
-        let mut config: Phi4MMConfig = serde_json::from_str(config)?;
-        config.use_flash_attn = use_flash_attn;
+        let cfg: crate::vision_models::phi4::Phi4MMConfig = serde_json::from_str(config)?;
         Ok(Box::new(Phi4MMModel::new(
-            &config,
+            &cfg,
             vb,
             self.is_gptx(),
             normal_loading_metadata,
@@ -2578,9 +2563,8 @@ impl VisionModelLoader for Phi4MMLoader {
         true
     }
     fn get_config_repr(&self, config: &str, use_flash_attn: bool) -> Result<Box<dyn Debug>> {
-        let mut config: Phi4MMConfig = serde_json::from_str(config)?;
-        config.use_flash_attn = use_flash_attn;
-        Ok(Box::new(config))
+        let cfg: crate::vision_models::phi4::Phi4MMConfig = serde_json::from_str(config)?;
+        Ok(Box::new(cfg))
     }
     fn get_processor(
         &self,
@@ -3474,10 +3458,9 @@ impl VisionModelLoader for Mistral3Loader {
         normal_loading_metadata: NormalLoadingMetadata,
         attention_mechanism: AttentionImplementation,
     ) -> Result<Box<dyn VisionModel + Send + Sync>> {
-        let mut config: Mistral3Config = serde_json::from_str(config)?;
-        config.text_config.use_flash_attn = use_flash_attn;
+        let cfg: crate::vision_models::mistral3::Mistral3Config = serde_json::from_str(config)?;
         Ok(Box::new(Mistral3Model::new(
-            &config,
+            &cfg,
             vb,
             self.is_gptx(),
             normal_loading_metadata,
@@ -3488,8 +3471,8 @@ impl VisionModelLoader for Mistral3Loader {
         true
     }
     fn get_config_repr(&self, config: &str, _use_flash_attn: bool) -> Result<Box<dyn Debug>> {
-        let config: Mistral3Config = serde_json::from_str(config)?;
-        Ok(Box::new(config))
+        let cfg: crate::vision_models::mistral3::Mistral3Config = serde_json::from_str(config)?;
+        Ok(Box::new(cfg))
     }
     fn get_processor(
         &self,
@@ -3777,10 +3760,9 @@ impl VisionModelLoader for VLlama4Loader {
         normal_loading_metadata: NormalLoadingMetadata,
         attention_mechanism: AttentionImplementation,
     ) -> Result<Box<dyn VisionModel + Send + Sync>> {
-        let mut config: Llama4Config = serde_json::from_str(config)?;
-        config.text_config.use_flash_attn = use_flash_attn;
+        let cfg: crate::vision_models::llama4::Llama4Config = serde_json::from_str(config)?;
         Ok(Box::new(Llama4Model::new(
-            &config,
+            &cfg,
             vb,
             self.is_gptx(),
             normal_loading_metadata,
@@ -3791,9 +3773,8 @@ impl VisionModelLoader for VLlama4Loader {
         false
     }
     fn get_config_repr(&self, config: &str, use_flash_attn: bool) -> Result<Box<dyn Debug>> {
-        let mut config: Llama4Config = serde_json::from_str(config)?;
-        config.text_config.use_flash_attn = use_flash_attn;
-        Ok(Box::new(config))
+        let cfg: crate::vision_models::llama4::Llama4Config = serde_json::from_str(config)?;
+        Ok(Box::new(cfg))
     }
     fn get_processor(
         &self,

--- a/mistralrs-core/src/pipeline/loaders/vision_loaders.rs
+++ b/mistralrs-core/src/pipeline/loaders/vision_loaders.rs
@@ -83,13 +83,12 @@ pub trait VisionModelLoader: IsqModelLoader + Send + Sync + DeviceMappedModelLoa
     fn load(
         &self,
         config: &str,
-        use_flash_attn: bool,
         vb: ShardedVarBuilder,
         normal_loading_metadata: NormalLoadingMetadata,
         attention_mechanism: AttentionImplementation,
     ) -> Result<Box<dyn VisionModel + Send + Sync>>;
     fn is_gptx(&self) -> bool;
-    fn get_config_repr(&self, config: &str, use_flash_attn: bool) -> Result<Box<dyn Debug>>;
+    fn get_config_repr(&self, config: &str) -> Result<Box<dyn Debug>>;
     fn get_processor(
         &self,
         model_config: &str,
@@ -261,7 +260,6 @@ impl VisionModelLoader for Phi3VLoader {
     fn load(
         &self,
         config: &str,
-        use_flash_attn: bool,
         vb: ShardedVarBuilder,
         normal_loading_metadata: NormalLoadingMetadata,
         attention_mechanism: AttentionImplementation,
@@ -278,7 +276,7 @@ impl VisionModelLoader for Phi3VLoader {
     fn is_gptx(&self) -> bool {
         true
     }
-    fn get_config_repr(&self, config: &str, use_flash_attn: bool) -> Result<Box<dyn Debug>> {
+    fn get_config_repr(&self, config: &str) -> Result<Box<dyn Debug>> {
         let cfg: crate::vision_models::phi3::Config = serde_json::from_str(config)?;
         Ok(Box::new(cfg))
     }
@@ -522,7 +520,6 @@ impl VisionModelLoader for Idefics2Loader {
     fn load(
         &self,
         config: &str,
-        use_flash_attn: bool,
         vb: ShardedVarBuilder,
         normal_loading_metadata: NormalLoadingMetadata,
         attention_mechanism: AttentionImplementation,
@@ -539,7 +536,7 @@ impl VisionModelLoader for Idefics2Loader {
     fn is_gptx(&self) -> bool {
         true
     }
-    fn get_config_repr(&self, config: &str, use_flash_attn: bool) -> Result<Box<dyn Debug>> {
+    fn get_config_repr(&self, config: &str) -> Result<Box<dyn Debug>> {
         let cfg: crate::vision_models::idefics2::Config = serde_json::from_str(config)?;
         Ok(Box::new(cfg))
     }
@@ -848,7 +845,6 @@ impl VisionModelLoader for LLaVANextLoader {
     fn load(
         &self,
         config: &str,
-        use_flash_attn: bool,
         vb: ShardedVarBuilder,
         normal_loading_metadata: NormalLoadingMetadata,
         attention_mechanism: AttentionImplementation,
@@ -865,7 +861,7 @@ impl VisionModelLoader for LLaVANextLoader {
     fn is_gptx(&self) -> bool {
         false
     }
-    fn get_config_repr(&self, config: &str, use_flash_attn: bool) -> Result<Box<dyn Debug>> {
+    fn get_config_repr(&self, config: &str) -> Result<Box<dyn Debug>> {
         let cfg: crate::vision_models::llava::config::Config = serde_json::from_str(config)?;
         Ok(Box::new(cfg))
     }
@@ -1094,7 +1090,6 @@ impl VisionModelLoader for LLaVALoader {
     fn load(
         &self,
         config: &str,
-        use_flash_attn: bool,
         vb: ShardedVarBuilder,
         normal_loading_metadata: NormalLoadingMetadata,
         attention_mechanism: AttentionImplementation,
@@ -1111,7 +1106,7 @@ impl VisionModelLoader for LLaVALoader {
     fn is_gptx(&self) -> bool {
         false
     }
-    fn get_config_repr(&self, config: &str, use_flash_attn: bool) -> Result<Box<dyn Debug>> {
+    fn get_config_repr(&self, config: &str) -> Result<Box<dyn Debug>> {
         let cfg: crate::vision_models::llava::config::Config = serde_json::from_str(config)?;
         Ok(Box::new(cfg))
     }
@@ -1332,7 +1327,6 @@ impl VisionModelLoader for VLlamaLoader {
     fn load(
         &self,
         config: &str,
-        use_flash_attn: bool,
         vb: ShardedVarBuilder,
         normal_loading_metadata: NormalLoadingMetadata,
         attention_mechanism: AttentionImplementation,
@@ -1349,7 +1343,7 @@ impl VisionModelLoader for VLlamaLoader {
     fn is_gptx(&self) -> bool {
         true
     }
-    fn get_config_repr(&self, config: &str, use_flash_attn: bool) -> Result<Box<dyn Debug>> {
+    fn get_config_repr(&self, config: &str) -> Result<Box<dyn Debug>> {
         let cfg: crate::vision_models::mllama::MLlamaConfig = serde_json::from_str(config)?;
         Ok(Box::new(cfg))
     }
@@ -1713,7 +1707,6 @@ impl VisionModelLoader for Qwen2VLLoader {
     fn load(
         &self,
         config: &str,
-        _use_flash_attn: bool,
         vb: ShardedVarBuilder,
         normal_loading_metadata: NormalLoadingMetadata,
         attention_mechanism: AttentionImplementation,
@@ -1730,7 +1723,7 @@ impl VisionModelLoader for Qwen2VLLoader {
     fn is_gptx(&self) -> bool {
         true
     }
-    fn get_config_repr(&self, config: &str, _use_flash_attn: bool) -> Result<Box<dyn Debug>> {
+    fn get_config_repr(&self, config: &str) -> Result<Box<dyn Debug>> {
         let config: Qwen2VLConfig = serde_json::from_str(config)?;
         Ok(Box::new(config))
     }
@@ -1991,7 +1984,6 @@ impl VisionModelLoader for Idefics3Loader {
     fn load(
         &self,
         config: &str,
-        use_flash_attn: bool,
         vb: ShardedVarBuilder,
         normal_loading_metadata: NormalLoadingMetadata,
         attention_mechanism: AttentionImplementation,
@@ -2008,7 +2000,7 @@ impl VisionModelLoader for Idefics3Loader {
     fn is_gptx(&self) -> bool {
         true
     }
-    fn get_config_repr(&self, config: &str, use_flash_attn: bool) -> Result<Box<dyn Debug>> {
+    fn get_config_repr(&self, config: &str) -> Result<Box<dyn Debug>> {
         let cfg: crate::vision_models::idefics3::Idefics3Config = serde_json::from_str(config)?;
         Ok(Box::new(cfg))
     }
@@ -2271,7 +2263,6 @@ impl VisionModelLoader for MiniCpmOLoader {
     fn load(
         &self,
         config: &str,
-        use_flash_attn: bool,
         vb: ShardedVarBuilder,
         normal_loading_metadata: NormalLoadingMetadata,
         attention_mechanism: AttentionImplementation,
@@ -2288,7 +2279,7 @@ impl VisionModelLoader for MiniCpmOLoader {
     fn is_gptx(&self) -> bool {
         true
     }
-    fn get_config_repr(&self, config: &str, use_flash_attn: bool) -> Result<Box<dyn Debug>> {
+    fn get_config_repr(&self, config: &str) -> Result<Box<dyn Debug>> {
         let cfg: crate::vision_models::minicpmo::MiniCpmOConfig = serde_json::from_str(config)?;
         Ok(Box::new(cfg))
     }
@@ -2545,7 +2536,6 @@ impl VisionModelLoader for Phi4MMLoader {
     fn load(
         &self,
         config: &str,
-        use_flash_attn: bool,
         vb: ShardedVarBuilder,
         normal_loading_metadata: NormalLoadingMetadata,
         attention_mechanism: AttentionImplementation,
@@ -2562,7 +2552,7 @@ impl VisionModelLoader for Phi4MMLoader {
     fn is_gptx(&self) -> bool {
         true
     }
-    fn get_config_repr(&self, config: &str, use_flash_attn: bool) -> Result<Box<dyn Debug>> {
+    fn get_config_repr(&self, config: &str) -> Result<Box<dyn Debug>> {
         let cfg: crate::vision_models::phi4::Phi4MMConfig = serde_json::from_str(config)?;
         Ok(Box::new(cfg))
     }
@@ -2862,7 +2852,6 @@ impl VisionModelLoader for Qwen2_5VLLoader {
     fn load(
         &self,
         config: &str,
-        _use_flash_attn: bool,
         vb: ShardedVarBuilder,
         normal_loading_metadata: NormalLoadingMetadata,
         attention_mechanism: AttentionImplementation,
@@ -2879,7 +2868,7 @@ impl VisionModelLoader for Qwen2_5VLLoader {
     fn is_gptx(&self) -> bool {
         true
     }
-    fn get_config_repr(&self, config: &str, _use_flash_attn: bool) -> Result<Box<dyn Debug>> {
+    fn get_config_repr(&self, config: &str) -> Result<Box<dyn Debug>> {
         let config: Qwen2_5VLConfig = serde_json::from_str(config)?;
         Ok(Box::new(config))
     }
@@ -3138,7 +3127,6 @@ impl VisionModelLoader for Gemma3Loader {
     fn load(
         &self,
         config: &str,
-        _use_flash_attn: bool,
         vb: ShardedVarBuilder,
         normal_loading_metadata: NormalLoadingMetadata,
         attention_mechanism: AttentionImplementation,
@@ -3155,7 +3143,7 @@ impl VisionModelLoader for Gemma3Loader {
     fn is_gptx(&self) -> bool {
         true
     }
-    fn get_config_repr(&self, config: &str, _use_flash_attn: bool) -> Result<Box<dyn Debug>> {
+    fn get_config_repr(&self, config: &str) -> Result<Box<dyn Debug>> {
         let config: Gemma3Config = serde_json::from_str(config)?;
         Ok(Box::new(config))
     }
@@ -3453,7 +3441,6 @@ impl VisionModelLoader for Mistral3Loader {
     fn load(
         &self,
         config: &str,
-        use_flash_attn: bool,
         vb: ShardedVarBuilder,
         normal_loading_metadata: NormalLoadingMetadata,
         attention_mechanism: AttentionImplementation,
@@ -3470,7 +3457,7 @@ impl VisionModelLoader for Mistral3Loader {
     fn is_gptx(&self) -> bool {
         true
     }
-    fn get_config_repr(&self, config: &str, _use_flash_attn: bool) -> Result<Box<dyn Debug>> {
+    fn get_config_repr(&self, config: &str) -> Result<Box<dyn Debug>> {
         let cfg: crate::vision_models::mistral3::Mistral3Config = serde_json::from_str(config)?;
         Ok(Box::new(cfg))
     }
@@ -3755,7 +3742,6 @@ impl VisionModelLoader for VLlama4Loader {
     fn load(
         &self,
         config: &str,
-        use_flash_attn: bool,
         vb: ShardedVarBuilder,
         normal_loading_metadata: NormalLoadingMetadata,
         attention_mechanism: AttentionImplementation,
@@ -3772,7 +3758,7 @@ impl VisionModelLoader for VLlama4Loader {
     fn is_gptx(&self) -> bool {
         false
     }
-    fn get_config_repr(&self, config: &str, use_flash_attn: bool) -> Result<Box<dyn Debug>> {
+    fn get_config_repr(&self, config: &str) -> Result<Box<dyn Debug>> {
         let cfg: crate::vision_models::llama4::Llama4Config = serde_json::from_str(config)?;
         Ok(Box::new(cfg))
     }

--- a/mistralrs-core/src/pipeline/macros.rs
+++ b/mistralrs-core/src/pipeline/macros.rs
@@ -386,7 +386,6 @@ macro_rules! normal_model_loader {
         $layer_devices:expr,
         $config:expr,
         $loader:expr,
-        $use_flash_attn:expr,
         $silent:expr,
         $mapper:expr,
         $loading_isq:expr,
@@ -423,7 +422,6 @@ macro_rules! normal_model_loader {
 
         $loader.load(
             &$config,
-            $use_flash_attn,
             vb,
             $crate::pipeline::NormalLoadingMetadata {
                 mapper: $mapper,
@@ -443,7 +441,6 @@ macro_rules! normal_model_loader_sharded {
         $vb:expr,
         $config:expr,
         $loader:expr,
-        $use_flash_attn:expr,
         $mapper:expr,
         $loading_isq:expr,
         $real_device:expr,
@@ -452,7 +449,6 @@ macro_rules! normal_model_loader_sharded {
     ) => {{
         $loader.load(
             &$config,
-            $use_flash_attn,
             $vb,
             $crate::pipeline::NormalLoadingMetadata {
                 mapper: $mapper,
@@ -475,7 +471,6 @@ macro_rules! vision_normal_model_loader {
         $layer_devices:expr,
         $config:expr,
         $loader:expr,
-        $use_flash_attn:expr,
         $silent:expr,
         $mapper:expr,
         $loading_isq:expr,
@@ -507,7 +502,6 @@ macro_rules! vision_normal_model_loader {
 
         $loader.load(
             &$config,
-            $use_flash_attn,
             vb,
             $crate::pipeline::NormalLoadingMetadata {
                 mapper: $mapper,
@@ -527,7 +521,6 @@ macro_rules! vision_normal_model_loader_sharded {
         $vb:expr,
         $config:expr,
         $loader:expr,
-        $use_flash_attn:expr,
         $mapper:expr,
         $loading_isq:expr,
         $real_device:expr,
@@ -536,7 +529,6 @@ macro_rules! vision_normal_model_loader_sharded {
     ) => {{
         $loader.load(
             &$config,
-            $use_flash_attn,
             $vb,
             $crate::pipeline::NormalLoadingMetadata {
                 mapper: $mapper,
@@ -559,7 +551,6 @@ macro_rules! xlora_model_loader {
         $layer_devices:expr,
         $config:expr,
         $loader:expr,
-        $use_flash_attn:expr,
         $silent:expr,
         $mapper:expr,
         $loading_isq:expr,
@@ -606,7 +597,6 @@ macro_rules! xlora_model_loader {
 
         $loader.load_xlora(
             &$config,
-            $use_flash_attn,
             vb,
             adapter_configs.as_ref().unwrap(),
             Some(xlora_config.as_ref().unwrap().clone()),
@@ -632,7 +622,6 @@ macro_rules! lora_model_loader {
         $layer_devices:expr,
         $config:expr,
         $loader:expr,
-        $use_flash_attn:expr,
         $silent:expr,
         $mapper:expr,
         $loading_isq:expr,
@@ -700,7 +689,6 @@ macro_rules! lora_model_loader {
 
         $loader.load(
             &$config,
-            $use_flash_attn,
             vb,
             $crate::pipeline::NormalLoadingMetadata {
                 mapper: $mapper,

--- a/mistralrs-core/src/pipeline/mod.rs
+++ b/mistralrs-core/src/pipeline/mod.rs
@@ -23,7 +23,7 @@ use crate::paged_attention::{CacheConfig, CacheEngine, ModelConfigLike};
 use crate::prefix_cacher::PrefixCacheManagerV2;
 pub use amoe::{AnyMoeLoader, AnyMoePipeline};
 use chat_template::ChatTemplate;
-pub use diffusion::{DiffusionLoader, DiffusionLoaderBuilder, DiffusionSpecificConfig};
+pub use diffusion::{DiffusionLoader, DiffusionLoaderBuilder};
 pub use ggml::{GGMLLoader, GGMLLoaderBuilder, GGMLSpecificConfig};
 pub use gguf::{GGUFLoader, GGUFLoaderBuilder, GGUFSpecificConfig};
 use image::DynamicImage;

--- a/mistralrs-core/src/pipeline/normal.rs
+++ b/mistralrs-core/src/pipeline/normal.rs
@@ -29,6 +29,7 @@ use crate::pipeline::text_models_inputs_processor::make_prompt_chunk;
 use crate::pipeline::{ChatTemplate, LocalModelPaths};
 use crate::prefix_cacher::PrefixCacheManagerV2;
 use crate::sequence::Sequence;
+use crate::utils::log::once_log_info;
 use crate::utils::tokenizer::get_tokenizer;
 use crate::utils::varbuilder_utils::DeviceForLoadTensor;
 use crate::utils::{tokens::get_token, varbuilder_utils::from_mmaped_safetensors};
@@ -461,6 +462,9 @@ impl Loader for NormalLoader {
         }
 
         info!("Model config: {:?}", self.inner.get_config_repr(&config)?);
+        if crate::using_flash_attn() {
+            once_log_info(format!("FlashAttention is enabled."));
+        }
 
         let mut loading_isq = in_situ_quant.is_some() || self.config.from_uqff.is_some();
         if let Some(ref topology) = self.config.topology {

--- a/mistralrs-core/src/pipeline/normal.rs
+++ b/mistralrs-core/src/pipeline/normal.rs
@@ -463,7 +463,7 @@ impl Loader for NormalLoader {
 
         info!("Model config: {:?}", self.inner.get_config_repr(&config)?);
         if crate::using_flash_attn() {
-            once_log_info(format!("FlashAttention is enabled."));
+            once_log_info("FlashAttention is enabled.");
         }
 
         let mut loading_isq = in_situ_quant.is_some() || self.config.from_uqff.is_some();

--- a/mistralrs-core/src/pipeline/normal.rs
+++ b/mistralrs-core/src/pipeline/normal.rs
@@ -117,7 +117,6 @@ pub struct NormalLoaderBuilder {
 #[derive(Clone, Default)]
 /// Config specific to loading a normal model.
 pub struct NormalSpecificConfig {
-    pub use_flash_attn: bool,
     pub prompt_chunksize: Option<NonZeroUsize>,
     pub topology: Option<Topology>,
     pub organization: IsqOrganization,
@@ -461,11 +460,7 @@ impl Loader for NormalLoader {
             paged_attn_config = None;
         }
 
-        info!(
-            "Model config: {:?}",
-            self.inner
-                .get_config_repr(&config, self.config.use_flash_attn)?
-        );
+        info!("Model config: {:?}", self.inner.get_config_repr(&config)?);
 
         let mut loading_isq = in_situ_quant.is_some() || self.config.from_uqff.is_some();
         if let Some(ref topology) = self.config.topology {
@@ -519,7 +514,6 @@ impl Loader for NormalLoader {
                     sharded_vb,
                     config,
                     self.inner,
-                    self.config.use_flash_attn,
                     mapper,
                     loading_isq,
                     device.clone(),
@@ -535,7 +529,6 @@ impl Loader for NormalLoader {
                     layer_devices.clone(),
                     config,
                     self.inner,
-                    self.config.use_flash_attn,
                     silent,
                     mapper,
                     loading_isq,
@@ -551,7 +544,6 @@ impl Loader for NormalLoader {
                     layer_devices.clone(),
                     config,
                     self.inner,
-                    self.config.use_flash_attn,
                     silent,
                     mapper,
                     loading_isq,
@@ -572,7 +564,6 @@ impl Loader for NormalLoader {
                     layer_devices.clone(),
                     config,
                     self.inner,
-                    self.config.use_flash_attn,
                     silent,
                     mapper,
                     loading_isq,
@@ -591,7 +582,6 @@ impl Loader for NormalLoader {
                     layer_devices.clone(),
                     config,
                     self.inner,
-                    self.config.use_flash_attn,
                     silent,
                     mapper,
                     loading_isq,
@@ -607,7 +597,6 @@ impl Loader for NormalLoader {
                     layer_devices.clone(),
                     config,
                     self.inner,
-                    self.config.use_flash_attn,
                     silent,
                     mapper,
                     loading_isq,

--- a/mistralrs-core/src/pipeline/vision.rs
+++ b/mistralrs-core/src/pipeline/vision.rs
@@ -109,7 +109,6 @@ pub struct VisionLoaderBuilder {
 #[derive(Clone, Default)]
 /// Config specific to loading a vision model.
 pub struct VisionSpecificConfig {
-    pub use_flash_attn: bool,
     pub prompt_chunksize: Option<NonZeroUsize>,
     pub topology: Option<Topology>,
     pub write_uqff: Option<PathBuf>,
@@ -396,11 +395,7 @@ impl Loader for VisionLoader {
             paged_attn_config = None;
         }
 
-        info!(
-            "Model config: {:?}",
-            self.inner
-                .get_config_repr(&config, self.config.use_flash_attn)?
-        );
+        info!("Model config: {:?}", self.inner.get_config_repr(&config)?);
 
         let mut loading_isq = in_situ_quant.is_some() || self.config.from_uqff.is_some();
         if let Some(ref topology) = self.config.topology {
@@ -452,7 +447,6 @@ impl Loader for VisionLoader {
                     sharded_vb,
                     config,
                     self.inner,
-                    self.config.use_flash_attn,
                     mapper,
                     loading_isq,
                     device.clone(),
@@ -470,7 +464,6 @@ impl Loader for VisionLoader {
                     layer_devices.clone(),
                     config,
                     self.inner,
-                    self.config.use_flash_attn,
                     silent,
                     mapper,
                     loading_isq,

--- a/mistralrs-core/src/pipeline/vision.rs
+++ b/mistralrs-core/src/pipeline/vision.rs
@@ -398,7 +398,7 @@ impl Loader for VisionLoader {
 
         info!("Model config: {:?}", self.inner.get_config_repr(&config)?);
         if crate::using_flash_attn() {
-            once_log_info(format!("FlashAttention is enabled."));
+            once_log_info("FlashAttention is enabled.");
         }
 
         let mut loading_isq = in_situ_quant.is_some() || self.config.from_uqff.is_some();

--- a/mistralrs-core/src/pipeline/vision.rs
+++ b/mistralrs-core/src/pipeline/vision.rs
@@ -22,6 +22,7 @@ use crate::pipeline::text_models_inputs_processor::make_prompt_chunk;
 use crate::pipeline::{get_chat_template, ChatTemplate, IsqOrganization, LocalModelPaths};
 use crate::prefix_cacher::PrefixCacheManagerV2;
 use crate::sequence::Sequence;
+use crate::utils::log::once_log_info;
 use crate::utils::tokenizer::get_tokenizer;
 use crate::utils::varbuilder_utils::DeviceForLoadTensor;
 use crate::utils::{tokens::get_token, varbuilder_utils::from_mmaped_safetensors};
@@ -396,6 +397,9 @@ impl Loader for VisionLoader {
         }
 
         info!("Model config: {:?}", self.inner.get_config_repr(&config)?);
+        if crate::using_flash_attn() {
+            once_log_info(format!("FlashAttention is enabled."));
+        }
 
         let mut loading_isq = in_situ_quant.is_some() || self.config.from_uqff.is_some();
         if let Some(ref topology) = self.config.topology {

--- a/mistralrs-core/src/toml_selector.rs
+++ b/mistralrs-core/src/toml_selector.rs
@@ -489,7 +489,6 @@ pub struct TomlSelector {
 
 #[derive(Clone)]
 struct TomlLoaderInnerParams {
-    use_flash_attn: bool,
     chat_template: Option<String>,
     no_kv_cache: bool,
     tokenizer_json: Option<String>,
@@ -498,7 +497,6 @@ struct TomlLoaderInnerParams {
 }
 
 pub struct TomlLoaderArgs {
-    pub use_flash_attn: bool,
     pub chat_template: Option<String>,
     pub no_kv_cache: bool,
     pub prompt_chunksize: Option<NonZeroUsize>,
@@ -591,7 +589,6 @@ fn loader_from_selected(
     args: TomlLoaderInnerParams,
     model: TomlModelSelected,
 ) -> anyhow::Result<Box<dyn Loader>> {
-    let use_flash_attn = args.use_flash_attn;
     let loader: Box<dyn Loader> = match model {
         TomlModelSelected::Plain {
             model_id,
@@ -608,7 +605,6 @@ fn loader_from_selected(
             hf_cache_path,
         } => NormalLoaderBuilder::new(
             NormalSpecificConfig {
-                use_flash_attn,
                 prompt_chunksize: args.prompt_chunksize,
                 topology: Topology::from_option_path(topology)?,
                 organization: organization.unwrap_or_default(),
@@ -645,7 +641,6 @@ fn loader_from_selected(
             hf_cache_path,
         } => NormalLoaderBuilder::new(
             NormalSpecificConfig {
-                use_flash_attn,
                 prompt_chunksize: args.prompt_chunksize,
                 topology: Topology::from_option_path(topology)?,
                 organization: Default::default(),
@@ -689,7 +684,6 @@ fn loader_from_selected(
             hf_cache_path,
         } => NormalLoaderBuilder::new(
             NormalSpecificConfig {
-                use_flash_attn,
                 prompt_chunksize: args.prompt_chunksize,
                 topology: Topology::from_option_path(topology)?,
                 organization: Default::default(),
@@ -918,7 +912,6 @@ fn loader_from_selected(
             hf_cache_path,
         } => VisionLoaderBuilder::new(
             VisionSpecificConfig {
-                use_flash_attn,
                 prompt_chunksize: args.prompt_chunksize,
                 topology: Topology::from_option_path(topology)?,
                 write_uqff,
@@ -948,7 +941,6 @@ impl TryInto<Box<dyn Loader>> for (TomlSelector, TomlLoaderArgs) {
     fn try_into(self) -> Result<Box<dyn Loader>, Self::Error> {
         let (selector, args) = self;
         let args = TomlLoaderInnerParams {
-            use_flash_attn: args.use_flash_attn,
             chat_template: args.chat_template,
             no_kv_cache: args.no_kv_cache,
             tokenizer_json: selector.tokenizer_json,

--- a/mistralrs-core/src/vision_models/gemma3/config.rs
+++ b/mistralrs-core/src/vision_models/gemma3/config.rs
@@ -15,7 +15,6 @@ serde_default_fn!(usize, vocab_size, 262208);
 serde_default_fn!(bool, tie_word_embeddings, true);
 serde_default_fn!(usize, query_pre_attn_scalar, 256);
 serde_default_fn!(usize, max_position_embeddings, 131072);
-serde_default_fn!(bool, use_flash_attn, false);
 serde_default_fn!(f64, rope_local_base_freq, 10000.);
 serde_default_fn!(usize, sliding_window_pattern, 6);
 serde_default_fn!(usize, num_attention_heads, 8);

--- a/mistralrs-core/src/vision_models/gemma3/config.rs
+++ b/mistralrs-core/src/vision_models/gemma3/config.rs
@@ -50,8 +50,6 @@ pub struct Gemma3TextConfig {
     #[serde(default = "max_position_embeddings")]
     pub max_position_embeddings: usize,
     pub quantization_config: Option<QuantizedConfig>,
-    #[serde(default = "use_flash_attn")]
-    pub use_flash_attn: bool,
     #[serde(default = "tie_word_embeddings")]
     pub tie_word_embeddings: bool,
     #[serde(default = "rope_local_base_freq")]

--- a/mistralrs-core/src/vision_models/gemma3/text.rs
+++ b/mistralrs-core/src/vision_models/gemma3/text.rs
@@ -139,7 +139,6 @@ impl Attention {
                     cfg.num_attention_heads,
                     comm,
                 ),
-                use_flash_attn: cfg.use_flash_attn,
                 softcap: cfg.attn_logit_softcapping.map(|x| x as f32),
                 softmax_scale: 1.0 / (cfg.query_pre_attn_scalar as f32).sqrt(),
                 sliding_window,

--- a/mistralrs-core/src/vision_models/idefics2/mod.rs
+++ b/mistralrs-core/src/vision_models/idefics2/mod.rs
@@ -171,8 +171,6 @@ pub(crate) struct TextConfig {
     #[serde(default = "default_sliding")]
     pub(crate) sliding_window: Option<usize>,
 
-    #[serde(default = "default_false")]
-    pub(crate) use_flash_attn: bool,
     model_type: String, // Must be mistral for now
 }
 
@@ -190,7 +188,6 @@ impl From<TextConfig> for mistral::Config {
             rms_norm_eps: val.rms_norm_eps,
             rope_theta: val.rope_theta,
             sliding_window: val.sliding_window,
-            use_flash_attn: val.use_flash_attn,
             head_dim: None,
             quantization_config: None,
             tie_word_embeddings: false,

--- a/mistralrs-core/src/vision_models/llama4/config.rs
+++ b/mistralrs-core/src/vision_models/llama4/config.rs
@@ -21,8 +21,6 @@ pub struct TextConfig {
     pub num_hidden_layers: usize,
     pub num_attention_heads: usize,
     pub num_key_value_heads: usize,
-    #[serde(default = "use_flash_attn_default")]
-    pub use_flash_attn: bool,
     pub rms_norm_eps: f64,
     pub rope_theta: f32,
     pub max_position_embeddings: usize,

--- a/mistralrs-core/src/vision_models/llama4/config.rs
+++ b/mistralrs-core/src/vision_models/llama4/config.rs
@@ -7,7 +7,6 @@ use crate::{
 };
 
 serde_default_fn!(bool, word_emb_default, false);
-serde_default_fn!(bool, use_flash_attn_default, false);
 serde_default_fn!(Option<f32>, attn_temperature_tuning, Some(4.));
 serde_default_fn!(Option<f32>, floor_scale, Some(8192.));
 serde_default_fn!(Option<f32>, attn_scale, Some(0.1));

--- a/mistralrs-core/src/vision_models/llama4/text.rs
+++ b/mistralrs-core/src/vision_models/llama4/text.rs
@@ -128,7 +128,6 @@ impl CausalSelfAttention {
                     cfg.num_attention_heads,
                     comm,
                 ),
-                use_flash_attn: cfg.use_flash_attn,
                 softcap: None,
                 softmax_scale: 1.0 / (head_dim as f32).sqrt(),
                 sliding_window: None,

--- a/mistralrs-core/src/vision_models/llama4/vision.rs
+++ b/mistralrs-core/src/vision_models/llama4/vision.rs
@@ -150,7 +150,6 @@ impl Llama4VisionAttention {
             )?,
             sdpa_params: SdpaParams {
                 n_kv_groups: 1,
-                use_flash_attn: false,
                 softcap: None,
                 softmax_scale: 1.0 / (head_dim as f32).sqrt(),
                 sliding_window: None,

--- a/mistralrs-core/src/vision_models/llava/config.rs
+++ b/mistralrs-core/src/vision_models/llava/config.rs
@@ -17,8 +17,6 @@ pub struct Config {
     pub vision_feature_select_strategy: String,
 }
 
-serde_default_fn!(bool, default_use_flash_attn, false);
-
 #[derive(Deserialize, Debug, Clone)]
 pub struct LLaVATextConfig {
     #[serde(default = "default_hidden_size")]

--- a/mistralrs-core/src/vision_models/llava/config.rs
+++ b/mistralrs-core/src/vision_models/llava/config.rs
@@ -15,8 +15,6 @@ pub struct Config {
     pub vision_config: LLaVAVisionConfig,
     pub vision_feature_layer: isize,
     pub vision_feature_select_strategy: String,
-    #[serde(default = "default_use_flash_attn")]
-    pub use_flash_attn: bool,
 }
 
 serde_default_fn!(bool, default_use_flash_attn, false);
@@ -74,7 +72,6 @@ impl Config {
             num_hidden_layers: self.text_config.num_hidden_layers,
             num_attention_heads: self.text_config.num_attention_heads,
             num_key_value_heads: self.text_config.num_key_value_heads,
-            use_flash_attn: self.use_flash_attn,
             rms_norm_eps: self.text_config.rms_norm_eps,
             rope_theta: self.text_config.rope_theta,
             max_position_embeddings: self.text_config.max_position_embeddings,
@@ -98,7 +95,6 @@ impl Config {
             rms_norm_eps: self.text_config.rms_norm_eps,
             rope_theta: self.text_config.rope_theta as f64,
             sliding_window: self.text_config.sliding_window,
-            use_flash_attn: self.use_flash_attn,
             head_dim: None,
             quantization_config: None,
             tie_word_embeddings: false,

--- a/mistralrs-core/src/vision_models/llava/llava_llm/llama.rs
+++ b/mistralrs-core/src/vision_models/llava/llava_llm/llama.rs
@@ -217,7 +217,6 @@ impl CausalSelfAttention {
                     cfg.num_attention_heads,
                     comm,
                 ),
-                use_flash_attn: cfg.use_flash_attn,
                 softcap: None,
                 softmax_scale: 1.0 / ((cfg.hidden_size / cfg.num_attention_heads) as f32).sqrt(),
                 sliding_window: None,

--- a/mistralrs-core/src/vision_models/llava/llava_llm/mistral.rs
+++ b/mistralrs-core/src/vision_models/llava/llava_llm/mistral.rs
@@ -219,7 +219,6 @@ impl Attention {
                     cfg.num_attention_heads,
                     comm,
                 ),
-                use_flash_attn: cfg.use_flash_attn,
                 softcap: None,
                 softmax_scale: 1.0 / (head_dim as f32).sqrt(),
                 sliding_window: cfg.sliding_window,

--- a/mistralrs-core/src/vision_models/mllama/config.rs
+++ b/mistralrs-core/src/vision_models/mllama/config.rs
@@ -103,8 +103,6 @@ pub struct MLlamaTextConfig {
     pub(crate) max_position_embeddings: usize,
     pub(crate) tie_word_embeddings: bool,
     pub(crate) cross_attention_layers: Vec<usize>,
-    #[serde(default = "d_flash_attn")]
-    pub(crate) use_flash_attn: bool,
     pub(crate) quantization_config: Option<QuantizedConfig>,
 }
 

--- a/mistralrs-core/src/vision_models/mllama/config.rs
+++ b/mistralrs-core/src/vision_models/mllama/config.rs
@@ -86,8 +86,6 @@ pub(crate) struct MLlamaRopeScaling {
     pub(crate) high_freq_factor: Option<f32>,
 }
 
-serde_default_fn!(bool, d_flash_attn, false);
-
 #[derive(Debug, Clone, serde::Deserialize)]
 pub struct MLlamaTextConfig {
     pub(crate) rope_scaling: Option<MLlamaRopeScaling>,

--- a/mistralrs-core/src/vision_models/mllama/text.rs
+++ b/mistralrs-core/src/vision_models/mllama/text.rs
@@ -139,7 +139,6 @@ impl MLlamaTextSelfAttention {
             )?,
             sdpa_params: SdpaParams {
                 n_kv_groups: cfg.num_attention_heads / cfg.num_key_value_heads,
-                use_flash_attn: false,
                 softcap: None,
                 softmax_scale: 1.0 / (head_dim as f32).sqrt(),
                 sliding_window: None,
@@ -361,7 +360,6 @@ impl MLlamaTextCrossAttention {
             head_dim: cfg.head_dim(),
             sdpa_params: SdpaParams {
                 n_kv_groups: cfg.num_attention_heads / cfg.num_key_value_heads,
-                use_flash_attn: false,
                 softcap: None,
                 softmax_scale: 1.0 / (cfg.head_dim() as f32).sqrt(),
                 sliding_window: None,

--- a/mistralrs-core/src/vision_models/mllama/vision.rs
+++ b/mistralrs-core/src/vision_models/mllama/vision.rs
@@ -179,7 +179,6 @@ impl MLlamaVisionAttention {
             )?,
             sdpa_params: SdpaParams {
                 n_kv_groups: 1,
-                use_flash_attn: false,
                 softcap: None,
                 softmax_scale: 1.0 / (head_dim as f32).sqrt(),
                 sliding_window: None,

--- a/mistralrs-core/src/vision_models/phi3/mod.rs
+++ b/mistralrs-core/src/vision_models/phi3/mod.rs
@@ -54,7 +54,6 @@ pub struct ImageProcessorConfig {
     pub type_feature: Option<String>,
 }
 
-serde_default_fn!(bool, d_flash_attn, false);
 serde_default_fn!(bool, word_emb_default, false);
 
 #[derive(Debug, Clone, serde::Deserialize, Default)]

--- a/mistralrs-core/src/vision_models/phi3/mod.rs
+++ b/mistralrs-core/src/vision_models/phi3/mod.rs
@@ -72,8 +72,6 @@ pub struct Config {
     pub eos_token_id: Option<u32>,
     pub rope_scaling: Option<PhiRopeScalingConfig>,
     pub max_position_embeddings: usize,
-    #[serde(default = "d_flash_attn")]
-    pub use_flash_attn: bool,
     pub sliding_window: Option<usize>,
     pub original_max_position_embeddings: usize,
     pub embd_layer: EmbedLayerConfig,

--- a/mistralrs-core/src/vision_models/phi3/mod.rs
+++ b/mistralrs-core/src/vision_models/phi3/mod.rs
@@ -205,7 +205,6 @@ impl Attention {
             paged_attn,
             sdpa_params: SdpaParams {
                 n_kv_groups: num_heads / num_kv_heads,
-                use_flash_attn: cfg.use_flash_attn,
                 softcap: None,
                 softmax_scale: 1.0 / (head_dim as f32).sqrt(),
                 sliding_window: cfg.sliding_window,

--- a/mistralrs-core/src/vision_models/phi4/config.rs
+++ b/mistralrs-core/src/vision_models/phi4/config.rs
@@ -3,12 +3,7 @@ use std::collections::HashMap;
 use mistralrs_quant::{QuantizedConfig, StaticLoraConfig};
 use serde::{Deserialize, Serialize};
 
-use crate::{
-    layers::{Activation, Phi4MMRopeScalingConfig},
-    serde_default_fn,
-};
-
-serde_default_fn!(bool, d_flash_attn, false);
+use crate::layers::{Activation, Phi4MMRopeScalingConfig};
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct Phi4MMLoraConfig {

--- a/mistralrs-core/src/vision_models/phi4/config.rs
+++ b/mistralrs-core/src/vision_models/phi4/config.rs
@@ -73,8 +73,6 @@ pub struct Phi4MMConfig {
     pub vision_lora: StaticLoraConfig,
     pub speech_lora: StaticLoraConfig,
     pub quantization_config: Option<QuantizedConfig>,
-    #[serde(default = "d_flash_attn")]
-    pub use_flash_attn: bool,
 }
 
 impl Phi4MMConfig {

--- a/mistralrs-core/src/vision_models/phi4/mod.rs
+++ b/mistralrs-core/src/vision_models/phi4/mod.rs
@@ -78,7 +78,6 @@ impl Attention {
             paged_attn,
             sdpa_params: SdpaParams {
                 n_kv_groups: num_heads / num_kv_heads,
-                use_flash_attn: cfg.use_flash_attn,
                 softcap: None,
                 softmax_scale: 1.0 / (head_dim as f32).sqrt(),
                 sliding_window: cfg.sliding_window,

--- a/mistralrs-core/src/vision_models/qwen2_5_vl/text.rs
+++ b/mistralrs-core/src/vision_models/qwen2_5_vl/text.rs
@@ -153,7 +153,6 @@ impl Attention {
                     cfg.num_attention_heads,
                     comm,
                 ),
-                use_flash_attn: false,
                 softcap: None,
                 softmax_scale: 1.0 / (head_dim as f32).sqrt(),
                 sliding_window: None,

--- a/mistralrs-core/src/vision_models/qwen2vl/text.rs
+++ b/mistralrs-core/src/vision_models/qwen2vl/text.rs
@@ -154,7 +154,6 @@ impl Attention {
                     cfg.num_attention_heads,
                     comm,
                 ),
-                use_flash_attn: false,
                 softcap: None,
                 softmax_scale: 1.0 / (head_dim as f32).sqrt(),
                 sliding_window: None,

--- a/mistralrs-core/src/vision_models/siglip.rs
+++ b/mistralrs-core/src/vision_models/siglip.rs
@@ -290,7 +290,6 @@ impl Attention {
             None,
             &SdpaParams {
                 n_kv_groups: 1,
-                use_flash_attn: false,
                 sliding_window: None,
                 softcap: None,
                 softmax_scale: self.scale,

--- a/mistralrs-core/src/xlora_models/gemma.rs
+++ b/mistralrs-core/src/xlora_models/gemma.rs
@@ -223,7 +223,6 @@ impl Attention {
             rotary_emb,
             sdpa_params: SdpaParams {
                 n_kv_groups: num_heads / num_kv_heads,
-                use_flash_attn: cfg.use_flash_attn,
                 softcap: None,
                 softmax_scale: 1.0 / (head_dim as f32).sqrt(),
                 sliding_window: None,

--- a/mistralrs-core/src/xlora_models/gemma2.rs
+++ b/mistralrs-core/src/xlora_models/gemma2.rs
@@ -227,7 +227,6 @@ impl Attention {
             sliding_window,
             sdpa_params: SdpaParams {
                 n_kv_groups: num_heads / num_kv_heads,
-                use_flash_attn: cfg.use_flash_attn,
                 softcap: cfg.attn_logit_softcapping.map(|x| x as f32),
                 softmax_scale: 1.0 / (cfg.query_pre_attn_scalar as f32).sqrt(),
                 sliding_window,

--- a/mistralrs-core/src/xlora_models/llama.rs
+++ b/mistralrs-core/src/xlora_models/llama.rs
@@ -202,7 +202,6 @@ impl CausalSelfAttention {
             max_seq_len: cfg.max_position_embeddings,
             sdpa_params: SdpaParams {
                 n_kv_groups: cfg.num_attention_heads / cfg.num_key_value_heads,
-                use_flash_attn: cfg.use_flash_attn,
                 softcap: None,
                 softmax_scale: 1.0 / ((cfg.hidden_size / cfg.num_attention_heads) as f32).sqrt(),
                 sliding_window: None,

--- a/mistralrs-core/src/xlora_models/mistral.rs
+++ b/mistralrs-core/src/xlora_models/mistral.rs
@@ -213,7 +213,6 @@ impl Attention {
             sliding_window: cfg.sliding_window,
             sdpa_params: SdpaParams {
                 n_kv_groups: num_heads / num_kv_heads,
-                use_flash_attn: cfg.use_flash_attn,
                 softcap: None,
                 softmax_scale: 1.0 / (head_dim as f32).sqrt(),
                 sliding_window: cfg.sliding_window,

--- a/mistralrs-core/src/xlora_models/mixtral.rs
+++ b/mistralrs-core/src/xlora_models/mixtral.rs
@@ -113,7 +113,6 @@ impl Attention {
             sliding_window: cfg.sliding_window,
             sdpa_params: SdpaParams {
                 n_kv_groups: num_heads / num_kv_heads,
-                use_flash_attn: cfg.use_flash_attn,
                 softcap: None,
                 softmax_scale: 1.0 / (head_dim as f32).sqrt(),
                 sliding_window: cfg.sliding_window,

--- a/mistralrs-core/src/xlora_models/phi2.rs
+++ b/mistralrs-core/src/xlora_models/phi2.rs
@@ -208,7 +208,6 @@ impl Attention {
             head_dim,
             sdpa_params: SdpaParams {
                 n_kv_groups: num_heads / num_kv_heads,
-                use_flash_attn: cfg.use_flash_attn,
                 softcap: None,
                 softmax_scale: 1.0 / (head_dim as f32).sqrt(),
                 sliding_window: None,

--- a/mistralrs-core/src/xlora_models/phi3.rs
+++ b/mistralrs-core/src/xlora_models/phi3.rs
@@ -90,7 +90,6 @@ impl Attention {
             sliding_window: cfg.sliding_window,
             sdpa_params: SdpaParams {
                 n_kv_groups: num_heads / num_kv_heads,
-                use_flash_attn: cfg.use_flash_attn,
                 softcap: None,
                 softmax_scale: 1.0 / (head_dim as f32).sqrt(),
                 sliding_window: cfg.sliding_window,

--- a/mistralrs-core/src/xlora_models/quantized_llama.rs
+++ b/mistralrs-core/src/xlora_models/quantized_llama.rs
@@ -395,7 +395,6 @@ impl ModelConfig::FromAdapterGGML for ModelWeights {
                 rotary: rotary.clone().into(),
                 sdpa_params: SdpaParams {
                     n_kv_groups: ct.hparams.n_head as usize / n_kv_head,
-                    use_flash_attn: false,
                     softcap: None,
                     softmax_scale: 1.0 / (head_dim as f32).sqrt(),
                     sliding_window: None,
@@ -697,7 +696,6 @@ impl ModelConfig::FromAdapterGGUF for ModelWeights {
                 rotary: rotary.clone(),
                 sdpa_params: SdpaParams {
                     n_kv_groups: head_count / head_count_kv,
-                    use_flash_attn: false,
                     softcap: None,
                     softmax_scale: 1.0 / (head_dim as f32).sqrt(),
                     sliding_window: None,

--- a/mistralrs-core/src/xlora_models/quantized_phi3.rs
+++ b/mistralrs-core/src/xlora_models/quantized_phi3.rs
@@ -342,7 +342,6 @@ impl ModelConfig::FromAdapterGGUF for ModelWeights {
                 sliding_window: context_window,
                 sdpa_params: SdpaParams {
                     n_kv_groups: head_count / head_count_kv,
-                    use_flash_attn: false,
                     softcap: None,
                     softmax_scale: 1.0 / (head_dim as f32).sqrt(),
                     sliding_window: Some(context_window),

--- a/mistralrs-core/src/xlora_models/starcoder2.rs
+++ b/mistralrs-core/src/xlora_models/starcoder2.rs
@@ -200,7 +200,6 @@ impl Attention {
             sliding_window: cfg.sliding_window,
             sdpa_params: SdpaParams {
                 n_kv_groups: num_heads / num_kv_heads,
-                use_flash_attn: cfg.use_flash_attn,
                 softcap: None,
                 softmax_scale: 1.0 / (head_dim as f32).sqrt(),
                 sliding_window: cfg.sliding_window,

--- a/mistralrs-pyo3/src/lib.rs
+++ b/mistralrs-pyo3/src/lib.rs
@@ -23,10 +23,10 @@ use mistralrs_core::{
     initialize_logging, paged_attn_supported, parse_isq_value, AnyMoeLoader, AutoDeviceMapParams,
     BertEmbeddingModel, ChatCompletionResponse, CompletionResponse, Constraint,
     DefaultSchedulerMethod, DetokenizationRequest, DeviceLayerMapMetadata, DeviceMapMetadata,
-    DeviceMapSetting, DiffusionGenerationParams, DiffusionLoaderBuilder, DiffusionSpecificConfig,
-    DrySamplingParams, GGMLLoaderBuilder, GGMLSpecificConfig, GGUFLoaderBuilder,
-    GGUFSpecificConfig, ImageGenerationResponse, ImageGenerationResponseFormat, LlguidanceGrammar,
-    Loader, MemoryGpuConfig, MistralRs, MistralRsBuilder, NormalLoaderBuilder, NormalRequest,
+    DeviceMapSetting, DiffusionGenerationParams, DiffusionLoaderBuilder, DrySamplingParams,
+    GGMLLoaderBuilder, GGMLSpecificConfig, GGUFLoaderBuilder, GGUFSpecificConfig,
+    ImageGenerationResponse, ImageGenerationResponseFormat, LlguidanceGrammar, Loader,
+    MemoryGpuConfig, MistralRs, MistralRsBuilder, NormalLoaderBuilder, NormalRequest,
     NormalSpecificConfig, PagedAttentionConfig, Request as _Request, RequestMessage, Response,
     ResponseOk, SamplingParams, SchedulerConfig, SpeculativeConfig, SpeculativeLoader, StopTokens,
     TokenSource, TokenizationRequest, Tool, Topology, VisionLoaderBuilder, VisionSpecificConfig,
@@ -83,8 +83,6 @@ fn parse_which(
     prompt_chunksize: Option<NonZeroUsize>,
     jinja_explicit: Option<String>,
 ) -> PyApiResult<Box<dyn Loader>> {
-    let use_flash_attn = mistralrs_core::using_flash_attn();
-
     Ok(match which {
         Which::Plain {
             model_id,
@@ -101,7 +99,6 @@ fn parse_which(
             hf_cache_path,
         } => NormalLoaderBuilder::new(
             NormalSpecificConfig {
-                use_flash_attn,
                 prompt_chunksize,
                 topology: Topology::from_option_path(topology)?,
                 organization: organization.map(Into::into).unwrap_or(Default::default()),
@@ -138,7 +135,6 @@ fn parse_which(
             hf_cache_path,
         } => NormalLoaderBuilder::new(
             NormalSpecificConfig {
-                use_flash_attn,
                 prompt_chunksize,
                 topology: Topology::from_option_path(topology)?,
                 organization: Default::default(),
@@ -182,7 +178,6 @@ fn parse_which(
             hf_cache_path,
         } => NormalLoaderBuilder::new(
             NormalSpecificConfig {
-                use_flash_attn,
                 prompt_chunksize,
                 topology: Topology::from_option_path(topology)?,
                 organization: Default::default(),
@@ -394,7 +389,6 @@ fn parse_which(
             hf_cache_path,
         } => VisionLoaderBuilder::new(
             VisionSpecificConfig {
-                use_flash_attn,
                 prompt_chunksize,
                 topology: Topology::from_option_path(topology)?,
                 write_uqff,
@@ -419,10 +413,7 @@ fn parse_which(
             model_id,
             arch,
             dtype: _,
-        } => {
-            DiffusionLoaderBuilder::new(DiffusionSpecificConfig { use_flash_attn }, Some(model_id))
-                .build(arch.into())
-        }
+        } => DiffusionLoaderBuilder::new(Some(model_id)).build(arch.into()),
     })
 }
 

--- a/mistralrs/src/anymoe.rs
+++ b/mistralrs/src/anymoe.rs
@@ -42,7 +42,6 @@ impl AnyMoeModelBuilder {
 
     pub async fn build(self) -> anyhow::Result<Model> {
         let config = NormalSpecificConfig {
-            use_flash_attn: self.base.use_flash_attn,
             prompt_chunksize: self.base.prompt_chunksize,
             topology: self.base.topology,
             organization: self.base.organization,

--- a/mistralrs/src/lora_model.rs
+++ b/mistralrs/src/lora_model.rs
@@ -24,7 +24,6 @@ impl LoraModelBuilder {
 
     pub async fn build(self) -> anyhow::Result<Model> {
         let config = NormalSpecificConfig {
-            use_flash_attn: self.text_model.use_flash_attn,
             prompt_chunksize: self.text_model.prompt_chunksize,
             topology: self.text_model.topology,
             organization: self.text_model.organization,

--- a/mistralrs/src/speculative.rs
+++ b/mistralrs/src/speculative.rs
@@ -40,7 +40,6 @@ impl TextSpeculativeBuilder {
 
     fn build_pipeline(builder: TextModelBuilder) -> anyhow::Result<Arc<Mutex<dyn Pipeline>>> {
         let config = NormalSpecificConfig {
-            use_flash_attn: builder.use_flash_attn,
             prompt_chunksize: builder.prompt_chunksize,
             topology: builder.topology,
             organization: builder.organization,

--- a/mistralrs/src/text_model.rs
+++ b/mistralrs/src/text_model.rs
@@ -26,7 +26,6 @@ pub struct TextModelBuilder {
     pub(crate) search_bert_model: Option<BertEmbeddingModel>,
 
     // Model running
-    pub(crate) use_flash_attn: bool,
     pub(crate) prompt_chunksize: Option<NonZeroUsize>,
     pub(crate) topology: Option<Topology>,
     pub(crate) organization: IsqOrganization,
@@ -88,7 +87,6 @@ impl TextModelBuilder {
     pub fn new(model_id: impl ToString) -> Self {
         Self {
             model_id: model_id.to_string(),
-            use_flash_attn: cfg!(feature = "flash-attn"),
             prompt_chunksize: None,
             topology: None,
             organization: IsqOrganization::Default,
@@ -287,7 +285,6 @@ impl TextModelBuilder {
 
     pub async fn build(self) -> anyhow::Result<Model> {
         let config = NormalSpecificConfig {
-            use_flash_attn: self.use_flash_attn,
             prompt_chunksize: self.prompt_chunksize,
             topology: self.topology,
             organization: self.organization,

--- a/mistralrs/src/vision_model.rs
+++ b/mistralrs/src/vision_model.rs
@@ -27,7 +27,6 @@ pub struct VisionModelBuilder {
     pub(crate) search_bert_model: Option<BertEmbeddingModel>,
 
     // Model running
-    pub(crate) use_flash_attn: bool,
     pub(crate) prompt_chunksize: Option<NonZeroUsize>,
     pub(crate) topology: Option<Topology>,
     pub(crate) loader_type: VisionLoaderType,
@@ -51,7 +50,6 @@ impl VisionModelBuilder {
     pub fn new(model_id: impl ToString, loader_type: VisionLoaderType) -> Self {
         Self {
             model_id: model_id.to_string(),
-            use_flash_attn: cfg!(feature = "flash-attn"),
             topology: None,
             write_uqff: None,
             from_uqff: None,
@@ -224,7 +222,6 @@ impl VisionModelBuilder {
 
     pub async fn build(self) -> anyhow::Result<Model> {
         let config = VisionSpecificConfig {
-            use_flash_attn: self.use_flash_attn,
             prompt_chunksize: self.prompt_chunksize,
             topology: self.topology,
             write_uqff: self.write_uqff,

--- a/mistralrs/src/xlora_model.rs
+++ b/mistralrs/src/xlora_model.rs
@@ -31,7 +31,6 @@ impl XLoraModelBuilder {
 
     pub async fn build(self) -> anyhow::Result<Model> {
         let config = NormalSpecificConfig {
-            use_flash_attn: self.text_model.use_flash_attn,
             prompt_chunksize: self.text_model.prompt_chunksize,
             topology: self.text_model.topology,
             organization: self.text_model.organization,


### PR DESCRIPTION
Now we are enabling flash attention via the feature flags ( `--features flash-attn` and `--features flash-attn-v3`). Documentation stays the same.

@Slowki does this cause any major conflicts with code on your end?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Removed the flash attention configuration option from all model, loader, and builder interfaces.
  - Simplified model and vision loader APIs by eliminating the `use_flash_attn` flag and related logic.
  - Updated configuration structures to no longer include flash attention toggles.
  - Streamlined model initialization and configuration loading for text, vision, and diffusion models.
  - Adjusted logging and removed flash attention-related messages in application entry points.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->