### PR TITLE
Add a script for server benchmarking

### DIFF
--- a/examples/server/chat.py
+++ b/examples/server/chat.py
@@ -28,7 +28,7 @@ def log_response(response: httpx.Response):
         print(f"    {key}: {value}")
 
 
-client = OpenAI(api_key="foobar", base_url="http://localhost:1234/v1/")
+client = OpenAI(api_key="foobar", base_url="http://localhost:8080/v1/")
 
 # Enable this to log requests and responses
 # client._client = httpx.Client(

--- a/mistralrs-core/src/engine/logger.rs
+++ b/mistralrs-core/src/engine/logger.rs
@@ -12,6 +12,8 @@ pub struct IntervalLogger {
     prefix_cache_hits: Arc<AtomicUsize>,
     tokens_processed: Arc<AtomicUsize>,
     total_new_seqs: Arc<AtomicUsize>,
+    num_running: Arc<AtomicUsize>,
+    num_waiting: Arc<AtomicUsize>,
 }
 
 impl IntervalLogger {
@@ -21,11 +23,15 @@ impl IntervalLogger {
         let tokens_processed = Arc::new(AtomicUsize::new(0));
         let total_new_seqs = Arc::new(AtomicUsize::new(0));
         let enable_logging = Arc::new(AtomicBool::new(false));
+        let num_running = Arc::new(AtomicUsize::new(0));
+        let num_waiting = Arc::new(AtomicUsize::new(0));
 
         let t_prefix_cache_hits = prefix_cache_hits.clone();
         let t_tokens_processed = tokens_processed.clone();
         let t_total_new_seqs = total_new_seqs.clone();
         let t_enable_logging = enable_logging.clone();
+        let t_num_running = num_running.clone();
+        let t_num_waiting = num_waiting.clone();
         thread::spawn(move || {
             // Start the actual logging
             loop {
@@ -37,10 +43,12 @@ impl IntervalLogger {
                 let total_new_seqs = t_total_new_seqs.load(Ordering::Relaxed);
                 let prefix_cache_hits = t_prefix_cache_hits.load(Ordering::Relaxed);
                 let tokens_processed = t_tokens_processed.swap(0, Ordering::Relaxed);
+                let num_running = t_num_running.load(Ordering::Relaxed);
+                let num_waiting = t_num_waiting.load(Ordering::Relaxed);
 
                 if total_new_seqs != 0 && tokens_processed != 0 {
                     info!(
-                        "Throughput (T/s) {:.2}, Prefix cache hitrate {:.2}%",
+                        "Throughput (T/s) {:.2}, Prefix cache hitrate {:.2}%, {num_running} running, {num_waiting} waiting",
                         tokens_processed as f64 / interval.as_secs_f64(),
                         100. * prefix_cache_hits as f64 / total_new_seqs as f64,
                     );
@@ -53,6 +61,8 @@ impl IntervalLogger {
             tokens_processed,
             total_new_seqs,
             enable_logging,
+            num_running,
+            num_waiting,
         }
     }
 
@@ -71,5 +81,13 @@ impl IntervalLogger {
 
     pub fn add_prefix_cache_hit(&self) {
         self.prefix_cache_hits.fetch_add(1, Ordering::Relaxed);
+    }
+
+    pub fn set_num_running(&self, running: usize) {
+        self.num_running.store(running, Ordering::Relaxed);
+    }
+
+    pub fn set_num_waiting(&self, waiting: usize) {
+        self.num_waiting.store(waiting, Ordering::Relaxed);
     }
 }

--- a/mistralrs-core/src/engine/mod.rs
+++ b/mistralrs-core/src/engine/mod.rs
@@ -14,7 +14,7 @@ use crate::{
 };
 use interprocess::local_socket::{traits::Listener, ListenerOptions};
 use llguidance::ParserFactory;
-use logger::IntervalLogger;
+pub use logger::IntervalLogger;
 use once_cell::sync::Lazy;
 use rand::SeedableRng;
 use rand_isaac::Isaac64Rng;
@@ -172,7 +172,7 @@ impl Engine {
 
             let run_start = Instant::now();
             let mut scheduler = get_mut_arcmutex!(self.scheduler);
-            let scheduled = scheduler.schedule();
+            let scheduled = scheduler.schedule(&self.logger);
 
             match scheduled {
                 SchedulerOutput::DefaultScheduler {

--- a/mistralrs-core/src/models/deepseek2.rs
+++ b/mistralrs-core/src/models/deepseek2.rs
@@ -93,6 +93,7 @@ pub struct DeepSeekV2Config {
     pub(crate) kv_lora_rank: usize,
     pub(crate) v_head_dim: usize,
     pub(crate) qk_nope_head_dim: usize,
+    #[serde(alias = "quantization")]
     pub(crate) quantization_config: Option<QuantizedConfig>,
     pub(crate) n_group: usize,
     pub(crate) topk_group: usize,

--- a/mistralrs-core/src/models/deepseek2.rs
+++ b/mistralrs-core/src/models/deepseek2.rs
@@ -789,7 +789,7 @@ impl DeepSeekV2 {
             ReplicatedLayer::new(
                 cfg.hidden_size,
                 cfg.vocab_size,
-                &None,
+                &cfg.quantization_config,
                 false,
                 mapper.set_nm_device(vb.pp("lm_head"), normal_loading_metadata.loading_isq),
             )?

--- a/mistralrs-core/src/models/deepseek3.rs
+++ b/mistralrs-core/src/models/deepseek3.rs
@@ -842,7 +842,7 @@ impl DeepSeekV3 {
             ReplicatedLayer::new(
                 cfg.hidden_size,
                 cfg.vocab_size,
-                &None,
+                &cfg.quantization_config,
                 false,
                 mapper.set_nm_device(vb.pp("lm_head"), normal_loading_metadata.loading_isq),
             )?

--- a/mistralrs-core/src/models/deepseek3.rs
+++ b/mistralrs-core/src/models/deepseek3.rs
@@ -93,6 +93,7 @@ pub struct DeepSeekV3Config {
     pub(crate) kv_lora_rank: usize,
     pub(crate) v_head_dim: usize,
     pub(crate) qk_nope_head_dim: usize,
+    #[serde(alias = "quantization")]
     pub(crate) quantization_config: Option<QuantizedConfig>,
     pub(crate) n_group: usize,
     pub(crate) topk_group: usize,

--- a/mistralrs-core/src/models/gemma.rs
+++ b/mistralrs-core/src/models/gemma.rs
@@ -50,6 +50,7 @@ pub struct Config {
 
     #[serde(default = "default_max_position_embeddings")]
     pub max_position_embeddings: usize,
+    #[serde(alias = "quantization")]
     pub quantization_config: Option<QuantizedConfig>,
     #[serde(default = "word_emb_default")]
     #[allow(dead_code)]

--- a/mistralrs-core/src/models/gemma2.rs
+++ b/mistralrs-core/src/models/gemma2.rs
@@ -44,6 +44,7 @@ pub struct Config {
     pub final_logit_softcapping: Option<f64>,
     pub query_pre_attn_scalar: usize,
     pub max_position_embeddings: usize,
+    #[serde(alias = "quantization")]
     pub quantization_config: Option<QuantizedConfig>,
     #[allow(dead_code)]
     pub tie_word_embeddings: bool,

--- a/mistralrs-core/src/models/llama.rs
+++ b/mistralrs-core/src/models/llama.rs
@@ -44,6 +44,7 @@ pub struct Config {
     pub rope_theta: f32,
     pub max_position_embeddings: usize,
     pub rope_scaling: Option<Llama3RopeConfig>,
+    #[serde(alias = "quantization")]
     pub quantization_config: Option<QuantizedConfig>,
     #[serde(default = "word_emb_default")]
     pub tie_word_embeddings: bool,

--- a/mistralrs-core/src/models/llama.rs
+++ b/mistralrs-core/src/models/llama.rs
@@ -382,7 +382,7 @@ impl Llama {
             ReplicatedLayer::new(
                 cfg.hidden_size,
                 cfg.vocab_size,
-                &None,
+                &cfg.quantization_config,
                 false,
                 mapper.set_nm_device(vb_lm_head, normal_loading_metadata.loading_isq),
             )?

--- a/mistralrs-core/src/models/mistral.rs
+++ b/mistralrs-core/src/models/mistral.rs
@@ -448,7 +448,7 @@ impl Model {
             ReplicatedLayer::new(
                 cfg.hidden_size,
                 cfg.vocab_size,
-                &None,
+                &cfg.quantization_config,
                 false,
                 mapper.set_nm_device(vb_lm_head, normal_loading_metadata.loading_isq),
             )?

--- a/mistralrs-core/src/models/mistral.rs
+++ b/mistralrs-core/src/models/mistral.rs
@@ -42,6 +42,7 @@ pub struct Config {
     pub(crate) rope_theta: f64,
     pub(crate) sliding_window: Option<usize>,
     pub(crate) head_dim: Option<usize>,
+    #[serde(alias = "quantization")]
     pub(crate) quantization_config: Option<QuantizedConfig>,
     #[serde(default = "tie_word_embeddings")]
     pub(crate) tie_word_embeddings: bool,

--- a/mistralrs-core/src/models/mixtral.rs
+++ b/mistralrs-core/src/models/mixtral.rs
@@ -581,7 +581,7 @@ impl Model {
             ReplicatedLayer::new(
                 cfg.hidden_size,
                 cfg.vocab_size,
-                &None,
+                &cfg.quantization_config,
                 false,
                 mapper.set_nm_device(vb.pp("lm_head"), normal_loading_metadata.loading_isq),
             )?

--- a/mistralrs-core/src/models/mixtral.rs
+++ b/mistralrs-core/src/models/mixtral.rs
@@ -45,6 +45,7 @@ pub struct Config {
     pub(crate) sliding_window: Option<usize>,
     pub(crate) num_experts_per_tok: usize,
     pub(crate) num_local_experts: usize,
+    #[serde(alias = "quantization")]
     pub(crate) quantization_config: Option<QuantizedConfig>,
     #[serde(default = "word_emb_default")]
     pub(crate) tie_word_embeddings: bool,

--- a/mistralrs-core/src/models/phi2.rs
+++ b/mistralrs-core/src/models/phi2.rs
@@ -527,7 +527,7 @@ impl Model {
             ReplicatedLayer::new(
                 cfg.hidden_size,
                 cfg.vocab_size,
-                &None,
+                &cfg.quantization_config,
                 false,
                 mapper.set_nm_device(vb.pp("lm_head"), normal_loading_metadata.loading_isq),
             )?

--- a/mistralrs-core/src/models/phi2.rs
+++ b/mistralrs-core/src/models/phi2.rs
@@ -51,6 +51,7 @@ pub struct Config {
     pub(crate) rope_theta: f32,
     pub(crate) partial_rotary_factor: f64,
     pub(crate) qk_layernorm: bool,
+    #[serde(alias = "quantization")]
     pub(crate) quantization_config: Option<QuantizedConfig>,
     #[serde(default = "word_emb_default")]
     pub(crate) tie_word_embeddings: bool,

--- a/mistralrs-core/src/models/phi3.rs
+++ b/mistralrs-core/src/models/phi3.rs
@@ -49,6 +49,7 @@ pub struct Config {
     pub max_position_embeddings: usize,
     pub sliding_window: Option<usize>,
     pub original_max_position_embeddings: usize,
+    #[serde(alias = "quantization")]
     pub quantization_config: Option<QuantizedConfig>,
     #[serde(default = "word_emb_default")]
     pub tie_word_embeddings: bool,

--- a/mistralrs-core/src/models/phi3_5_moe.rs
+++ b/mistralrs-core/src/models/phi3_5_moe.rs
@@ -658,7 +658,7 @@ impl Model {
             ReplicatedLayer::new(
                 cfg.hidden_size,
                 cfg.vocab_size,
-                &None,
+                &cfg.quantization_config,
                 cfg.lm_head_bias,
                 mapper.set_nm_device(vb.pp("lm_head"), normal_loading_metadata.loading_isq),
             )?

--- a/mistralrs-core/src/models/phi3_5_moe.rs
+++ b/mistralrs-core/src/models/phi3_5_moe.rs
@@ -45,6 +45,8 @@ pub struct Config {
     pub(crate) max_position_embeddings: usize,
     pub(crate) sliding_window: Option<usize>,
     pub(crate) original_max_position_embeddings: usize,
+
+    #[serde(alias = "quantization")]
     pub(crate) quantization_config: Option<QuantizedConfig>,
     pub(crate) lm_head_bias: bool,
     pub(crate) attention_bias: bool,

--- a/mistralrs-core/src/models/qwen2.rs
+++ b/mistralrs-core/src/models/qwen2.rs
@@ -420,7 +420,7 @@ impl Model {
             ReplicatedLayer::new(
                 cfg.hidden_size,
                 cfg.vocab_size,
-                &None,
+                &cfg.quantization_config,
                 false,
                 mapper.set_nm_device(vb.pp("lm_head"), normal_loading_metadata.loading_isq),
             )?

--- a/mistralrs-core/src/models/qwen2.rs
+++ b/mistralrs-core/src/models/qwen2.rs
@@ -40,6 +40,7 @@ pub struct Config {
     pub rope_theta: f64,
     pub rms_norm_eps: f64,
     pub hidden_act: Activation,
+    #[serde(alias = "quantization")]
     pub quantization_config: Option<QuantizedConfig>,
     #[serde(default = "word_emb_default")]
     pub tie_word_embeddings: bool,

--- a/mistralrs-core/src/models/qwen3.rs
+++ b/mistralrs-core/src/models/qwen3.rs
@@ -489,7 +489,7 @@ impl Model {
             ReplicatedLayer::new(
                 cfg.hidden_size,
                 cfg.vocab_size,
-                &None,
+                &cfg.quantization_config,
                 false,
                 mapper.set_nm_device(vb_lm_head, normal_loading_metadata.loading_isq),
             )?

--- a/mistralrs-core/src/models/qwen3.rs
+++ b/mistralrs-core/src/models/qwen3.rs
@@ -56,6 +56,7 @@ pub struct Config {
     pub(crate) rope_theta: f64,
     pub(crate) sliding_window: Option<usize>,
     pub(crate) head_dim: Option<usize>,
+    #[serde(alias = "quantization")]
     pub(crate) quantization_config: Option<QuantizedConfig>,
     #[serde(default = "tie_word_embeddings")]
     pub(crate) tie_word_embeddings: bool,

--- a/mistralrs-core/src/models/qwen3_moe.rs
+++ b/mistralrs-core/src/models/qwen3_moe.rs
@@ -692,7 +692,7 @@ impl Model {
             ReplicatedLayer::new(
                 cfg.hidden_size,
                 cfg.vocab_size,
-                &None,
+                &cfg.quantization_config,
                 false,
                 mapper.set_nm_device(vb_lm_head, normal_loading_metadata.loading_isq),
             )?

--- a/mistralrs-core/src/models/qwen3_moe.rs
+++ b/mistralrs-core/src/models/qwen3_moe.rs
@@ -54,6 +54,7 @@ pub struct Config {
     pub(crate) rope_theta: f64,
     pub(crate) sliding_window: Option<usize>,
     pub(crate) head_dim: Option<usize>,
+    #[serde(alias = "quantization")]
     pub(crate) quantization_config: Option<QuantizedConfig>,
     #[serde(default = "tie_word_embeddings")]
     pub(crate) tie_word_embeddings: bool,

--- a/mistralrs-core/src/models/starcoder2.rs
+++ b/mistralrs-core/src/models/starcoder2.rs
@@ -42,6 +42,7 @@ pub struct Config {
     pub(crate) rope_theta: f64,
     pub(crate) use_bias: bool,
     pub(crate) sliding_window: Option<usize>,
+    #[serde(alias = "quantization")]
     pub(crate) quantization_config: Option<QuantizedConfig>,
     #[serde(default = "word_emb_default")]
     #[allow(dead_code)]

--- a/mistralrs-core/src/scheduler/default_scheduler.rs
+++ b/mistralrs-core/src/scheduler/default_scheduler.rs
@@ -5,7 +5,7 @@ use std::{
 };
 
 use crate::{
-    engine::TERMINATE_ALL_NEXT_STEP,
+    engine::{IntervalLogger, TERMINATE_ALL_NEXT_STEP},
     paged_attention::{BlockEngine, BlockTables},
     sequence::{Sequence, SequenceState, StopReason},
 };
@@ -203,7 +203,7 @@ impl<Backer: FcfsBacker> DefaultScheduler<Backer> {
     }
 
     /// Schedule all sequences based on their state and the available space.
-    pub fn schedule(&mut self) -> DefaultSchedulerOutput {
+    pub fn schedule(&mut self, logger: &IntervalLogger) -> DefaultSchedulerOutput {
         // Filter out all done sequences
         let running = std::mem::take(&mut self.running);
         let mut waiting = std::mem::take(&mut self.waiting);
@@ -215,6 +215,8 @@ impl<Backer: FcfsBacker> DefaultScheduler<Backer> {
         match (waiting.len(), running.len()) {
             (0, 0) => {
                 self.running = running;
+                logger.set_num_running(self.running.len());
+                logger.set_num_waiting(self.waiting.len());
                 return DefaultSchedulerOutput {
                     prompt: vec![].into(),
                     completion: vec![].into(),
@@ -228,6 +230,8 @@ impl<Backer: FcfsBacker> DefaultScheduler<Backer> {
                 self.waiting = Backer::new();
                 let running = std::mem::take(&mut self.running);
                 self.running = self.bucket_and_waitlist_seqs(running);
+                logger.set_num_running(self.running.len());
+                logger.set_num_waiting(self.waiting.len());
                 return DefaultSchedulerOutput {
                     prompt: self.running.iter_mut().collect::<Vec<_>>().into(),
                     completion: vec![].into(),
@@ -241,6 +245,8 @@ impl<Backer: FcfsBacker> DefaultScheduler<Backer> {
                         .for_each(|seq| seq.set_state(SequenceState::Done(StopReason::Canceled)));
                     TERMINATE_ALL_NEXT_STEP.store(false, Ordering::SeqCst);
                 }
+                logger.set_num_running(self.running.len());
+                logger.set_num_waiting(self.waiting.len());
                 return DefaultSchedulerOutput {
                     prompt: vec![].into(),
                     completion: self.running.iter_mut().collect::<Vec<_>>().into(),
@@ -275,6 +281,9 @@ impl<Backer: FcfsBacker> DefaultScheduler<Backer> {
         self.running = running;
         self.waiting = new_waiting;
 
+        logger.set_num_running(self.running.len());
+        logger.set_num_waiting(self.waiting.len());
+
         let mut completion = Vec::new();
         let mut prompt = Vec::new();
         for seq in &mut self.running {
@@ -299,9 +308,9 @@ impl<Backer: FcfsBacker> DefaultScheduler<Backer> {
 }
 
 impl Scheduler for DefaultScheduler<VecDeque<Sequence>> {
-    fn schedule(&mut self) -> SchedulerOutput<'_> {
+    fn schedule(&mut self, logger: &IntervalLogger) -> SchedulerOutput<'_> {
         SchedulerOutput::DefaultScheduler {
-            output: self.schedule(),
+            output: self.schedule(logger),
         }
     }
     fn waiting_len(&self) -> usize {

--- a/mistralrs-core/src/scheduler/mod.rs
+++ b/mistralrs-core/src/scheduler/mod.rs
@@ -6,6 +6,7 @@ pub use default_scheduler::{DefaultScheduler, DefaultSchedulerMethod, DefaultSch
 use tokio::sync::Mutex;
 
 use crate::{
+    engine::IntervalLogger,
     paged_attention::{
         BlockEngine, BlockTables, CacheConfig, PagedAttentionScheduler,
         PagedAttentionSchedulerConfig, PagedAttentionSchedulerOutput,
@@ -51,7 +52,7 @@ pub enum SchedulerOutput<'a> {
 }
 
 pub trait Scheduler: Send + Sync {
-    fn schedule(&mut self) -> SchedulerOutput<'_>;
+    fn schedule(&mut self, logger: &IntervalLogger) -> SchedulerOutput<'_>;
     fn waiting_len(&self) -> usize;
     fn running_len(&self) -> usize;
     fn add_seq(&mut self, seq: Sequence);

--- a/mistralrs-core/src/vision_models/gemma3/config.rs
+++ b/mistralrs-core/src/vision_models/gemma3/config.rs
@@ -48,6 +48,7 @@ pub struct Gemma3TextConfig {
     pub query_pre_attn_scalar: usize,
     #[serde(default = "max_position_embeddings")]
     pub max_position_embeddings: usize,
+    #[serde(alias = "quantization")]
     pub quantization_config: Option<QuantizedConfig>,
     #[serde(default = "tie_word_embeddings")]
     pub tie_word_embeddings: bool,

--- a/mistralrs-core/src/vision_models/gemma3/text.rs
+++ b/mistralrs-core/src/vision_models/gemma3/text.rs
@@ -491,7 +491,7 @@ impl TextModel {
             ReplicatedLayer::new(
                 cfg.hidden_size,
                 cfg.vocab_size,
-                &None,
+                &cfg.quantization_config,
                 false,
                 mapper.set_nm_device(vb.pp("lm_head"), normal_loading_metadata.loading_isq),
             )?

--- a/mistralrs-core/src/vision_models/llama4/config.rs
+++ b/mistralrs-core/src/vision_models/llama4/config.rs
@@ -24,6 +24,7 @@ pub struct TextConfig {
     pub rope_theta: f32,
     pub max_position_embeddings: usize,
     pub rope_scaling: Option<Llama3RopeConfig>,
+    #[serde(alias = "quantization")]
     pub quantization_config: Option<QuantizedConfig>,
     #[serde(default = "word_emb_default")]
     pub tie_word_embeddings: bool,

--- a/mistralrs-core/src/vision_models/llama4/text.rs
+++ b/mistralrs-core/src/vision_models/llama4/text.rs
@@ -611,7 +611,7 @@ impl TextModel {
             ReplicatedLayer::new(
                 cfg.hidden_size,
                 cfg.vocab_size,
-                &None,
+                &cfg.quantization_config,
                 false,
                 mapper.set_nm_device(vb_lm_head, normal_loading_metadata.loading_isq),
             )?

--- a/mistralrs-core/src/vision_models/mllama/config.rs
+++ b/mistralrs-core/src/vision_models/mllama/config.rs
@@ -101,6 +101,7 @@ pub struct MLlamaTextConfig {
     pub(crate) max_position_embeddings: usize,
     pub(crate) tie_word_embeddings: bool,
     pub(crate) cross_attention_layers: Vec<usize>,
+    #[serde(alias = "quantization")]
     pub(crate) quantization_config: Option<QuantizedConfig>,
 }
 

--- a/mistralrs-core/src/vision_models/mllama/text.rs
+++ b/mistralrs-core/src/vision_models/mllama/text.rs
@@ -577,7 +577,7 @@ impl MLlamaTextModel {
             ReplicatedLayer::new(
                 cfg.hidden_size,
                 cfg.vocab_size,
-                &None,
+                &cfg.quantization_config,
                 false,
                 mapper.set_nm_device(vb.pp("lm_head"), false),
             )?

--- a/mistralrs-core/src/vision_models/phi3/mod.rs
+++ b/mistralrs-core/src/vision_models/phi3/mod.rs
@@ -1027,7 +1027,7 @@ impl Model {
             ReplicatedLayer::new(
                 cfg.hidden_size,
                 cfg.vocab_size,
-                &None,
+                &cfg.quantization_config,
                 false,
                 mapper.set_nm_device(vb.pp("lm_head"), normal_loading_metadata.loading_isq),
             )?

--- a/mistralrs-core/src/vision_models/phi3/mod.rs
+++ b/mistralrs-core/src/vision_models/phi3/mod.rs
@@ -75,6 +75,7 @@ pub struct Config {
     pub original_max_position_embeddings: usize,
     pub embd_layer: EmbedLayerConfig,
     pub img_processor: ImageProcessorConfig,
+    #[serde(alias = "quantization")]
     pub quantization_config: Option<QuantizedConfig>,
     #[serde(default = "word_emb_default")]
     pub tie_word_embeddings: bool,

--- a/mistralrs-core/src/vision_models/phi4/config.rs
+++ b/mistralrs-core/src/vision_models/phi4/config.rs
@@ -67,6 +67,7 @@ pub struct Phi4MMConfig {
     // pub audio_processor: Option<String>,
     pub vision_lora: StaticLoraConfig,
     pub speech_lora: StaticLoraConfig,
+    #[serde(alias = "quantization")]
     pub quantization_config: Option<QuantizedConfig>,
 }
 

--- a/mistralrs-core/src/vision_models/phi4/mod.rs
+++ b/mistralrs-core/src/vision_models/phi4/mod.rs
@@ -409,7 +409,7 @@ impl Phi4MMModel {
             ReplicatedLayer::new(
                 cfg.hidden_size,
                 cfg.vocab_size,
-                &None,
+                &cfg.quantization_config,
                 false,
                 mapper.set_nm_device(vb.pp("lm_head"), normal_loading_metadata.loading_isq),
             )?

--- a/mistralrs-core/src/vision_models/qwen2_5_vl/config.rs
+++ b/mistralrs-core/src/vision_models/qwen2_5_vl/config.rs
@@ -73,6 +73,7 @@ pub struct Config {
     pub sliding_window: Option<usize>,
     pub vision_config: VisionConfig,
     pub rope_scaling: MRopeScaling,
+    #[serde(alias = "quantization")]
     pub quantization_config: Option<QuantizedConfig>,
     pub image_token_id: u32,
     pub video_token_id: u32,

--- a/mistralrs-core/src/vision_models/qwen2_5_vl/text.rs
+++ b/mistralrs-core/src/vision_models/qwen2_5_vl/text.rs
@@ -396,7 +396,7 @@ impl Qwen2_5VLTextModel {
             ReplicatedLayer::new(
                 cfg.hidden_size,
                 cfg.vocab_size,
-                &None,
+                &cfg.quantization_config,
                 false,
                 mapper.set_nm_device(vb.pp("lm_head"), normal_loading_metadata.loading_isq),
             )?

--- a/mistralrs-core/src/vision_models/qwen2vl/config.rs
+++ b/mistralrs-core/src/vision_models/qwen2vl/config.rs
@@ -47,6 +47,7 @@ pub struct Config {
     pub sliding_window: Option<usize>,
     pub vision_config: VisionConfig,
     pub rope_scaling: MRopeScaling,
+    #[serde(alias = "quantization")]
     pub quantization_config: Option<QuantizedConfig>,
     pub image_token_id: u32,
     pub video_token_id: u32,

--- a/mistralrs-core/src/vision_models/qwen2vl/text.rs
+++ b/mistralrs-core/src/vision_models/qwen2vl/text.rs
@@ -392,7 +392,7 @@ impl Qwen2VLTextModel {
             ReplicatedLayer::new(
                 cfg.hidden_size,
                 cfg.vocab_size,
-                &None,
+                &cfg.quantization_config,
                 false,
                 mapper.set_nm_device(vb.pp("lm_head"), normal_loading_metadata.loading_isq),
             )?

--- a/mistralrs-quant/kernels/marlin/marlin_kernel.cu
+++ b/mistralrs-quant/kernels/marlin/marlin_kernel.cu
@@ -70,7 +70,6 @@ template <int lut> __device__ inline int lop3(int a, int b, int c) {
   return res;
 }
 
-
 template <typename scalar_t, ScalarTypeID w_type_id>
 __device__ inline typename ScalarType<scalar_t>::FragB dequant(int q);
 
@@ -79,10 +78,10 @@ __device__ inline typename ScalarType<scalar_t>::FragB dequant(int q);
 // changes:
 // https://github.com/NVIDIA/FasterTransformer/blob/main/src/fastertransformer/cutlass_extensions/include/cutlass_extensions/interleaved_numeric_conversion.h
 
-//gptq dequant
+// gptq dequant
 template <>
 __device__ inline typename ScalarType<half>::FragB
-      dequant<half, ScalarTypeID::kU4B8>(int q) {
+dequant<half, ScalarTypeID::kU4B8>(int q) {
   const int LO = 0x000f000f;
   const int HI = 0x00f000f0;
   const int EX = 0x64006400;
@@ -128,7 +127,7 @@ dequant<nv_bfloat16, ScalarTypeID::kU4B8>(int q) {
   return frag_b;
 }
 
-//awq dequant
+// awq dequant
 template <>
 __device__ inline typename ScalarType<half>::FragB
 dequant<half, ScalarTypeID::kU4>(int q) {
@@ -143,11 +142,11 @@ dequant<half, ScalarTypeID::kU4>(int q) {
   const int MUL = 0x2c002c00;
   const int ADD = 0xd400d400;
   typename ScalarType<half>::FragB frag_b;
-  frag_b[0] = __hsub2(*reinterpret_cast<half2*>(&lo),
-                      *reinterpret_cast<const half2*>(&SUB));
-  frag_b[1] = __hfma2(*reinterpret_cast<half2*>(&hi),
-                      *reinterpret_cast<const half2*>(&MUL),
-                      *reinterpret_cast<const half2*>(&ADD));
+  frag_b[0] = __hsub2(*reinterpret_cast<half2 *>(&lo),
+                      *reinterpret_cast<const half2 *>(&SUB));
+  frag_b[1] = __hfma2(*reinterpret_cast<half2 *>(&hi),
+                      *reinterpret_cast<const half2 *>(&MUL),
+                      *reinterpret_cast<const half2 *>(&ADD));
   return frag_b;
 }
 
@@ -167,12 +166,12 @@ dequant<nv_bfloat16, ScalarTypeID::kU4>(int q) {
   static constexpr uint32_t MUL = 0x3F803F80;
   static constexpr uint32_t ADD = 0xC300C300;
 
-  frag_b[0] = __hfma2(*reinterpret_cast<nv_bfloat162*>(&lo),
-                      *reinterpret_cast<const nv_bfloat162*>(&MUL),
-                      *reinterpret_cast<const nv_bfloat162*>(&ADD));
-  frag_b[1] = __hfma2(*reinterpret_cast<nv_bfloat162*>(&hi),
-                      *reinterpret_cast<const nv_bfloat162*>(&MUL),
-                      *reinterpret_cast<const nv_bfloat162*>(&ADD));
+  frag_b[0] = __hfma2(*reinterpret_cast<nv_bfloat162 *>(&lo),
+                      *reinterpret_cast<const nv_bfloat162 *>(&MUL),
+                      *reinterpret_cast<const nv_bfloat162 *>(&ADD));
+  frag_b[1] = __hfma2(*reinterpret_cast<nv_bfloat162 *>(&hi),
+                      *reinterpret_cast<const nv_bfloat162 *>(&MUL),
+                      *reinterpret_cast<const nv_bfloat162 *>(&ADD));
   return frag_b;
 }
 // Multiply dequantized values by the corresponding quantization scale; used
@@ -188,69 +187,68 @@ __device__ inline void scale(typename ScalarType<scalar_t>::FragB &frag_b,
   frag_b[1] = __hmul2(frag_b[1], s);
 }
 
-
 template <typename scalar_t>
-__device__ inline void sub_zp(typename ScalarType<scalar_t>::FragB& frag_b,
-                              typename ScalarType<scalar_t>::scalar_t2& frag_zp,
+__device__ inline void sub_zp(typename ScalarType<scalar_t>::FragB &frag_b,
+                              typename ScalarType<scalar_t>::scalar_t2 &frag_zp,
                               int i) {
   using scalar_t2 = typename ScalarType<scalar_t>::scalar_t2;
   scalar_t2 zp =
-      ScalarType<scalar_t>::num2num2(reinterpret_cast<scalar_t*>(&frag_zp)[i]);
+      ScalarType<scalar_t>::num2num2(reinterpret_cast<scalar_t *>(&frag_zp)[i]);
   frag_b[0] = __hsub2(frag_b[0], zp);
   frag_b[1] = __hsub2(frag_b[1], zp);
 }
 
 // Same as above, but for act_order (each K is multiplied individually)
 template <typename scalar_t>
-__device__ inline void scale4(typename ScalarType<scalar_t>::FragB& frag_b,
-                              typename ScalarType<scalar_t>::FragS& frag_s_1,
-                              typename ScalarType<scalar_t>::FragS& frag_s_2,
-                              typename ScalarType<scalar_t>::FragS& frag_s_3,
-                              typename ScalarType<scalar_t>::FragS& frag_s_4,
+__device__ inline void scale4(typename ScalarType<scalar_t>::FragB &frag_b,
+                              typename ScalarType<scalar_t>::FragS &frag_s_1,
+                              typename ScalarType<scalar_t>::FragS &frag_s_2,
+                              typename ScalarType<scalar_t>::FragS &frag_s_3,
+                              typename ScalarType<scalar_t>::FragS &frag_s_4,
                               int i) {
   using scalar_t2 = typename ScalarType<scalar_t>::scalar_t2;
   scalar_t2 s_val_1_2;
-  s_val_1_2.x = reinterpret_cast<scalar_t*>(&frag_s_1)[i];
-  s_val_1_2.y = reinterpret_cast<scalar_t*>(&frag_s_2)[i];
+  s_val_1_2.x = reinterpret_cast<scalar_t *>(&frag_s_1)[i];
+  s_val_1_2.y = reinterpret_cast<scalar_t *>(&frag_s_2)[i];
 
   scalar_t2 s_val_3_4;
-  s_val_3_4.x = reinterpret_cast<scalar_t*>(&frag_s_3)[i];
-  s_val_3_4.y = reinterpret_cast<scalar_t*>(&frag_s_4)[i];
+  s_val_3_4.x = reinterpret_cast<scalar_t *>(&frag_s_3)[i];
+  s_val_3_4.y = reinterpret_cast<scalar_t *>(&frag_s_4)[i];
 
   frag_b[0] = __hmul2(frag_b[0], s_val_1_2);
   frag_b[1] = __hmul2(frag_b[1], s_val_3_4);
 }
 
 template <typename scalar_t,
-          const int threads,          // number of threads in a threadblock
-          const int thread_m_blocks,  // number of 16x16 blocks in the m
-                                      // dimension (batchsize) of the
-                                      // threadblock
-          const int thread_n_blocks,  // same for n dimension (output)
-          const int thread_k_blocks,  // same for k dimension (reduction)
-          const int stages,  // number of stages for the async global->shared
-                             // fetch pipeline
-          const int group_blocks = -1,  // number of consecutive 16x16 blocks
+          const int threads,         // number of threads in a threadblock
+          const int thread_m_blocks, // number of 16x16 blocks in the m
+                                     // dimension (batchsize) of the
+                                     // threadblock
+          const int thread_n_blocks, // same for n dimension (output)
+          const int thread_k_blocks, // same for k dimension (reduction)
+          const int stages, // number of stages for the async global->shared
+                            // fetch pipeline
+          const int group_blocks = -1, // number of consecutive 16x16 blocks
           const ScalarTypeID w_type_id,
-          const bool has_act_order,     // whether act_order is enabled
-          const bool has_zp,            // whether zero-points are enabled
+          const bool has_act_order, // whether act_order is enabled
+          const bool has_zp,        // whether zero-points are enabled
           const int num_bits
-                                       // with a separate quantization scale
+          // with a separate quantization scale
           >
-__global__ void Marlin(
-    const int4* __restrict__ A,  // fp16 input matrix of shape mxk
-    const int4* __restrict__ B,  // 4bit quantized weight matrix of shape kxn
-    int4* __restrict__ C,        // fp16 output buffer of shape mxn
-    const int4* __restrict__ scales_ptr,  // fp16 quantization scales of shape
-    const int4* __restrict__ zp_ptr,      // 4bit packed zero-points of shape
-                                          // (k/groupsize)x(n/pack_factor)
-    const int* __restrict__ g_idx,        // int32 group indices of shape k
-                                 // (k/groupsize)xn
-    int prob_m,                  // batch dimension m
-    int prob_n,                  // output dimension n
-    int prob_k,                  // reduction dimension k
-    int num_groups,
-    int* locks  // extra global storage for barrier synchronization
+__global__ void
+Marlin(const int4 *__restrict__ A, // fp16 input matrix of shape mxk
+       const int4 *__restrict__ B, // 4bit quantized weight matrix of shape kxn
+       int4 *__restrict__ C,       // fp16 output buffer of shape mxn
+       const int4 *__restrict__ scales_ptr, // fp16 quantization scales of shape
+       const int4 *__restrict__ zp_ptr,     // 4bit packed zero-points of shape
+                                            // (k/groupsize)x(n/pack_factor)
+       const int *__restrict__ g_idx,       // int32 group indices of shape k
+                                            // (k/groupsize)xn
+       int prob_m,                          // batch dimension m
+       int prob_n,                          // output dimension n
+       int prob_k,                          // reduction dimension k
+       int num_groups,
+       int *locks // extra global storage for barrier synchronization
 ) {
   // Each threadblock processes one "stripe" of the B matrix with (roughly) the
   // same size, which might involve multiple column "slices" (of width 16 *
@@ -301,11 +299,11 @@ __global__ void Marlin(
   int slice_row = (iters * blockIdx.x) % k_tiles;
   int slice_col_par = (iters * blockIdx.x) / k_tiles;
   int slice_col = slice_col_par;
-  int slice_iters;  // number of threadblock tiles in the current slice
+  int slice_iters; // number of threadblock tiles in the current slice
   int slice_count =
-      0;          // total number of active threadblocks in the current slice
-  int slice_idx;  // index of threadblock in current slice; numbered bottom to
-                  // top
+      0;         // total number of active threadblocks in the current slice
+  int slice_idx; // index of threadblock in current slice; numbered bottom to
+                 // top
 
   int par_id = 0;
 
@@ -324,22 +322,27 @@ __global__ void Marlin(
   auto init_slice = [&]() {
     slice_iters =
         iters * (blockIdx.x + 1) - (k_tiles * slice_col_par + slice_row);
-    if (slice_iters < 0 || slice_col_par >= n_tiles * parallel) slice_iters = 0;
-    if (slice_iters == 0) return;
-    if (slice_row + slice_iters > k_tiles) slice_iters = k_tiles - slice_row;
+    if (slice_iters < 0 || slice_col_par >= n_tiles * parallel)
+      slice_iters = 0;
+    if (slice_iters == 0)
+      return;
+    if (slice_row + slice_iters > k_tiles)
+      slice_iters = k_tiles - slice_row;
     slice_count = 1;
     slice_idx = 0;
     int col_first = iters * div_ceil(k_tiles * slice_col_par, iters);
     if (col_first <= k_tiles * (slice_col_par + 1)) {
       int col_off = col_first - k_tiles * slice_col_par;
       slice_count = div_ceil(k_tiles - col_off, iters);
-      if (col_off > 0) slice_count++;
+      if (col_off > 0)
+        slice_count++;
       int delta_first = iters * blockIdx.x - col_first;
       if (delta_first < 0 || (col_off == 0 && delta_first == 0))
         slice_idx = slice_count - 1;
       else {
         slice_idx = slice_count - 1 - delta_first / iters;
-        if (col_off > 0) slice_idx--;
+        if (col_off > 0)
+          slice_idx--;
       }
     }
     if (slice_col == n_tiles) {
@@ -501,7 +504,7 @@ __global__ void Marlin(
   // needed if there are more threads than required for a certain tilesize or
   // when the batchsize is not a multiple of 16.
   bool a_sh_wr_pred[a_sh_wr_iters];
-  #pragma unroll
+#pragma unroll
   for (int i = 0; i < a_sh_wr_iters; i++)
     a_sh_wr_pred[i] = a_sh_wr_delta * i + a_sh_wr < a_sh_stride * prob_m;
 
@@ -519,13 +522,13 @@ __global__ void Marlin(
   // loop unrolls, all shared memory accesses are static, we simply precompute
   // both transformed reads and writes.
   int a_sh_wr_trans[a_sh_wr_iters];
-  #pragma unroll
+#pragma unroll
   for (int i = 0; i < a_sh_wr_iters; i++)
     a_sh_wr_trans[i] = transform_a(a_sh_wr_delta * i + a_sh_wr);
   int a_sh_rd_trans[b_sh_wr_iters][thread_m_blocks];
-  #pragma unroll
+#pragma unroll
   for (int i = 0; i < b_sh_wr_iters; i++) {
-  #pragma unroll
+#pragma unroll
     for (int j = 0; j < thread_m_blocks; j++)
       a_sh_rd_trans[i][j] =
           transform_a(a_sh_rd_delta_o * i + a_sh_rd_delta_i * j + a_sh_rd);
@@ -535,35 +538,35 @@ __global__ void Marlin(
   // runtime; we break dependencies between subsequent accesses with a tile by
   // maintining multiple pointers (we have enough registers), a tiny
   // optimization.
-  const int4* B_ptr[b_sh_wr_iters];
-  #pragma unroll
+  const int4 *B_ptr[b_sh_wr_iters];
+#pragma unroll
   for (int i = 0; i < b_sh_wr_iters; i++)
     B_ptr[i] = B + b_gl_rd_delta_i * i + b_gl_rd;
 
   extern __shared__ int4 sh[];
   // Shared memory storage for global fetch pipelines.
-  int4* sh_a = sh;
-  int4* sh_b = sh_a + (stages * a_sh_stage);
-  int4* sh_g_idx = sh_b + (stages * b_sh_stage);
-  int4* sh_zp = sh_g_idx + (stages * g_idx_stage);
-  int4* sh_s = sh_zp + (stages * zp_sh_stage);
-  int4* sh_red = sh_s + (stages * s_sh_stage);
+  int4 *sh_a = sh;
+  int4 *sh_b = sh_a + (stages * a_sh_stage);
+  int4 *sh_g_idx = sh_b + (stages * b_sh_stage);
+  int4 *sh_zp = sh_g_idx + (stages * g_idx_stage);
+  int4 *sh_s = sh_zp + (stages * zp_sh_stage);
+  int4 *sh_red = sh_s + (stages * s_sh_stage);
 
   // Register storage for double buffer of shared memory reads.
   FragA frag_a[2][thread_m_blocks];
   I4 frag_b_quant[2][b_thread_vecs];
   FragC frag_c[thread_m_blocks][4][2];
-  FragS frag_s[2][4];                    // No act-order
-  FragS act_frag_s[2][4][4];             // For act-order
-  int frag_qzp[2][num_ints_per_thread];  // Zero-points
-  FragZP frag_zp;                        // Zero-points in fp16
-  FragZP frag_zpf[2];                    // Zero-points in fp16 in HQQ
+  FragS frag_s[2][4];                   // No act-order
+  FragS act_frag_s[2][4][4];            // For act-order
+  int frag_qzp[2][num_ints_per_thread]; // Zero-points
+  FragZP frag_zp;                       // Zero-points in fp16
+  FragZP frag_zpf[2];                   // Zero-points in fp16 in HQQ
 
   // Zero accumulators.
   auto zero_accums = [&]() {
-  #pragma unroll
+#pragma unroll
     for (int i = 0; i < thread_m_blocks * 4 * 2 * 4; i++)
-      reinterpret_cast<float*>(frag_c)[i] = 0;
+      reinterpret_cast<float *>(frag_c)[i] = 0;
   };
 
   int sh_first_group_id = -1;
@@ -607,18 +610,18 @@ __global__ void Marlin(
   // shared memory pipeline location.
   auto fetch_to_shared = [&](int pipe, int a_off, bool pred = true) {
     if (pred) {
-      int4* sh_a_stage = sh_a + a_sh_stage * pipe;
-  #pragma unroll
+      int4 *sh_a_stage = sh_a + a_sh_stage * pipe;
+#pragma unroll
       for (int i = 0; i < a_sh_wr_iters; i++) {
         cp_async4_pred(
             &sh_a_stage[a_sh_wr_trans[i]],
             &A[a_gl_rd_delta_i * i + a_gl_rd + a_gl_rd_delta_o * a_off],
             a_sh_wr_pred[i]);
       }
-      int4* sh_b_stage = sh_b + b_sh_stage * pipe;
-  #pragma unroll
+      int4 *sh_b_stage = sh_b + b_sh_stage * pipe;
+#pragma unroll
       for (int i = 0; i < b_sh_wr_iters; i++) {
-  #pragma unroll
+#pragma unroll
         for (int j = 0; j < b_thread_vecs; j++) {
           cp_async4(&sh_b_stage[b_sh_wr_delta * i + b_sh_wr + j], B_ptr[i] + j);
         }
@@ -631,10 +634,10 @@ __global__ void Marlin(
         int full_pipe = a_off;
         int cur_k = slice_k_start_shared_fetch + tb_k * full_pipe;
         if (cur_k < prob_k && cur_k < slice_k_finish) {
-          int4* sh_g_idx_stage = sh_g_idx + g_idx_stage * pipe;
+          int4 *sh_g_idx_stage = sh_g_idx + g_idx_stage * pipe;
 
-          int4 const* cur_g_idx_stage_ptr =
-              reinterpret_cast<int4 const*>(&g_idx[cur_k]);
+          int4 const *cur_g_idx_stage_ptr =
+              reinterpret_cast<int4 const *>(&g_idx[cur_k]);
 
           if (threadIdx.x < g_idx_stage) {
             cp_async4_pred(&sh_g_idx_stage[threadIdx.x],
@@ -643,7 +646,7 @@ __global__ void Marlin(
         }
       } else {
         if constexpr (group_blocks != -1) {
-          int4* sh_s_stage = sh_s + s_sh_stage * pipe;
+          int4 *sh_s_stage = sh_s + s_sh_stage * pipe;
 
           if constexpr (group_blocks >= thread_k_blocks) {
             if (s_sh_wr_pred) {
@@ -665,7 +668,7 @@ __global__ void Marlin(
         }
 
         if constexpr (has_zp && group_blocks != -1) {
-          int4* sh_zp_stage = sh_zp + zp_sh_stage * pipe;
+          int4 *sh_zp_stage = sh_zp + zp_sh_stage * pipe;
 
           if constexpr (group_blocks >= thread_k_blocks) {
             // Only fetch zero-points if this tile starts a new group
@@ -711,16 +714,16 @@ __global__ void Marlin(
   // Load the next sub-tile from the current location in the shared memory pipe
   // into the current register buffer.
   auto fetch_to_registers = [&](int k, int pipe) {
-    int4* sh_a_stage = sh_a + a_sh_stage * pipe;
-  #pragma unroll
+    int4 *sh_a_stage = sh_a + a_sh_stage * pipe;
+#pragma unroll
     for (int i = 0; i < thread_m_blocks; i++)
       ldsm4<scalar_t>(frag_a[k % 2][i],
                       &sh_a_stage[a_sh_rd_trans[k % b_sh_wr_iters][i]]);
-    int4* sh_b_stage = sh_b + b_sh_stage * pipe;
+    int4 *sh_b_stage = sh_b + b_sh_stage * pipe;
 
-  #pragma unroll
+#pragma unroll
     for (int i = 0; i < b_thread_vecs; i++) {
-      frag_b_quant[k % 2][i] = *reinterpret_cast<I4*>(
+      frag_b_quant[k % 2][i] = *reinterpret_cast<I4 *>(
           &sh_b_stage[b_sh_rd_delta * (k % b_sh_wr_iters) + b_sh_rd + i]);
     }
   };
@@ -735,8 +738,8 @@ __global__ void Marlin(
       return;
     }
 
-    int4* sh_g_idx_stage = sh_g_idx + g_idx_stage * pipe;
-    int* sh_g_idx_int_ptr = reinterpret_cast<int*>(sh_g_idx_stage);
+    int4 *sh_g_idx_stage = sh_g_idx + g_idx_stage * pipe;
+    int *sh_g_idx_int_ptr = reinterpret_cast<int *>(sh_g_idx_stage);
 
     int group_id_1 = sh_g_idx_int_ptr[0];
     int group_id_2 = sh_g_idx_int_ptr[tb_k - 1];
@@ -752,8 +755,8 @@ __global__ void Marlin(
       // No act-order case
       if constexpr (group_blocks != -1) {
         if constexpr (group_blocks >= thread_k_blocks) {
-          int4* sh_s_stage = sh_s + s_sh_stage * pipe;
-          reinterpret_cast<int4*>(&frag_s[k % 2])[0] = sh_s_stage[s_sh_rd];
+          int4 *sh_s_stage = sh_s + s_sh_stage * pipe;
+          reinterpret_cast<int4 *>(&frag_s[k % 2])[0] = sh_s_stage[s_sh_rd];
         } else {
           auto warp_id = threadIdx.x / 32;
           int n_warps = thread_n_blocks / 4;
@@ -766,9 +769,9 @@ __global__ void Marlin(
           int k_blocks = cur_k / 16;
           int cur_group_id = k_blocks / group_blocks;
 
-          int4* sh_s_stage = sh_s + s_sh_stage * pipe;
+          int4 *sh_s_stage = sh_s + s_sh_stage * pipe;
 
-          reinterpret_cast<int4*>(&frag_s[k % 2])[0] =
+          reinterpret_cast<int4 *>(&frag_s[k % 2])[0] =
               sh_s_stage[s_sh_rd + cur_group_id * s_sh_stride];
         }
       }
@@ -795,7 +798,7 @@ __global__ void Marlin(
     // thread-id)
     auto warp_id = threadIdx.x / 32;
     int n_warps =
-        thread_n_blocks / 4;  // Each warp processes 4 16-size tiles over N
+        thread_n_blocks / 4; // Each warp processes 4 16-size tiles over N
 
     int warp_row = warp_id / n_warps;
     int warp_col = warp_id % n_warps;
@@ -803,7 +806,7 @@ __global__ void Marlin(
     cur_k += warp_row * 16;
 
     auto th_id = threadIdx.x % 32;
-    cur_k += (th_id % 4) * 2;  // Due to tensor-core layout for fp16 B matrix
+    cur_k += (th_id % 4) * 2; // Due to tensor-core layout for fp16 B matrix
 
     int s_col_shift =
         /*slice_n_offset +*/ (act_s_col_warp_stride * warp_col) +
@@ -811,35 +814,35 @@ __global__ void Marlin(
 
     if (is_same_group[pipe]) {
       if (k % 2 == 0) {
-        *(reinterpret_cast<int4*>(&(act_frag_s[k % 2][0][0]))) =
+        *(reinterpret_cast<int4 *>(&(act_frag_s[k % 2][0][0]))) =
             sh_s[(same_group_id[pipe] - sh_first_group_id) * s_sh_stride +
                  s_col_shift];
       } else {
-        *(reinterpret_cast<int4*>(&(act_frag_s[k % 2][0][0]))) =
-            *(reinterpret_cast<int4*>(&(act_frag_s[(k - 1) % 2][0][0])));
+        *(reinterpret_cast<int4 *>(&(act_frag_s[k % 2][0][0]))) =
+            *(reinterpret_cast<int4 *>(&(act_frag_s[(k - 1) % 2][0][0])));
       }
 
       for (int i = 1; i < 4; i++) {
-        *(reinterpret_cast<int4*>(&(act_frag_s[k % 2][i][0]))) =
-            *(reinterpret_cast<int4*>(&(act_frag_s[k % 2][0][0])));
+        *(reinterpret_cast<int4 *>(&(act_frag_s[k % 2][i][0]))) =
+            *(reinterpret_cast<int4 *>(&(act_frag_s[k % 2][0][0])));
       }
       return;
     }
 
-    int4* sh_g_idx_stage = sh_g_idx + g_idx_stage * pipe;
-    int* sh_g_idx_int_ptr = reinterpret_cast<int*>(sh_g_idx_stage);
+    int4 *sh_g_idx_stage = sh_g_idx + g_idx_stage * pipe;
+    int *sh_g_idx_int_ptr = reinterpret_cast<int *>(sh_g_idx_stage);
 
     constexpr int k_frag_offsets[4] = {0, 1, 8,
-                                       9};  // Tensor core offsets per thread
+                                       9}; // Tensor core offsets per thread
 
-  #pragma unroll
+#pragma unroll
     for (int i = 0; i < 4; i++) {
       int actual_k = cur_k + k_frag_offsets[i];
 
       int group_id = sh_g_idx_int_ptr[actual_k];
       int rel_group_id = group_id - sh_first_group_id;
 
-      *(reinterpret_cast<int4*>(&(act_frag_s[k % 2][i][0]))) =
+      *(reinterpret_cast<int4 *>(&(act_frag_s[k % 2][i][0]))) =
           sh_s[rel_group_id * s_sh_stride + s_col_shift];
     }
   };
@@ -855,16 +858,16 @@ __global__ void Marlin(
 
       if constexpr (group_blocks == -1) {
         for (int i = 0; i < num_ints_per_thread; i++) {
-          frag_qzp[k % 2][i] = (reinterpret_cast<int*>(sh_zp))[zp_sh_rd + i];
+          frag_qzp[k % 2][i] = (reinterpret_cast<int *>(sh_zp))[zp_sh_rd + i];
         }
 
       } else if constexpr (group_blocks >= thread_k_blocks) {
-        int4* sh_zp_stage =
+        int4 *sh_zp_stage =
             sh_zp + zp_sh_stage * ((group_blocks / thread_k_blocks) *
                                    (pipe / (group_blocks / thread_k_blocks)));
         for (int i = 0; i < num_ints_per_thread; i++) {
           frag_qzp[k % 2][i] =
-              (reinterpret_cast<int*>(sh_zp_stage))[zp_sh_rd + i];
+              (reinterpret_cast<int *>(sh_zp_stage))[zp_sh_rd + i];
         }
       } else {
         auto warp_id = threadIdx.x / 32;
@@ -879,18 +882,18 @@ __global__ void Marlin(
         int cur_group_id = 0;
 
         // Suppress bogus and persistent divide-by-zero warning
-  #pragma nv_diagnostic push
-  #pragma nv_diag_suppress divide_by_zero
+#pragma nv_diagnostic push
+#pragma nv_diag_suppress divide_by_zero
         cur_group_id = k_blocks / group_blocks;
-  #pragma nv_diagnostic pop
+#pragma nv_diagnostic pop
 
-        int4* sh_zp_stage = sh_zp + zp_sh_stage * pipe;
+        int4 *sh_zp_stage = sh_zp + zp_sh_stage * pipe;
 
         sh_zp_stage += cur_group_id * zp_sh_stride;
 
         for (int i = 0; i < num_ints_per_thread; i++) {
           frag_qzp[k % 2][i] =
-              (reinterpret_cast<int*>(sh_zp_stage))[zp_sh_rd + i];
+              (reinterpret_cast<int *>(sh_zp_stage))[zp_sh_rd + i];
         }
       }
     }
@@ -921,9 +924,9 @@ __global__ void Marlin(
       frag_zp[3] = frag_zp_1[1];
     }
 
-  // We have the m dimension as the inner loop in order to encourage overlapping
-  // dequantization and matmul operations.
-  #pragma unroll
+// We have the m dimension as the inner loop in order to encourage overlapping
+// dequantization and matmul operations.
+#pragma unroll
     for (int j = 0; j < 4; j++) {
       FragB frag_b0;
       FragB frag_b1;
@@ -970,7 +973,7 @@ __global__ void Marlin(
         }
       }
 
-  #pragma unroll
+#pragma unroll
       for (int i = 0; i < thread_m_blocks; i++) {
         mma<scalar_t>(frag_a[k % 2][i], frag_b0, frag_c[i][j][0]);
         mma<scalar_t>(frag_a[k % 2][i], frag_b1, frag_c[i][j][1]);
@@ -995,38 +998,38 @@ __global__ void Marlin(
       // unnecessary read or write iterations, e.g., for two warps we write only
       // once by warp 1 and read only once by warp 0.
 
-  #pragma unroll
+#pragma unroll
       for (int m_block = 0; m_block < thread_m_blocks; m_block++) {
-  #pragma unroll
+#pragma unroll
         for (int i = red_off; i > 0; i /= 2) {
           if (i <= red_idx && red_idx < 2 * i) {
-  #pragma unroll
+#pragma unroll
             for (int j = 0; j < 4 * 2; j++) {
               int red_sh_wr =
                   red_sh_delta * j + (red_sh_rd - red_sh_stride * i);
               if (i < red_off) {
-                float* c_rd = reinterpret_cast<float*>(
+                float *c_rd = reinterpret_cast<float *>(
                     &sh_red[red_sh_delta * j + red_sh_rd]);
-                float* c_wr = reinterpret_cast<float*>(&sh_red[red_sh_wr]);
-  #pragma unroll
+                float *c_wr = reinterpret_cast<float *>(&sh_red[red_sh_wr]);
+#pragma unroll
                 for (int k = 0; k < 4; k++)
-                  reinterpret_cast<FragC*>(frag_c)[4 * 2 * m_block + j][k] +=
+                  reinterpret_cast<FragC *>(frag_c)[4 * 2 * m_block + j][k] +=
                       c_rd[k] + c_wr[k];
               }
               sh_red[red_sh_wr] =
-                  reinterpret_cast<int4*>(&frag_c)[4 * 2 * m_block + j];
+                  reinterpret_cast<int4 *>(&frag_c)[4 * 2 * m_block + j];
             }
           }
           __syncthreads();
         }
         if (red_idx == 0) {
-  #pragma unroll
+#pragma unroll
           for (int i = 0; i < 4 * 2; i++) {
-            float* c_rd =
-                reinterpret_cast<float*>(&sh_red[red_sh_delta * i + red_sh_rd]);
-  #pragma unroll
+            float *c_rd = reinterpret_cast<float *>(
+                &sh_red[red_sh_delta * i + red_sh_rd]);
+#pragma unroll
             for (int j = 0; j < 4; j++)
-              reinterpret_cast<FragC*>(frag_c)[4 * 2 * m_block + i][j] +=
+              reinterpret_cast<FragC *>(frag_c)[4 * 2 * m_block + i][j] +=
                   c_rd[j];
           }
         }
@@ -1057,39 +1060,39 @@ __global__ void Marlin(
       int row = (threadIdx.x % 32) / 4;
 
       if (!first) {
-  // Interestingly, doing direct global accesses here really seems to mess up
-  // the compiler and lead to slowdowns, hence we also use async-copies even
-  // though these fetches are not actually asynchronous.
-  #pragma unroll
+// Interestingly, doing direct global accesses here really seems to mess up
+// the compiler and lead to slowdowns, hence we also use async-copies even
+// though these fetches are not actually asynchronous.
+#pragma unroll
         for (int i = 0; i < thread_m_blocks * 4; i++) {
-          cp_async4_pred(
-              &sh_red[c_sh_wr + c_sh_wr_delta * i],
-              &C[c_gl_wr + c_gl_wr_delta_o * (i / 2) +
-                 c_gl_wr_delta_i * (i % 2)],
-              i < (thread_m_blocks - 1) * 4 || 8 * (i / 2) + row < prob_m);
+          cp_async4_pred(&sh_red[c_sh_wr + c_sh_wr_delta * i],
+                         &C[c_gl_wr + c_gl_wr_delta_o * (i / 2) +
+                            c_gl_wr_delta_i * (i % 2)],
+                         i < (thread_m_blocks - 1) * 4 ||
+                             8 * (i / 2) + row < prob_m);
         }
         cp_async_fence();
         cp_async_wait<0>();
       }
 
-  #pragma unroll
+#pragma unroll
       for (int i = 0; i < thread_m_blocks * 4; i++) {
         if (i < (thread_m_blocks - 1) * 4 || 8 * (i / 2) + row < prob_m) {
           if (!first) {
             int4 c_red = sh_red[c_sh_wr + i * c_sh_wr_delta];
-  #pragma unroll
+#pragma unroll
             for (int j = 0; j < 2 * 4; j++) {
-              reinterpret_cast<float*>(
+              reinterpret_cast<float *>(
                   &frag_c)[4 * 2 * 4 * (i / 4) + 4 * j + (i % 4)] +=
-                  Dtype::num2float(reinterpret_cast<scalar_t*>(&c_red)[j]);
+                  Dtype::num2float(reinterpret_cast<scalar_t *>(&c_red)[j]);
             }
           }
           if (!last) {
             int4 c;
-  #pragma unroll
+#pragma unroll
             for (int j = 0; j < 2 * 4; j++) {
-              reinterpret_cast<scalar_t*>(&c)[j] =
-                  Dtype::float2num(reinterpret_cast<float*>(
+              reinterpret_cast<scalar_t *>(&c)[j] =
+                  Dtype::float2num(reinterpret_cast<float *>(
                       &frag_c)[4 * 2 * 4 * (i / 4) + 4 * j + (i % 4)]);
             }
             C[c_gl_wr + c_gl_wr_delta_o * (i / 2) + c_gl_wr_delta_i * (i % 2)] =
@@ -1123,24 +1126,23 @@ __global__ void Marlin(
 
     // We first reorder in shared memory to guarantee the most efficient final
     // global write patterns
-    auto write = [&](int idx, float c0, float c1, FragS& s) {
+    auto write = [&](int idx, float c0, float c1, FragS &s) {
       scalar_t2 res =
           Dtype::nums2num2(Dtype::float2num(c0), Dtype::float2num(c1));
 
       // For per-column quantization we finally apply the scale here (only for
       // 4-bit)
-      if constexpr (!has_act_order && group_blocks == -1 &&
-                    num_bits == 4) {
+      if constexpr (!has_act_order && group_blocks == -1 && num_bits == 4) {
         res = __hmul2(res, s[0]);
       }
 
-      ((scalar_t2*)sh_red)[idx] = res;
+      ((scalar_t2 *)sh_red)[idx] = res;
     };
 
     if (threadIdx.x / 32 < thread_n_blocks / 4) {
-  #pragma unroll
+#pragma unroll
       for (int i = 0; i < thread_m_blocks; i++) {
-  #pragma unroll
+#pragma unroll
         for (int j = 0; j < 4; j++) {
           int wr = c_sh_wr + 8 * j;
           write(wr + (4 * c_sh_stride) * 0 + 0, frag_c[i][j][0][0],
@@ -1157,7 +1159,7 @@ __global__ void Marlin(
     }
     __syncthreads();
 
-  #pragma unroll
+#pragma unroll
     for (int i = 0;
          i < div_ceil(16 * thread_m_blocks, threads / (2 * thread_n_blocks));
          i++) {
@@ -1172,7 +1174,7 @@ __global__ void Marlin(
   // Start global fetch and register load pipelines.
   auto start_pipes = [&]() {
 
-  #pragma unroll
+#pragma unroll
     for (int i = 0; i < stages - 1; i++) {
       if (has_act_order && i == 0) {
         int last_g_idx = slice_k_start + stages * tb_k * 2;
@@ -1212,9 +1214,9 @@ __global__ void Marlin(
     // have even length meaning that the next iteration will always start at
     // index 0.
 
-  #pragma unroll
+#pragma unroll
     for (int pipe = 0; pipe < stages;) {
-  #pragma unroll
+#pragma unroll
       for (int k = 0; k < b_sh_wr_iters; k++) {
         fetch_to_registers(k + 1, pipe % stages);
         fetch_scales_to_registers(k + 1, pipe);
@@ -1262,7 +1264,8 @@ __global__ void Marlin(
       // For per-column scales, we only fetch them here in the final step before
       // write-out
       if (group_blocks == -1 && last) {
-        if (s_sh_wr_pred) cp_async4(&sh_s[s_sh_wr], &scales_ptr[s_gl_rd]);
+        if (s_sh_wr_pred)
+          cp_async4(&sh_s[s_sh_wr], &scales_ptr[s_gl_rd]);
         cp_async_fence();
       }
       thread_block_reduce();
@@ -1270,17 +1273,17 @@ __global__ void Marlin(
         cp_async_wait<0>();
         __syncthreads();
         if (threadIdx.x / 32 < thread_n_blocks / 4) {
-          reinterpret_cast<int4*>(&frag_s)[0] = sh_s[s_sh_rd + 0];
-          reinterpret_cast<int4*>(&frag_s)[1] = sh_s[s_sh_rd + 4];
+          reinterpret_cast<int4 *>(&frag_s)[0] = sh_s[s_sh_rd + 0];
+          reinterpret_cast<int4 *>(&frag_s)[1] = sh_s[s_sh_rd + 4];
         }
       }
-      if (slice_count > 1) {  // only globally reduce if there is more than one
-                              // block in a slice
+      if (slice_count > 1) { // only globally reduce if there is more than one
+                             // block in a slice
         barrier_acquire(&locks[slice_col], slice_idx);
         global_reduce(slice_idx == 0, last);
         barrier_release(&locks[slice_col], last);
       }
-      if (last)  // only the last block in a slice actually writes the result
+      if (last) // only the last block in a slice actually writes the result
         write_result();
       slice_row = 0;
       slice_col_par++;
@@ -1289,12 +1292,13 @@ __global__ void Marlin(
       if (slice_iters) {
         a_gl_rd = a_gl_stride * (threadIdx.x / a_gl_rd_delta_o) +
                   (threadIdx.x % a_gl_rd_delta_o);
-  #pragma unroll
+#pragma unroll
         for (int i = 0; i < b_sh_wr_iters; i++)
           B_ptr[i] += b_sh_stride - b_gl_rd_delta_o * k_tiles;
         if (slice_col == 0) {
-  #pragma unroll
-          for (int i = 0; i < b_sh_wr_iters; i++) B_ptr[i] -= b_gl_stride;
+#pragma unroll
+          for (int i = 0; i < b_sh_wr_iters; i++)
+            B_ptr[i] -= b_gl_stride;
         }
 
         // Update slice k/n for scales loading
@@ -1315,14 +1319,16 @@ __global__ void Marlin(
   }
 }
 
-
 // 8 warps are a good choice since every SM has 4 schedulers and having more
 // than 1 warp per schedule allows some more latency hiding. At the same time,
 // we want relatively few warps to have many registers per warp and small tiles.
-const int USER_THREADS = 256; // Note: This is only used with user-provided thread_k/n
-const int STAGES = 4;  // 4 pipeline stages fit into shared memory
-const int SHARED_MEM = 96 * 1024;  // max shared memory on compute capability 8.6 (< 8.0)
-static constexpr int pack_factor_4bit = 8;  // We have 8 4-bit vals inside a 32 bit
+const int USER_THREADS =
+    256;              // Note: This is only used with user-provided thread_k/n
+const int STAGES = 4; // 4 pipeline stages fit into shared memory
+const int SHARED_MEM =
+    96 * 1024; // max shared memory on compute capability 8.6 (< 8.0)
+static constexpr int pack_factor_4bit =
+    8; // We have 8 4-bit vals inside a 32 bit
 
 #define __CALL_IF(THREAD_M_BLOCKS, THREAD_N_BLOCKS, THREAD_K_BLOCKS,           \
                   GROUP_BLOCKS, NUM_THREADS)                                   \
@@ -1330,13 +1336,16 @@ static constexpr int pack_factor_4bit = 8;  // We have 8 4-bit vals inside a 32 
            thread_n_blocks == THREAD_N_BLOCKS &&                               \
            thread_k_blocks == THREAD_K_BLOCKS &&                               \
            group_blocks == GROUP_BLOCKS && num_threads == NUM_THREADS) {       \
-    cudaFuncSetAttribute(Marlin<scalar_t, NUM_THREADS, THREAD_M_BLOCKS, THREAD_N_BLOCKS, \
-                                THREAD_K_BLOCKS, STAGES, GROUP_BLOCKS, w_type_id, false, has_zp, num_bits>,        \
-                         cudaFuncAttributeMaxDynamicSharedMemorySize,          \
-                         SHARED_MEM);                                          \
-    Marlin<scalar_t, NUM_THREADS, THREAD_M_BLOCKS, THREAD_N_BLOCKS, THREAD_K_BLOCKS,     \
-           STAGES, GROUP_BLOCKS, w_type_id, false, has_zp, num_bits><<<blocks, NUM_THREADS, SHARED_MEM, stream>>>( \
-        A_ptr, B_ptr, C_ptr, s_ptr, zp_ptr, g_idx_ptr, prob_m, prob_n, prob_k, num_groups, locks);            \
+    cudaFuncSetAttribute(                                                      \
+        Marlin<scalar_t, NUM_THREADS, THREAD_M_BLOCKS, THREAD_N_BLOCKS,        \
+               THREAD_K_BLOCKS, STAGES, GROUP_BLOCKS, w_type_id, false,        \
+               has_zp, num_bits>,                                              \
+        cudaFuncAttributeMaxDynamicSharedMemorySize, SHARED_MEM);              \
+    Marlin<scalar_t, NUM_THREADS, THREAD_M_BLOCKS, THREAD_N_BLOCKS,            \
+           THREAD_K_BLOCKS, STAGES, GROUP_BLOCKS, w_type_id, false, has_zp,    \
+           num_bits><<<blocks, NUM_THREADS, SHARED_MEM, stream>>>(             \
+        A_ptr, B_ptr, C_ptr, s_ptr, zp_ptr, g_idx_ptr, prob_m, prob_n, prob_k, \
+        num_groups, locks);                                                    \
   }
 
 typedef struct {
@@ -1368,7 +1377,7 @@ thread_config_t large_batch_thread_configs[] = {
     {128, 64, 128},  // Reduce N 4X, increase K 2X
 };
 
-int get_scales_cache_size(thread_config_t const& th_config, int prob_m,
+int get_scales_cache_size(thread_config_t const &th_config, int prob_m,
                           int prob_n, int prob_k, int num_bits, int group_size,
                           bool has_act_order, bool is_k_full) {
   bool cache_scales_chunk = has_act_order && !is_k_full;
@@ -1381,15 +1390,15 @@ int get_scales_cache_size(thread_config_t const& th_config, int prob_m,
   if (group_size == -1) {
     tb_groups = 1;
   } else if (group_size == 0) {
-    tb_groups = div_ceil(tb_k, 32);  // Worst case is 32 group size
+    tb_groups = div_ceil(tb_k, 32); // Worst case is 32 group size
   } else {
     tb_groups = div_ceil(tb_k, group_size);
   }
 
   if (cache_scales_chunk) {
     int load_groups =
-        tb_groups * pipe_stages * 2;     // Chunk size is 2x pipeline over dim K
-    load_groups = max(load_groups, 32);  // We load at least 32 scale groups
+        tb_groups * pipe_stages * 2;    // Chunk size is 2x pipeline over dim K
+    load_groups = max(load_groups, 32); // We load at least 32 scale groups
     return load_groups * tb_n * 2;
 
   } else {
@@ -1399,7 +1408,7 @@ int get_scales_cache_size(thread_config_t const& th_config, int prob_m,
   }
 }
 
-bool is_valid_cache_size(thread_config_t const& th_config, int max_m_blocks,
+bool is_valid_cache_size(thread_config_t const &th_config, int max_m_blocks,
                          int prob_m, int prob_n, int prob_k, int num_bits,
                          int scales_cache_size, int max_shared_mem) {
   int pack_factor = 32 / num_bits;
@@ -1433,12 +1442,12 @@ bool is_valid_cache_size(thread_config_t const& th_config, int max_m_blocks,
   float reduce_size = max(th_config.num_threads * 32 * 4,
                           (tb_n / 64) * 32 * (tb_max_m / 16) * 4 * 2 * 4 * 2);
 
-  CHECK(max_shared_mem / 2 > scales_cache_size);  // Sanity
+  CHECK(max_shared_mem / 2 > scales_cache_size); // Sanity
 
   return pipe_size + reduce_size < 0.95f * (max_shared_mem - scales_cache_size);
 }
 
-bool is_valid_config(thread_config_t const& th_config, int max_m_blocks,
+bool is_valid_config(thread_config_t const &th_config, int max_m_blocks,
                      int prob_m, int prob_n, int prob_k, int num_bits,
                      int group_size, bool has_act_order, bool is_k_full,
                      int max_shared_mem) {
@@ -1501,41 +1510,39 @@ exec_config_t determine_thread_config(int prob_m, int prob_n, int prob_k,
       }
     }
 
-    max_m_blocks--;  // Process less M blocks per invocation to reduce cache
-                     // usage
+    max_m_blocks--; // Process less M blocks per invocation to reduce cache
+                    // usage
   }
 
   return exec_config_t{0, {-1, -1, -1}};
 }
 
-#define CALL_IF(N_BLOCKS, K_BLOCKS, NUM_THREADS)    \
-  __CALL_IF(1, N_BLOCKS, K_BLOCKS, -1, NUM_THREADS) \
-  __CALL_IF(1, N_BLOCKS, K_BLOCKS, 4, NUM_THREADS)  \
-  __CALL_IF(1, N_BLOCKS, K_BLOCKS, 8, NUM_THREADS)  \
-  __CALL_IF(2, N_BLOCKS, K_BLOCKS, -1, NUM_THREADS) \
-  __CALL_IF(2, N_BLOCKS, K_BLOCKS, 4, NUM_THREADS)  \
-  __CALL_IF(2, N_BLOCKS, K_BLOCKS, 8, NUM_THREADS)  \
-  __CALL_IF(3, N_BLOCKS, K_BLOCKS, -1, NUM_THREADS) \
-  __CALL_IF(3, N_BLOCKS, K_BLOCKS, 4, NUM_THREADS)  \
-  __CALL_IF(3, N_BLOCKS, K_BLOCKS, 8, NUM_THREADS)  \
-  __CALL_IF(4, N_BLOCKS, K_BLOCKS, -1, NUM_THREADS) \
-  __CALL_IF(4, N_BLOCKS, K_BLOCKS, 4, NUM_THREADS) \
+#define CALL_IF(N_BLOCKS, K_BLOCKS, NUM_THREADS)                               \
+  __CALL_IF(1, N_BLOCKS, K_BLOCKS, -1, NUM_THREADS)                            \
+  __CALL_IF(1, N_BLOCKS, K_BLOCKS, 4, NUM_THREADS)                             \
+  __CALL_IF(1, N_BLOCKS, K_BLOCKS, 8, NUM_THREADS)                             \
+  __CALL_IF(2, N_BLOCKS, K_BLOCKS, -1, NUM_THREADS)                            \
+  __CALL_IF(2, N_BLOCKS, K_BLOCKS, 4, NUM_THREADS)                             \
+  __CALL_IF(2, N_BLOCKS, K_BLOCKS, 8, NUM_THREADS)                             \
+  __CALL_IF(3, N_BLOCKS, K_BLOCKS, -1, NUM_THREADS)                            \
+  __CALL_IF(3, N_BLOCKS, K_BLOCKS, 4, NUM_THREADS)                             \
+  __CALL_IF(3, N_BLOCKS, K_BLOCKS, 8, NUM_THREADS)                             \
+  __CALL_IF(4, N_BLOCKS, K_BLOCKS, -1, NUM_THREADS)                            \
+  __CALL_IF(4, N_BLOCKS, K_BLOCKS, 4, NUM_THREADS)                             \
   __CALL_IF(4, N_BLOCKS, K_BLOCKS, 8, NUM_THREADS)
 
-template<typename scalar_t,
-          const ScalarTypeID w_type_id,
-          const bool has_zp,            // whether zero-points are enabled
-          const int num_bits
->
-void marlin_matmul(const void* A, const void* B, void* scales, void* zeros, void* C, int prob_m, int prob_k, 
-                 int prob_n, void* workspace, int groupsize, int64_t stream_
-                 ) {
-  
-  int dev = 0; 
-  cudaStream_t stream = (cudaStream_t)stream_; 
+template <typename scalar_t, const ScalarTypeID w_type_id,
+          const bool has_zp, // whether zero-points are enabled
+          const int num_bits>
+void marlin_matmul(const void *A, const void *B, void *scales, void *zeros,
+                   void *C, int prob_m, int prob_k, int prob_n, void *workspace,
+                   int groupsize, int64_t stream_) {
+
+  int dev = 0;
+  cudaStream_t stream = (cudaStream_t)stream_;
   int thread_k = -1;
-  int thread_n = -1; 
-  int sms = -1; 
+  int thread_n = -1;
+  int sms = -1;
   int max_par = 16;
 
   int tot_m = prob_m;
@@ -1577,14 +1584,13 @@ void marlin_matmul(const void* A, const void* B, void* scales, void* zeros, void
     return;
   }
 
-  const int4* A_ptr = (const int4*)A;
-  const int4* B_ptr = (const int4*)B;
-  int4* C_ptr = (int4*)C;
-  const int4* s_ptr = (const int4*)scales;
-  const int4* zp_ptr = (const int4*)zeros;
-  const int* g_idx_ptr = (const int*)nullptr;
-  int* locks = (int*)workspace;
-
+  const int4 *A_ptr = (const int4 *)A;
+  const int4 *B_ptr = (const int4 *)B;
+  int4 *C_ptr = (int4 *)C;
+  const int4 *s_ptr = (const int4 *)scales;
+  const int4 *zp_ptr = (const int4 *)zeros;
+  const int *g_idx_ptr = (const int *)nullptr;
+  int *locks = (int *)workspace;
 
   // if (has_act_order) {
   //   // Permute A columns
@@ -1595,7 +1601,8 @@ void marlin_matmul(const void* A, const void* B, void* scales, void* zeros, void
   // }
 
   // // If we have a full K, then we can run the non-act-order version of Marlin
-  // // (since the weight rows are reordered by increasing group ids, and by having
+  // // (since the weight rows are reordered by increasing group ids, and by
+  // having
   // // a full K, we have full original groups)
   // if (is_k_full) {
   //   has_act_order = false;
@@ -1609,12 +1616,12 @@ void marlin_matmul(const void* A, const void* B, void* scales, void* zeros, void
       // Note that parallel > 1 currently only works for inputs without any
       // padding
       par = (16 * thread_m_blocks - pad) / (16 * exec_cfg.max_m_blocks);
-      if (par > max_par) par = max_par;
+      if (par > max_par)
+        par = max_par;
       prob_m = (16 * exec_cfg.max_m_blocks) * par;
       i += exec_cfg.max_m_blocks * (par - 1);
       thread_m_blocks = exec_cfg.max_m_blocks;
     }
-
 
     // For compilation speed, we only define the kernel configurations that have
     // seemed useful (in terms of performance) in our testing, however many more
@@ -1634,30 +1641,42 @@ void marlin_matmul(const void* A, const void* B, void* scales, void* zeros, void
   }
 }
 
-extern "C" void marlin_gptq_4bit_f16(const void* A, const void* B, void* scales, void* zeros, void* C, int prob_m, int prob_k, 
-                 int prob_n, void* workspace, int groupsize, int64_t stream
-                 ) {
-    marlin_matmul<half, ScalarTypeID::kU4B8, false, 4>(A, B, scales, zeros, C, prob_m, prob_k, prob_n, workspace, groupsize, stream);
+extern "C" void marlin_gptq_4bit_f16(const void *A, const void *B, void *scales,
+                                     void *zeros, void *C, int prob_m,
+                                     int prob_k, int prob_n, void *workspace,
+                                     int groupsize, int64_t stream) {
+  marlin_matmul<half, ScalarTypeID::kU4B8, false, 4>(
+      A, B, scales, zeros, C, prob_m, prob_k, prob_n, workspace, groupsize,
+      stream);
 }
 
-extern "C" void marlin_gptq_4bit_bf16(const void* A, const void* B, void* scales, void* zeros, void* C, int prob_m, int prob_k, 
-                 int prob_n, void* workspace, int groupsize, int64_t stream
-                 ) {
-    marlin_matmul<nv_bfloat16, ScalarTypeID::kU4B8, false, 4>(A, B, scales, zeros, C, prob_m, prob_k, prob_n, workspace, groupsize, stream);
+extern "C" void marlin_gptq_4bit_bf16(const void *A, const void *B,
+                                      void *scales, void *zeros, void *C,
+                                      int prob_m, int prob_k, int prob_n,
+                                      void *workspace, int groupsize,
+                                      int64_t stream) {
+  marlin_matmul<nv_bfloat16, ScalarTypeID::kU4B8, false, 4>(
+      A, B, scales, zeros, C, prob_m, prob_k, prob_n, workspace, groupsize,
+      stream);
 }
 
-extern "C" void marlin_awq_4bit_f16(const void* A, const void* B, void* scales, void* zeros, void* C, int prob_m, int prob_k, 
-                 int prob_n, void* workspace, int groupsize, int64_t stream
-                 ) {
-    marlin_matmul<half, ScalarTypeID::kU4, true, 4>(A, B, scales, zeros, C, prob_m, prob_k, prob_n, workspace, groupsize, stream);
+extern "C" void marlin_awq_4bit_f16(const void *A, const void *B, void *scales,
+                                    void *zeros, void *C, int prob_m,
+                                    int prob_k, int prob_n, void *workspace,
+                                    int groupsize, int64_t stream) {
+  marlin_matmul<half, ScalarTypeID::kU4, true, 4>(A, B, scales, zeros, C,
+                                                  prob_m, prob_k, prob_n,
+                                                  workspace, groupsize, stream);
 }
 
-extern "C" void marlin_awq_4bit_bf16(const void* A, const void* B, void* scales, void* zeros, void* C, int prob_m, int prob_k, 
-                 int prob_n, void* workspace, int groupsize, int64_t stream
-                 ) {
-    marlin_matmul<nv_bfloat16, ScalarTypeID::kU4, true, 4>(A, B, scales, zeros, C, prob_m, prob_k, prob_n, workspace, groupsize, stream);
+extern "C" void marlin_awq_4bit_bf16(const void *A, const void *B, void *scales,
+                                     void *zeros, void *C, int prob_m,
+                                     int prob_k, int prob_n, void *workspace,
+                                     int groupsize, int64_t stream) {
+  marlin_matmul<nv_bfloat16, ScalarTypeID::kU4, true, 4>(
+      A, B, scales, zeros, C, prob_m, prob_k, prob_n, workspace, groupsize,
+      stream);
 }
-
 
 template <int const num_threads, int const num_bits, bool const has_perm>
 __global__ void
@@ -1901,7 +1920,8 @@ gptq_marlin_repack_kernel(uint32_t const *__restrict__ b_q_weight_ptr,
   }
 
 extern "C" void gptq_marlin_repack(void *weight, void *perm, void *out,
-                                   int size_k, int size_n, int num_bits, int64_t stream_) {
+                                   int size_k, int size_n, int num_bits,
+                                   int64_t stream_) {
   // Verify compatibility with marlin tile of 16x64
   assert(size_k % tile_k_size == 0);
   assert(size_n % tile_n_size == 0);
@@ -1936,11 +1956,11 @@ extern "C" void gptq_marlin_repack(void *weight, void *perm, void *out,
   }
 }
 
-
 template <int const num_threads, int const num_bits>
-__global__ void awq_marlin_repack_kernel(
-    uint32_t const* __restrict__ b_q_weight_ptr, uint32_t* __restrict__ out_ptr,
-    int size_k, int size_n) {
+__global__ void
+awq_marlin_repack_kernel(uint32_t const *__restrict__ b_q_weight_ptr,
+                         uint32_t *__restrict__ out_ptr, int size_k,
+                         int size_n) {
   constexpr int pack_factor = 32 / num_bits;
 
   int k_tiles = size_k / tile_k_size;
@@ -1981,7 +2001,7 @@ __global__ void awq_marlin_repack_kernel(
     int first_n = n_tile_id * tile_n_size;
     int first_n_packed = first_n / pack_factor;
 
-    int4* sh_ptr = sh + stage_size * pipe;
+    int4 *sh_ptr = sh + stage_size * pipe;
 
     if (threadIdx.x < stage_size) {
       auto k_id = threadIdx.x / stage_n_threads;
@@ -1990,7 +2010,7 @@ __global__ void awq_marlin_repack_kernel(
       int first_k = k_tile_id * tile_k_size;
 
       cp_async4(&sh_ptr[k_id * stage_n_threads + n_id],
-                reinterpret_cast<int4 const*>(
+                reinterpret_cast<int4 const *>(
                     &(b_q_weight_ptr[(first_k + k_id) * (size_n / pack_factor) +
                                      first_n_packed + (n_id * 4)])));
     }
@@ -2022,8 +2042,8 @@ __global__ void awq_marlin_repack_kernel(
     constexpr int sh_stride = tile_n_ints;
     constexpr uint32_t mask = (1 << num_bits) - 1;
 
-    int4* sh_stage_ptr = sh + stage_size * pipe;
-    uint32_t* sh_stage_int_ptr = reinterpret_cast<uint32_t*>(sh_stage_ptr);
+    int4 *sh_stage_ptr = sh + stage_size * pipe;
+    uint32_t *sh_stage_int_ptr = reinterpret_cast<uint32_t *>(sh_stage_ptr);
 
     // Undo interleaving
     int cur_n_pos_unpacked;
@@ -2107,41 +2127,40 @@ __global__ void awq_marlin_repack_kernel(
   }
 }
 
-#define CALL_IF3(NUM_BITS)                                                   \
-  else if (num_bits == NUM_BITS) {                                          \
-    cudaFuncSetAttribute(                                                   \
-        awq_marlin_repack_kernel<repack_threads, NUM_BITS>, \
-        cudaFuncAttributeMaxDynamicSharedMemorySize, max_shared_mem);       \
-    awq_marlin_repack_kernel<repack_threads, NUM_BITS>      \
-        <<<blocks, repack_threads, max_shared_mem, stream>>>(       \
-            weight_ptr, out_ptr, size_k, size_n);                       \
+#define CALL_IF3(NUM_BITS)                                                     \
+  else if (num_bits == NUM_BITS) {                                             \
+    cudaFuncSetAttribute(awq_marlin_repack_kernel<repack_threads, NUM_BITS>,   \
+                         cudaFuncAttributeMaxDynamicSharedMemorySize,          \
+                         max_shared_mem);                                      \
+    awq_marlin_repack_kernel<repack_threads, NUM_BITS>                         \
+        <<<blocks, repack_threads, max_shared_mem, stream>>>(                  \
+            weight_ptr, out_ptr, size_k, size_n);                              \
   }
 
-extern "C" void awq_marlin_repack(void* in, void* perm, void* out, int k,
-                                int n, int num_bits, int64_t stream_) {
+extern "C" void awq_marlin_repack(void *in, void *perm, void *out, int k, int n,
+                                  int num_bits, int64_t stream_) {
 
-  //in_dim 4096, out_dim 1024 (/pack_factor)
-  //ws shape [4096, 128]
-  //out_shape [256, 2048]
+  // in_dim 4096, out_dim 1024 (/pack_factor)
+  // ws shape [4096, 128]
+  // out_shape [256, 2048]
 
-   //recover original size_k and size_n
-   int const pack_factor = 32 / num_bits;
-   int size_k = k;
-   int size_n = n * pack_factor;
+  // recover original size_k and size_n
+  int const pack_factor = 32 / num_bits;
+  int size_k = k;
+  int size_n = n * pack_factor;
 
   // Verify compatibility with marlin tile of 16x64
   CHECK(size_k % marlin::tile_k_size == 0, "size_k = ", size_k,
-              " is not divisible by tile_k_size = ", marlin::tile_k_size);
+        " is not divisible by tile_k_size = ", marlin::tile_k_size);
   CHECK(size_n % marlin::tile_n_size == 0, "size_n = ", size_n,
-              " is not divisible by tile_n_size = ", marlin::tile_n_size);
+        " is not divisible by tile_n_size = ", marlin::tile_n_size);
 
   CHECK(num_bits == 4 || num_bits == 8,
-              "num_bits must be 4 or 8. Got = ", num_bits);
+        "num_bits must be 4 or 8. Got = ", num_bits);
   cudaStream_t stream = (cudaStream_t)stream_;
 
-  uint32_t const* weight_ptr =
-      reinterpret_cast<uint32_t const*>(in);
-  uint32_t* out_ptr = reinterpret_cast<uint32_t*>(out);
+  uint32_t const *weight_ptr = reinterpret_cast<uint32_t const *>(in);
+  uint32_t *out_ptr = reinterpret_cast<uint32_t *>(out);
 
   int blocks;
   cudaDeviceGetAttribute(&blocks, cudaDevAttrMultiProcessorCount, 0);

--- a/mistralrs-quant/src/metal_kernels/bitwise.metal
+++ b/mistralrs-quant/src/metal_kernels/bitwise.metal
@@ -81,15 +81,15 @@ instantiate_bitwise_leftshift(int);
 
 template <typename T>
 [[kernel]] void bitwise_not(const device T *a [[buffer(0)]],
-                           device T *output [[buffer(1)]],
-                           uint tid [[thread_position_in_grid]]) {
+                            device T *output [[buffer(1)]],
+                            uint tid [[thread_position_in_grid]]) {
   output[tid] = ~a[tid];
 }
 
-#define instantiate_bitwise_not(type)                                           \
-  template [[host_name("bitwise_not_" #type)]] [[kernel]] void                  \
-  bitwise_not<type>(const device type *a [[buffer(0)]],                         \
-                   device type *out [[buffer(1)]],                            \            
+#define instantiate_bitwise_not(type)                                          \
+  template [[host_name("bitwise_not_" #type)]] [[kernel]] void                 \
+  bitwise_not<type>(const device type *a [[buffer(0)]],                        \
+                    device type *out [[buffer(1)]],                            \            
     uint tid [[thread_position_in_grid]]);
 
 instantiate_bitwise_not(uint8_t);

--- a/mistralrs-quant/src/safetensors.rs
+++ b/mistralrs-quant/src/safetensors.rs
@@ -206,12 +206,7 @@ impl MmapedSafetensors {
     }
 
     pub fn load(&self, name: &str, dev: &Device, dtype: Option<DType>) -> Result<Tensor> {
-        let t = self.get(name)?.load(dev, None)?;
-        if let Some(dt) = dtype {
-            t.to_dtype(dt)
-        } else {
-            Ok(t)
-        }
+        self.get(name)?.load(dev, dtype)
     }
 
     pub fn tensors(&self) -> Vec<(String, st::TensorView<'_>)> {

--- a/scripts/bench.py
+++ b/scripts/bench.py
@@ -51,7 +51,7 @@ async def timed_chat(client: AsyncOpenAI, messages):
 
 
 # Use the async-capable client
-client = AsyncOpenAI(api_key="foobar", base_url="http://localhost:8080/v1/")
+client = AsyncOpenAI(api_key="foobar", base_url="http://localhost:1234/v1/")
 
 # Enable this to log requests and responses
 # client._client = httpx.AsyncClient(

--- a/scripts/bench.py
+++ b/scripts/bench.py
@@ -1,5 +1,6 @@
 # cargo run --release --features metal '--' --port 1234 --isq 8 --paged-attn --max-seqs 1000 plain -m ../hf_models/llama3.2_3b --max-seq-len 131072
 # cargo run --release --features metal '--' --port 1234 --paged-attn --max-seqs 1000 plain -m mlx-community/Mistral-7B-Instruct-v0.3-4bit --max-seq-len 131072
+# ./llama-server -m ../gguf_models/Llama-3.2-3B-Instruct-Q8_0.gguf
 # mlx_lm.server --model mlx-community/Mistral-7B-Instruct-v0.3-4bit --port 8080
 
 import asyncio
@@ -9,7 +10,7 @@ import textwrap
 import json
 import time
 
-NUM_USERS = 30
+NUM_USERS = 8
 REQUESTS_PER_USER = 8
 PORT = 1234
 

--- a/scripts/bench.py
+++ b/scripts/bench.py
@@ -1,0 +1,103 @@
+# cargo run --release --features metal '--' --port 1234 --isq 8 --paged-attn --max-seqs 1000 plain -m ../hf_models/llama3.2_3b --max-seq-len 131072      
+# cargo run --release --features metal '--' --port 1234 --paged-attn --max-seqs 1000 plain -m mlx-community/Mistral-7B-Instruct-v0.3-4bit --max-seq-len 131072
+# mlx_lm.server --model mlx-community/Mistral-7B-Instruct-v0.3-4bit --port 8080 
+
+import asyncio
+from openai import AsyncOpenAI
+import httpx
+import textwrap
+import json
+import time
+
+
+def log_response(response: httpx.Response):
+    request = response.request
+    print(f"Request: {request.method} {request.url}")
+    print("  Headers:")
+    for key, value in request.headers.items():
+        if key.lower() == "authorization":
+            value = "[...]"
+        if key.lower() == "cookie":
+            value = value.split("=")[0] + "=..."
+        print(f"    {key}: {value}")
+    print("  Body:")
+    try:
+        request_body = json.loads(request.content)
+        print(textwrap.indent(json.dumps(request_body, indent=2), "    "))
+    except json.JSONDecodeError:
+        print(textwrap.indent(request.content.decode(), "    "))
+    print(f"Response: status_code={response.status_code}")
+    print("  Headers:")
+    for key, value in response.headers.items():
+        if key.lower() == "set-cookie":
+            value = value.split("=")[0] + "=..."
+        print(f"    {key}: {value}")
+
+
+async def timed_chat(client: AsyncOpenAI, messages):
+    """
+    Send one chat completion request and return (completion, elapsed_seconds).
+    """
+    start = time.perf_counter()
+    completion = await client.chat.completions.create(
+        model="mlx-community/Mistral-7B-Instruct-v0.3-4bit",
+        messages=messages,
+        max_tokens=256,
+        frequency_penalty=1.0,
+        top_p=0.1,
+        temperature=0,
+    )
+    return completion, time.perf_counter() - start
+
+
+# Use the async-capable client
+client = AsyncOpenAI(api_key="foobar", base_url="http://localhost:8080/v1/")
+
+# Enable this to log requests and responses
+# client._client = httpx.AsyncClient(
+#     event_hooks={"request": [print], "response": [log_response]}
+# )
+
+
+async def main() -> None:
+    """
+    Simple REPL that fires **10 concurrent** chat completion requests for every user prompt.
+    """
+    messages = []
+
+    # Optional system prompt
+    prompt = input("Enter system prompt >>> ")
+    if prompt:
+        messages.append({"role": "system", "content": prompt})
+
+    while True:
+        user_prompt = input(">>> ")
+        messages.append({"role": "user", "content": user_prompt})
+
+        # Create 10 concurrent requests
+        tasks = [timed_chat(client, list(messages)) for _ in range(30)]
+
+        # Wait for them all to finish
+        results = await asyncio.gather(*tasks)
+
+        elapsed_times = []
+        t_s = []
+        # Show the responses
+        for i, (completion, elapsed) in enumerate(results, 1):
+            usage = completion.usage
+            print(f"{elapsed:.2f}s {usage.total_tokens / elapsed:.2f} T/s")
+            t_s.append(usage.total_tokens / elapsed)
+            elapsed_times.append(elapsed)
+
+        print(
+            f"Average: {sum(elapsed_times) / len(elapsed_times):.2f}s {sum(t_s) / len(t_s):.2f} T/s"
+        )
+
+        # Keep only the first assistant reply in the conversation history
+        messages.append(
+            {"role": "assistant", "content": results[0][0].choices[0].message.content}
+        )
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/scripts/bench.py
+++ b/scripts/bench.py
@@ -9,7 +9,7 @@ import textwrap
 import json
 import time
 
-NUM_USERS = 100
+NUM_USERS = 30
 REQUESTS_PER_USER = 8
 PORT = 1234
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a benchmarking script to measure chat completion performance and throughput with concurrent requests.
- **Improvements**
  - Enhanced model configuration loading to support both "quantization_config" and "quantization" keys for quantization settings.
  - Quantization configuration is now correctly applied to language model head layers during initialization.
  - Added new metrics for running and waiting sequence counts to the engine's logging output.
  - Scheduler now updates these metrics during scheduling operations.
  - Updated chat example to use the correct default API server port.
- **Bug Fixes**
  - Fixed default API server port in chat example from 1234 to 8080.
- **Style**
  - Improved formatting and readability in conversion scripts.
  - Code style and formatting improvements in CUDA and Metal kernel sources.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->