### PR TITLE
Add automatic vision loader type

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Please submit requests for new models [here](https://github.com/EricLBuehler/mis
 - 🦙🦙🦙🦙 Run the **Llama 4** Models with long context length and vision support: [documentation](docs/LLAMA4.md)
 
     ```
-    ./mistralrs-server -i --isq q4k vision-plain -m meta-llama/Llama-4-Scout-17B-16E-Instruct -a llama4
+    ./mistralrs-server -i --isq q4k vision-plain -m meta-llama/Llama-4-Scout-17B-16E-Instruct
     ```
 
 - Run the **Qwen 3** hybrid reasoning models with full tool calling support: [documentation](docs/QWEN3.md)
@@ -59,13 +59,13 @@ Please submit requests for new models [here](https://github.com/EricLBuehler/mis
 - 💎💎💎 Run the entire **Gemma 3** Model family (1b, 4b, 12b, 27b) with 128k context length and vision support: [documentation](docs/GEMMA3.md)
 
     ```
-    ./mistralrs-server -i vision-plain -m google/gemma-3-4b-it -a gemma3
+    ./mistralrs-server -i vision-plain -m google/gemma-3-4b-it
     ```
 
 - Run the **Mistral 3** Model with 128k context length and strong vision support: [documentation](docs/MISTRAL3.md)
 
     ```
-    ./mistralrs-server -i --isq q4k vision-plain -m mistralai/Mistral-Small-3.1-24B-Instruct-2503 -a mistral3
+    ./mistralrs-server -i --isq q4k vision-plain -m mistralai/Mistral-Small-3.1-24B-Instruct-2503
     ```
 
 - 🐋🐋🐋 Run the **Deepseek R1/V3** model with automatic **tensor parallelism**: [documentation](docs/DEEPSEEKV3.md)
@@ -88,19 +88,19 @@ Please submit requests for new models [here](https://github.com/EricLBuehler/mis
     <h6><a href = "https://www.nhmagazine.com/mount-washington/">Credit</a></h6>
 
     ```
-    ./mistralrs-server -i vision-plain -m lamm-mit/Cephalo-Llama-3.2-11B-Vision-Instruct-128k -a vllama
+    ./mistralrs-server -i vision-plain -m lamm-mit/Cephalo-Llama-3.2-11B-Vision-Instruct-128k
     ```
 
 - φ⁴ 📷 Run the **Phi 4 Multimodal** model: [documentation and guide here](docs/PHI4MM.md)
 
     ```
-    ./mistralrs-server -i vision-plain -m microsoft/Phi-4-multimodal-instruct -a phi4mm
+    ./mistralrs-server -i vision-plain -m microsoft/Phi-4-multimodal-instruct
     ```
 
 - φ⁴ Run the new **Phi 4/Phi 4 Mini** models with 128K context window
 
     ```
-    ./mistralrs-server -i plain -m microsoft/Phi-4-mini-instruct -a phi3
+    ./mistralrs-server -i plain -m microsoft/Phi-4-mini-instruct
     ```
 
 - 🧮 Enhance ISQ by collecting an imatrix from calibration data: [documentation](docs/IMATRIX.md)
@@ -357,7 +357,7 @@ Mistral.rs can automatically download models from HF Hub. To access gated models
 This is passed in the following ways:
 - Command line:
 ```bash
-./mistralrs-server --token-source none -i plain -m microsoft/Phi-3-mini-128k-instruct -a phi3
+./mistralrs-server --token-source none -i plain -m microsoft/Phi-3-mini-128k-instruct
 ```
 - Python:
 
@@ -369,7 +369,7 @@ If token cannot be loaded, no token will be used (i.e. effectively using `none`)
 
 You can also instruct mistral.rs to load models fully locally by modifying the `*_model_id` arguments or options:
 ```bash
-./mistralrs-server --port 1234 plain -m . -a mistral
+./mistralrs-server --port 1234 plain -m .
 ```
 
 Throughout mistral.rs, any model ID argument or option may be a local path and should contain the following files for each model ID option:
@@ -507,13 +507,13 @@ If you do not specify the architecture, an attempt will be made to use the model
 You can launch interactive mode, a simple chat application running in the terminal, by passing `-i`:
 
 ```bash
-./mistralrs-server -i plain -m microsoft/Phi-3-mini-128k-instruct -a phi3
+./mistralrs-server -i plain -m microsoft/Phi-3-mini-128k-instruct
 ```
 
 Vision models work too:
 
 ```bash
-./mistralrs-server -i vision-plain -m lamm-mit/Cephalo-Llama-3.2-11B-Vision-Instruct-128k -a vllama
+./mistralrs-server -i vision-plain -m lamm-mit/Cephalo-Llama-3.2-11B-Vision-Instruct-128k
 ```
 
 And even diffusion models:
@@ -534,7 +534,7 @@ cargo build --release --features metal
 You can an HTTP server
 
 ```bash
-./mistralrs-server --port 1234 plain -m microsoft/Phi-3.5-MoE-instruct -a phi3.5moe
+./mistralrs-server --port 1234 plain -m microsoft/Phi-3.5-MoE-instruct
 ```
 
 ### Structured selection with a `.toml` file

--- a/docs/CHAT_TOK.md
+++ b/docs/CHAT_TOK.md
@@ -8,7 +8,7 @@ We provide some chat templates [here](../chat_templates/), and it is easy to mod
 To use this, add the `jinja-explicit` parameter to the various APIs
 
 ```bash
-./mistralrs-server --port 1234 --isq q4k --jinja-explicit chat_templates/mistral_small_tool_call.jinja vision-plain -m mistralai/Mistral-Small-3.1-24B-Instruct-2503 -a mistral3  
+./mistralrs-server --port 1234 --isq q4k --jinja-explicit chat_templates/mistral_small_tool_call.jinja vision-plain -m mistralai/Mistral-Small-3.1-24B-Instruct-2503  
 ```
 
 ## Chat template overrides
@@ -37,6 +37,6 @@ $ ./mistralrs-server --port 1234 --log output.log plain -m microsoft/Orca-2-13b 
 Putting it all together, to run, for example, an [Orca](https://huggingface.co/microsoft/Orca-2-13b) model (which does not come with a `tokenizer.json` or chat template):
 1) Generate the `tokenizer.json` by running the script at `scripts/get_tokenizers_json.py`. This will output some files including `tokenizer.json` in the working directory.
 2) Find and copy the correct chat template from `chat-templates` to the working directory (eg., `cp chat_templates/chatml.json .`)
-3) Run `mistralrs-server`, specifying the tokenizer and chat template: `cargo run --release --features cuda -- --port 1234 --log output.txt --chat-template chatml.json plain -m microsoft/Orca-2-13b -t tokenizer.json -a llama`
+3) Run `mistralrs-server`, specifying the tokenizer and chat template: `cargo run --release --features cuda -- --port 1234 --log output.txt --chat-template chatml.json plain -m microsoft/Orca-2-13b -t tokenizer.json`
 
 > Note: For GGUF models, the tokenizer may be loaded directly from the GGUF file by omitting the tokenizer model ID.

--- a/docs/DEVICE_MAPPING.md
+++ b/docs/DEVICE_MAPPING.md
@@ -59,12 +59,12 @@ The format for the ordinals and number of layers is `ORD:NUM;...` where ORD is t
 
 ## Example of specifying ordinals
 ```
-cargo run --release --features cuda -- -n "0:16;1:16" -i plain -m gradientai/Llama-3-8B-Instruct-262k -a llama
+cargo run --release --features cuda -- -n "0:16;1:16" -i plain -m gradientai/Llama-3-8B-Instruct-262k
 ```
 
 > Note: In the Python API, the "0:16;1:16" string is passed as the list `["0:16", "1:16"]`.
 
 ## Example of specifying the number of GPU layers
 ```
-cargo run --release --features cuda -- -n 16 -i plain -m gradientai/Llama-3-8B-Instruct-262k -a llama
+cargo run --release --features cuda -- -n 16 -i plain -m gradientai/Llama-3-8B-Instruct-262k
 ```

