### PR TITLE
Don't use mmap on cuda

### DIFF
--- a/mistralrs-core/src/pipeline/sampling.rs
+++ b/mistralrs-core/src/pipeline/sampling.rs
@@ -59,6 +59,7 @@ pub(crate) async fn finish_or_add_toks_to_seq(
                     Ok((None, _tools))
                 )
             {
+                println!("DONE!");
                 seq.set_state(SequenceState::Done(StopReason::Eos));
                 is_done = Some(StopReason::Eos);
             }
@@ -85,9 +86,6 @@ pub(crate) async fn finish_or_add_toks_to_seq(
                             parse_text_tools(this, delta.as_str(), seq.tools.clone())
                                 .map_err(candle_core::Error::msg)?;
 
-                        if !tool_calls.is_empty() && is_done.is_none() {
-                            is_done = Some(StopReason::Eos);
-                        };
                         seq.add_streaming_chunk_choice_to_group(crate::ChunkChoice {
                             delta: crate::Delta {
                                 content: fixup_sentencepiece!(

--- a/mistralrs-core/src/pipeline/sampling.rs
+++ b/mistralrs-core/src/pipeline/sampling.rs
@@ -59,7 +59,6 @@ pub(crate) async fn finish_or_add_toks_to_seq(
                     Ok((None, _tools))
                 )
             {
-                println!("DONE!");
                 seq.set_state(SequenceState::Done(StopReason::Eos));
                 is_done = Some(StopReason::Eos);
             }

--- a/mistralrs-core/src/utils/progress.rs
+++ b/mistralrs-core/src/utils/progress.rs
@@ -190,6 +190,6 @@ where
         F: Fn(<T as IntoParallelIterator>::Item) -> candle_core::Result<U> + Sync + Send,
         U: Send,
     {
-        self.run(get_immediate_isq().ty.is_some(), f)
+        self.run(get_immediate_isq().is_some_and(|x| x.ty.is_some()), f)
     }
 }

--- a/mistralrs-core/src/utils/varbuilder_utils.rs
+++ b/mistralrs-core/src/utils/varbuilder_utils.rs
@@ -74,7 +74,8 @@ pub(crate) fn from_mmaped_safetensors(
     predicate: impl Fn(String) -> bool + Send + Sync + Clone + 'static,
     get_device_for_tensor: Arc<dyn Fn(String) -> DeviceForLoadTensor + Send + Sync + 'static>,
 ) -> Result<ShardedVarBuilder> {
-    if xlora_paths.is_empty() {
+    // No mmap for cuda.
+    if xlora_paths.is_empty() && base_device.is_cuda() {
         if !silent {
             tracing::info!("Loading model using mmap strategy.");
         }

--- a/mistralrs-quant/src/lib.rs
+++ b/mistralrs-quant/src/lib.rs
@@ -86,12 +86,16 @@ pub fn set_immediate_isq(isq: Option<IsqType>, predicates: Vec<Regex>) {
         .ty = isq;
 }
 
-pub fn get_immediate_isq() -> ImmediateIsqParams {
-    IMMEDIATE_ISQ.get().unwrap().lock().unwrap().clone()
+pub fn get_immediate_isq() -> Option<ImmediateIsqParams> {
+    IMMEDIATE_ISQ
+        .get()
+        .map(|guard| guard.lock().unwrap().clone())
 }
 
 pub fn should_apply_immediate_isq(vb: &ShardedVarBuilder) -> bool {
-    let immediate_isq = get_immediate_isq();
+    let Some(immediate_isq) = get_immediate_isq() else {
+        return false;
+    };
     // Add a .weight to match the ISQ regexes!
     let prefix = format!("{}.weight", vb.prefix());
     immediate_isq.ty.is_some()

--- a/mistralrs-quant/src/utils/isq.rs
+++ b/mistralrs-quant/src/utils/isq.rs
@@ -27,11 +27,11 @@ pub(crate) fn apply_immediate_isq_always(
     layer: Arc<dyn QuantMethod>,
     device: &Device,
 ) -> Result<Arc<dyn QuantMethod>> {
-    if let ImmediateIsqParams {
+    if let Some(ImmediateIsqParams {
         guard,
         ty: Some(immediate_isq),
         predicates: _,
-    } = get_immediate_isq()
+    }) = get_immediate_isq()
     {
         layer.clone().apply_isq(
             Some(immediate_isq),


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Improved handling of immediate ISQ quantization to account for device type, preventing unintended behavior on CUDA devices.
	- Enhanced safety around optional ISQ parameters, reducing the risk of errors when parameters are uninitialized.
	- Adjusted model loading logic to refine when quantization and mmap loading strategies are applied based on device and configuration.
	- Removed override of completion state during streaming when tool calls are present.

- **Other Changes**
	- Refined progress bar behavior to safely handle optional ISQ states.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->