### PR TITLE
Fixes for cuda UQFF

### DIFF
--- a/mistralrs-core/src/pipeline/loaders/normal_loaders.rs
+++ b/mistralrs-core/src/pipeline/loaders/normal_loaders.rs
@@ -1470,7 +1470,8 @@ impl DeviceMappedModelLoader for Phi3Loader {
 
             let size_in = cfg.hidden_size;
             let head_dim = cfg.head_dim();
-            let op_size = head_dim * head_dim + 2 * cfg.num_key_value_heads * head_dim;
+            let op_size =
+                cfg.num_attention_heads * head_dim + 2 * cfg.num_key_value_heads * head_dim;
             let qkv_proj = size_in * op_size / weight_pack_factor;
             let o_proj =
                 (cfg.num_attention_heads * head_dim) * size_in / weight_pack_factor + size_in;

--- a/mistralrs-core/src/pipeline/loaders/vision_loaders.rs
+++ b/mistralrs-core/src/pipeline/loaders/vision_loaders.rs
@@ -656,7 +656,8 @@ impl DeviceMappedModelLoader for Phi3VLoader {
 
             let size_in = cfg.hidden_size;
             let head_dim = cfg.head_dim();
-            let op_size = head_dim * head_dim + 2 * cfg.num_key_value_heads * head_dim;
+            let op_size =
+                cfg.num_attention_heads * head_dim + 2 * cfg.num_key_value_heads * head_dim;
             let qkv_proj = size_in * op_size / weight_pack_factor;
             let o_proj = (cfg.num_attention_heads * head_dim) * size_in / weight_pack_factor;
 
@@ -3082,7 +3083,8 @@ impl DeviceMappedModelLoader for Phi4MMLoader {
 
             let size_in = cfg.hidden_size;
             let head_dim = cfg.head_dim();
-            let op_size = head_dim * head_dim + 2 * cfg.num_key_value_heads() * head_dim;
+            let op_size =
+                cfg.num_attention_heads * head_dim + 2 * cfg.num_key_value_heads() * head_dim;
             let qkv_proj = size_in * op_size / weight_pack_factor;
             let o_proj = (cfg.num_attention_heads * head_dim) * size_in / weight_pack_factor;
 

--- a/mistralrs-core/src/pipeline/normal.rs
+++ b/mistralrs-core/src/pipeline/normal.rs
@@ -729,7 +729,7 @@ impl Loader for NormalLoader {
         }
 
         // Only if loading from UQFF
-        if loading_isq || (self.config.topology.is_some() && self.config.from_uqff.is_none()) {
+        if (loading_isq || self.config.topology.is_some()) && self.config.from_uqff.is_none() {
             let imatrix_source = match (
                 self.config.imatrix.as_ref(),
                 self.config.calibration_file.is_some(),

--- a/mistralrs-core/src/pipeline/vision.rs
+++ b/mistralrs-core/src/pipeline/vision.rs
@@ -612,7 +612,7 @@ impl Loader for VisionLoader {
         }
 
         // Only if loading from UQFF
-        if loading_isq || (self.config.topology.is_some() && self.config.from_uqff.is_none()) {
+        if (loading_isq || self.config.topology.is_some()) && self.config.from_uqff.is_none() {
             let imatrix_source = match (
                 self.config.imatrix.as_ref(),
                 self.config.calibration_file.is_some(),

--- a/mistralrs-quant/src/lib.rs
+++ b/mistralrs-quant/src/lib.rs
@@ -361,42 +361,30 @@ impl IsqType {
     /// original size / pack factor = quantized size
     pub fn pack_factor(&self, dtype: DType) -> usize {
         match self {
-            Self::Q4_0 | Self::AFQ4 => {
-                (dtype.size_in_bytes() * GgmlDType::Q4_0.block_size()) / GgmlDType::Q4_0.type_size()
-            }
-            Self::Q4_1 => {
-                (dtype.size_in_bytes() * GgmlDType::Q4_1.block_size()) / GgmlDType::Q4_1.type_size()
-            }
-            Self::Q5_0 => {
-                (dtype.size_in_bytes() * GgmlDType::Q5_0.block_size()) / GgmlDType::Q5_0.type_size()
-            }
-            Self::Q5_1 => {
-                (dtype.size_in_bytes() * GgmlDType::Q5_1.block_size()) / GgmlDType::Q5_1.type_size()
-            }
-            Self::Q8_0 | Self::AFQ8 => {
-                (dtype.size_in_bytes() * GgmlDType::Q8_0.block_size()) / GgmlDType::Q8_0.type_size()
-            }
-            Self::Q8_1 => {
-                (dtype.size_in_bytes() * GgmlDType::Q8_1.block_size()) / GgmlDType::Q8_1.type_size()
-            }
-            Self::Q2K | Self::AFQ2 => {
-                (dtype.size_in_bytes() * GgmlDType::Q2K.block_size()) / GgmlDType::Q2K.type_size()
-            }
-            Self::Q3K | Self::AFQ3 => {
-                (dtype.size_in_bytes() * GgmlDType::Q3K.block_size()) / GgmlDType::Q3K.type_size()
-            }
-            Self::Q4K => {
-                (dtype.size_in_bytes() * GgmlDType::Q4K.block_size()) / GgmlDType::Q4K.type_size()
-            }
-            Self::Q5K => {
-                (dtype.size_in_bytes() * GgmlDType::Q5K.block_size()) / GgmlDType::Q5K.type_size()
-            }
-            Self::Q6K | Self::AFQ6 => {
-                (dtype.size_in_bytes() * GgmlDType::Q6K.block_size()) / GgmlDType::Q6K.type_size()
-            }
-            Self::Q8K => {
-                (dtype.size_in_bytes() * GgmlDType::Q8K.block_size()) / GgmlDType::Q8K.type_size()
-            }
+            Self::Q4_0 | Self::AFQ4 => (dtype.size_in_bytes() * GgmlDType::Q4_0.block_size())
+                .div_ceil(GgmlDType::Q4_0.type_size()),
+            Self::Q4_1 => (dtype.size_in_bytes() * GgmlDType::Q4_1.block_size())
+                .div_ceil(GgmlDType::Q4_1.type_size()),
+            Self::Q5_0 => (dtype.size_in_bytes() * GgmlDType::Q5_0.block_size())
+                .div_ceil(GgmlDType::Q5_0.type_size()),
+            Self::Q5_1 => (dtype.size_in_bytes() * GgmlDType::Q5_1.block_size())
+                .div_ceil(GgmlDType::Q5_1.type_size()),
+            Self::Q8_0 | Self::AFQ8 => (dtype.size_in_bytes() * GgmlDType::Q8_0.block_size())
+                .div_ceil(GgmlDType::Q8_0.type_size()),
+            Self::Q8_1 => (dtype.size_in_bytes() * GgmlDType::Q8_1.block_size())
+                .div_ceil(GgmlDType::Q8_1.type_size()),
+            Self::Q2K | Self::AFQ2 => (dtype.size_in_bytes() * GgmlDType::Q2K.block_size())
+                .div_ceil(GgmlDType::Q2K.type_size()),
+            Self::Q3K | Self::AFQ3 => (dtype.size_in_bytes() * GgmlDType::Q3K.block_size())
+                .div_ceil(GgmlDType::Q3K.type_size()),
+            Self::Q4K => (dtype.size_in_bytes() * GgmlDType::Q4K.block_size())
+                .div_ceil(GgmlDType::Q4K.type_size()),
+            Self::Q5K => (dtype.size_in_bytes() * GgmlDType::Q5K.block_size())
+                .div_ceil(GgmlDType::Q5K.type_size()),
+            Self::Q6K | Self::AFQ6 => (dtype.size_in_bytes() * GgmlDType::Q6K.block_size())
+                .div_ceil(GgmlDType::Q6K.type_size()),
+            Self::Q8K => (dtype.size_in_bytes() * GgmlDType::Q8K.block_size())
+                .div_ceil(GgmlDType::Q8K.type_size()),
             // Estimates
             Self::HQQ4 => 4,
             Self::HQQ8 => 2,

--- a/mistralrs/examples/uqff/main.rs
+++ b/mistralrs/examples/uqff/main.rs
@@ -1,7 +1,6 @@
 use anyhow::Result;
 use mistralrs::{
-    IsqType, PagedAttentionMetaBuilder, RequestBuilder, TextMessageRole, TextMessages,
-    UqffTextModelBuilder,
+    PagedAttentionMetaBuilder, RequestBuilder, TextMessageRole, TextMessages, UqffTextModelBuilder,
 };
 
 #[tokio::main]
@@ -11,7 +10,6 @@ async fn main() -> Result<()> {
         vec!["phi3.5-mini-instruct-q8_0.uqff".into()],
     )
     .into_inner()
-    .with_isq(IsqType::Q8_0)
     .with_logging()
     .with_paged_attn(|| PagedAttentionMetaBuilder::default().build())?
     .build()

--- a/mistralrs/src/text_model.rs
+++ b/mistralrs/src/text_model.rs
@@ -330,12 +330,17 @@ impl TextModelBuilder {
                     .get_metadata()
                     .cache_config
                     .as_ref()
-                    .unwrap()
-                    .clone();
+                    .cloned();
 
-                SchedulerConfig::PagedAttentionMeta {
-                    max_num_seqs: self.max_num_seqs,
-                    config,
+                if let Some(config) = config {
+                    SchedulerConfig::PagedAttentionMeta {
+                        max_num_seqs: self.max_num_seqs,
+                        config,
+                    }
+                } else {
+                    SchedulerConfig::DefaultScheduler {
+                        method: DefaultSchedulerMethod::Fixed(self.max_num_seqs.try_into()?),
+                    }
                 }
             }
             None => SchedulerConfig::DefaultScheduler {

--- a/mistralrs/src/vision_model.rs
+++ b/mistralrs/src/vision_model.rs
@@ -273,12 +273,17 @@ impl VisionModelBuilder {
                     .get_metadata()
                     .cache_config
                     .as_ref()
-                    .unwrap()
-                    .clone();
+                    .cloned();
 
-                SchedulerConfig::PagedAttentionMeta {
-                    max_num_seqs: self.max_num_seqs,
-                    config,
+                if let Some(config) = config {
+                    SchedulerConfig::PagedAttentionMeta {
+                        max_num_seqs: self.max_num_seqs,
+                        config,
+                    }
+                } else {
+                    SchedulerConfig::DefaultScheduler {
+                        method: DefaultSchedulerMethod::Fixed(self.max_num_seqs.try_into()?),
+                    }
                 }
             }
             None => SchedulerConfig::DefaultScheduler {


### PR DESCRIPTION
Fixes #1351.

- Fix Phi 3 device mapping code
- Fix edge-cases in ISQ pack factor calculation, ISQ+UQFF on CUDA, and paged attention device-map-related disable.
- 