### PR TITLE
Improve normalization integration test

### DIFF
--- a/mistralrs-vision/tests/integration.rs
+++ b/mistralrs-vision/tests/integration.rs
@@ -14,6 +14,8 @@ fn normalize() {
     };
     let transformed = image.apply(transforms, &Device::Cpu).unwrap();
     assert_eq!(transformed.dims(), &[3, 4, 3]);
+    let expected = vec![vec![vec![-1f32; 3]; 4]; 3];
+    assert_eq!(transformed.to_vec3::<f32>().unwrap(), expected);
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- verify element-wise correctness of Normalize

## Testing
- `cargo test -p mistralrs-vision --quiet` *(fails: failed to fetch `candle-core`)*