### PR TITLE
Add blockwise fp8 gemm kernel

### DIFF
--- a/mistralrs-quant/build.rs
+++ b/mistralrs-quant/build.rs
@@ -76,6 +76,24 @@ fn main() -> Result<(), String> {
                 ),
             );
         }
+
+        if blockwise_fp8_ffi_ct
+            .contains("pub(crate) const HAVE_BLOCKWISE_GEMM_KERNELS: bool = true;")
+        {
+            blockwise_fp8_ffi_ct = blockwise_fp8_ffi_ct.replace(
+                "pub(crate) const HAVE_BLOCKWISE_GEMM_KERNELS: bool = true;",
+                &format!(
+                    "pub(crate) const HAVE_BLOCKWISE_GEMM_KERNELS: bool = {cc_is_over_800};"
+                ),
+            );
+        } else {
+            blockwise_fp8_ffi_ct = blockwise_fp8_ffi_ct.replace(
+                "pub(crate) const HAVE_BLOCKWISE_GEMM_KERNELS: bool = false;",
+                &format!(
+                    "pub(crate) const HAVE_BLOCKWISE_GEMM_KERNELS: bool = {cc_is_over_800};"
+                ),
+            );
+        }
         std::fs::write(BLOCKWISE_FP8_FFI_PATH, blockwise_fp8_ffi_ct).unwrap();
         // ========
 
