### PR TITLE
Fix missing vision weights in Mistral3 UQFF

### DIFF
--- a/mistralrs-core/src/vision_models/mistral3/mod.rs
+++ b/mistralrs-core/src/vision_models/mistral3/mod.rs
@@ -283,6 +283,8 @@ impl IsqModel for Mistral3Model {
         let uvb = UnVarBuilder::new();
         uvb.pp("multi_modal_projector")
             .extend(self.mmproj.residual_tensors());
+        uvb.pp("vision_tower")
+            .extend(self.vision_model.residual_tensors());
         uvb.pp("language_model")
             .extend(self.text_model.residual_tensors());
 

--- a/mistralrs-core/src/vision_models/mistral3/vision.rs
+++ b/mistralrs-core/src/vision_models/mistral3/vision.rs
@@ -6,6 +6,7 @@ use mistralrs_quant::{linear_b, QuantMethod, ShardedVarBuilder};
 use crate::{
     layers::{self, GetFloatInfo, RmsNorm},
     pipeline::NormalLoadingMetadata,
+    utils::unvarbuilder::UnVarBuilder,
 };
 
 fn default_act() -> candle_nn::Activation {
@@ -480,5 +481,20 @@ impl Mistral3VisionModel {
             tensors.push((&mut layer.feed_forward.down_proj, None));
         }
         tensors
+    }
+
+    pub fn residual_tensors(&self) -> Vec<(String, Tensor)> {
+        let uvb = UnVarBuilder::new();
+
+        uvb.pp("patch_conv").add(&self.patch_conv);
+        uvb.pp("ln_pre").add(&self.ln_pre);
+
+        {
+            let uvb_pos = uvb.pp("patch_positional_embedding");
+            uvb_pos.add_tensor("cos", self.patch_positional_embedding.cos.clone());
+            uvb_pos.add_tensor("sin", self.patch_positional_embedding.sin.clone());
+        }
+
+        uvb.to_safetensors()
     }
 }


### PR DESCRIPTION
## Summary
- include patch conv and other vision tensors when serializing a Mistral3 vision model
- add those tensors to the model's UQFF residuals

## Testing
- `cargo fmt --all` *(fails: rustfmt component missing)*
- `cargo check -p mistralrs-core --quiet` *(fails: could not fetch git dependencies)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added the ability to extract and view residual tensors from the vision model, including details for convolutional, normalization, and positional embedding components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->