### PR TITLE
Fix normalization formula in comment

### DIFF
--- a/mistralrs-vision/src/transforms.rs
+++ b/mistralrs-vision/src/transforms.rs
@@ -31,7 +31,7 @@ impl ImageTransform for ToTensorNoNorm {
 /// Normalize the image data based on the mean and standard deviation.
 /// The value is computed as follows:
 /// `
-/// x[channel]=(x[channel - mean[channel]) / std[channel]
+/// x[channel] = (x[channel] - mean[channel]) / std[channel]
 /// `
 ///
 /// Expects an input tensor of shape (channels, height, width).


### PR DESCRIPTION
## Summary
- fix comment formula in the Normalize transform

## Testing
- `cargo test --no-run` *(fails: failed to get `candle-core`)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Corrected the documentation comment for the normalization formula to accurately describe the operation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->