### PR TITLE
Handle receiver disconnects

### DIFF
--- a/mistralrs-bench/src/main.rs
+++ b/mistralrs-bench/src/main.rs
@@ -90,9 +90,9 @@ fn run_bench(
 
     for _ in 0..repetitions {
         for _ in 0..concurrency {
-            sender
-                .blocking_send(req.clone())
-                .expect("Expected receiver.");
+            if sender.blocking_send(req.clone()).is_err() {
+                eprintln!("Receiver disconnected");
+            }
         }
         for _ in 0..concurrency {
             match rx.blocking_recv() {
@@ -258,9 +258,9 @@ fn warmup_run(mistralrs: Arc<MistralRs>) {
         web_search_options: None,
     }));
 
-    sender
-        .blocking_send(req.clone())
-        .expect("Expected receiver.");
+    if sender.blocking_send(req.clone()).is_err() {
+        eprintln!("Receiver disconnected");
+    }
 
     let _ = rx.blocking_recv();
 }

--- a/mistralrs-core/src/engine/add_request.rs
+++ b/mistralrs-core/src/engine/add_request.rs
@@ -85,9 +85,11 @@ impl Engine {
                     .response
                     .send(Response::ValidationError(
                         "Received messages for a model which does not have a chat template. Either use a different model or pass a single string as the prompt".into(),
-                    )).await.expect("Expected receiver.");
-            return;
-        }
+                    ))
+                    .await
+                    .unwrap_or_else(|_| warn!("Receiver disconnected"));
+                return;
+            }
 
         // Verify the model's category matches the messages received.
         match (
@@ -110,7 +112,7 @@ impl Engine {
                         "Received a request incompatible for this model's category.".into(),
                     ))
                     .await
-                    .expect("Expected receiver.");
+                    .unwrap_or_else(|_| warn!("Receiver disconnected"));
                 return;
             }
         }
@@ -178,7 +180,7 @@ impl Engine {
                             "Completion requests require the pipeline to have a tokenizer".into(),
                         ))
                         .await
-                        .expect("Expected receiver.");
+                        .unwrap_or_else(|_| warn!("Receiver disconnected"));
                     return;
                 };
                 let prompt = tokenizer
@@ -201,7 +203,7 @@ impl Engine {
                             "Completion requests w/ raw tokens require the pipeline to have a tokenizer".into(),
                         ))
                         .await
-                        .expect("Expected receiver.");
+                        .unwrap_or_else(|_| warn!("Receiver disconnected"));
                     return;
                 };
                 let prompt = tokenizer
@@ -217,7 +219,7 @@ impl Engine {
                     "Received an empty prompt.".into(),
                 ))
                 .await
-                .expect("Expected receiver.");
+                .unwrap_or_else(|_| warn!("Receiver disconnected"));
             return;
         }
 
@@ -227,7 +229,9 @@ impl Engine {
                     .response
                     .send(Response::ValidationError(
                         format!("Prompt sequence length is greater than {}, perhaps consider using `truncate_sequence`?", get_mut_arcmutex!(self.pipeline).get_metadata().max_seq_len).into(),
-                    )).await.expect("Expected receiver.");
+                    ))
+                    .await
+                    .unwrap_or_else(|_| warn!("Receiver disconnected"));
                 return;
             } else {
                 let prompt_len = prompt_tokens.len();
@@ -275,7 +279,8 @@ impl Engine {
                                 .send(Response::ValidationError(
                                     format!("Stop token {:?} is also a prefix of other tokens and cannot be used as a stop token.", tok_trie.token_str(*id)).into(),
                                 ))
-                                .await .expect("Expected receiver.");
+                                .await
+                                .unwrap_or_else(|_| warn!("Receiver disconnected"));
                             return;
                         }
                     }
@@ -303,7 +308,7 @@ impl Engine {
                                     .into(),
                             ))
                             .await
-                            .expect("Expected receiver.");
+                            .unwrap_or_else(|_| warn!("Receiver disconnected"));
                         return;
                     };
                     let encoded = tokenizer.encode_fast(stop_txt.to_string(), true);
@@ -359,7 +364,7 @@ impl Engine {
                     "Number of choices must be greater than 0.".into(),
                 ))
                 .await
-                .expect("Expected receiver.");
+                .unwrap_or_else(|_| warn!("Receiver disconnected"));
             return;
         }
 
@@ -378,7 +383,7 @@ impl Engine {
                             format!("Invalid grammar. {}", err).into(),
                         ))
                         .await
-                        .expect("Expected receiver.");
+                        .unwrap_or_else(|_| warn!("Receiver disconnected"));
                     return;
                 }
             };
@@ -434,7 +439,7 @@ impl Engine {
                                         .into(),
                                 ))
                                 .await
-                                .expect("Expected receiver.");
+                                .unwrap_or_else(|_| warn!("Receiver disconnected"));
                             return;
                         }
                     }
