### PR TITLE
Fix typo in expect messages

### DIFF
--- a/mistralrs-core/src/engine/mod.rs
+++ b/mistralrs-core/src/engine/mod.rs
@@ -150,7 +150,7 @@ impl Engine {
             if matches!(
                 ENGINE_INSTRUCTIONS
                     .lock()
-                    .expect("`ENGINE_INSTRUCTIONS` was poisioned")
+                    .expect("`ENGINE_INSTRUCTIONS` was poisoned")
                     .get(get_mut_arcmutex!(self.id).deref()),
                 Some(Some(EngineInstruction::Terminate))
             ) {

--- a/mistralrs-core/src/lib.rs
+++ b/mistralrs-core/src/lib.rs
@@ -258,7 +258,7 @@ impl Drop for MistralRs {
     fn drop(&mut self) {
         ENGINE_INSTRUCTIONS
             .lock()
-            .expect("`ENGINE_INSTRUCTIONS` was poisioned")
+            .expect("`ENGINE_INSTRUCTIONS` was poisoned")
             .insert(self.engine_id, Some(EngineInstruction::Terminate));
     }
 }


### PR DESCRIPTION
## Summary
- fix typo 'poisioned' -> 'poisoned' in engine and core library

## Testing
- `cargo test --workspace --all-targets --no-run --locked --offline` *(fails: failed to load source for dependency `candle-core`)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Corrected spelling errors in certain error messages to improve clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->