### PR TITLE
Experimental AFQ on CPU support

### DIFF
--- a/mistralrs-quant/src/afq/ops.rs
+++ b/mistralrs-quant/src/afq/ops.rs
@@ -107,7 +107,7 @@ pub(crate) fn afq_quantize_op(
     }
     #[cfg(not(feature = "metal"))]
     {
-        candle_core::bail!("`afq_quantize_op` only works on Metal.")
+        return cpu_backend::afq_quantize_op(w, group_size, bits);
     }
 }
 
@@ -200,7 +200,7 @@ pub(crate) fn afq_dequantize_op(
     }
     #[cfg(not(feature = "metal"))]
     {
-        candle_core::bail!("`afq_dequantize_op` only works on Metal.")
+        return cpu_backend::afq_dequantize_op(w_q, scales, biases, group_size, bits);
     }
 }
 
@@ -416,7 +416,17 @@ pub(crate) fn afq_mm_op(
     }
     #[cfg(not(feature = "metal"))]
     {
-        candle_core::bail!("`afq_mm_op` only works on Metal.")
+        return cpu_backend::afq_mm_op(
+            x,
+            w,
+            scales,
+            biases,
+            lhs_indices,
+            rhs_indices,
+            group_size,
+            bits,
+            transpose,
+        );
     }
 }
 
