### PR TITLE
Add immediate isq predicates for qwen3

### DIFF
--- a/mistralrs-core/src/pipeline/isq.rs
+++ b/mistralrs-core/src/pipeline/isq.rs
@@ -59,19 +59,20 @@ pub const UQFF_MULTI_FILE_DELIMITER: &str = ";";
 /// - `AFQ4`
 /// - `AFQ6`
 /// - `AFQ8`
-pub fn parse_isq_value(s: &str) -> Result<IsqType, String> {
+pub fn parse_isq_value(s: &str, device: Option<&Device>) -> Result<IsqType, String> {
+    let is_metal = device.map(|device| device.is_metal()).unwrap_or(false);
     let tp = match s.to_lowercase().as_str() {
-        "2" if cfg!(feature = "metal") => IsqType::AFQ2,
-        "2" if !cfg!(feature = "metal") => IsqType::Q2K,
-        "3" if cfg!(feature = "metal") => IsqType::AFQ3,
-        "3" if !cfg!(feature = "metal") => IsqType::Q3K,
-        "4" if cfg!(feature = "metal") => IsqType::AFQ4,
-        "4" if !cfg!(feature = "metal") => IsqType::Q4K,
+        "2" if is_metal => IsqType::AFQ2,
+        "2" if !is_metal => IsqType::Q2K,
+        "3" if is_metal => IsqType::AFQ3,
+        "3" if !is_metal => IsqType::Q3K,
+        "4" if is_metal => IsqType::AFQ4,
+        "4" if !is_metal => IsqType::Q4K,
         "5" => IsqType::Q5K,
-        "6" if cfg!(feature = "metal") => IsqType::AFQ6,
-        "6" if !cfg!(feature = "metal") => IsqType::Q6K,
-        "8" if cfg!(feature = "metal") => IsqType::AFQ8,
-        "8" if !cfg!(feature = "metal") => IsqType::Q8_0,
+        "6" if is_metal => IsqType::AFQ6,
+        "6" if !is_metal => IsqType::Q6K,
+        "8" if is_metal => IsqType::AFQ8,
+        "8" if !is_metal => IsqType::Q8_0,
         "q4_0" => IsqType::Q4_0,
         "q4_1" => IsqType::Q4_1,
         "q5_0" => IsqType::Q5_0,

--- a/mistralrs-core/src/pipeline/loaders/normal_loaders.rs
+++ b/mistralrs-core/src/pipeline/loaders/normal_loaders.rs
@@ -3004,8 +3004,8 @@ impl IsqModelLoader for Qwen3Loader {
             Regex::new(r"layers\.(\d+)\.mlp\.down_proj\.(weight|bias)$")?,
         ])
     }
-    fn immediate_isq_predicates_moqe(&self, config: &str) -> Result<Vec<Regex>> {
-        self.isq_layer_regexes_moqe(config)
+    fn immediate_isq_predicates(&self, config: &str) -> Result<Vec<Regex>> {
+        self.isq_layer_regexes(config)
     }
 }
 
@@ -3188,6 +3188,9 @@ impl IsqModelLoader for Qwen3MoELoader {
             Regex::new(r"layers\.(\d+)\.mlp\.experts\.(\d+)\.up_proj\.(weight|bias)$")?,
             Regex::new(r"layers\.(\d+)\.mlp\.experts\.(\d+)\.down_proj\.(weight|bias)$")?,
         ])
