### PR TITLE
Remove two spaces from PR comment

### DIFF
--- a/.github/workflows/analysis.yaml
+++ b/.github/workflows/analysis.yaml
@@ -30,9 +30,7 @@ jobs:
             const codeReport = `
               <details>
               <summary>${uniqueIdentifier}</summary>
-              <pre>
-              ${tokeiOutput}
-              </pre>
+              <pre>${tokeiOutput}</pre>
               </details>
             `;
 


### PR DESCRIPTION
Two whitespaces were added to tokei output.
![image](https://github.com/user-attachments/assets/214dce69-11cc-4ad9-a45c-e2453d7b279a)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Improved formatting of the code metrics report in workflow comments for a more compact and cleaner appearance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->