### PR TITLE
Support web chat file uploading

### DIFF
--- a/.typos.toml
+++ b/.typos.toml
@@ -9,7 +9,8 @@ extend-ignore-identifiers-re = [
     "_thw",
     "thr",
     "nd",
-    "uneeded"
+    "uneeded",
+    "tese"
 ]
 
 [files]

--- a/mistralrs-web-chat/README.md
+++ b/mistralrs-web-chat/README.md
@@ -1,6 +1,6 @@
 # Mistral.rs Web Chat App
 
-A minimal, fast, and modern web chat interface for [mistral.rs](https://github.com/EricBuehler/mistral.rs), supporting both text and vision models with drag-and-drop image upload, markdown rendering, and multi-model selection.
+A minimal, fast, and modern web chat interface for [mistral.rs](https://github.com/EricBuehler/mistral.rs), supporting both text and vision models with drag-and-drop image and file upload, markdown rendering, and multi-model selection.
 
 <img src="../res/chat.gif" alt="Demonstration" />
 
@@ -9,6 +9,7 @@ A minimal, fast, and modern web chat interface for [mistral.rs](https://github.c
 ## Features
 
 - **Text & Vision Model Support:** Choose from multiple loaded models.
+- **File Upload:** Upload and work with files.
 - **Drag & Drop Image Upload:** Instantly preview and send images to vision models.
 - **Markdown Output:** Responses are rendered in markdown, including code blocks.
 - **Copy Button:** One-click copying for all code snippets.

--- a/mistralrs-web-chat/src/handlers/api.rs
+++ b/mistralrs-web-chat/src/handlers/api.rs
@@ -82,9 +82,8 @@ fn validate_text_upload(
         "c" | "cpp" | "cc" | "cxx" | "h" | "hpp" | "hxx" | "java" | "kt" | "swift" | "go"
         | "rb" | "php" => Ok(ext),
         // GPU and shader languages
-        "cu" | "cuh" | "cl" | "ptx"
-        | "glsl" | "vert" | "frag" | "geom" | "comp" | "tesc" | "tese"
-        | "hlsl" | "metal" | "wgsl" => Ok(ext),
+        "cu" | "cuh" | "cl" | "ptx" | "glsl" | "vert" | "frag" | "geom" | "comp" | "tesc"
+        | "tese" | "hlsl" | "metal" | "wgsl" => Ok(ext),
         // Shell and other scripts
         "sh" | "bash" | "zsh" | "fish" | "ps1" | "bat" | "cmd" | "sql" | "dockerfile"
         | "makefile" => Ok(ext),

--- a/mistralrs-web-chat/src/handlers/api.rs
+++ b/mistralrs-web-chat/src/handlers/api.rs
@@ -81,6 +81,11 @@ fn validate_text_upload(
         | "less" => Ok(ext),
         "c" | "cpp" | "cc" | "cxx" | "h" | "hpp" | "hxx" | "java" | "kt" | "swift" | "go"
         | "rb" | "php" => Ok(ext),
+        // GPU and shader languages
+        "cu" | "cuh" | "cl" | "ptx"
+        | "glsl" | "vert" | "frag" | "geom" | "comp" | "tesc" | "tese"
+        | "hlsl" | "metal" | "wgsl" => Ok(ext),
+        // Shell and other scripts
         "sh" | "bash" | "zsh" | "fish" | "ps1" | "bat" | "cmd" | "sql" | "dockerfile"
         | "makefile" => Ok(ext),
         "r" | "R" | "scala" | "clj" | "cljs" | "hs" | "elm" | "ex" | "exs" | "erl" | "fs"

--- a/mistralrs-web-chat/src/handlers/api.rs
+++ b/mistralrs-web-chat/src/handlers/api.rs
@@ -42,6 +42,77 @@ fn validate_image_upload(
     }
 }
 
+fn validate_text_upload(
+    filename: Option<&str>,
+    content_type: Option<&str>,
+) -> Result<String, &'static str> {
+    // Check MIME type first (allow text/* and application/json)
+    if let Some(mime) = content_type {
+        if !mime.starts_with("text/")
+            && mime != "application/json"
+            && mime != "application/javascript"
+        {
+            // Also allow common binary MIME types that are actually text
+            if !matches!(
+                mime,
+                "application/octet-stream"
+                    | "application/x-python"
+                    | "application/x-rust"
+                    | "application/x-sh"
+            ) {
+                return Err("File must be a text file");
+            }
+        }
+    }
+
+    // Validate file extension
+    let ext = if let Some(name) = filename {
+        name.rsplit('.').next().unwrap_or("").to_lowercase()
+    } else {
+        return Err("No filename provided");
+    };
+
+    match ext.as_str() {
+        // Text files
+        "txt" | "md" | "markdown" | "log" | "csv" | "tsv" | "json" | "xml" | "yaml" | "yml"
+        | "toml" | "ini" | "cfg" | "conf" => Ok(ext),
+        // Code files
+        "rs" | "py" | "js" | "ts" | "jsx" | "tsx" | "html" | "htm" | "css" | "scss" | "sass"
+        | "less" => Ok(ext),
+        "c" | "cpp" | "cc" | "cxx" | "h" | "hpp" | "hxx" | "java" | "kt" | "swift" | "go"
+        | "rb" | "php" => Ok(ext),
+        "sh" | "bash" | "zsh" | "fish" | "ps1" | "bat" | "cmd" | "sql" | "dockerfile"
+        | "makefile" => Ok(ext),
+        "r" | "R" | "scala" | "clj" | "cljs" | "hs" | "elm" | "ex" | "exs" | "erl" | "fs"
+        | "fsx" | "ml" | "mli" => Ok(ext),
+        "vue" | "svelte" | "astro" | "lua" | "nim" | "zig" | "d" | "dart" | "jl" | "pl" | "pm"
+        | "tcl" => Ok(ext),
+        // Config and other text-like files
+        "gitignore" | "dockerignore" | "editorconfig" | "env" | "htaccess" => Ok(ext),
+        "" => {
+            // Files without extension - check the filename
+            if let Some(name) = filename {
+                let name_lower = name.to_lowercase();
+                if matches!(
+                    name_lower.as_str(),
+                    "readme"
+                        | "license"
+                        | "changelog"
+                        | "makefile"
+                        | "dockerfile"
+                        | "vagrantfile"
+                        | "gemfile"
+                        | "rakefile"
+                ) {
+                    return Ok("txt".to_string());
+                }
+            }
+            Err("No file extension")
+        }
+        _ => Err("Unsupported text file format"),
+    }
+}
+
 /// Accepts multipart image upload, stores it under `cache/uploads/`, and returns its URL.
 pub async fn upload_image(
     State(_app): State<Arc<AppState>>,
@@ -49,10 +120,12 @@ pub async fn upload_image(
 ) -> impl IntoResponse {
     // Expect single "image" part
     if let Ok(Some(field)) = multipart.next_field().await {
-        let filename = field.file_name();
-        let content_type = field.content_type();
+        // Clone filename and content type to avoid borrowing `field`
+        let orig_filename = field.file_name().map(|s| s.to_string());
+        let content_type_opt = field.content_type().map(|s| s.to_string());
 
-        let ext = match validate_image_upload(filename, content_type) {
+        let ext = match validate_image_upload(orig_filename.as_deref(), content_type_opt.as_deref())
+        {
             Ok(extension) => extension,
             Err(msg) => {
                 return (StatusCode::BAD_REQUEST, msg).into_response();
@@ -101,6 +174,75 @@ pub async fn upload_image(
     }
 
     (StatusCode::BAD_REQUEST, "no image field").into_response()
+}
+
+/// Accepts multipart text file upload and returns the file content
+pub async fn upload_text(
+    State(_app): State<Arc<AppState>>,
+    mut multipart: Multipart,
+) -> impl IntoResponse {
+    // Expect single "file" part
+    if let Ok(Some(field)) = multipart.next_field().await {
+        // Clone filename and content type to avoid borrowing `field`
+        let orig_filename = field.file_name().map(|s| s.to_string());
+        let content_type_opt = field.content_type().map(|s| s.to_string());
+
+        let _ext = match validate_text_upload(orig_filename.as_deref(), content_type_opt.as_deref())
+        {
+            Ok(extension) => extension,
+            Err(msg) => {
+                return (StatusCode::BAD_REQUEST, msg).into_response();
+            }
+        };
+
+        let data = match field.bytes().await {
+            Ok(b) => b,
+            Err(e) => {
+                error!("multipart bytes error: {}", e);
+                let msg = if e.to_string().contains("exceeded") {
+                    "file too large (limit 10 MB)"
+                } else {
+                    "failed to read upload"
+                };
+                return (StatusCode::BAD_REQUEST, msg).into_response();
+            }
+        };
+
+        const MAX_SIZE: usize = 10 * 1024 * 1024; // 10MB for text files
+        if data.len() > MAX_SIZE {
+            return (StatusCode::BAD_REQUEST, "file too large (limit 10 MB)").into_response();
+        }
+
+        // Try to decode as UTF-8
+        let content = match String::from_utf8(data.to_vec()) {
+            Ok(text) => text,
+            Err(_) => {
+                return (StatusCode::BAD_REQUEST, "file is not valid UTF-8 text").into_response();
+            }
+        };
+
+        // Limit content length for safety
+        const MAX_CHARS: usize = 1_000_000; // 1 million characters
+        if content.len() > MAX_CHARS {
+            return (
+                StatusCode::BAD_REQUEST,
+                "file content too large (limit 1M characters)",
+            )
+                .into_response();
+        }
+
+        return (
+            StatusCode::OK,
+            Json(json!({
+                "content": content,
+                "filename": orig_filename.unwrap_or_else(|| "untitled".to_string()),
+                "size": data.len()
+            })),
+        )
+            .into_response();
+    }
+
+    (StatusCode::BAD_REQUEST, "no file field").into_response()
 }
 
 pub async fn list_models(State(app): State<Arc<AppState>>) -> impl IntoResponse {

--- a/mistralrs-web-chat/src/handlers/websocket.rs
+++ b/mistralrs-web-chat/src/handlers/websocket.rs
@@ -16,6 +16,7 @@ use tracing::error;
 use crate::chat::append_chat_message;
 use crate::models::LoadedModel;
 use crate::types::AppState;
+use crate::utils::get_cache_dir;
 
 const CLEAR_CMD: &str = "__CLEAR__";
 
@@ -68,8 +69,9 @@ where
 
 /// Validate that a file path is safe and within the uploads directory
 fn validate_image_path(path: &str) -> Result<String, &'static str> {
-    let uploads_dir = format!("{}/cache/uploads", env!("CARGO_MANIFEST_DIR"));
-    let uploads_path = Path::new(&uploads_dir);
+    // Determine upload directory under user cache
+    let uploads_dir = get_cache_dir().join("uploads");
+    let uploads_path = uploads_dir.as_path();
 
     // Resolve the full path
     let file_path = Path::new(path);

--- a/mistralrs-web-chat/src/main.rs
+++ b/mistralrs-web-chat/src/main.rs
@@ -15,6 +15,7 @@ mod chat;
 mod handlers;
 mod models;
 mod types;
+mod utils;
 
 use handlers::{api::*, websocket::ws_handler};
 use models::LoadedModel;
@@ -77,7 +78,10 @@ async fn main() -> Result<()> {
         models.insert(name, LoadedModel::Vision(Arc::new(m)));
     }
 
-    let chats_dir = format!("{}/cache/chats", env!("CARGO_MANIFEST_DIR"));
+    // Initialize cache directory and chats subdirectory
+    let base_cache = utils::get_cache_dir();
+    println!("🔧 Using cache directory: {}", base_cache.display());
+    let chats_dir = base_cache.join("chats").to_string_lossy().to_string();
     tokio::fs::create_dir_all(&chats_dir).await?;
     let mut next_id = 1u32;
     if let Ok(mut dir) = fs::read_dir(&chats_dir).await {

--- a/mistralrs-web-chat/src/main.rs
+++ b/mistralrs-web-chat/src/main.rs
@@ -106,6 +106,7 @@ async fn main() -> Result<()> {
     let app = Router::new()
         .route("/ws", get(ws_handler))
         .route("/api/upload_image", post(upload_image))
+        .route("/api/upload_text", post(upload_text))
         .route("/api/list_models", get(list_models))
         .route("/api/select_model", post(select_model))
         .route("/api/list_chats", get(list_chats))

--- a/mistralrs-web-chat/src/main.rs
+++ b/mistralrs-web-chat/src/main.rs
@@ -114,6 +114,7 @@ async fn main() -> Result<()> {
         .route("/api/delete_chat", post(delete_chat))
         .route("/api/load_chat", post(load_chat))
         .route("/api/rename_chat", post(rename_chat))
+        .route("/api/append_message", post(append_message))
         .nest_service(
             "/",
             get_service(ServeDir::new(concat!(

--- a/mistralrs-web-chat/src/utils.rs
+++ b/mistralrs-web-chat/src/utils.rs
@@ -1,0 +1,15 @@
+use std::path::PathBuf;
+
+/// Determine the base cache directory for the application.
+/// Uses XDG_CACHE_HOME or falls back to ~/.cache/mistralrs-web-chat.
+pub fn get_cache_dir() -> PathBuf {
+    // XDG_CACHE_HOME or default to ~/.cache
+    let cache_home = std::env::var("XDG_CACHE_HOME")
+        .map(PathBuf::from)
+        .unwrap_or_else(|_| {
+            std::env::var("HOME")
+                .map(|h| PathBuf::from(h).join(".cache"))
+                .unwrap_or_else(|_| PathBuf::from(".cache"))
+        });
+    cache_home.join("mistralrs-web-chat")
+}

--- a/mistralrs-web-chat/static/index.html
+++ b/mistralrs-web-chat/static/index.html
@@ -36,6 +36,7 @@
       <label for="imageInput" class="btn" id="imageLabel">📎 Image</label>
       <label for="textInput" class="btn" id="textLabel">📄 File</label>
       <button type="submit" class="btn">Send</button>
+      <button type="button" class="btn" id="stopBtn">⏹️ Stop</button>
       <div id="spinner" class="spinner hidden" aria-hidden="true"></div>
     </form>
 

--- a/mistralrs-web-chat/static/index.html
+++ b/mistralrs-web-chat/static/index.html
@@ -28,16 +28,19 @@
         placeholder="Type your message… (Press Ctrl+Enter to send)"
       ></textarea>
 
-      <!-- hidden file input -->
+      <!-- hidden file inputs -->
       <input type="file" id="imageInput" accept="image/*" hidden />
+      <input type="file" id="textInput" accept=".txt,.md,.markdown,.py,.js,.ts,.rs,.html,.css,.json,.xml,.yaml,.yml,.toml,.c,.cpp,.java,.go,.rb,.php,.sh,.sql,.log,.csv" hidden />
 
-      <!-- image label and send button share the same class -->
+      <!-- file upload buttons and send button share the same class -->
       <label for="imageInput" class="btn" id="imageLabel">📎 Image</label>
+      <label for="textInput" class="btn" id="textLabel">📄 File</label>
       <button type="submit" class="btn">Send</button>
       <div id="spinner" class="spinner hidden" aria-hidden="true"></div>
     </form>
 
     <div id="image-container"></div>
+    <div id="text-files-container"></div>
 
     <!-- External dependencies -->
     <script src="marked.min.js"></script>

--- a/mistralrs-web-chat/static/js/chat.js
+++ b/mistralrs-web-chat/static/js/chat.js
@@ -130,6 +130,7 @@ async function loadChat(id) {
   
   log.innerHTML = '';
   clearImagePreviews();
+  clearTextFilePreviews();
   
   data.messages.forEach(m => {
     // ---- render text ----
@@ -164,17 +165,7 @@ async function loadChat(id) {
     }
   });
   
-  // Show last user-sent images in the image-container preview
-  const lastUserMsg = data.messages.slice().reverse().find(m => m.role === 'user' && m.images && m.images.length);
-  if (lastUserMsg) {
-    clearImagePreviews();
-    lastUserMsg.images.forEach(src => {
-      const img = document.createElement('img');
-      img.src = src;
-      img.className = 'chat-preview';
-      document.getElementById('image-container').appendChild(img);
-    });
-  }
+  // No pending attachments to restore on chat load
 }
 
 /**
@@ -215,6 +206,7 @@ function initChatHandlers() {
       // Clear current UI state before loading
       document.getElementById('log').innerHTML = '';
       clearImagePreviews();
+      clearTextFilePreviews();
       
       // Load the existing blank chat instead of creating a new one
       await loadChat(blankChatId);
@@ -236,6 +228,7 @@ function initChatHandlers() {
     currentChatId = id;
     document.getElementById('log').innerHTML = '';
     clearImagePreviews();
+    clearTextFilePreviews();
     await refreshChatList();
   });
 
@@ -247,6 +240,7 @@ function initChatHandlers() {
     if (ws.readyState === WebSocket.OPEN) ws.send(CLEAR_CMD);
     log.innerHTML = '';
     clearImagePreviews();
+    clearTextFilePreviews();
   });
 
   renameBtn.addEventListener('click', async () => {
@@ -287,6 +281,7 @@ function initChatHandlers() {
     currentChatId = null;
     document.getElementById('log').innerHTML = '';
     clearImagePreviews();
+    clearTextFilePreviews();
     await refreshChatList();
     
     // Move to newest chat if any, otherwise create a fresh one

--- a/mistralrs-web-chat/static/js/chat.js
+++ b/mistralrs-web-chat/static/js/chat.js
@@ -166,6 +166,10 @@ async function loadChat(id) {
   });
   
   // No pending attachments to restore on chat load
+  // Notify WebSocket of current chat ID
+  if (ws.readyState === WebSocket.OPEN) {
+    ws.send(JSON.stringify({ chat_id: id }));
+  }
 }
 
 /**
@@ -225,10 +229,8 @@ function initChatHandlers() {
       return; 
     }
     const { id } = await res.json();
-    currentChatId = id;
-    document.getElementById('log').innerHTML = '';
-    clearImagePreviews();
-    clearTextFilePreviews();
+    // Load and activate the new chat
+    await loadChat(id);
     await refreshChatList();
   });
 

--- a/mistralrs-web-chat/static/js/models.js
+++ b/mistralrs-web-chat/static/js/models.js
@@ -62,6 +62,7 @@ function initModelSelection() {
     }
     updateImageVisibility(models[name]);
     clearImagePreviews();
+    clearTextFilePreviews();
     prevModel = name;
     await selectModel(name);
   });

--- a/mistralrs-web-chat/static/js/ui.js
+++ b/mistralrs-web-chat/static/js/ui.js
@@ -129,11 +129,16 @@ async function handleTextUpload(file) {
   
   const fileExt = file.name.split('.').pop()?.toLowerCase();
   const allowedExtensions = [
-    'txt', 'md', 'markdown', 'py', 'js', 'ts', 'jsx', 'tsx', 'rs', 'html', 'htm', 'css', 'json', 
-    'xml', 'yaml', 'yml', 'toml', 'c', 'cpp', 'cc', 'h', 'hpp', 'java', 'go', 'rb', 'php', 
+    'txt', 'md', 'markdown', 'py', 'js', 'ts', 'jsx', 'tsx', 'rs', 'html', 'htm', 'css', 'json',
+    'xml', 'yaml', 'yml', 'toml', 'c', 'cpp', 'cc', 'cxx', 'h', 'hpp', 'hxx', 'java', 'kt', 'swift', 'go',
+    'rb', 'php',
+    // GPU and shader languages
+    'cu', 'cuh', 'cl', 'ptx', 'glsl', 'vert', 'frag', 'geom', 'comp', 'tesc', 'tese', 'hlsl', 'metal', 'wgsl',
+    // Shell and scripts
     'sh', 'bash', 'sql', 'log', 'csv', 'tsv', 'ini', 'cfg', 'conf', 'dockerfile', 'makefile',
-    'gitignore', 'env', 'lock', 'swift', 'kt', 'scala', 'clj', 'hs', 'elm', 'ex', 'erl', 'fs', 
-    'ml', 'vue', 'svelte', 'lua', 'nim', 'zig', 'd', 'dart', 'jl', 'pl', 'tcl'
+    'gitignore', 'env', 'lock',
+    'swift', 'kt', 'scala', 'clj', 'hs', 'elm', 'ex', 'erl', 'fs', 'fsx', 'ml', 'mli',
+    'vue', 'svelte', 'lua', 'nim', 'zig', 'd', 'dart', 'jl', 'pl', 'pm', 'tcl'
   ];
   
   if (!allowedTypes.includes(file.type) && !allowedExtensions.includes(fileExt) && file.type !== '') {
@@ -233,11 +238,17 @@ function initDragAndDrop() {
     const textFile = files.find(f => {
       const ext = f.name.split('.').pop()?.toLowerCase();
       const allowedExtensions = [
-        'txt', 'md', 'markdown', 'py', 'js', 'ts', 'jsx', 'tsx', 'rs', 'html', 'htm', 'css', 'json', 
-        'xml', 'yaml', 'yml', 'toml', 'c', 'cpp', 'cc', 'h', 'hpp', 'java', 'go', 'rb', 'php', 
+        'txt', 'md', 'markdown', 'py', 'js', 'ts', 'jsx', 'tsx', 'rs', 'html', 'htm', 'css', 'json',
+        'xml', 'yaml', 'yml', 'toml',
+        'c', 'cpp', 'cc', 'cxx', 'h', 'hpp', 'hxx', 'java', 'kt', 'swift', 'go',
+        'rb', 'php',
+        // GPU and shader languages
+        'cu', 'cuh', 'cl', 'ptx', 'glsl', 'vert', 'frag', 'geom', 'comp', 'tesc', 'tese', 'hlsl', 'metal', 'wgsl',
+        // Shell and scripts
         'sh', 'bash', 'sql', 'log', 'csv', 'tsv', 'ini', 'cfg', 'conf', 'dockerfile', 'makefile',
-        'gitignore', 'env', 'lock', 'swift', 'kt', 'scala', 'clj', 'hs', 'elm', 'ex', 'erl', 'fs', 
-        'ml', 'vue', 'svelte', 'lua', 'nim', 'zig', 'd', 'dart', 'jl', 'pl', 'tcl'
+        'gitignore', 'env', 'lock',
+        'swift', 'kt', 'scala', 'clj', 'hs', 'elm', 'ex', 'erl', 'fs', 'fsx', 'ml', 'mli',
+        'vue', 'svelte', 'lua', 'nim', 'zig', 'd', 'dart', 'jl', 'pl', 'pm', 'tcl'
       ];
       return f.type.startsWith('text/') || allowedExtensions.includes(ext) || f.type === 'application/json';
     });

--- a/mistralrs-web-chat/static/js/ui.js
+++ b/mistralrs-web-chat/static/js/ui.js
@@ -264,6 +264,37 @@ function initDragAndDrop() {
 }
 
 /**
+ * Initialize stop button functionality: abort assistant streaming
+ */
+function initStopButton() {
+  const stopBtn = document.getElementById('stopBtn');
+  if (!stopBtn) return;
+  stopBtn.addEventListener('click', async () => {
+    // Save partial assistant response
+    if (typeof assistantBuf !== 'undefined' && assistantBuf) {
+      if (typeof currentChatId !== 'undefined' && currentChatId) {
+        try {
+          await fetch('/api/append_message', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ id: currentChatId, role: 'assistant', content: assistantBuf })
+          });
+        } catch (e) {
+          console.error('Failed to append partial message:', e);
+        }
+      }
+    }
+    // Close and reset WebSocket
+    if (ws && ws.readyState === WebSocket.OPEN) ws.close();
+    hideSpinner();
+    assistantBuf = '';
+    assistantDiv = null;
+    // Reconnect WebSocket for further messages
+    initWebSocket();
+  });
+}
+
+/**
  * Initialize all UI interactions
  */
 function initUI() {
@@ -271,4 +302,5 @@ function initUI() {
   initImageUpload();
   initTextUpload();
   initDragAndDrop();
+  initStopButton();
 }

--- a/mistralrs-web-chat/static/js/utils.js
+++ b/mistralrs-web-chat/static/js/utils.js
@@ -96,6 +96,14 @@ function clearImagePreviews() {
 }
 
 /**
+ * Clear text file previews from the text files container
+ */
+function clearTextFilePreviews() {
+  const textContainer = document.getElementById('text-files-container');
+  if (textContainer) textContainer.innerHTML = '';
+}
+
+/**
  * Update image input visibility based on model kind
  */
 function updateImageVisibility(kind) {
@@ -104,4 +112,57 @@ function updateImageVisibility(kind) {
   
   imageLabel.style.display = (kind === 'vision') ? 'inline-block' : 'none';
   if (kind !== 'vision') imageInput.value = '';
+}
+
+/**
+ * Create an image preview element with delete button
+ */
+function createImagePreview(imageSrc) {
+  const container = document.createElement('div');
+  container.className = 'image-preview-container';
+  container.style.position = 'relative';
+  container.style.display = 'inline-block';
+  
+  const img = document.createElement('img');
+  img.src = imageSrc;
+  img.className = 'chat-preview';
+  
+  const removeBtn = document.createElement('button');
+  removeBtn.className = 'image-remove-btn';
+  removeBtn.textContent = '×';
+  removeBtn.title = 'Remove image';
+  removeBtn.style.position = 'absolute';
+  removeBtn.style.top = '5px';
+  removeBtn.style.right = '5px';
+  removeBtn.style.background = 'rgba(0,0,0,0.7)';
+  removeBtn.style.color = 'white';
+  removeBtn.style.border = 'none';
+  removeBtn.style.borderRadius = '50%';
+  removeBtn.style.width = '20px';
+  removeBtn.style.height = '20px';
+  removeBtn.style.cursor = 'pointer';
+  removeBtn.style.fontSize = '12px';
+  removeBtn.style.display = 'flex';
+  removeBtn.style.alignItems = 'center';
+  removeBtn.style.justifyContent = 'center';
+  
+  removeBtn.addEventListener('click', () => {
+    container.remove();
+  });
+  
+  removeBtn.addEventListener('mouseenter', () => {
+    removeBtn.style.background = '#ff4444';
+  });
+  
+  removeBtn.addEventListener('mouseleave', () => {
+    removeBtn.style.background = 'rgba(0,0,0,0.7)';
+  });
+  
+  container.appendChild(img);
+  container.appendChild(removeBtn);
+
+  // Store the upload URL for sending to the server
+  container.dataset.uploadUrl = imageSrc;
+
+  return container;
 }

--- a/mistralrs-web-chat/static/js/websocket.js
+++ b/mistralrs-web-chat/static/js/websocket.js
@@ -92,7 +92,31 @@ function sendMessage() {
     return;
   }
   
-  append(renderMarkdown(msg), 'user');
+  // Create the user message div
+  const userDiv = append(renderMarkdown(msg), 'user');
+  
+  // Check if there are any images in the image-container
+  const imageContainer = document.getElementById('image-container');
+  const images = imageContainer.querySelectorAll('img');
+  
+  if (images.length > 0) {
+    // Add thumbnails to the user message
+    const imgWrap = document.createElement('div');
+    imgWrap.className = 'chat-images';
+    imgWrap.style.display = 'flex';
+    imgWrap.style.flexWrap = 'wrap';
+    imgWrap.style.gap = '1rem';
+    
+    images.forEach(img => {
+      const thumbnail = document.createElement('img');
+      thumbnail.src = img.src;
+      thumbnail.className = 'chat-preview';
+      imgWrap.appendChild(thumbnail);
+    });
+    
+    userDiv.appendChild(imgWrap);
+  }
+  
   assistantBuf = ''; 
   assistantDiv = null;
   
@@ -100,6 +124,9 @@ function sendMessage() {
   
   ws.send(msg);
   input.value = ''; 
+  
+  // Clear images after sending
+  clearImagePreviews();
   
   // Trigger textarea resize
   const event = new Event('input');

--- a/mistralrs-web-chat/static/js/websocket.js
+++ b/mistralrs-web-chat/static/js/websocket.js
@@ -117,7 +117,14 @@ function sendMessage() {
     textFiles.forEach(preview => {
       const filename = preview.dataset.filename;
       const content = preview.dataset.content;
-      fileContents += `\n\n--- ${filename} ---\n${content}\n--- End of ${filename} ---\n`;
+      // Wrap file content in a fenced code block to preserve literal text
+      fileContents += `
+--- ${filename} ---
+\`\`\`text
+${content}
+\`\`\`
+--- End of ${filename} ---
+`;
     });
     
     if (msg) {

--- a/mistralrs-web-chat/static/js/websocket.js
+++ b/mistralrs-web-chat/static/js/websocket.js
@@ -73,9 +73,13 @@ function handleWebSocketMessage(ev) {
   
   assistantBuf += ev.data;
   assistantDiv.innerHTML = renderMarkdown(assistantBuf);
-  addCopyBtns(assistantDiv); 
+  addCopyBtns(assistantDiv);
   fixLinks(assistantDiv);
-  log.scrollTop = log.scrollHeight;
+  // Auto-scroll only if the user is already near the bottom
+  const threshold = 20;
+  if (log.scrollHeight - log.clientHeight - log.scrollTop < threshold) {
+    log.scrollTop = log.scrollHeight;
+  }
 }
 
 /**

--- a/mistralrs-web-chat/static/styles.css
+++ b/mistralrs-web-chat/static/styles.css
@@ -342,6 +342,12 @@ img.chat-preview {
 
 /* ---------- Mobile tweaks ---------- */
 @media (max-width: 600px) {
+/* ---------- Drag and drop highlight ---------- */
+#main.drag-over {
+  outline: 4px dashed var(--primary);
+  outline-offset: -4px;
+  cursor: copy;
+}
   body { 
     flex-direction: column; 
   }

--- a/mistralrs-web-chat/static/styles.css
+++ b/mistralrs-web-chat/static/styles.css
@@ -214,8 +214,8 @@ body {
   background: var(--primary-hov);
 }
 
-/* ----- image previews ----- */
-#imageInput { 
+/* ----- file upload and previews ----- */
+#imageInput, #textInput { 
   display:none; 
 }
 
@@ -233,11 +233,111 @@ img.chat-preview {
   max-height: 120px;
 }
 
-#image-container {
+#image-container, #text-files-container {
   display: flex;
   flex-wrap: wrap;
   gap: 1rem;
   margin-top: 1rem;
+}
+
+/* Image preview container styles */
+.image-preview-container {
+  position: relative;
+  display: inline-block;
+}
+
+.image-preview-container:hover .image-remove-btn {
+  opacity: 1;
+}
+
+.image-remove-btn {
+  position: absolute;
+  top: 5px;
+  right: 5px;
+  background: rgba(0, 0, 0, 0.7);
+  color: white;
+  border: none;
+  border-radius: 50%;
+  width: 20px;
+  height: 20px;
+  cursor: pointer;
+  font-size: 12px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  opacity: 0.8;
+  transition: all 0.2s ease;
+}
+
+.image-remove-btn:hover {
+  background: #ff4444 !important;
+  opacity: 1;
+}
+
+/* Text file preview styles */
+.text-file-preview {
+  border: 1px solid var(--border-color);
+  border-radius: var(--radius);
+  padding: 0.75rem;
+  background: var(--chat-bg);
+  max-width: 300px;
+  position: relative;
+}
+
+.text-file-preview .file-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 0.5rem;
+  font-weight: bold;
+  font-size: 0.9rem;
+}
+
+.text-file-preview .file-name {
+  color: var(--primary);
+  text-overflow: ellipsis;
+  overflow: hidden;
+  white-space: nowrap;
+  flex: 1;
+}
+
+.text-file-preview .file-size {
+  color: var(--text-muted);
+  font-size: 0.8rem;
+  margin-left: 0.5rem;
+}
+
+.text-file-preview .remove-btn {
+  background: var(--text-muted);
+  color: white;
+  border: none;
+  border-radius: 50%;
+  width: 20px;
+  height: 20px;
+  cursor: pointer;
+  font-size: 0.8rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  margin-left: 0.5rem;
+  transition: background 0.2s ease;
+}
+
+.text-file-preview .remove-btn:hover {
+  background: #ff4444;
+}
+
+.text-file-preview .file-content {
+  background: var(--main-bg);
+  border: 1px solid var(--border-color);
+  border-radius: 4px;
+  padding: 0.5rem;
+  font-family: 'Monaco', 'Menlo', 'Ubuntu Mono', monospace;
+  font-size: 0.8rem;
+  max-height: 100px;
+  overflow: auto;
+  white-space: pre-wrap;
+  color: var(--text-color);
 }
 
 /* ---------- Mobile tweaks ---------- */


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for uploading and previewing text/code files (e.g., .txt, .md, .py, .js) alongside images in the chat interface.
  - Users can now send uploaded text/code files with their messages, with content and filenames displayed in the chat.
  - Enhanced drag-and-drop to accept both image and text/code files.
  - Added dedicated UI previews and removal options for both image and text/code files.
  - Introduced new API endpoints for text file uploads and appending partial messages to chats.
  - Added security validation to ensure image file paths are within the designated uploads directory.

- **Improvements**
  - File uploads now include stricter validation for type, size (50MB for images, 10MB for text), and content decoding.
  - Enhanced error handling and user feedback for invalid or failed uploads.
  - Improved chat state management by reusing blank chats and consistently clearing file previews during chat transitions.
  - Added loading spinner to indicate message sending progress and a stop button to abort assistant streaming.
  - Improved message sending to include uploaded files and handle connection states gracefully.
  - Updated chat message persistence to associate messages with the correct chat ID.

- **Style**
  - Updated styles for file upload buttons and preview containers, including interactive remove buttons and improved layout for file previews.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->