### PR TITLE
Fix streaming example print statement

### DIFF
--- a/mistralrs/src/lib.rs
+++ b/mistralrs/src/lib.rs
@@ -91,7 +91,7 @@
 //!                    ..
 //!                }) = choices.first()
 //!                {
-//!                    print!("content");
+//!                    print!("{}", content);
 //!                };
 //!            }
 //!        }


### PR DESCRIPTION
## Summary
- update streaming doc example to print the `content` variable

## Testing
- `cargo test --doc` *(fails: could not fetch `candle-core` dependency)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Corrected an example in the documentation to display the actual streamed chat content instead of a fixed string.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->