+    }
+    fn immediate_isq_predicates(&self, config: &str) -> Result<Vec<Regex>> {
+        self.isq_layer_regexes(config)
     }
     fn immediate_isq_predicates_moqe(&self, config: &str) -> Result<Vec<Regex>> {
         self.isq_layer_regexes_moqe(config)

--- a/mistralrs-core/src/pipeline/normal.rs
+++ b/mistralrs-core/src/pipeline/normal.rs
@@ -478,6 +478,10 @@ impl Loader for NormalLoader {
             } else {
                 self.inner.immediate_isq_predicates(&config)?
             };
+            info!("Applying ISQ to {in_situ_quant:?}");
+            if predicates.is_empty() {
+                warn!("No predicates for this model and ISQ setting deteced. ISQ will not be applied to any weights!");
+            }
             mistralrs_quant::set_immediate_isq(in_situ_quant, predicates);
             false
         } else {

--- a/mistralrs-core/src/pipeline/normal.rs
+++ b/mistralrs-core/src/pipeline/normal.rs
@@ -480,7 +480,7 @@ impl Loader for NormalLoader {
             };
             info!("Applying ISQ to {in_situ_quant:?}");
             if predicates.is_empty() {
-                warn!("No predicates for this model and ISQ setting deteced. ISQ will not be applied to any weights!");
+                warn!("No predicates for this model and ISQ setting detected. ISQ will not be applied to any weights!");
             }
             mistralrs_quant::set_immediate_isq(in_situ_quant, predicates);
             false

--- a/mistralrs-core/src/pipeline/vision.rs
+++ b/mistralrs-core/src/pipeline/vision.rs
@@ -409,6 +409,10 @@ impl Loader for VisionLoader {
             && self.config.write_uqff.is_none()
         {
             let predicates = self.inner.immediate_isq_predicates(&config)?;
+            info!("Applying ISQ to {in_situ_quant:?}");
+            if predicates.is_empty() {
+                warn!("No predicates for this model and ISQ setting deteced. ISQ will not be applied to any weights!");
+            }
             mistralrs_quant::set_immediate_isq(in_situ_quant, predicates);
             false
         } else {

--- a/mistralrs-core/src/pipeline/vision.rs
+++ b/mistralrs-core/src/pipeline/vision.rs
@@ -411,7 +411,7 @@ impl Loader for VisionLoader {
             let predicates = self.inner.immediate_isq_predicates(&config)?;
             info!("Applying ISQ to {in_situ_quant:?}");
             if predicates.is_empty() {
-                warn!("No predicates for this model and ISQ setting deteced. ISQ will not be applied to any weights!");
+                warn!("No predicates for this model and ISQ setting detected. ISQ will not be applied to any weights!");
             }
             mistralrs_quant::set_immediate_isq(in_situ_quant, predicates);
             false

--- a/mistralrs-core/src/topology/mod.rs
+++ b/mistralrs-core/src/topology/mod.rs
@@ -107,7 +107,7 @@ impl Topology {
             }
             let range = CustomRange { start, end };
             let isq = if let Some(isq) = isq {
-                Some(parse_isq_value(&isq).map_err(anyhow::Error::msg)?)
+                Some(parse_isq_value(&isq, None).map_err(anyhow::Error::msg)?)
             } else {
                 None
             };

--- a/mistralrs-pyo3/src/lib.rs
+++ b/mistralrs-pyo3/src/lib.rs
@@ -682,7 +682,7 @@ impl Runner {
 
         let device = get_device(seed).as_ref().map_err(PyApiErr::from)?;
         let isq = if let Some(isq) = in_situ_quant {
-            Some(parse_isq_value(&isq).map_err(PyApiErr::from)?)
+            Some(parse_isq_value(&isq, Some(device)).map_err(PyApiErr::from)?)
         } else {
             None
         };
@@ -1416,7 +1416,7 @@ impl Runner {
     /// Send a request to re-ISQ the model. If the model was loaded as GGUF or GGML
     /// then nothing will happen.
     fn send_re_isq(&self, dtype: String) -> PyApiResult<()> {
-        let request = _Request::ReIsq(parse_isq_value(&dtype)?);
+        let request = _Request::ReIsq(parse_isq_value(&dtype, None)?);
         self.runner.get_sender()?.blocking_send(request).unwrap();
         Ok(())
     }

--- a/mistralrs/examples/perplexity/main.rs
+++ b/mistralrs/examples/perplexity/main.rs
@@ -74,7 +74,7 @@ async fn main() -> Result<()> {
     let args = Args::parse();
 
     let quant = if let Some(isq) = &args.isq {
-        Some(parse_isq_value(isq).map_err(anyhow::Error::msg)?)
+        Some(parse_isq_value(isq, None).map_err(anyhow::Error::msg)?)
     } else {
         None
     };


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Added informative logging to provide visibility into the application of immediate in-situ quantization (ISQ) during model loading. Users will now see messages indicating the ISQ type being applied and warnings if no ISQ predicates are detected.
- **Bug Fixes**
	- Standardized the handling of ISQ predicate methods across different model loaders to ensure consistent behavior.
- **Improvements**
	- Enhanced ISQ parsing to consider device context dynamically, improving compatibility across hardware types.
	- Updated device selection logic to better support CPU and Metal devices, respecting user preferences.
	- Deferred parsing of ISQ options until device context is available, improving configuration flexibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->