--- a/docs/GEMMA3.md
+++ b/docs/GEMMA3.md
@@ -103,12 +103,12 @@ This is a minimal example of running the Gemma 3 model with a dummy image.
 
 ```rust
 use anyhow::Result;
-use mistralrs::{IsqType, TextMessageRole, VisionLoaderType, VisionMessages, VisionModelBuilder};
+use mistralrs::{IsqType, TextMessageRole, VisionMessages, VisionModelBuilder};
 
 #[tokio::main]
 async fn main() -> Result<()> {
     let model =
-        VisionModelBuilder::new("google/gemma-3-12b-it", VisionLoaderType::Gemma3)
+        VisionModelBuilder::new("google/gemma-3-12b-it")
             .with_isq(IsqType::Q4K)
             .with_logging()
             .build()

--- a/docs/GEMMA3.md
+++ b/docs/GEMMA3.md
@@ -47,7 +47,7 @@ The winding path visible on the mountain slopes appears to be part of the Mount 
 > You should replace `--features ...` with one of the features specified [here](../README.md#supported-accelerators), or remove it for pure CPU inference.
 
 ```
-cargo run --release --features ... -- --port 1234 vision-plain -m google/gemma-3-12b-it -a gemma3
+cargo run --release --features ... -- --port 1234 vision-plain -m google/gemma-3-12b-it
 ```
 
 2) Send a request

--- a/docs/IDEFICS2.md
+++ b/docs/IDEFICS2.md
@@ -47,7 +47,7 @@ The image depicts a group of orange ants climbing over a black pole. The ants ar
 > You should replace `--features ...` with one of the features specified [here](../README.md#supported-accelerators), or remove it for pure CPU inference.
 
 ```
-cargo run --release --features ... -- --port 1234 --isq Q4K vision-plain -m HuggingFaceM4/idefics2-8b-chatty -a idefics2
+cargo run --release --features ... -- --port 1234 --isq Q4K vision-plain -m HuggingFaceM4/idefics2-8b-chatty
 ```
 
 2) Send a request

--- a/docs/IDEFICS2.md
+++ b/docs/IDEFICS2.md
@@ -97,13 +97,12 @@ This is a minimal example of running the Idefics 2 model with a dummy image.
 
 ```rust
 use anyhow::Result;