@@ -491,5 +501,174 @@ mod metal_tests {
         let rmse = run_afq_roundtrip(AfqBits::Two)?;
         assert!(rmse < 0.35, "{rmse}");
         Ok(())
+    }
+}
+
+// ============================================================
+//                    Portable CPU back‑end
+// ============================================================
+#[cfg(not(feature = "metal"))]
+mod cpu_backend {
+    use super::*;
+    use candle_core::{DType, Device, Result, Tensor, D};
+
+    /// Simple scalar (reference) quantiser: per‑`group_size` affine.
+    pub(crate) fn afq_quantize_op(
+        w: &Tensor,
+        group_size: usize,
+        bits: usize,
+    ) -> Result<(Tensor, Tensor, Tensor)> {
+        let device = Device::Cpu;
+        let levels = ((1u32 << bits) - 1) as f32;
+
+        // Flatten everything except the last dim.
+        let w_vec = w.flatten_all()?.to_dtype(DType::F32)?.to_vec1::<f32>()?;
+        let outer: usize = w_vec.len() / w.dim(D::Minus1)?;
+        let inner = w.dim(D::Minus1)?;
+
+        let packed_row = inner * bits / 32;
+        let groups_per_row = inner / group_size;
+
+        let mut q_codes = vec![0u32; outer * packed_row];
+        let mut scales = vec![0f32; outer * groups_per_row];
+        let mut biases = vec![0f32; outer * groups_per_row];
+
+        for row in 0..outer {
+            for g in 0..groups_per_row {
+                let base = row * inner + g * group_size;
+                let slice = &w_vec[base..base + group_size];
+                let (min_v, max_v) = slice
+                    .iter()
+                    .fold((f32::MAX, f32::MIN), |(a, b), &v| (a.min(v), b.max(v)));
+                let scale = if (max_v - min_v).abs() < 1e-12 {
+                    1.0
+                } else {
+                    (max_v - min_v) / levels
+                };
+                let bias = min_v;
+                scales[row * groups_per_row + g] = scale;
+                biases[row * groups_per_row + g] = bias;
+
+                for i in 0..group_size {
+                    let j = g * group_size + i;          // position in this row
+                    let bit_off = j * bits;              // overall bit offset
+                    let word_id = bit_off / 32;          // u32 index
+                    let shift   = bit_off % 32;          // intra‑word shift
+
+                    let q_mask = ((1u32 << bits) - 1) as u32;
+                    let q_val  = ((w_vec[base + i] - bias) / scale)
+                        .round()
+                        .clamp(0.0, levels) as u32 & q_mask;
+
+                    let row_base = row * packed_row;
+                    q_codes[row_base + word_id] |= q_val << shift;
+                    if shift + bits > 32 {
+                        q_codes[row_base + word_id + 1] |= q_val >> (32 - shift);
+                    }
+                }
+            }
+        }
+
+        let w_q = Tensor::from_vec(
+            q_codes,
+            {
+                let mut d = w.dims().to_vec();
+                *d.last_mut().unwrap() = packed_row;
+                d
+            },
+            &device,
+        )?
+        .to_dtype(DType::U32)?;
+        let sc = Tensor::from_vec(
+            scales,
+            {
+                let mut d = w.dims().to_vec();
+                *d.last_mut().unwrap() = groups_per_row;
+                d
+            },
+            &device,
+        )?;
+        let bs = Tensor::from_vec(
+            biases,
+            {
+                let mut d = w.dims().to_vec();
+                *d.last_mut().unwrap() = groups_per_row;
+                d
+            },
+            &device,
+        )?;
+        Ok((w_q, sc, bs))
+    }
+
+    /// Scalar de‑quantiser (inverse of the above).
+    pub(crate) fn afq_dequantize_op(
+        w_q: &Tensor,
+        scales: &Tensor,
+        biases: &Tensor,
+        group_size: usize,
+        _bits: usize,
+    ) -> Result<Tensor> {
+        let device = Device::Cpu;
+        let codes = w_q.flatten_all()?.to_vec1::<u32>()?;
+        let sc = scales.flatten_all()?.to_vec1::<f32>()?;
+        let bs = biases.flatten_all()?.to_vec1::<f32>()?;
+
+        let packed_row = w_q.dim(D::Minus1)?;
+        let outer = codes.len() / packed_row;
+        let inner = packed_row * 32 / _bits;
+        let groups_per_row = inner / group_size;
+
+        let mut out = vec![0f32; outer * inner];
+        for row in 0..outer {
+            for g in 0..groups_per_row {
+                let scale = sc[row * groups_per_row + g];
+                let bias = bs[row * groups_per_row + g];
+                for i in 0..group_size {
+                    let j = g * group_size + i;
+                    let bit_off = j * _bits;
+                    let word_id = bit_off / 32;
+                    let shift   = bit_off % 32;
+
+                    let row_base = row * packed_row;
+                    let mut q = (codes[row_base + word_id] >> shift) & ((1u32 << _bits) - 1);
+                    if shift + _bits > 32 {
+                        q |= (codes[row_base + word_id + 1] << (32 - shift)) & ((1u32 << _bits) - 1);
+                    }
+
+                    let idx = row * inner + j;
+                    out[idx] = bias + q as f32 * scale;
+                }
+            }
+        }
+        Tensor::from_vec(
+            out,
+            {
+                let mut d = w_q.dims().to_vec();
+                *d.last_mut().unwrap() = inner;
+                d
+            },
+            &device,
+        )
+    }
+
+    /// Very simple (and slow) matmul after full de‑quantisation.  Handles 2‑D tensors.
+    #[allow(clippy::too_many_arguments)]
+    pub(crate) fn afq_mm_op(
+        x: &Tensor,
+        w: &Tensor,
+        scales: &Tensor,
+        biases: &Tensor,
+        _lhs_indices: Option<&Tensor>,
+        _rhs_indices: Option<&Tensor>,
+        group_size: usize,
+        bits: usize,
+        transpose: bool,
+    ) -> Result<Tensor> {
+        let w_f32 = afq_dequantize_op(w, scales, biases, group_size, bits)?.to_dtype(x.dtype())?;
+        if transpose {
+            x.broadcast_matmul(&w_f32.t()?)
+        } else {
+            x.broadcast_matmul(&w_f32)
+        }
     }
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added CPU support for quantization, dequantization, and matrix multiplication operations when the "metal" feature is not enabled. These operations now work on all platforms, not just those with "metal" support.

- **Bug Fixes**
  - Resolved previous errors that occurred when attempting to use quantization features without "metal" support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->