### PR TITLE
Conditionally build seqlens tensors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,5 @@
 *.a
 .DS_Store
 .idea
+mistral.rs/
 mistralrs-web-chat/cache


### PR DESCRIPTION
## Summary
- generate cumulative seqlen tensors only when flash attention is enabled
- ignore nested `mistral.rs` repo

## Testing
- `cargo fmt`
- `cargo test --workspace --quiet` *(fails: command was interrupted due to resource constraints)*

------
https://chatgpt.com/codex/tasks/task_e_6840d1743c4083229a4c1ea083fbdf90

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated ignored files to exclude the `mistral.rs` directory from version control.

- **Bug Fixes**
	- Improved handling of sequence length processing to ensure correct behavior when flash attention is enabled or disabled, preventing unnecessary computations when not needed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->