### PR TITLE
Fix case where prefix cacher returns no toks

### DIFF
--- a/mistralrs-core/src/pipeline/mod.rs
+++ b/mistralrs-core/src/pipeline/mod.rs
@@ -438,7 +438,7 @@ pub trait Pipeline:
                     _ => unreachable!("Unreachable POST cache op."),
                 }
 
-                if !raw_out_logits[0].is_empty() && raw_out_logits[0][0].is_some() {
+                if raw_out_logits[0][0].is_some() {
                     let start = Instant::now();
                     response::send_raw_responses(
                         input_seqs,
@@ -594,7 +594,7 @@ pub trait Pipeline:
                     }
                 }
 
-                if !raw_out_logits[0].is_empty() && raw_out_logits[0][0].is_some() {
+                if raw_out_logits[0][0].is_some() {
                     let start = Instant::now();
                     response::send_raw_responses(
                         input_seqs,

--- a/mistralrs-core/src/prefix_cacher.rs
+++ b/mistralrs-core/src/prefix_cacher.rs
@@ -340,6 +340,11 @@ impl PrefixCacheManagerV2 {
         }
 
         if let Some((match_len, cache_element, images_match_until)) = best_match {
+            let new_toks = toks.0[match_len..].to_vec();
+            if new_toks.is_empty() {
+                return Ok(None);
+            }
+
             let mut cache = cache_element.clone();
             // Count how many input images are not already cached
             let images_to_keep = if let Some(input_hashes) = image_hashes {
@@ -356,7 +361,7 @@ impl PrefixCacheManagerV2 {
             return Ok(Some(MatchingCache::Normal {
                 normal: cache.cache,
                 images_to_keep,
-                toks: toks.0[match_len..].to_vec(),
+                toks: new_toks,
                 offset: match_len,
             }));
         }


### PR DESCRIPTION
Fixes issue re-introduced in #1359 after it rolled back the prefix cacher.

This only affected non-PagedAttention uses of the prefix cacher.

Fixes #1376.