@@ -455,7 +460,7 @@ impl Engine {
                                         .into(),
                                 ))
                                 .await
-                                .expect("Expected receiver.");
+                                .unwrap_or_else(|_| warn!("Receiver disconnected"));
                             return;
                         }
                     }
@@ -587,7 +592,7 @@ impl Engine {
                             .response
                             .send(Err(e))
                             .await
-                            .expect("Expected receiver.");
+                            .unwrap_or_else(|_| warn!("Receiver disconnected"));
                         return;
                     }
                 };
@@ -609,7 +614,7 @@ impl Engine {
                                 "Pipeline does not include a toksnizer.",
                             )))
                             .await
-                            .expect("Expected receiver.");
+                            .unwrap_or_else(|_| warn!("Receiver disconnected"));
                         return;
                     }
                 };
@@ -621,7 +626,7 @@ impl Engine {
                             .response
                             .send(Err(anyhow::Error::msg(e)))
                             .await
-                            .expect("Expected receiver.");
+                            .unwrap_or_else(|_| warn!("Receiver disconnected"));
                         return;
                     }
                 };
@@ -646,7 +651,7 @@ impl Engine {
                         "Pipeline does not include a toksnizer.",
                     )))
                     .await
-                    .expect("Expected receiver.");
+                    .unwrap_or_else(|_| warn!("Receiver disconnected"));
                 return;
             }
         };
@@ -658,7 +663,7 @@ impl Engine {
                     .response
                     .send(Err(anyhow::Error::msg(e)))
                     .await
-                    .expect("Expected receiver.");
+                    .unwrap_or_else(|_| warn!("Receiver disconnected"));
                 return;
             }
         };

--- a/mistralrs-core/src/engine/add_request.rs
+++ b/mistralrs-core/src/engine/add_request.rs
@@ -88,8 +88,8 @@ impl Engine {
                     ))
                     .await
                     .unwrap_or_else(|_| warn!("Receiver disconnected"));
-                return;
-            }
+            return;
+        }
 
         // Verify the model's category matches the messages received.
         match (

--- a/mistralrs-core/src/utils/mod.rs
+++ b/mistralrs-core/src/utils/mod.rs
@@ -29,10 +29,7 @@ macro_rules! handle_seq_error {
             Ok(v) => v,
             Err(e) => {
                 use $crate::response::Response;
-                if let Err(_) = $response
-                    .send(Response::InternalError(e.into()))
-                    .await
-                {
+                if let Err(_) = $response.send(Response::InternalError(e.into())).await {
                     tracing::warn!("Receiver disconnected");
                 }
                 return;
@@ -49,10 +46,7 @@ macro_rules! handle_seq_error_ok {
             Ok(v) => v,
             Err(e) => {
                 use $crate::response::Response;
-                if let Err(_) = $response
-                    .send(Response::InternalError(e.into()))
-                    .await
-                {
+                if let Err(_) = $response.send(Response::InternalError(e.into())).await {
                     tracing::warn!("Receiver disconnected");
                 }
                 return Ok(());

--- a/mistralrs-core/src/utils/mod.rs
+++ b/mistralrs-core/src/utils/mod.rs
@@ -29,10 +29,12 @@ macro_rules! handle_seq_error {
             Ok(v) => v,
             Err(e) => {
                 use $crate::response::Response;
-                $response
+                if let Err(_) = $response
                     .send(Response::InternalError(e.into()))
                     .await
-                    .expect("Expected receiver.");
+                {
+                    tracing::warn!("Receiver disconnected");
+                }
                 return;
             }
         }
@@ -47,10 +49,12 @@ macro_rules! handle_seq_error_ok {
             Ok(v) => v,
             Err(e) => {
                 use $crate::response::Response;
-                $response
+                if let Err(_) = $response
                     .send(Response::InternalError(e.into()))
                     .await
-                    .expect("Expected receiver.");
+                {
+                    tracing::warn!("Receiver disconnected");
+                }
                 return Ok(());
             }
         }
@@ -66,10 +70,13 @@ macro_rules! handle_seq_error_stateaware_ok {
             Err(e) => {
                 use $crate::response::Response;
                 use $crate::sequence::SequenceState;
-                $seq.responder()
+                if let Err(_) = $seq
+                    .responder()
                     .send(Response::InternalError(e.into()))
                     .await
-                    .expect("Expected receiver.");
+                {
+                    tracing::warn!("Receiver disconnected");
+                }
                 $seq.set_state(SequenceState::Error);
                 return Ok(());
             }


### PR DESCRIPTION
## Summary
- avoid panics when the response channel is closed
- emit a warning instead of crashing

## Testing
- `cargo test` *(fails: spurious network error)*

------
https://chatgpt.com/codex/tasks/task_e_683e4d95e1208322ace0d828f227f03b