-use mistralrs::{IsqType, TextMessageRole, VisionLoaderType, VisionMessages, VisionModelBuilder};
+use mistralrs::{IsqType, TextMessageRole, VisionMessages, VisionModelBuilder};
 
 #[tokio::main]
 async fn main() -> Result<()> {
     let model = VisionModelBuilder::new(
         "HuggingFaceM4/idefics2-8b-chatty",
-        VisionLoaderType::Idefics2,
     )
     .with_isq(IsqType::Q4K)
     .with_logging()

--- a/docs/IDEFICS3.md
+++ b/docs/IDEFICS3.md
@@ -157,13 +157,13 @@ You can find this example [here](../mistralrs/examples/idefics3/main.rs).
 
 ```rust
 use anyhow::Result;
-use mistralrs::{IsqType, TextMessageRole, VisionLoaderType, VisionMessages, VisionModelBuilder};
+use mistralrs::{IsqType, TextMessageRole, VisionMessages, VisionModelBuilder};
 
 const MODEL_ID: &str = "HuggingFaceM4/Idefics3-8B-Llama3";
 
 #[tokio::main]
 async fn main() -> Result<()> {
-    let model = VisionModelBuilder::new(MODEL_ID, VisionLoaderType::Idefics3)
+    let model = VisionModelBuilder::new(MODEL_ID)
         .with_isq(IsqType::Q8_0)
         .with_logging()
         .build()

--- a/docs/IDEFICS3.md
+++ b/docs/IDEFICS3.md
@@ -14,11 +14,14 @@ The Rust API takes an image from the [image](https://docs.rs/image/latest/image/
 > Note: When using device mapping or model topology, only the text model and its layers will be managed. This is because it contains most of the model parameters. Check the Hugging Face text model config for more information or raise an issue.
 
 ## ToC
-- [Interactive mode](#interactive-mode)
-- [HTTP server](#http-server)
-- [Rust API](#rust)
-- [Python API](#python)
-- [UQFF models](#uqff-models)
+- [Idefics 3 Vision: `HuggingFaceM4/Idefics3-8B-Llama3`](#idefics-3-vision-huggingfacem4idefics3-8b-llama3)
+  - [ToC](#toc)
+  - [Using the 🤗 Smol VLM models](#using-the--smol-vlm-models)
+  - [Interactive mode](#interactive-mode)
+  - [HTTP server](#http-server)
+  - [Rust](#rust)
+  - [Python](#python)
+  - [UQFF models](#uqff-models)
 
 ## Using the [🤗 Smol VLM](HuggingFaceTB/SmolVLM-Instruct) models
 
@@ -34,7 +37,7 @@ Mistral.rs supports interactive mode for vision models! It is an easy way to int
 > You should replace `--features ...` with one of the features specified [here](../README.md#supported-accelerators), or remove it for pure CPU inference.
 
 ```
-cargo run --features ... --release -- -i --isq Q4K vision-plain -m HuggingFaceM4/Idefics3-8B-Llama3 -a idefics3
+cargo run --features ... --release -- -i --isq Q4K vision-plain -m HuggingFaceM4/Idefics3-8B-Llama3
 ```
 
 2) Ask a question
@@ -106,7 +109,7 @@ On closer inspection near one side of this grandeur scene stands tall trees with
 > You should replace `--features ...` with one of the features specified [here](../README.md#supported-accelerators), or remove it for pure CPU inference.
 
 ```
-cargo run --release --features ... -- --port 1234 --isq Q4K vision-plain -m HuggingFaceM4/Idefics3-8B-Llama3 -a idefics3
+cargo run --release --features ... -- --port 1234 --isq Q4K vision-plain -m HuggingFaceM4/Idefics3-8B-Llama3
 ```
 
 2) Send a request

--- a/docs/ISQ.md
+++ b/docs/ISQ.md
@@ -86,5 +86,5 @@ let model = TextModelBuilder::new("microsoft/Phi-3.5-mini-instruct")
 
 ## Server example
 ```
-cargo run --release --features "cuda flash-attn" -- --port 1234 --log output.txt --isq Q2K plain -m mistralai/Mistral-7B-Instruct-v0.1 -a mistral
+cargo run --release --features "cuda flash-attn" -- --port 1234 --log output.txt --isq Q2K plain -m mistralai/Mistral-7B-Instruct-v0.1
 ```

--- a/docs/LLAMA4.md
+++ b/docs/LLAMA4.md
@@ -122,13 +122,12 @@ This is a minimal example of running the Llama 4 model with a dummy image.
 
 ```rust
 use anyhow::Result;
-use mistralrs::{IsqType, TextMessageRole, VisionLoaderType, VisionMessages, VisionModelBuilder};
+use mistralrs::{IsqType, TextMessageRole, VisionMessages, VisionModelBuilder};
 
 #[tokio::main]
 async fn main() -> Result<()> {
     let model = VisionModelBuilder::new(
         "meta-llama/Llama-4-Scout-17B-16E-Instruct",
-        VisionLoaderType::Llama4,
     )
     .with_isq(IsqType::Q4K)
     .with_logging()

--- a/docs/LLAMA4.md
+++ b/docs/LLAMA4.md
@@ -66,7 +66,7 @@ The image exudes a sense of serenity and majesty, capturing the beauty of nature
 > You should replace `--features ...` with one of the features specified [here](../README.md#supported-accelerators), or remove it for pure CPU inference.
 
 ```
-cargo run --release --features ... -- --port 1234 --isq q4k vision-plain -m meta-llama/Llama-4-Scout-17B-16E-Instruct -a llama4
+cargo run --release --features ... -- --port 1234 --isq q4k vision-plain -m meta-llama/Llama-4-Scout-17B-16E-Instruct
 ```
 
 2) Send a request

--- a/docs/LLaVA.md
+++ b/docs/LLaVA.md
@@ -55,9 +55,9 @@ Text: The image shows a steep, snow-covered hillside with a pine tree on the rig
 > You should replace `--features ...` with one of the features specified [here](../README.md#supported-accelerators), or remove it for pure CPU inference.
 
 ```
-cargo run --release --features ... -- --port 1234 --isq Q4K vision-plain -m llava-hf/llava-v1.6-mistral-7b-hf -a llava_next
+cargo run --release --features ... -- --port 1234 --isq Q4K vision-plain -m llava-hf/llava-v1.6-mistral-7b-hf
 //or 
-cargo run  --features cuda -- --port 1234  --isq Q4K --chat-template ./chat_templates/vicuna.json vision-plain -m /root/autodl-tmp/llava-v1.6-vicuna-7b-hf -a llava_next // if use vicuna as backend llm, then we need to specific the chat-template
+cargo run  --features cuda -- --port 1234  --isq Q4K --chat-template ./chat_templates/vicuna.json vision-plain -m /root/autodl-tmp/llava-v1.6-vicuna-7b-hf // if use vicuna as backend llm, then we need to specific the chat-template
 ```
 
 2) Send a request

--- a/docs/LLaVA.md
+++ b/docs/LLaVA.md
@@ -107,13 +107,12 @@ This is a minimal example of running the LLaVA and LLaVANext model with a dummy 
 
 ```rust
 use anyhow::Result;
-use mistralrs::{IsqType, TextMessageRole, VisionLoaderType, VisionMessages, VisionModelBuilder};
+use mistralrs::{IsqType, TextMessageRole, VisionMessages, VisionModelBuilder};
 
 #[tokio::main]
 async fn main() -> Result<()> {
     let model = VisionModelBuilder::new(
         "llava-hf/llava-v1.6-mistral-7b-hf",
-        VisionLoaderType::LLaVANext,
     )
     .with_isq(IsqType::Q4K)
     .with_logging()

--- a/docs/MINICPMO_2_6.md
+++ b/docs/MINICPMO_2_6.md
@@ -143,14 +143,14 @@ You can find this example [here](../mistralrs/examples/minicpmo_2_6/main.rs).
 
 ```rust
 use anyhow::Result;
-use mistralrs::{IsqType, TextMessageRole, VisionLoaderType, VisionMessages, VisionModelBuilder};
+use mistralrs::{IsqType, TextMessageRole, VisionMessages, VisionModelBuilder};
 
 const MODEL_ID: &str = "openbmb/MiniCPM-o-2_6";
 
 #[tokio::main]
 async fn main() -> Result<()> {
     let model =
-        VisionModelBuilder::new(MODEL_ID, VisionLoaderType::VLlama)
+        VisionModelBuilder::new(MODEL_ID)
             .with_isq(IsqType::Q4K)
             .with_logging()
             .build()

--- a/docs/MINICPMO_2_6.md
+++ b/docs/MINICPMO_2_6.md
@@ -15,10 +15,12 @@ The Python and HTTP APIs support sending images as:
 The Rust API takes an image from the [image](https://docs.rs/image/latest/image/index.html) crate.
 
 ## ToC
-- [Interactive mode](#interactive-mode)
-- [HTTP server](#http-server)
-- [Rust API](#rust)
-- [Python API](#python)
+- [MiniCPM-O 2.6 Model: `openbmb/MiniCPM-o-2_6`](#minicpm-o-26-model-openbmbminicpm-o-2_6)
+  - [ToC](#toc)
+  - [Interactive mode](#interactive-mode)
+  - [HTTP server](#http-server)
+  - [Rust](#rust)
+  - [Python](#python)
 
 ## Interactive mode
 
@@ -30,7 +32,7 @@ Mistral.rs supports interactive mode for vision models! It is an easy way to int
 > You should replace `--features ...` with one of the features specified [here](../README.md#supported-accelerators), or remove it for pure CPU inference.
 
 ```
-cargo run --features ... --release -- -i --isq Q4K vision-plain -m openbmb/MiniCPM-o-2_6 -a minicpmo
+cargo run --features ... --release -- -i --isq Q4K vision-plain -m openbmb/MiniCPM-o-2_6
 ```
 
 2) Say hello!
@@ -92,7 +94,7 @@ Overall, the image showcases the diverse geological and ecological features of M
 > You should replace `--features ...` with one of the features specified [here](../README.md#supported-accelerators), or remove it for pure CPU inference.
 
 ```
-cargo run --release --features ... -- --port 1234 --isq Q4K vision-plain -m openbmb/MiniCPM-o-2_6 -a minicpmo
+cargo run --release --features ... -- --port 1234 --isq Q4K vision-plain -m openbmb/MiniCPM-o-2_6
 ```
 
 2) Send a request

--- a/docs/MISTRAL3.md
+++ b/docs/MISTRAL3.md
@@ -113,12 +113,12 @@ This is a minimal example of running the Mistral 3 model with a dummy image.
 
 ```rust
 use anyhow::Result;
-use mistralrs::{IsqType, TextMessageRole, VisionLoaderType, VisionMessages, VisionModelBuilder};
+use mistralrs::{IsqType, TextMessageRole, VisionMessages, VisionModelBuilder};
 
 #[tokio::main]
 async fn main() -> Result<()> {
     let model =
-        VisionModelBuilder::new("mistralai/Mistral-Small-3.1-24B-Instruct-2503", VisionLoaderType::Mistral3)
+        VisionModelBuilder::new("mistralai/Mistral-Small-3.1-24B-Instruct-2503")
             .with_isq(IsqType::Q4K)
             .with_logging()
             .build()

--- a/docs/MISTRAL3.md
+++ b/docs/MISTRAL3.md
@@ -17,7 +17,7 @@ The Mistral Small 3.1 model itself does not come with the correct JINJA chat tem
 tool calling with Mistral Small 3.1, and you can use it by specifying the `jinja_explicit` parameter in the various APIs. For example:
 
 ```bash
-./mistralrs-server --port 1234 --isq q4k --jinja-explicit chat_templates/mistral_small_tool_call.jinja vision-plain -m mistralai/Mistral-Small-3.1-24B-Instruct-2503 -a mistral3  
+./mistralrs-server --port 1234 --isq q4k --jinja-explicit chat_templates/mistral_small_tool_call.jinja vision-plain -m mistralai/Mistral-Small-3.1-24B-Instruct-2503  
 ```
 
 
@@ -57,7 +57,7 @@ If there's anything specific about this flower or its care that interests you fu
 > You should replace `--features ...` with one of the features specified [here](../README.md#supported-accelerators), or remove it for pure CPU inference.
 
 ```
-cargo run --release --features ... -- --port 1234 vision-plain -m mistralai/Mistral-Small-3.1-24B-Instruct-2503 -a mistral3
+cargo run --release --features ... -- --port 1234 vision-plain -m mistralai/Mistral-Small-3.1-24B-Instruct-2503
 ```
 
 2) Send a request

--- a/docs/PAGED_ATTENTION.md
+++ b/docs/PAGED_ATTENTION.md
@@ -37,7 +37,7 @@ the prefill phase.
 Add the `--pa-gpu-mem`/`--pa-gpu-mem-usage` and `--pa-blk-size` parameters before the model kind selector. The GPU memory is in MBs and the block size means the number of tokens per block. These parameters may be passed on any supported model type.
 
 ```
-cargo run --release --features cuda -- -i --pa-gpu-mem 8192 --pa-blk-size 32 --isq Q4K plain -m microsoft/Phi-3-mini-128k-instruct -a phi3
+cargo run --release --features cuda -- -i --pa-gpu-mem 8192 --pa-blk-size 32 --isq Q4K plain -m microsoft/Phi-3-mini-128k-instruct
 ```
 
 ```

--- a/docs/PHI3V.md
+++ b/docs/PHI3V.md
@@ -51,7 +51,7 @@ The perspective from which this photo is taken offers an expansive view of the m
 > You should replace `--features ...` with one of the features specified [here](../README.md#supported-accelerators), or remove it for pure CPU inference.
 
 ```
-cargo run --release --features ... -- --port 1234 vision-plain -m microsoft/Phi-3.5-vision-instruct -a phi3v
+cargo run --release --features ... -- --port 1234 vision-plain -m microsoft/Phi-3.5-vision-instruct
 ```
 
 2) Send a request

--- a/docs/PHI3V.md
+++ b/docs/PHI3V.md
@@ -102,12 +102,12 @@ This is a minimal example of running the Phi 3 Vision model with a dummy image.
 
 ```rust
 use anyhow::Result;
-use mistralrs::{IsqType, TextMessageRole, VisionLoaderType, VisionMessages, VisionModelBuilder};
+use mistralrs::{IsqType, TextMessageRole, VisionMessages, VisionModelBuilder};
 
 #[tokio::main]
 async fn main() -> Result<()> {
     let model =
-        VisionModelBuilder::new("microsoft/Phi-3.5-vision-instruct", VisionLoaderType::Phi3V)
+        VisionModelBuilder::new("microsoft/Phi-3.5-vision-instruct")
             .with_isq(IsqType::Q4K)
             .with_logging()
             .build()

--- a/docs/PHI4MM.md
+++ b/docs/PHI4MM.md
@@ -49,7 +49,7 @@ A mountain with snow on it.
 > You should replace `--features ...` with one of the features specified [here](../README.md#supported-accelerators), or remove it for pure CPU inference.
 
 ```
-cargo run --release --features ... -- --port 1234 vision-plain -m microsoft/Phi-4-multimodal-instruct -a phi4mm
+cargo run --release --features ... -- --port 1234 vision-plain -m microsoft/Phi-4-multimodal-instruct
 ```
 
 2) Send a request

--- a/docs/PHI4MM.md
+++ b/docs/PHI4MM.md
@@ -100,12 +100,12 @@ This is a minimal example of running the Phi 4 Multimodal model with a dummy ima
 
 ```rust
 use anyhow::Result;
-use mistralrs::{IsqType, TextMessageRole, VisionLoaderType, VisionMessages, VisionModelBuilder};
+use mistralrs::{IsqType, TextMessageRole, VisionMessages, VisionModelBuilder};
 
 #[tokio::main]
 async fn main() -> Result<()> {
     let model =
-        VisionModelBuilder::new("microsoft/Phi-4-multimodal-instruct", VisionLoaderType::Phi4MM)
+        VisionModelBuilder::new("microsoft/Phi-4-multimodal-instruct")
             .with_isq(IsqType::Q4K)
             .with_logging()
             .build()

--- a/docs/QUANTS.md
+++ b/docs/QUANTS.md
@@ -52,7 +52,7 @@ cargo run --features cuda -- -i gguf -f my-gguf-file.gguf
 See the [docs](ISQ.md)
 
 ```
-cargo run --features cuda -- -i --isq Q4K plain -m microsoft/Phi-3-mini-4k-instruct -a phi3
+cargo run --features cuda -- -i --isq Q4K plain -m microsoft/Phi-3-mini-4k-instruct
 ```
 
 ## Using a GPTQ quantized model

--- a/docs/QWEN2VL.md
+++ b/docs/QWEN2VL.md
@@ -14,11 +14,12 @@ The Rust API takes an image from the [image](https://docs.rs/image/latest/image/
 > Note: When using device mapping or model topology, only the text model and its layers will be managed. This is because it contains most of the model parameters. *The text model has 28 layers*.
 
 ## ToC
-- [Interactive mode](#interactive-mode)
-- [HTTP server](#http-server)
-- [Rust API](#rust)
-- [Python API](#python)
-- [UQFF models](#uqff-models)
+- [Qwen 2 Vision Model: `Qwen2-VL Collection`](#qwen-2-vision-model-qwen2-vl-collection)
+  - [ToC](#toc)
+  - [Interactive mode](#interactive-mode)
+  - [HTTP server](#http-server)
+  - [Rust](#rust)
+  - [Python](#python)
 
 ## Interactive mode
 
@@ -30,7 +31,7 @@ Mistral.rs supports interactive mode for vision models! It is an easy way to int
 > You should replace `--features ...` with one of the features specified [here](../README.md#supported-accelerators), or remove it for pure CPU inference.
 
 ```
-cargo run --features ... --release -- -i vision-plain -m Qwen/Qwen2-VL-2B-Instruct -a qwen2vl
+cargo run --features ... --release -- -i vision-plain -m Qwen/Qwen2-VL-2B-Instruct
 ```
 
 2) Say hello!
@@ -91,7 +92,7 @@ In conclusion, camellias are beautiful flowers that add color and interest to ga
 > You should replace `--features ...` with one of the features specified [here](../README.md#supported-accelerators), or remove it for pure CPU inference.
 
 ```
-cargo run --release --features ... -- --port 1234 -m Qwen/Qwen2-VL-2B-Instruct -a qwen2vl
+cargo run --release --features ... -- --port 1234 -m Qwen/Qwen2-VL-2B-Instruct
 ```
 
 2) Send a request

--- a/docs/QWEN2VL.md
+++ b/docs/QWEN2VL.md
@@ -141,14 +141,14 @@ You can find this example [here](../mistralrs/examples/qwen2vl/main.rs).
 
 ```rust
 use anyhow::Result;
-use mistralrs::{IsqType, TextMessageRole, VisionLoaderType, VisionMessages, VisionModelBuilder};
+use mistralrs::{IsqType, TextMessageRole, VisionMessages, VisionModelBuilder};
 
 const MODEL_ID: &str = "Qwen/Qwen2-VL-2B-Instruct";
 
 #[tokio::main]
 async fn main() -> Result<()> {
     let model =
-        VisionModelBuilder::new(MODEL_ID, VisionLoaderType::Qwen2VL)
+        VisionModelBuilder::new(MODEL_ID)
             .with_isq(IsqType::Q4K)
             .with_logging()
             .build()

--- a/docs/TOOL_CALLING.md
+++ b/docs/TOOL_CALLING.md
@@ -7,7 +7,7 @@ LLMs use tool calling to interact with the outside world. Mistral.rs has OpenAI 
 Note that some models, such as Mistral Small/Nemo models, require a chat template to be specified. For example:
 
 ```bash
-./mistralrs-server --port 1234 --isq q4k --jinja-explicit chat_templates/mistral_small_tool_call.jinja vision-plain -m mistralai/Mistral-Small-3.1-24B-Instruct-2503 -a mistral3  
+./mistralrs-server --port 1234 --isq q4k --jinja-explicit chat_templates/mistral_small_tool_call.jinja vision-plain -m mistralai/Mistral-Small-3.1-24B-Instruct-2503  
 ```
 
 OpenAI docs: https://cookbook.openai.com/examples/how_to_call_functions_with_chat_models

--- a/docs/TOPOLOGY.md
+++ b/docs/TOPOLOGY.md
@@ -53,7 +53,7 @@ Model topologies may be applied to all model types.
 > You should replace `--features ...` with one of the features specified [here](../README.md#supported-accelerators), or remove it for pure CPU inference.
 
 ```
-cargo run --features ... -- -i plain -m microsoft/Phi-3-mini-128k-instruct -a phi3 --topology topologies/isq.yml   
+cargo run --features ... -- -i plain -m microsoft/Phi-3-mini-128k-instruct --topology topologies/isq.yml   
 ```
 
 ## HTTP server example
@@ -62,7 +62,7 @@ cargo run --features ... -- -i plain -m microsoft/Phi-3-mini-128k-instruct -a ph
 > You should replace `--features ...` with one of the features specified [here](../README.md#supported-accelerators), or remove it for pure CPU inference.
 
 ```
-cargo run --features ... -- --port 1234 plain -m microsoft/Phi-3-mini-128k-instruct -a phi3 --topology topologies/isq.yml   
+cargo run --features ... -- --port 1234 plain -m microsoft/Phi-3-mini-128k-instruct --topology topologies/isq.yml   
 ```
 
 ## Rust example

--- a/docs/VLLAMA.md
+++ b/docs/VLLAMA.md
@@ -156,14 +156,14 @@ You can find this example [here](../mistralrs/examples/llama_vision/main.rs).
 
 ```rust
 use anyhow::Result;
-use mistralrs::{IsqType, TextMessageRole, VisionLoaderType, VisionMessages, VisionModelBuilder};
+use mistralrs::{IsqType, TextMessageRole, VisionMessages, VisionModelBuilder};
 
 const MODEL_ID: &str = "lamm-mit/Cephalo-Llama-3.2-11B-Vision-Instruct-128k";
 
 #[tokio::main]
 async fn main() -> Result<()> {
     let model =
-        VisionModelBuilder::new(MODEL_ID, VisionLoaderType::VLlama)
+        VisionModelBuilder::new(MODEL_ID)
             .with_isq(IsqType::Q4K)
             .with_logging()
             .build()

--- a/docs/VLLAMA.md
+++ b/docs/VLLAMA.md
@@ -36,7 +36,7 @@ https://github.com/user-attachments/assets/4d11c35c-9ea2-42b8-8cab-5f7e8e2ee9ff
 > You should replace `--features ...` with one of the features specified [here](../README.md#supported-accelerators), or remove it for pure CPU inference.
 
 ```
-cargo run --features ... --release -- -i --isq Q4K vision-plain -m lamm-mit/Cephalo-Llama-3.2-11B-Vision-Instruct-128k -a vllama
+cargo run --features ... --release -- -i --isq Q4K vision-plain -m lamm-mit/Cephalo-Llama-3.2-11B-Vision-Instruct-128k
 ```
 
 2) Say hello!
@@ -107,7 +107,7 @@ Overall, the image showcases the diverse geological and ecological features of M
 > You should replace `--features ...` with one of the features specified [here](../README.md#supported-accelerators), or remove it for pure CPU inference.
 
 ```
-cargo run --release --features ... -- --port 1234 --isq Q4K vision-plain -m lamm-mit/Cephalo-Llama-3.2-11B-Vision-Instruct-128k -a vllama
+cargo run --release --features ... -- --port 1234 --isq Q4K vision-plain -m lamm-mit/Cephalo-Llama-3.2-11B-Vision-Instruct-128k
 ```
 
 2) Send a request
@@ -258,5 +258,5 @@ You can use these UQFF files to easily use quantized versions of Llama 3.2 Visio
 
 For example:
 ```
-./mistralrs-server -i vision-plain -m meta-llama/Llama-3.2-11B-Vision-Instruct -a vllama --from-uqff EricB/Llama-3.2-11B-Vision-Instruct-UQFF/llama-3.2-11b-vision-q4k.uqff
+./mistralrs-server -i vision-plain -m meta-llama/Llama-3.2-11B-Vision-Instruct --from-uqff EricB/Llama-3.2-11B-Vision-Instruct-UQFF/llama-3.2-11b-vision-q4k.uqff
 ```

--- a/docs/WEB_SEARCH.md
+++ b/docs/WEB_SEARCH.md
@@ -33,7 +33,7 @@ Here are some examples using various models. Note that this works for both strea
 ```
 
 ```
-./mistralrs-server --enable-search --port 1234 --isq 4 --jinja-explicit chat_templates/mistral_small_tool_call.jinja vision-plain -m mistralai/Mistral-Small-3.1-24B-Instruct-2503 -a mistral3
+./mistralrs-server --enable-search --port 1234 --isq 4 --jinja-explicit chat_templates/mistral_small_tool_call.jinja vision-plain -m mistralai/Mistral-Small-3.1-24B-Instruct-2503
 ```
 
 ```

--- a/mistralrs-core/src/model_selected.rs
+++ b/mistralrs-core/src/model_selected.rs
@@ -472,7 +472,7 @@ pub enum ModelSelected {
 
         /// The architecture of the model.
         #[arg(short, long, value_parser = parse_vision_arch)]
-        arch: VisionLoaderType,
+        arch: Option<VisionLoaderType>,
 
         /// Model data type. Defaults to `auto`.
         #[arg(short, long, default_value_t = ModelDType::Auto, value_parser = parse_model_dtype)]

--- a/mistralrs-core/src/pipeline/loaders/mod.rs
+++ b/mistralrs-core/src/pipeline/loaders/mod.rs
@@ -17,7 +17,7 @@ use mistralrs_quant::IsqType;
 use tokio::sync::Mutex;
 
 pub use normal_loaders::{
-    AutoLoader, DeepSeekV2Loader, DeepSeekV3Loader, Gemma2Loader, GemmaLoader, LlamaLoader,
+    AutoNormalLoader, DeepSeekV2Loader, DeepSeekV3Loader, Gemma2Loader, GemmaLoader, LlamaLoader,
     MistralLoader, MixtralLoader, NormalLoaderType, NormalLoadingMetadata, NormalModel,
     NormalModelLoader, Phi2Loader, Phi3Loader, Phi3_5MoELoader, Qwen2Loader, Qwen3Loader,
     Qwen3MoELoader, Starcoder2Loader,
@@ -25,9 +25,9 @@ pub use normal_loaders::{
 
 use tracing::{info, warn};
 pub use vision_loaders::{
-    Gemma3Loader, Idefics2Loader, Idefics3Loader, LLaVALoader, LLaVANextLoader, MiniCpmOLoader,
-    Mistral3Loader, Phi3VLoader, Phi4MMLoader, Qwen2VLLoader, Qwen2_5VLLoader, VLlama4Loader,
-    VLlamaLoader, VisionLoaderType, VisionModel, VisionModelLoader,
+    AutoVisionLoader, Gemma3Loader, Idefics2Loader, Idefics3Loader, LLaVALoader, LLaVANextLoader,
+    MiniCpmOLoader, Mistral3Loader, Phi3VLoader, Phi4MMLoader, Qwen2VLLoader, Qwen2_5VLLoader,
+    VLlama4Loader, VLlamaLoader, VisionLoaderType, VisionModel, VisionModelLoader,
 };
 
 pub use diffusion_loaders::{

--- a/mistralrs-core/src/pipeline/loaders/normal_loaders.rs
+++ b/mistralrs-core/src/pipeline/loaders/normal_loaders.rs
@@ -170,7 +170,6 @@ pub enum NormalLoaderType {
 }
 
 // https://github.com/huggingface/transformers/blob/cff06aac6fad28019930be03f5d467055bf62177/src/transformers/models/auto/modeling_auto.py#L448
-
 impl NormalLoaderType {
     pub fn from_causal_lm_name(name: &str) -> Result<Self> {
         match name {
@@ -250,16 +249,16 @@ macro_rules! bias_if {
 }
 
 /// Load a model based on the Hugging Face Transformers -CausalLM model class
-pub struct AutoLoader;
+pub struct AutoNormalLoader;
 
 #[derive(Deserialize)]
-struct AutoLoaderConfig {
+struct AutoNormalLoaderConfig {
     architectures: Vec<String>,
 }
 
-impl AutoLoader {
+impl AutoNormalLoader {
     fn get_loader(config: &str) -> Result<Box<dyn NormalModelLoader>> {
-        let auto_cfg: AutoLoaderConfig = serde_json::from_str(config)?;
+        let auto_cfg: AutoNormalLoaderConfig = serde_json::from_str(config)?;
         if auto_cfg.architectures.len() != 1 {
             anyhow::bail!("Expected to have one name for `architectures` config field.")
         }
@@ -289,7 +288,7 @@ impl AutoLoader {
     }
 }
 
-impl NormalModelLoader for AutoLoader {
+impl NormalModelLoader for AutoNormalLoader {
     fn load(
         &self,
         config: &str,
@@ -330,7 +329,7 @@ impl NormalModelLoader for AutoLoader {
     }
 }
 
-impl IsqModelLoader for AutoLoader {
+impl IsqModelLoader for AutoNormalLoader {
     fn immediate_isq_predicates(&self, config: &str) -> Result<Vec<Regex>> {
         Self::get_loader(config)?.immediate_isq_predicates(config)
     }
@@ -345,7 +344,7 @@ impl IsqModelLoader for AutoLoader {
     }
 }
 
-impl DeviceMappedModelLoader for AutoLoader {
+impl DeviceMappedModelLoader for AutoNormalLoader {
     fn non_mapped_size_in_bytes(
         &self,
         config: &str,

--- a/mistralrs-core/src/pipeline/mod.rs
+++ b/mistralrs-core/src/pipeline/mod.rs
@@ -32,15 +32,15 @@ pub(crate) use isq::IsqModelLoader;
 pub use isq::{parse_isq_value, IsqModel, IsqOrganization, UQFF_MULTI_FILE_DELIMITER};
 use llguidance::toktrie::TokEnv;
 pub use loaders::{
-    AdapterKind, AutoDeviceMapParams, AutoLoader, DeepSeekV2Loader, DeepSeekV3Loader,
-    DeviceMappedModelLoader, DiffusionLoaderType, DiffusionModel, DiffusionModelLoader, FluxLoader,
-    Gemma2Loader, Gemma3Loader, GemmaLoader, Idefics2Loader, Idefics3Loader, LLaVALoader,
-    LLaVANextLoader, LlamaLoader, Loader, LocalModelPaths, MiniCpmOLoader, Mistral3Loader,
-    MistralLoader, MixtralLoader, ModelKind, ModelPaths, NormalLoaderType, NormalLoadingMetadata,
-    NormalModel, NormalModelLoader, Phi2Loader, Phi3Loader, Phi3VLoader, Phi3_5MoELoader,
-    Phi4MMLoader, PrettyName, QuantizationKind, Qwen2Loader, Qwen2VLLoader, Qwen2_5VLLoader,
-    Qwen3Loader, Qwen3MoELoader, Starcoder2Loader, TokenSource, VLlama4Loader, VLlamaLoader,
-    VisionLoaderType, VisionModel, VisionModelLoader,
+    AdapterKind, AutoDeviceMapParams, AutoNormalLoader, AutoVisionLoader, DeepSeekV2Loader,
+    DeepSeekV3Loader, DeviceMappedModelLoader, DiffusionLoaderType, DiffusionModel,
+    DiffusionModelLoader, FluxLoader, Gemma2Loader, Gemma3Loader, GemmaLoader, Idefics2Loader,
+    Idefics3Loader, LLaVALoader, LLaVANextLoader, LlamaLoader, Loader, LocalModelPaths,
+    MiniCpmOLoader, Mistral3Loader, MistralLoader, MixtralLoader, ModelKind, ModelPaths,
+    NormalLoaderType, NormalLoadingMetadata, NormalModel, NormalModelLoader, Phi2Loader,
+    Phi3Loader, Phi3VLoader, Phi3_5MoELoader, Phi4MMLoader, PrettyName, QuantizationKind,
+    Qwen2Loader, Qwen2VLLoader, Qwen2_5VLLoader, Qwen3Loader, Qwen3MoELoader, Starcoder2Loader,
+    TokenSource, VLlama4Loader, VLlamaLoader, VisionLoaderType, VisionModel, VisionModelLoader,
 };
 use mistralrs_quant::IsqType;
 pub use normal::{NormalLoader, NormalLoaderBuilder, NormalSpecificConfig};

--- a/mistralrs-core/src/pipeline/normal.rs
+++ b/mistralrs-core/src/pipeline/normal.rs
@@ -11,7 +11,7 @@ use super::{
     IsqPipelineMixin, MetadataMixin, ModelCategory, PreProcessingMixin,
 };
 use super::{
-    AutoLoader, DeepSeekV2Loader, DeepSeekV3Loader, Gemma2Loader, GemmaLoader, LlamaLoader,
+    AutoNormalLoader, DeepSeekV2Loader, DeepSeekV3Loader, Gemma2Loader, GemmaLoader, LlamaLoader,
     MistralLoader, MixtralLoader, NormalLoaderType, Phi2Loader, Phi3Loader, Phi3_5MoELoader,
     Qwen2Loader, Qwen3Loader, Qwen3MoELoader, Starcoder2Loader,
 };
@@ -221,7 +221,7 @@ impl NormalLoaderBuilder {
             Some(NormalLoaderType::DeepSeekV3) => Box::new(DeepSeekV3Loader),
             Some(NormalLoaderType::Qwen3) => Box::new(Qwen3Loader),
             Some(NormalLoaderType::Qwen3Moe) => Box::new(Qwen3MoELoader),
-            None => Box::new(AutoLoader),
+            None => Box::new(AutoNormalLoader),
         };
         Ok(Box::new(NormalLoader {
             inner: loader,

--- a/mistralrs-core/src/toml_selector.rs
+++ b/mistralrs-core/src/toml_selector.rs
@@ -394,7 +394,7 @@ pub enum TomlModelSelected {
         model_id: String,
 
         /// The architecture of the model.
-        arch: VisionLoaderType,
+        arch: Option<VisionLoaderType>,
 
         /// Model data type. Defaults to `auto`.
         #[serde(default = "default_dtype")]

--- a/mistralrs-pyo3/src/lib.rs
+++ b/mistralrs-pyo3/src/lib.rs
@@ -408,7 +408,7 @@ fn parse_which(
             Some(model_id),
             jinja_explicit,
         )
-        .build(arch.into()),
+        .build(arch.map(Into::into)),
         Which::DiffusionPlain {
             model_id,
             arch,

--- a/mistralrs-pyo3/src/which.rs
+++ b/mistralrs-pyo3/src/which.rs
@@ -397,7 +397,7 @@ pub enum Which {
 
     #[pyo3(constructor = (
         model_id,
-        arch,
+        arch = None,
         tokenizer_json = None,
         topology = None,
         write_uqff = None,
@@ -411,7 +411,7 @@ pub enum Which {
     ))]
     VisionPlain {
         model_id: String,
-        arch: VisionArchitecture,
+        arch: Option<VisionArchitecture>,
         tokenizer_json: Option<String>,
         topology: Option<String>,
         write_uqff: Option<PathBuf>,

--- a/mistralrs/examples/gemma3/main.rs
+++ b/mistralrs/examples/gemma3/main.rs
@@ -1,9 +1,9 @@
 use anyhow::Result;
-use mistralrs::{IsqType, TextMessageRole, VisionLoaderType, VisionMessages, VisionModelBuilder};
+use mistralrs::{IsqType, TextMessageRole, VisionMessages, VisionModelBuilder};
 
 #[tokio::main]
 async fn main() -> Result<()> {
-    let model = VisionModelBuilder::new("google/gemma-3-12b-it", VisionLoaderType::Gemma3)
+    let model = VisionModelBuilder::new("google/gemma-3-12b-it")
         .with_isq(IsqType::Q4K)
         .with_logging()
         .build()

--- a/mistralrs/examples/idefics2/main.rs
+++ b/mistralrs/examples/idefics2/main.rs
@@ -1,16 +1,13 @@
 use anyhow::Result;
-use mistralrs::{IsqType, TextMessageRole, VisionLoaderType, VisionMessages, VisionModelBuilder};
+use mistralrs::{IsqType, TextMessageRole, VisionMessages, VisionModelBuilder};
 
 #[tokio::main]
 async fn main() -> Result<()> {
-    let model = VisionModelBuilder::new(
-        "HuggingFaceM4/idefics2-8b-chatty",
-        VisionLoaderType::Idefics2,
-    )
-    .with_isq(IsqType::Q4K)
-    .with_logging()
-    .build()
-    .await?;
+    let model = VisionModelBuilder::new("HuggingFaceM4/idefics2-8b-chatty")
+        .with_isq(IsqType::Q4K)
+        .with_logging()
+        .build()
+        .await?;
 
     let bytes = match reqwest::blocking::get(
         "https://cdn.britannica.com/45/5645-050-B9EC0205/head-treasure-flower-disk-flowers-inflorescence-ray.jpg",

--- a/mistralrs/examples/idefics3/main.rs
+++ b/mistralrs/examples/idefics3/main.rs
@@ -1,11 +1,11 @@
 use anyhow::Result;
-use mistralrs::{IsqType, TextMessageRole, VisionLoaderType, VisionMessages, VisionModelBuilder};
+use mistralrs::{IsqType, TextMessageRole, VisionMessages, VisionModelBuilder};
 
 const MODEL_ID: &str = "HuggingFaceM4/Idefics3-8B-Llama3";
 
 #[tokio::main]
 async fn main() -> Result<()> {
-    let model = VisionModelBuilder::new(MODEL_ID, VisionLoaderType::Idefics3)
+    let model = VisionModelBuilder::new(MODEL_ID)
         .with_isq(IsqType::Q8_0)
         .with_logging()
         .build()

--- a/mistralrs/examples/llama4/main.rs
+++ b/mistralrs/examples/llama4/main.rs
@@ -1,16 +1,13 @@
 use anyhow::Result;
-use mistralrs::{IsqType, TextMessageRole, VisionLoaderType, VisionMessages, VisionModelBuilder};
+use mistralrs::{IsqType, TextMessageRole, VisionMessages, VisionModelBuilder};
 
 #[tokio::main]
 async fn main() -> Result<()> {
-    let model = VisionModelBuilder::new(
-        "meta-llama/Llama-4-Scout-17B-16E-Instruct",
-        VisionLoaderType::Llama4,
-    )
-    .with_isq(IsqType::Q4K)
-    .with_logging()
-    .build()
-    .await?;
+    let model = VisionModelBuilder::new("meta-llama/Llama-4-Scout-17B-16E-Instruct")
+        .with_isq(IsqType::Q4K)
+        .with_logging()
+        .build()
+        .await?;
 
     let bytes = match reqwest::blocking::get(
         "https://www.nhmagazine.com/content/uploads/2019/05/mtwashingtonFranconia-2-19-18-108-Edit-Edit.jpg",

--- a/mistralrs/examples/llama_vision/main.rs
+++ b/mistralrs/examples/llama_vision/main.rs
@@ -1,12 +1,12 @@
 use anyhow::Result;
-use mistralrs::{IsqType, TextMessageRole, VisionLoaderType, VisionMessages, VisionModelBuilder};
+use mistralrs::{IsqType, TextMessageRole, VisionMessages, VisionModelBuilder};
 
 // const MODEL_ID: &str = "meta-llama/Llama-3.2-11B-Vision-Instruct";
 const MODEL_ID: &str = "lamm-mit/Cephalo-Llama-3.2-11B-Vision-Instruct-128k";
 
 #[tokio::main]
 async fn main() -> Result<()> {
-    let model = VisionModelBuilder::new(MODEL_ID, VisionLoaderType::VLlama)
+    let model = VisionModelBuilder::new(MODEL_ID)
         .with_isq(IsqType::Q4K)
         .with_logging()
         .build()

--- a/mistralrs/examples/llama_vision_multiturn/main.rs
+++ b/mistralrs/examples/llama_vision_multiturn/main.rs
@@ -1,13 +1,11 @@
 use anyhow::Result;
-use mistralrs::{
-    RequestBuilder, TextMessageRole, VisionLoaderType, VisionMessages, VisionModelBuilder,
-};
+use mistralrs::{RequestBuilder, TextMessageRole, VisionMessages, VisionModelBuilder};
 
 const MODEL_ID: &str = "meta-llama/Llama-3.2-11B-Vision-Instruct";
 
 #[tokio::main]
 async fn main() -> Result<()> {
-    let model = VisionModelBuilder::new(MODEL_ID, VisionLoaderType::VLlama)
+    let model = VisionModelBuilder::new(MODEL_ID)
         .with_logging()
         .with_isq(mistralrs::IsqType::Q8_0)
         .build()

--- a/mistralrs/examples/llava/main.rs
+++ b/mistralrs/examples/llava/main.rs
@@ -1,9 +1,9 @@
 use anyhow::Result;
-use mistralrs::{IsqType, TextMessageRole, VisionLoaderType, VisionMessages, VisionModelBuilder};
+use mistralrs::{IsqType, TextMessageRole, VisionMessages, VisionModelBuilder};
 
 #[tokio::main]
 async fn main() -> Result<()> {
-    let model = VisionModelBuilder::new("llava-hf/llava-1.5-7b-hf", VisionLoaderType::LLaVA)
+    let model = VisionModelBuilder::new("llava-hf/llava-1.5-7b-hf")
         .with_isq(IsqType::Q4K)
         .with_chat_template("chat_templates/vicuna.json")
         .with_logging()

--- a/mistralrs/examples/llava_next/main.rs
+++ b/mistralrs/examples/llava_next/main.rs
@@ -1,16 +1,13 @@
 use anyhow::Result;
-use mistralrs::{IsqType, TextMessageRole, VisionLoaderType, VisionMessages, VisionModelBuilder};
+use mistralrs::{IsqType, TextMessageRole, VisionMessages, VisionModelBuilder};
 
 #[tokio::main]
 async fn main() -> Result<()> {
-    let model = VisionModelBuilder::new(
-        "llava-hf/llava-v1.6-mistral-7b-hf",
-        VisionLoaderType::LLaVANext,
-    )
-    .with_isq(IsqType::Q4K)
-    .with_logging()
-    .build()
-    .await?;
+    let model = VisionModelBuilder::new("llava-hf/llava-v1.6-mistral-7b-hf")
+        .with_isq(IsqType::Q4K)
+        .with_logging()
+        .build()
+        .await?;
 
     let bytes = match reqwest::blocking::get(
         "https://cdn.britannica.com/45/5645-050-B9EC0205/head-treasure-flower-disk-flowers-inflorescence-ray.jpg",

--- a/mistralrs/examples/minicpmo_2_6/main.rs
+++ b/mistralrs/examples/minicpmo_2_6/main.rs
@@ -1,9 +1,9 @@
 use anyhow::Result;
-use mistralrs::{IsqType, TextMessageRole, VisionLoaderType, VisionMessages, VisionModelBuilder};
+use mistralrs::{IsqType, TextMessageRole, VisionMessages, VisionModelBuilder};
 
 #[tokio::main]
 async fn main() -> Result<()> {
-    let model = VisionModelBuilder::new("openbmb/MiniCPM-o-2_6", VisionLoaderType::MiniCpmO)
+    let model = VisionModelBuilder::new("openbmb/MiniCPM-o-2_6")
         .with_isq(IsqType::Q4K)
         .with_logging()
         .build()

--- a/mistralrs/examples/mistral3/main.rs
+++ b/mistralrs/examples/mistral3/main.rs
@@ -1,16 +1,13 @@
 use anyhow::Result;
-use mistralrs::{IsqType, TextMessageRole, VisionLoaderType, VisionMessages, VisionModelBuilder};
+use mistralrs::{IsqType, TextMessageRole, VisionMessages, VisionModelBuilder};
 
 #[tokio::main]
 async fn main() -> Result<()> {
-    let model = VisionModelBuilder::new(
-        "mistralai/Mistral-Small-3.1-24B-Instruct-2503",
-        VisionLoaderType::Mistral3,
-    )
-    .with_isq(IsqType::Q4K)
-    .with_logging()
-    .build()
-    .await?;
+    let model = VisionModelBuilder::new("mistralai/Mistral-Small-3.1-24B-Instruct-2503")
+        .with_isq(IsqType::Q4K)
+        .with_logging()
+        .build()
+        .await?;
 
     let bytes = match reqwest::blocking::get(
         "https://www.nhmagazine.com/content/uploads/2019/05/mtwashingtonFranconia-2-19-18-108-Edit-Edit.jpg",

--- a/mistralrs/examples/phi3v/main.rs
+++ b/mistralrs/examples/phi3v/main.rs
@@ -1,14 +1,13 @@
 use anyhow::Result;
-use mistralrs::{IsqType, TextMessageRole, VisionLoaderType, VisionMessages, VisionModelBuilder};
+use mistralrs::{IsqType, TextMessageRole, VisionMessages, VisionModelBuilder};
 
 #[tokio::main]
 async fn main() -> Result<()> {
-    let model =
-        VisionModelBuilder::new("microsoft/Phi-3.5-vision-instruct", VisionLoaderType::Phi3V)
-            .with_isq(IsqType::Q4K)
-            .with_logging()
-            .build()
-            .await?;
+    let model = VisionModelBuilder::new("microsoft/Phi-3.5-vision-instruct")
+        .with_isq(IsqType::Q4K)
+        .with_logging()
+        .build()
+        .await?;
 
     let bytes = match reqwest::blocking::get(
         "https://cdn.britannica.com/45/5645-050-B9EC0205/head-treasure-flower-disk-flowers-inflorescence-ray.jpg",

--- a/mistralrs/examples/phi4mm/main.rs
+++ b/mistralrs/examples/phi4mm/main.rs
@@ -1,16 +1,13 @@
 use anyhow::Result;
-use mistralrs::{IsqType, TextMessageRole, VisionLoaderType, VisionMessages, VisionModelBuilder};
+use mistralrs::{IsqType, TextMessageRole, VisionMessages, VisionModelBuilder};
 
 #[tokio::main]
 async fn main() -> Result<()> {
-    let model = VisionModelBuilder::new(
-        "microsoft/Phi-4-multimodal-instruct",
-        VisionLoaderType::Phi4MM,
-    )
-    .with_isq(IsqType::Q4K)
-    .with_logging()
-    .build()
-    .await?;
+    let model = VisionModelBuilder::new("microsoft/Phi-4-multimodal-instruct")
+        .with_isq(IsqType::Q4K)
+        .with_logging()
+        .build()
+        .await?;
 
     let bytes = match reqwest::blocking::get(
         "https://cdn.britannica.com/45/5645-050-B9EC0205/head-treasure-flower-disk-flowers-inflorescence-ray.jpg",

--- a/mistralrs/examples/qwen2_5vl/main.rs
+++ b/mistralrs/examples/qwen2_5vl/main.rs
@@ -1,6 +1,6 @@
 use anyhow::Result;
 use clap::Parser;
-use mistralrs::{IsqType, TextMessageRole, VisionLoaderType, VisionMessages, VisionModelBuilder};
+use mistralrs::{IsqType, TextMessageRole, VisionMessages, VisionModelBuilder};
 use mistralrs_core::initialize_logging;
 use tokio::task;
 
@@ -27,7 +27,7 @@ async fn main() -> Result<()> {
 
     let image = image::load_from_memory(&bytes)?;
 
-    let model = VisionModelBuilder::new(args.model_id, VisionLoaderType::Qwen2_5VL)
+    let model = VisionModelBuilder::new(args.model_id)
         .with_isq(IsqType::Q8_0)
         .with_logging()
         .build()

--- a/mistralrs/examples/qwen2vl/main.rs
+++ b/mistralrs/examples/qwen2vl/main.rs
@@ -1,11 +1,11 @@
 use anyhow::Result;
-use mistralrs::{IsqType, TextMessageRole, VisionLoaderType, VisionMessages, VisionModelBuilder};
+use mistralrs::{IsqType, TextMessageRole, VisionMessages, VisionModelBuilder};
 
 const MODEL_ID: &str = "Qwen/Qwen2-VL-2B-Instruct";
 
 #[tokio::main]
 async fn main() -> Result<()> {
-    let model = VisionModelBuilder::new(MODEL_ID, VisionLoaderType::Qwen2VL)
+    let model = VisionModelBuilder::new(MODEL_ID)
         .with_isq(IsqType::Q4K)
         .with_logging()
         .build()

--- a/mistralrs/examples/smolvlm/main.rs
+++ b/mistralrs/examples/smolvlm/main.rs
@@ -1,11 +1,11 @@
 use anyhow::Result;
-use mistralrs::{IsqType, TextMessageRole, VisionLoaderType, VisionMessages, VisionModelBuilder};
+use mistralrs::{IsqType, TextMessageRole, VisionMessages, VisionModelBuilder};
 
 const MODEL_ID: &str = "HuggingFaceTB/SmolVLM-Instruct";
 
 #[tokio::main]
 async fn main() -> Result<()> {
-    let model = VisionModelBuilder::new(MODEL_ID, VisionLoaderType::Idefics3)
+    let model = VisionModelBuilder::new(MODEL_ID)
         .with_isq(IsqType::Q8_0)
         .with_logging()
         .build()

--- a/mistralrs/examples/uqff_vision/main.rs
+++ b/mistralrs/examples/uqff_vision/main.rs
@@ -1,13 +1,10 @@
 use anyhow::Result;
-use mistralrs::{
-    IsqType, TextMessageRole, UqffVisionModelBuilder, VisionLoaderType, VisionMessages,
-};
+use mistralrs::{IsqType, TextMessageRole, UqffVisionModelBuilder, VisionMessages};
 
 #[tokio::main]
 async fn main() -> Result<()> {
     let model = UqffVisionModelBuilder::new(
         "EricB/Phi-3.5-vision-instruct-UQFF",
-        VisionLoaderType::Phi3V,
         vec!["phi3.5-vision-instruct-q8_0.uqff".into()],
     )
     .into_inner()

--- a/mistralrs/examples/vision_auto_device_map/main.rs
+++ b/mistralrs/examples/vision_auto_device_map/main.rs
@@ -1,7 +1,7 @@
 use anyhow::Result;
 use mistralrs::{
-    AutoDeviceMapParams, DeviceMapSetting, IsqType, TextMessageRole, VisionLoaderType,
-    VisionMessages, VisionModelBuilder,
+    AutoDeviceMapParams, DeviceMapSetting, IsqType, TextMessageRole, VisionMessages,
+    VisionModelBuilder,
 };
 
 // const MODEL_ID: &str = "meta-llama/Llama-3.2-11B-Vision-Instruct";
@@ -13,7 +13,7 @@ async fn main() -> Result<()> {
         max_seq_len: 4096,
         max_batch_size: 2,
     };
-    let model = VisionModelBuilder::new(MODEL_ID, VisionLoaderType::VLlama)
+    let model = VisionModelBuilder::new(MODEL_ID)
         .with_isq(IsqType::Q4K)
         .with_logging()
         .with_device_mapping(DeviceMapSetting::Auto(auto_map_params))

--- a/mistralrs/src/vision_model.rs
+++ b/mistralrs/src/vision_model.rs
@@ -29,7 +29,7 @@ pub struct VisionModelBuilder {
     // Model running
     pub(crate) prompt_chunksize: Option<NonZeroUsize>,
     pub(crate) topology: Option<Topology>,
-    pub(crate) loader_type: VisionLoaderType,
+    pub(crate) loader_type: Option<VisionLoaderType>,
     pub(crate) dtype: ModelDType,
     pub(crate) force_cpu: bool,
     pub(crate) isq: Option<IsqType>,
@@ -47,7 +47,7 @@ impl VisionModelBuilder {
     /// - Maximum number of sequences running is 32
     /// - Automatic device mapping with model defaults according to `AutoDeviceMapParams`
     /// - By default, web searching compatible with the OpenAI `web_search_options` setting is disabled.
-    pub fn new(model_id: impl ToString, loader_type: VisionLoaderType) -> Self {
+    pub fn new(model_id: impl ToString) -> Self {
         Self {
             model_id: model_id.to_string(),
             topology: None,
@@ -57,7 +57,7 @@ impl VisionModelBuilder {
             chat_template: None,
             tokenizer_json: None,
             max_edge: None,
-            loader_type,
+            loader_type: None,
             dtype: ModelDType::Auto,
             force_cpu: false,
             token_source: TokenSource::CacheToken,
@@ -115,6 +115,13 @@ impl VisionModelBuilder {
     /// Path to a discrete `tokenizer.json` file.
     pub fn with_tokenizer_json(mut self, tokenizer_json: impl ToString) -> Self {
         self.tokenizer_json = Some(tokenizer_json.to_string());
+        self
+    }
+
+    /// Manually set the model loader type. Otherwise, it will attempt to automatically
+    /// determine the loader type.
+    pub fn with_loader_type(mut self, loader_type: VisionLoaderType) -> Self {
+        self.loader_type = Some(loader_type);
         self
     }
 
@@ -302,12 +309,8 @@ impl UqffVisionModelBuilder {
     /// - Token source is from the cache (.cache/huggingface/token)
     /// - Maximum number of sequences running is 32
     /// - Automatic device mapping with model defaults according to `AutoDeviceMapParams`
-    pub fn new(
-        model_id: impl ToString,
-        loader_type: VisionLoaderType,
-        uqff_file: Vec<PathBuf>,
-    ) -> Self {
-        let mut inner = VisionModelBuilder::new(model_id, loader_type);
+    pub fn new(model_id: impl ToString, uqff_file: Vec<PathBuf>) -> Self {
+        let mut inner = VisionModelBuilder::new(model_id);
         inner = inner.from_uqff(uqff_file);
         Self(inner)
     }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Vision model initialization now automatically selects the appropriate loader type based on the model configuration, removing the need to specify the loader type manually.
  - Added support for optionally specifying the architecture when building vision models.

- **Refactor**
  - Simplified vision model builder APIs, making the loader type parameter optional and introducing a method to set it if needed.
  - Updated trait and method signatures to accept configuration parameters, enabling more flexible model handling.
  - Renamed and reorganized loader types for clarity and improved modularity.

- **Style**
  - Example usages and documentation updated to remove explicit architecture or loader type specifications, reflecting the streamlined initialization process.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->