@@ -90,9 +108,11 @@ fn main() -> Result<(), String> {
         if cc_over_800 {
             lib_files.push("kernels/marlin/marlin_kernel.cu");
             lib_files.push("kernels/blockwise_fp8/blockwise_fp8.cu");
+            lib_files.push("kernels/blockwise_fp8/blockwise_fp8_gemm.cu");
         } else {
             lib_files.push("kernels/marlin/dummy_marlin_kernel.cu");
             lib_files.push("kernels/blockwise_fp8/blockwise_fp8_dummy.cu");
+            lib_files.push("kernels/blockwise_fp8/blockwise_fp8_gemm_dummy.cu");
         }
         for lib_file in lib_files.iter() {
             println!("cargo:rerun-if-changed={lib_file}");

--- a/mistralrs-quant/kernels/blockwise_fp8/blockwise_fp8_gemm.cu
+++ b/mistralrs-quant/kernels/blockwise_fp8/blockwise_fp8_gemm.cu
@@ -1,0 +1,124 @@
+#include <cstdint>
+#include <cuda.h>
+#include <cuda_bf16.h>
+#include <cuda_fp16.h>
+#include <cuda_fp8.h>
+
+#define CUDA_CHECK(call) \
+  do { \
+    cudaError_t err = call; \
+    if (err != cudaSuccess) { \
+      fprintf(stderr, "CUDA error at %s:%d: %s\n", __FILE__, __LINE__, cudaGetErrorString(err)); \
+      exit(err); \
+    } \
+  } while (0)
+
+namespace {
+
+template <typename T> __device__ inline float to_float(T v);
+template <> __device__ inline float to_float(__half v) { return __half2float(v); }
+template <> __device__ inline float to_float(__nv_bfloat16 v) { return __bfloat162float(v); }
+template <> __device__ inline float to_float(float v) { return v; }
+
+template <typename T> __device__ inline T from_float(float v);
+template <> __device__ inline __half from_float(float v) { return __float2half(v); }
+template <> __device__ inline __nv_bfloat16 from_float(float v) { return __float2bfloat16(v); }
+template <> __device__ inline float from_float(float v) { return v; }
+
+template <typename T>
+__global__ void gemm_fp8_blockwise_kernel(
+    const __nv_fp8_e4m3* __restrict__ weight,
+    const float* __restrict__ scale,
+    const T* __restrict__ input,
+    T* __restrict__ output,
+    int batch,
+    int in_dim,
+    int out_dim,
+    int weight_row_stride,
+    int scale_stride,
+    int block_y,
+    int block_x) {
+  int row = blockIdx.y * blockDim.y + threadIdx.y;
+  int col = blockIdx.x * blockDim.x + threadIdx.x;
+
+  if (row >= batch || col >= out_dim) return;
+
+  float acc = 0.f;
+  for (int k = 0; k < in_dim; ++k) {
+    float x_val = to_float(input[row * in_dim + k]);
+    float w_val = __half2float(__nv_cvt_fp8_to_halfraw(weight[col * weight_row_stride + k].__x, __NV_E4M3));
+    float s = scale[(col / block_y) * scale_stride + (k / block_x)];
+    acc += x_val * (w_val * s);
+  }
+  output[row * out_dim + col] = from_float<T>(acc);
+}
+
+} // namespace
+
+extern "C" void launch_gemm_fp8_blockwise_kernel_f16(
+    const __nv_fp8_e4m3* weight,
+    const float* scale,
+    const __half* input,
+    __half* output,
+    int batch,
+    int in_dim,
+    int out_dim,
+    int weight_row_stride,
+    int scale_stride,
+    int block_y,
+    int block_x,
+    cudaStream_t stream) {
+  dim3 blockDim(16,16);
+  dim3 gridDim((out_dim + blockDim.x - 1)/blockDim.x,
+               (batch + blockDim.y - 1)/blockDim.y);
+  gemm_fp8_blockwise_kernel<<<gridDim, blockDim, 0, stream>>>(
+      weight, scale, input, output, batch, in_dim, out_dim,
+      weight_row_stride, scale_stride, block_y, block_x);
+  CUDA_CHECK(cudaGetLastError());
+}
+
+extern "C" void launch_gemm_fp8_blockwise_kernel_bf16(
+    const __nv_fp8_e4m3* weight,
+    const float* scale,
+    const __nv_bfloat16* input,
+    __nv_bfloat16* output,
+    int batch,
+    int in_dim,
+    int out_dim,
+    int weight_row_stride,
+    int scale_stride,
+    int block_y,
+    int block_x,
+    cudaStream_t stream) {
+  dim3 blockDim(16,16);
+  dim3 gridDim((out_dim + blockDim.x - 1)/blockDim.x,
+               (batch + blockDim.y - 1)/blockDim.y);
+  gemm_fp8_blockwise_kernel<<<gridDim, blockDim, 0, stream>>>(
+      weight, scale, input, output, batch, in_dim, out_dim,
+      weight_row_stride, scale_stride, block_y, block_x);
+  CUDA_CHECK(cudaGetLastError());
+}
+
+extern "C" void launch_gemm_fp8_blockwise_kernel_f32(
+    const __nv_fp8_e4m3* weight,
+    const float* scale,
+    const float* input,
+    float* output,
+    int batch,
+    int in_dim,
+    int out_dim,
+    int weight_row_stride,
+    int scale_stride,
+    int block_y,
+    int block_x,
+    cudaStream_t stream) {
+  dim3 blockDim(16,16);
+  dim3 gridDim((out_dim + blockDim.x - 1)/blockDim.x,
+               (batch + blockDim.y - 1)/blockDim.y);
+  gemm_fp8_blockwise_kernel<<<gridDim, blockDim, 0, stream>>>(
+      weight, scale, input, output, batch, in_dim, out_dim,
+      weight_row_stride, scale_stride, block_y, block_x);
+  CUDA_CHECK(cudaGetLastError());
+}
+
+

--- a/mistralrs-quant/kernels/blockwise_fp8/blockwise_fp8_gemm_dummy.cu
+++ b/mistralrs-quant/kernels/blockwise_fp8/blockwise_fp8_gemm_dummy.cu
@@ -1,0 +1,25 @@
+#include <cassert>
+#include <cstdint>
+#include <cuda.h>
+
+extern "C" void launch_gemm_fp8_blockwise_kernel_f16(
+    const uint8_t* weight, const float* scale, const uint16_t* input,
+    uint16_t* output, int batch, int in_dim, int out_dim,
+    int weight_row_stride, int scale_stride, int block_y, int block_x) {
+  assert(false);
+}
+
+extern "C" void launch_gemm_fp8_blockwise_kernel_bf16(
+    const uint8_t* weight, const float* scale, const uint16_t* input,
+    uint16_t* output, int batch, int in_dim, int out_dim,
+    int weight_row_stride, int scale_stride, int block_y, int block_x) {
+  assert(false);
+}
+
+extern "C" void launch_gemm_fp8_blockwise_kernel_f32(
+    const uint8_t* weight, const float* scale, const float* input,
+    float* output, int batch, int in_dim, int out_dim,
+    int weight_row_stride, int scale_stride, int block_y, int block_x) {
+  assert(false);
+}
+

--- a/mistralrs-quant/src/blockwise_fp8/ffi.rs
+++ b/mistralrs-quant/src/blockwise_fp8/ffi.rs
@@ -2,6 +2,7 @@ use float8::F8E4M3;
 use half::{bf16, f16};
 
 pub(crate) const HAVE_BLOCKWISE_DEQUANT_KERNELS: bool = true;
+pub(crate) const HAVE_BLOCKWISE_GEMM_KERNELS: bool = true;
 
 extern "C" {
     pub(crate) fn launch_dequant_fp8_blockwise_kernel_f32(
@@ -36,6 +37,51 @@ extern "C" {
         d_output: *mut bf16,
         weight_height: i32,
         weight_width: i32,
+        weight_row_stride: i32,
+        scale_stride: i32,
+        weight_block_size_y: i32,
+        weight_block_size_x: i32,
+        stream: candle_core::cuda::cudarc::driver::sys::CUstream,
+    );
+
+    pub(crate) fn launch_gemm_fp8_blockwise_kernel_f16(
+        d_weight: *const F8E4M3,
+        d_scale: *const f32,
+        d_input: *const f16,
+        d_output: *mut f16,
+        batch: i32,
+        in_dim: i32,
+        out_dim: i32,
+        weight_row_stride: i32,
+        scale_stride: i32,
+        weight_block_size_y: i32,
+        weight_block_size_x: i32,
+        stream: candle_core::cuda::cudarc::driver::sys::CUstream,
+    );
+
+    pub(crate) fn launch_gemm_fp8_blockwise_kernel_bf16(
+        d_weight: *const F8E4M3,
+        d_scale: *const f32,
+        d_input: *const bf16,
+        d_output: *mut bf16,
+        batch: i32,
+        in_dim: i32,
+        out_dim: i32,
+        weight_row_stride: i32,
+        scale_stride: i32,
+        weight_block_size_y: i32,
+        weight_block_size_x: i32,
+        stream: candle_core::cuda::cudarc::driver::sys::CUstream,
+    );
+
+    pub(crate) fn launch_gemm_fp8_blockwise_kernel_f32(
+        d_weight: *const F8E4M3,
+        d_scale: *const f32,
+        d_input: *const f32,
+        d_output: *mut f32,
+        batch: i32,
+        in_dim: i32,
+        out_dim: i32,
         weight_row_stride: i32,
         scale_stride: i32,
         weight_block_size_y: i32,

--- a/mistralrs-quant/src/blockwise_fp8/ops.rs
+++ b/mistralrs-quant/src/blockwise_fp8/ops.rs
@@ -7,6 +7,10 @@ struct Fp8BlockwiseDequantize {
     out_ty: DType,
 }
 
+struct Fp8BlockwiseGemm {
+    weight_block_size: Vec<usize>,
+}
+
 impl Fp8BlockwiseDequantize {
     fn dispatch_dequant_blockwise<T: WithDType>(
         &self,
@@ -303,6 +307,145 @@ impl CustomOp2 for Fp8BlockwiseDequantize {
     }
 }
 
+impl CustomOp3 for Fp8BlockwiseGemm {
+    fn name(&self) -> &'static str {
+        "fp8-blockwise-gemm"
+    }
+
+    fn cpu_fwd(
+        &self,
+        _x: &CpuStorage,
+        _x_l: &candle_core::Layout,
+        _w: &CpuStorage,
+        _w_l: &candle_core::Layout,
+        _scale: &CpuStorage,
+        _scale_l: &candle_core::Layout,
+    ) -> candle_core::Result<(CpuStorage, candle_core::Shape)> {
+        candle_core::bail!("no cpu support for fp8 blockwise gemm")
+    }
+
+    #[cfg(feature = "cuda")]
+    fn cuda_fwd(
+        &self,
+        x_s: &candle_core::CudaStorage,
+        x_l: &candle_core::Layout,
+        w_s: &candle_core::CudaStorage,
+        w_l: &candle_core::Layout,
+        scale_s: &candle_core::CudaStorage,
+        scale_l: &candle_core::Layout,
+    ) -> Result<(candle_core::CudaStorage, candle_core::Shape)> {
+        use candle_core::{backend::BackendStorage, cuda::{cudarc::driver::DevicePtr, WrapErr}, CudaStorage};
+        use half::{bf16, f16};
+
+        use crate::blockwise_fp8::ffi;
+
+        if !ffi::HAVE_BLOCKWISE_GEMM_KERNELS {
+            candle_core::bail!("Do not have blockwise FP8 gemm kernels.");
+        }
+
+        if !(x_l.is_contiguous() && w_l.is_contiguous() && scale_l.is_contiguous()) {
+            candle_core::bail!("All inputs must be contiguous");
+        }
+
+        if w_l.dims().len() != 2 || scale_l.dims().len() != 2 || self.weight_block_size.len() != 2 {
+            candle_core::bail!("Unexpected dims");
+        }
+
+        if x_l.dims().len() != 2 {
+            candle_core::bail!("Expected x to be rank 2");
+        }
+
+        if x_l.dims()[1] != w_l.dims()[1] {
+            candle_core::bail!("Input dim mismatch");
+        }
+
+        let dev = x_s.device();
+
+        let x = x_s.as_cuda_slice::<f32>()?; // will cast later based on dtype
+        let w = w_s.as_cuda_slice::<F8E4M3>()?.slice(w_l.start_offset()..);
+        let scale = scale_s.as_cuda_slice::<f32>()?.slice(scale_l.start_offset()..);
+
+        let batch = x_l.dim(0)? as i32;
+        let in_dim = x_l.dim(1)? as i32;
+        let out_dim = w_l.dim(0)? as i32;
+        let weight_row_stride = w_l.stride()[0] as i32;
+        let scale_stride = scale_l.stride()[0] as i32;
+        let block_y = self.weight_block_size[0] as i32;
+        let block_x = self.weight_block_size[1] as i32;
+
+        let out_shape = candle_core::Shape::from_dims(&[batch as usize, out_dim as usize]);
+
+        let res = match x_s.dtype() {
+            DType::F16 => {
+                let x = x_s.as_cuda_slice::<f16>()?.slice(x_l.start_offset()..);
+                let output = dev.alloc_zeros::<f16>(out_shape.elem_count()).w()?;
+                unsafe {
+                    ffi::launch_gemm_fp8_blockwise_kernel_f16(
+                        (*w.device_ptr()) as *const _,
+                        (*scale.device_ptr()) as *const _,
+                        (*x.device_ptr()) as *const _,
+                        (*output.device_ptr()) as *mut _,
+                        batch,
+                        in_dim,
+                        out_dim,
+                        weight_row_stride,
+                        scale_stride,
+                        block_y,
+                        block_x,
+                        *dev.cu_stream(),
+                    )
+                };
+                CudaStorage::wrap_cuda_slice(output, dev.clone())
+            }
+            DType::BF16 => {
+                let x = x_s.as_cuda_slice::<bf16>()?.slice(x_l.start_offset()..);
+                let output = dev.alloc_zeros::<bf16>(out_shape.elem_count()).w()?;
+                unsafe {
+                    ffi::launch_gemm_fp8_blockwise_kernel_bf16(
+                        (*w.device_ptr()) as *const _,
+                        (*scale.device_ptr()) as *const _,
+                        (*x.device_ptr()) as *const _,
+                        (*output.device_ptr()) as *mut _,
+                        batch,
+                        in_dim,
+                        out_dim,
+                        weight_row_stride,
+                        scale_stride,
+                        block_y,
+                        block_x,
+                        *dev.cu_stream(),
+                    )
+                };
+                CudaStorage::wrap_cuda_slice(output, dev.clone())
+            }
+            DType::F32 => {
+                let x = x_s.as_cuda_slice::<f32>()?.slice(x_l.start_offset()..);
+                let output = dev.alloc_zeros::<f32>(out_shape.elem_count()).w()?;
+                unsafe {
+                    ffi::launch_gemm_fp8_blockwise_kernel_f32(
+                        (*w.device_ptr()) as *const _,
+                        (*scale.device_ptr()) as *const _,
+                        (*x.device_ptr()) as *const _,
+                        (*output.device_ptr()) as *mut _,
+                        batch,
+                        in_dim,
+                        out_dim,
+                        weight_row_stride,
+                        scale_stride,
+                        block_y,
+                        block_x,
+                        *dev.cu_stream(),
+                    )
+                };
+                CudaStorage::wrap_cuda_slice(output, dev.clone())
+            }
+            dt => candle_core::bail!("Unsupported dtype {dt:?} for fp8 blockwise gemm"),
+        };
+
+        Ok((res, out_shape))
+    }
+}
+
 /// FP8 blockwise dequantize.
 /// - Expects weight to be fp8
 /// - Expects inv_scales to be f32
@@ -319,6 +462,19 @@ pub fn fp8_blockwise_dequantize(
             weight_block_size,
             out_ty,
         },
+    )
+}
+
+pub fn fp8_blockwise_gemm(
+    x: &Tensor,
+    weight: &Tensor,
+    scales: &Tensor,
+    weight_block_size: Vec<usize>,
+) -> Result<Tensor> {
+    x.apply_op3(
+        weight,
+        scales,
+        Fp8BlockwiseGemm { weight_block_size },
     )
 }
 
@@ -562,14 +718,17 @@ mod tests {
 
         let truth = {
             let weight_dq =
-                ops::fp8_blockwise_dequantize(&weight, &scale, weight_block_size, DType::BF16)?;
+                ops::fp8_blockwise_dequantize(&weight, &scale, weight_block_size.clone(), DType::BF16)?;
 
             let lin_dq = Linear::new(weight_dq, None);
             lin_dq.forward(&xs)?
         };
 
-        // TODO: will be adding real blockwise fp8 gemm shortly ;)
-        assert_eq!((32, 7168), truth.dims2()?);
+        let test = ops::fp8_blockwise_gemm(&xs, &weight, &scale, weight_block_size)?;
+
+        assert_eq!(test.dims(), truth.dims());
+        let test = test.to_dtype(DType::BF16)?;
+        candle_core::test_util::assert_all_close(&test, &truth, 1e-2, 1e-2)?;
 
         Ok(())
     }


### PR DESCRIPTION
## Summary
- add CUDA kernels for blockwise FP8 matmul
- wire up new FFI and rust bindings
- provide helper `fp8_blockwise_gemm` and test
- compile new kernels only on CUDA >= 8.0

## Testing
- `cargo test -p mistralrs-quant test_blockwise_fp8_gemm --features=cuda` *(fails: failed to get `candle-core` as a dependency due to network issues)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for blockwise FP8 matrix multiplication (GEMM) on CUDA, enabling efficient computation with FP8 weights and multiple input/output precisions (FP16, BF16, FP32).
  - Introduced a new operation for blockwise FP8 GEMM, accessible via a public function.
- **Tests**
  - Added tests to validate the new blockwise FP8 GEMM operation against reference outputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->