### PR TITLE
Fix interactive mode URL parsing

### DIFF
--- a/mistralrs-server/src/interactive_mode.rs
+++ b/mistralrs-server/src/interactive_mode.rs
@@ -335,20 +335,6 @@ async fn text_interactive_mode(
     rl.save_history(&history_file_path()).unwrap();
 }
 
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn parse_files_and_message_trims_trailing_punctuation() {
-        let regex = Regex::new(IMAGE_REGEX).unwrap();
-        let input = "Look at this https://example.com/test.png.";
-        let (urls, text) = parse_files_and_message(input, &regex);
-        assert_eq!(urls, vec!["https://example.com/test.png"]);
-        assert_eq!(text, "Look at this .");
-    }
-}
-
 fn parse_files_and_message(input: &str, regex: &Regex) -> (Vec<String>, String) {
     // Collect all URLs
     let urls: Vec<String> = regex
@@ -797,4 +783,18 @@ async fn speech_interactive_mode(mistralrs: Arc<MistralRs>, do_search: bool) {
     }
 
     rl.save_history(&history_file_path()).unwrap();
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_files_and_message_trims_trailing_punctuation() {
+        let regex = Regex::new(IMAGE_REGEX).unwrap();
+        let input = "Look at this https://example.com/test.png.";
+        let (urls, text) = parse_files_and_message(input, &regex);
+        assert_eq!(urls, vec!["https://example.com/test.png"]);
+        assert_eq!(text, "Look at this .");
+    }
 }

--- a/mistralrs-server/src/interactive_mode.rs
+++ b/mistralrs-server/src/interactive_mode.rs
@@ -134,10 +134,8 @@ const EXIT_CMD: &str = "\\exit";
 const SYSTEM_CMD: &str = "\\system";
 const CLEAR_CMD: &str = "\\clear";
 
-/// Regex string used to extract image URLs from prompts without capturing
-/// trailing punctuation like periods or parentheses.
-const IMAGE_REGEX: &str =
-    r#"((?:https?://|file://)?\S+?\.(?:png|jpe?g|bmp|gif|webp)(?:\?\S+?)?)(?=[\s,.;:!?)]|$)"#;
+/// Regex string used to extract image URLs from prompts.
+const IMAGE_REGEX: &str = r#"((?:https?://|file://)?\S+?\.(?:png|jpe?g|bmp|gif|webp)(?:\?\S+?)?)"#;
 
 fn interactive_sample_parameters() -> SamplingParams {
     SamplingParams {
@@ -358,7 +356,12 @@ fn parse_files_and_message(input: &str, regex: &Regex) -> (Vec<String>, String) 
         .filter_map(|cap| {
             cap.get(1).map(|m| {
                 m.as_str()
-                    .trim_end_matches(|c: char| matches!(c, '.' | ',' | ';' | ':' | '!' | '?' | ')' | ']' | '}' | '"' | '\''))
+                    .trim_end_matches(|c: char| {
+                        matches!(
+                            c,
+                            '.' | ',' | ';' | ':' | '!' | '?' | ')' | ']' | '}' | '"' | '\''
+                        )
+                    })
                     .to_string()
             })
         })


### PR DESCRIPTION
## Summary
- avoid trailing punctuation in vision interactive mode URL regex
- clean parsed URLs and add regression test

## Testing
- `cargo test -p mistralrs-server --lib --quiet` *(fails: could not fetch dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_683e4dbf62b48322a46297b66b0ece15

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved extraction of image URLs from user input to prevent accidental inclusion of trailing punctuation (such as periods, commas, or quotes) in the detected URLs.

- **Tests**
  - Added a test to ensure image URLs are correctly extracted without trailing punctuation and that message text remains accurate.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->