### PR TITLE
Fix CPU block is_gpu init

### DIFF
--- a/mistralrs-core/src/dummy_paged_attention/block_engine.rs
+++ b/mistralrs-core/src/dummy_paged_attention/block_engine.rs
@@ -176,7 +176,7 @@ impl Allocator<CPUAllocator> {
                     block_id: id,
                     block_size,
                     refcount: 0,
-                    is_gpu: true,
+                    is_gpu: false,
                 },
             ))))
         }

--- a/mistralrs-core/src/paged_attention/block_engine.rs
+++ b/mistralrs-core/src/paged_attention/block_engine.rs
@@ -190,7 +190,7 @@ impl Allocator<CPUAllocator> {
                     block_id: id,
                     block_size,
                     refcount: 0,
-                    is_gpu: true,
+                    is_gpu: false,
                 },
             ))))
         }


### PR DESCRIPTION
## Summary
- fix CPU BlockEngine is_gpu flag for paged attention implementations

## Testing
- `cargo test --workspace --quiet` *(fails: Could not clone git dependency)*