### PR TITLE
Update docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,6 +182,7 @@ OpenAI API compatible API server
 - [API Docs](docs/HTTP.md).
 - [Launching the server or use the CLI](README.md#run-with-the-cli)
 - [Example](examples/server/chat.py)
+- [Use or extend the server in other axum projects](https://ericlbuehler.github.io/mistral.rs/mistralrs_server_core/)
 
 
 ### Llama Index integration

--- a/mistralrs-server-core/README.md
+++ b/mistralrs-server-core/README.md
@@ -2,4 +2,4 @@
 
 Core crate that powers `mistral.rs server`.
 
-Documentation: TBD
+Documentation: https://ericlbuehler.github.io/mistral.rs/mistralrs_server_core/

--- a/mistralrs-server-core/src/mistralrs_for_server_builder.rs
+++ b/mistralrs-server-core/src/mistralrs_for_server_builder.rs
@@ -44,7 +44,7 @@ pub mod defaults {
     pub const TOKEN_SOURCE: mistralrs_core::TokenSource = mistralrs_core::TokenSource::CacheToken;
 }
 
-/// A builder for creating a the mistral.rs instance with configured options used for the mistral.rs server.
+/// A builder for creating a mistral.rs instance with configured options for the mistral.rs server.
 ///
 /// ### Examples
 ///


### PR DESCRIPTION
Just some minor docs updates:

- server core lib.rs: clean up example var names and match logging change from https://github.com/EricLBuehler/mistral.rs/commit/201d6bece4cba487d82bdec9b62079f3f5ebdbad
- server_builder: fix typo
- READMEs: link to crate docs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added a link to documentation for using or extending the HTTP server in the main README.
  - Updated the `mistralrs-server-core` README to include a direct link to its documentation.
  - Improved clarity in documentation comments for the server builder.
  - Updated example code and comments to use consistent naming for internal state variables.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->