### PR TITLE
Disable immediate isq if write_uqff

### DIFF
--- a/mistralrs-core/src/pipeline/normal.rs
+++ b/mistralrs-core/src/pipeline/normal.rs
@@ -470,6 +470,7 @@ impl Loader for NormalLoader {
         let mut loading_isq = if self.config.imatrix.is_none()
             && self.config.calibration_file.is_none()
             && !device.is_cuda()
+            && self.config.write_uqff.is_none()
         {
             let predicates = if matches!(self.config.organization, IsqOrganization::MoeExpertsOnly)
             {

--- a/mistralrs-core/src/pipeline/vision.rs
+++ b/mistralrs-core/src/pipeline/vision.rs
@@ -406,6 +406,7 @@ impl Loader for VisionLoader {
         let mut loading_isq = if self.config.imatrix.is_none()
             && self.config.calibration_file.is_none()
             && !device.is_cuda()
+            && self.config.write_uqff.is_none()
         {
             let predicates = self.inner.immediate_isq_predicates(&config)?;
             mistralrs_quant::set_immediate_isq(in_situ_quant, predicates);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved the logic for immediate in-situ quantization loading, ensuring it is only enabled when specific configuration options are unset. This prevents unintended behavior when certain options are active.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->