### PR TITLE
Refactor Option references for model paths

### DIFF
--- a/mistralrs-core/src/kv_cache/rotating_cache.rs
+++ b/mistralrs-core/src/kv_cache/rotating_cache.rs
@@ -44,8 +44,8 @@ impl RotatingCache {
         self.max_seq_len
     }
 
-    pub fn all_data(&self) -> &Option<Tensor> {
-        &self.all_data
+    pub fn all_data(&self) -> Option<&Tensor> {
+        self.all_data.as_ref()
     }
 
     pub fn current_data(&self) -> Result<Option<Tensor>> {

--- a/mistralrs-core/src/kv_cache/single_cache.rs
+++ b/mistralrs-core/src/kv_cache/single_cache.rs
@@ -38,8 +38,8 @@ impl SingleCache {
         self.max_seq_len
     }
 
-    pub fn all_data(&self) -> &Option<Tensor> {
-        &self.all_data
+    pub fn all_data(&self) -> Option<&Tensor> {
+        self.all_data.as_ref()
     }
 
     pub fn current_data(&self) -> Result<Option<Tensor>> {

--- a/mistralrs-core/src/pipeline/ggml.rs
+++ b/mistralrs-core/src/pipeline/ggml.rs
@@ -347,15 +347,15 @@ impl Loader for GGMLLoader {
             serde_json::from_str(&fs::read_to_string(f).unwrap())
                 .expect("bos_token_id/eos_token_id missing in generation_config.json")
         });
+        let chat_template_explicit = paths
+            .get_chat_template_explicit()
+            .as_ref()
+            .map(|x| x.to_string_lossy().to_string());
         let chat_template = get_chat_template(
             paths,
-            &self.jinja_explicit,
-            &paths
-                .get_chat_template_explicit()
-                .as_ref()
-                .map(|x| x.to_string_lossy().to_string())
-                .clone(),
-            &self.chat_template,
+            self.jinja_explicit.as_ref(),
+            chat_template_explicit.as_ref(),
+            self.chat_template.as_ref(),
             None,
         );
 

--- a/mistralrs-core/src/pipeline/gguf.rs
+++ b/mistralrs-core/src/pipeline/gguf.rs
@@ -490,15 +490,15 @@ impl Loader for GGUFLoader {
             serde_json::from_str(&fs::read_to_string(f).unwrap())
                 .expect("bos_token_id/eos_token_id missing in generation_config.json")
         });
+        let chat_template_explicit = paths
+            .get_chat_template_explicit()
+            .as_ref()
+            .map(|x| x.to_string_lossy().to_string());
         let mut chat_template = get_chat_template(
             paths,
-            &self.jinja_explicit,
-            &paths
-                .get_chat_template_explicit()
-                .as_ref()
-                .map(|x| x.to_string_lossy().to_string())
-                .clone(),
-            &self.chat_template,
+            self.jinja_explicit.as_ref(),
+            chat_template_explicit.as_ref(),
+            self.chat_template.as_ref(),
             gguf_chat_template,
         );
 

--- a/mistralrs-core/src/pipeline/macros.rs
+++ b/mistralrs-core/src/pipeline/macros.rs
@@ -96,19 +96,19 @@ macro_rules! get_paths {
         let filenames = get_model_paths(
             revision.clone(),
             &$token_source,
-            &$quantized_model_id,
-            &$quantized_filename,
+            $quantized_model_id.as_ref(),
+            $quantized_filename.as_ref(),
             &api,
             &model_id,
             $loading_uqff,
         )?;
         let adapter_paths = get_xlora_paths(
             $this.model_id.clone(),
-            &$this.xlora_model_id,
-            &$this.lora_adapter_ids,
+            $this.xlora_model_id.as_ref(),
+            $this.lora_adapter_ids.as_ref(),
             &$token_source,
             revision.clone(),
-            &$this.xlora_order,
+            $this.xlora_order.as_ref(),
         )?;
         let gen_conf = if $crate::api_dir_list!(api, model_id)
             .collect::<Vec<_>>()
@@ -283,8 +283,8 @@ macro_rules! get_paths_gguf {
         let filenames = get_model_paths(
             revision.clone(),
             &$token_source,
-            &Some($quantized_model_id),
-            &Some($quantized_filenames),
+            Some(&$quantized_model_id),
+            Some(&$quantized_filenames),
             &api,
             &model_id,
             false, // Never loading UQFF
@@ -292,11 +292,11 @@ macro_rules! get_paths_gguf {
 
         let adapter_paths = get_xlora_paths(
             this_model_id.clone(),
-            &$this.xlora_model_id,
-            &$this.lora_adapter_ids,
+            $this.xlora_model_id.as_ref(),
+            $this.lora_adapter_ids.as_ref(),
             &$token_source,
             revision.clone(),
-            &$this.xlora_order,
+            $this.xlora_order.as_ref(),
         )?;
 
         let gen_conf = if $crate::api_dir_list!(api, model_id)

--- a/mistralrs-core/src/pipeline/normal.rs
+++ b/mistralrs-core/src/pipeline/normal.rs
@@ -636,15 +636,15 @@ impl Loader for NormalLoader {
                 .expect("bos_token_id/eos_token_id missing in generation_config.json")
         });
 
+        let chat_template_explicit = paths
+            .get_chat_template_explicit()
+            .as_ref()
+            .map(|x| x.to_string_lossy().to_string());
         let chat_template = get_chat_template(
             paths,
-            &self.jinja_explicit,
-            &paths
-                .get_chat_template_explicit()
-                .as_ref()
-                .map(|x| x.to_string_lossy().to_string())
-                .clone(),
-            &self.chat_template,
+            self.jinja_explicit.as_ref(),
+            chat_template_explicit.as_ref(),
+            self.chat_template.as_ref(),
             None,
         );
 

--- a/mistralrs-core/src/pipeline/paths.rs
+++ b/mistralrs-core/src/pipeline/paths.rs
@@ -54,11 +54,11 @@ pub enum AdapterPaths {
 
 pub fn get_xlora_paths(
     base_model_id: String,
-    xlora_model_id: &Option<String>,
-    lora_adapter_ids: &Option<Vec<String>>,
+    xlora_model_id: Option<&String>,
+    lora_adapter_ids: Option<&Vec<String>>,
     token_source: &TokenSource,
     revision: String,
-    xlora_order: &Option<Ordering>,
+    xlora_order: Option<&Ordering>,
 ) -> Result<AdapterPaths> {
     match (lora_adapter_ids, xlora_model_id, xlora_order) {
         (None, Some(xlora_id), Some(xlora_order)) => {
@@ -309,15 +309,15 @@ pub fn get_xlora_paths(
 pub fn get_model_paths(
     revision: String,
     token_source: &TokenSource,
-    quantized_model_id: &Option<String>,
-    quantized_filename: &Option<Vec<String>>,
+    quantized_model_id: Option<&String>,
+    quantized_filename: Option<&Vec<String>>,
     api: &ApiRepo,
     model_id: &Path,
     loading_from_uqff: bool,
 ) -> Result<Vec<PathBuf>> {
-    match &quantized_filename {
+    match quantized_filename {
         Some(names) => {
-            let id = quantized_model_id.as_ref().unwrap();
+            let id = quantized_model_id.unwrap();
             let mut files = Vec::new();
 
             for name in names {
@@ -407,9 +407,9 @@ pub fn get_model_paths(
 #[allow(clippy::borrowed_box)]
 pub(crate) fn get_chat_template(
     paths: &Box<dyn ModelPaths>,
-    jinja_explicit: &Option<String>,
-    chat_template_explicit: &Option<String>,
-    chat_template_fallback: &Option<String>,
+    jinja_explicit: Option<&String>,
+    chat_template_explicit: Option<&String>,
+    chat_template_fallback: Option<&String>,
     chat_template_ovrd: Option<String>,
 ) -> ChatTemplate {
     // Get template content, this may be overridden.
@@ -426,12 +426,10 @@ pub(crate) fn get_chat_template(
         }
         Some(fs::read_to_string(template_filename).expect("Loading chat template failed."))
     } else if chat_template_fallback
-        .as_ref()
         .is_some_and(|f| f.ends_with(".json"))
     {
         // User specified a file
         let template_filename = chat_template_fallback
-            .as_ref()
             .expect("A tokenizer config or chat template file path must be specified.");
         Some(fs::read_to_string(template_filename).expect("Loading chat template failed."))
     } else if chat_template_ovrd.is_some() {
@@ -512,7 +510,7 @@ pub(crate) fn get_chat_template(
             let mut deser: HashMap<String, Value> =
                 serde_json::from_str(&template_content.unwrap()).unwrap();
 
-            match chat_template_fallback.clone() {
+            match chat_template_fallback.cloned() {
                 Some(t) => {
                     info!("Loading specified loading chat template file at `{t}`.");
                     let templ: SpecifiedTemplate =

--- a/mistralrs-core/src/pipeline/paths.rs
+++ b/mistralrs-core/src/pipeline/paths.rs
@@ -425,9 +425,7 @@ pub(crate) fn get_chat_template(
             panic!("Template filename {template_filename:?} must end with `.json` or `.jinja`.");
         }
         Some(fs::read_to_string(template_filename).expect("Loading chat template failed."))
-    } else if chat_template_fallback
-        .is_some_and(|f| f.ends_with(".json"))
-    {
+    } else if chat_template_fallback.is_some_and(|f| f.ends_with(".json")) {
         // User specified a file
         let template_filename = chat_template_fallback
             .expect("A tokenizer config or chat template file path must be specified.");

--- a/mistralrs-core/src/pipeline/vision.rs
+++ b/mistralrs-core/src/pipeline/vision.rs
@@ -521,15 +521,15 @@ impl Loader for VisionLoader {
             serde_json::from_str(&fs::read_to_string(f).unwrap())
                 .expect("bos_token_id/eos_token_id missing in generation_config.json")
         });
+        let chat_template_explicit = paths
+            .get_chat_template_explicit()
+            .as_ref()
+            .map(|x| x.to_string_lossy().to_string());
         let chat_template = get_chat_template(
             paths,
-            &self.jinja_explicit,
-            &paths
-                .get_chat_template_explicit()
-                .as_ref()
-                .map(|x| x.to_string_lossy().to_string())
-                .clone(),
-            &self.chat_template,
+            self.jinja_explicit.as_ref(),
+            chat_template_explicit.as_ref(),
+            self.chat_template.as_ref(),
             None,
         );
 


### PR DESCRIPTION
## Summary
- adjust helper functions in `paths.rs` to accept `Option<&T>`
- update macros and loaders to use new signatures
- forward `Option` references when loading chat templates

## Testing
- `cargo check --workspace --quiet` *(fails: could not fetch `candle-core`)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Improved clarity and consistency by updating how optional values are passed and handled throughout the pipeline, including changes to method and function signatures for more direct access to referenced values.
  - Extracted and reused local variables for chat template handling, reducing inline expressions and enhancing code readability.
  - Adjusted internal option handling patterns to streamline parameter passing and dereferencing.

- **Bug Fixes**
  - Resolved potential confusion when accessing optional data by updating method return types for cache data retrieval, enabling more direct and intuitive access to contained data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->