### PR TITLE
Provide chat_templates to container users

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -37,3 +37,6 @@ COPY --from=builder /mistralrs/target/release/mistralrs-web-chat /usr/local/bin/
 
 # Make the binaries executable
 RUN chmod +x /usr/local/bin/mistralrs-bench /usr/local/bin/mistralrs-server /usr/local/bin/mistralrs-web-chat
+
+# Copy chat templates for users running models which may not include them
+COPY --from=builder /mistralrs/chat_templates /chat_templates

--- a/Dockerfile.cuda-all
+++ b/Dockerfile.cuda-all
@@ -53,3 +53,6 @@ COPY --from=builder /mistralrs/target/release/mistralrs-server /usr/local/bin/mi
 RUN chmod +x /usr/local/bin/mistralrs-server
 COPY --from=builder /mistralrs/target/release/mistralrs-web-chat /usr/local/bin/mistralrs-web-chat
 RUN chmod +x /usr/local/bin/mistralrs-web-chat
+
+# Copy chat templates for users running models which may not include them
+COPY --from=builder /mistralrs/chat_templates /chat_templates


### PR DESCRIPTION
Models often come without chat templates requiring mapping them from the source repository into a container for access by the mistralrs-server.

Copy the templates from the build tree into the root of the image to permit use via `--chat-template /chat_templates/something.json`

TODO:
  With the increase in quantized models and support for other
formats, the initial benchmark run during model load can be used to qualify/select existing chat templates embedded into the binary for models which do not come with any (to include output of the functional failures in each test allowing users to modify the ones already provided correctly to suit the model being loaded).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Chat templates are now included in the runtime environment, making them available for users running models that may not provide templates by default.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->