### PR TITLE
Fix AFQ8 parsing for --isq

### DIFF
--- a/mistralrs-core/src/pipeline/isq.rs
+++ b/mistralrs-core/src/pipeline/isq.rs
@@ -60,43 +60,7 @@ pub const UQFF_MULTI_FILE_DELIMITER: &str = ";";
 /// - `AFQ6`
 /// - `AFQ8`
 pub fn parse_isq_value(s: &str) -> Result<IsqType, String> {
-    let tp = match s.to_lowercase().as_str() {
-        "2" if cfg!(feature = "metal") => IsqType::AFQ2,
-        "2" if !cfg!(feature = "metal") => IsqType::Q2K,
-        "3" if cfg!(feature = "metal") => IsqType::AFQ3,
-        "3" if !cfg!(feature = "metal") => IsqType::Q3K,
-        "4" if cfg!(feature = "metal") => IsqType::AFQ4,
-        "4" if !cfg!(feature = "metal") => IsqType::Q4K,
-        "5" => IsqType::Q5K,
-        "6" if cfg!(feature = "metal") => IsqType::AFQ6,
-        "6" if !cfg!(feature = "metal") => IsqType::Q6K,
-        "8" if cfg!(feature = "metal") => IsqType::AFQ8,
-        "8" if !cfg!(feature = "metal") => IsqType::Q8_0,
-        "q4_0" => IsqType::Q4_0,
-        "q4_1" => IsqType::Q4_1,
-        "q5_0" => IsqType::Q5_0,
-        "q5_1" => IsqType::Q5_1,
-        "q8_0" => IsqType::Q8_0,
-        "q8_1" => IsqType::Q8_1,
-        "q2k" => IsqType::Q2K,
-        "q3k" => IsqType::Q3K,
-        "q4k" => IsqType::Q4K,
-        "q5k" => IsqType::Q5K,
-        "q6k" => IsqType::Q6K,
-        "q8k" => IsqType::Q8K,
-        "hqq8" => IsqType::HQQ8,
-        "hqq4" => IsqType::HQQ4,
-        "fp8" => IsqType::F8E4M3,
-        "afq8" => IsqType::AFQ8,
-        "afq6" => IsqType::AFQ6,
-        "afq4" => IsqType::AFQ4,
-        "afq3" => IsqType::AFQ3,
-        "afq2" => IsqType::AFQ2,
-        // "hqq3" => IsqType::HQQ3,
-        // "hqq2" => IsqType::HQQ2,
-        // "hqq1" => IsqType::HQQ1,
-        _ => return Err(format!("ISQ type {s} unknown, choose one of `2`, `3`, `4`, `6`, `8`, `Q4_0`, `Q4_1`, `Q5_0`, `Q5_1`, `Q8_0`, `Q8_1`, `Q2K`, `Q3K`, `Q4K`, `Q5K`, `Q6K`, `Q8K`, `HQQ8`, `HQQ4`, `FP8`, `AFQ8`, `AFQ6`, `AFQ4`, `AFQ3`, `AFQ2`.")),
-    };
+    let tp = IsqType::from_str(s)?;
     #[cfg(feature = "cuda")]
     {
         if !matches!(

--- a/mistralrs-quant/src/lib.rs
+++ b/mistralrs-quant/src/lib.rs
@@ -3,6 +3,7 @@ use std::{
     fmt::Debug,
     num::NonZeroUsize,
     sync::{atomic::AtomicUsize, Arc, Mutex, MutexGuard, OnceLock},
+    str::FromStr,
 };
 
 use blockwise_fp8::blockwise_fp8_linear_b;
@@ -347,6 +348,49 @@ pub enum IsqType {
     AFQ4,
     AFQ3,
     AFQ2,
+}
+
+impl FromStr for IsqType {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s.to_ascii_lowercase().as_str() {
+            "2" if cfg!(feature = "metal") => Ok(Self::AFQ2),
+            "2" => Ok(Self::Q2K),
+            "3" if cfg!(feature = "metal") => Ok(Self::AFQ3),
+            "3" => Ok(Self::Q3K),
+            "4" if cfg!(feature = "metal") => Ok(Self::AFQ4),
+            "4" => Ok(Self::Q4K),
+            "5" => Ok(Self::Q5K),
+            "6" if cfg!(feature = "metal") => Ok(Self::AFQ6),
+            "6" => Ok(Self::Q6K),
+            "8" if cfg!(feature = "metal") => Ok(Self::AFQ8),
+            "8" => Ok(Self::Q8_0),
+            "q4_0" => Ok(Self::Q4_0),
+            "q4_1" => Ok(Self::Q4_1),
+            "q5_0" => Ok(Self::Q5_0),
+            "q5_1" => Ok(Self::Q5_1),
+            "q8_0" => Ok(Self::Q8_0),
+            "q8_1" => Ok(Self::Q8_1),
+            "q2k" => Ok(Self::Q2K),
+            "q3k" => Ok(Self::Q3K),
+            "q4k" => Ok(Self::Q4K),
+            "q5k" => Ok(Self::Q5K),
+            "q6k" => Ok(Self::Q6K),
+            "q8k" => Ok(Self::Q8K),
+            "hqq8" => Ok(Self::HQQ8),
+            "hqq4" => Ok(Self::HQQ4),
+            "fp8" => Ok(Self::F8E4M3),
+            "afq8" => Ok(Self::AFQ8),
+            "afq6" => Ok(Self::AFQ6),
+            "afq4" => Ok(Self::AFQ4),
+            "afq3" => Ok(Self::AFQ3),
+            "afq2" => Ok(Self::AFQ2),
+            _ => Err(format!(
+                "ISQ type {s} unknown, choose one of `2`, `3`, `4`, `6`, `8`, `Q4_0`, `Q4_1`, `Q5_0`, `Q5_1`, `Q8_0`, `Q8_1`, `Q2K`, `Q3K`, `Q4K`, `Q5K`, `Q6K`, `Q8K`, `HQQ8`, `HQQ4`, `FP8`, `AFQ8`, `AFQ6`, `AFQ4`, `AFQ3`, `AFQ2`."
+            )),
+        }
+    }
 }
 
 impl IsqType {


### PR DESCRIPTION
## Summary
- implement `FromStr` for `IsqType`
- delegate ISQ string parsing to `IsqType::from_str`

## Testing
- `cargo fmt` *(fails: `rustfmt` not installed)*
- `cargo check --locked` *(fails: could not fetch `candle` git dependency)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for parsing quantization type strings directly, allowing users to specify quantization types using various string formats.

- **Bug Fixes**
  - Improved error messages when specifying invalid quantization types, now listing all valid options for easier correction.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->