### PR TITLE
Support QWen3 GGUF model

### DIFF
--- a/mistralrs-core/src/gguf/mod.rs
+++ b/mistralrs-core/src/gguf/mod.rs
@@ -27,6 +27,7 @@ pub enum GGUFArchitecture {
     Phi3,
     Starcoder2,
     Qwen2,
+    Qwen3,
 }
 
 // Wraps from_str() for some convenience:

--- a/mistralrs-core/src/models/mod.rs
+++ b/mistralrs-core/src/models/mod.rs
@@ -11,7 +11,7 @@ pub(crate) mod phi3_5_moe;
 pub(crate) mod quantized_llama;
 pub(crate) mod quantized_phi2;
 pub(crate) mod quantized_phi3;
-pub(crate) mod quantized_qwen2;
+pub(crate) mod quantized_qwen;
 pub(crate) mod quantized_starcoder2;
 pub(crate) mod qwen2;
 pub(crate) mod qwen3;

--- a/mistralrs-core/src/models/quantized_qwen.rs
+++ b/mistralrs-core/src/models/quantized_qwen.rs
@@ -193,7 +193,7 @@ impl TryFrom<ContentMetadata<'_>> for PropsGGUF {
     type Error = anyhow::Error;
 
     fn try_from(c: ContentMetadata) -> std::result::Result<Self, Self::Error> {
-        let _ = verify_qwen_arch(&c.metadata, &["qwen2", "qwen3"])?;
+        let _ = verify_qwen_arch(c.metadata, &["qwen2", "qwen3"])?;
 
         let required = [
             "attention.head_count",

--- a/mistralrs-core/src/utils/gguf_metadata.rs
+++ b/mistralrs-core/src/utils/gguf_metadata.rs
@@ -489,24 +489,21 @@ impl DeviceMappedModelLoader for GgufDeviceMapLoaderInner<'_, '_> {
                 let mut attn_q =
                     tensor_info_size_in_bytes!(self.model.tensor_info("blk.0.attn_q.weight")?);
                 if let GGUFArchitecture::Qwen2 = self.arch {
-                    attn_q += tensor_info_size_in_bytes!(self
-                        .model
-                        .tensor_info("blk.0.attn_q.bias")?);
+                    attn_q +=
+                        tensor_info_size_in_bytes!(self.model.tensor_info("blk.0.attn_q.bias")?);
                 }
                 let mut attn_k =
                     tensor_info_size_in_bytes!(self.model.tensor_info("blk.0.attn_k.weight")?);
                 if let GGUFArchitecture::Qwen2 = self.arch {
-                    attn_k += tensor_info_size_in_bytes!(self
-                        .model
-                        .tensor_info("blk.0.attn_k.bias")?);
+                    attn_k +=
+                        tensor_info_size_in_bytes!(self.model.tensor_info("blk.0.attn_k.bias")?);
                 }
 
                 let mut attn_v =
                     tensor_info_size_in_bytes!(self.model.tensor_info("blk.0.attn_v.weight")?);
                 if let GGUFArchitecture::Qwen2 = self.arch {
-                    attn_v += tensor_info_size_in_bytes!(self
-                        .model
-                        .tensor_info("blk.0.attn_v.bias")?);
+                    attn_v +=
+                        tensor_info_size_in_bytes!(self.model.tensor_info("blk.0.attn_v.bias")?);
                 }
 
                 let attn_output = tensor_info_size_in_bytes!(self

--- a/mistralrs-core/src/utils/gguf_metadata.rs
+++ b/mistralrs-core/src/utils/gguf_metadata.rs
@@ -488,34 +488,25 @@ impl DeviceMappedModelLoader for GgufDeviceMapLoaderInner<'_, '_> {
 
                 let mut attn_q =
                     tensor_info_size_in_bytes!(self.model.tensor_info("blk.0.attn_q.weight")?);
-                match self.arch {
-                    GGUFArchitecture::Qwen2 => {
-                        attn_q += tensor_info_size_in_bytes!(self
-                            .model
-                            .tensor_info("blk.0.attn_q.bias")?);
-                    }
-                    _ => {}
+                if let GGUFArchitecture::Qwen2 = self.arch {
+                    attn_q += tensor_info_size_in_bytes!(self
+                        .model
+                        .tensor_info("blk.0.attn_q.bias")?);
                 }
                 let mut attn_k =
                     tensor_info_size_in_bytes!(self.model.tensor_info("blk.0.attn_k.weight")?);
-                match self.arch {
-                    GGUFArchitecture::Qwen2 => {
-                        attn_k += tensor_info_size_in_bytes!(self
-                            .model
-                            .tensor_info("blk.0.attn_k.bias")?);
-                    }
-                    _ => {}
+                if let GGUFArchitecture::Qwen2 = self.arch {
+                    attn_k += tensor_info_size_in_bytes!(self
+                        .model
+                        .tensor_info("blk.0.attn_k.bias")?);
                 }
 
                 let mut attn_v =
                     tensor_info_size_in_bytes!(self.model.tensor_info("blk.0.attn_v.weight")?);
-                match self.arch {
-                    GGUFArchitecture::Qwen2 => {
-                        attn_v += tensor_info_size_in_bytes!(self
-                            .model
-                            .tensor_info("blk.0.attn_v.bias")?);
-                    }
-                    _ => {}
+                if let GGUFArchitecture::Qwen2 = self.arch {
+                    attn_v += tensor_info_size_in_bytes!(self
+                        .model
+                        .tensor_info("blk.0.attn_v.bias")?);
                 }
 
                 let attn_output = tensor_info_size_in_bytes!(self

--- a/mistralrs-core/src/utils/model_config.rs
+++ b/mistralrs-core/src/utils/model_config.rs
@@ -298,7 +298,7 @@ use crate::{
     models::quantized_llama::ModelWeights as QLlama,
     models::quantized_phi2::ModelWeights as QPhi,
     models::quantized_phi3::ModelWeights as QPhi3,
-    models::quantized_qwen2::ModelWeights as QQwen2,
+    models::quantized_qwen::ModelWeights as QQwen,
     models::quantized_starcoder2::ModelWeights as QStarcoder2,
     xlora_models::{XLoraQLlama, XLoraQPhi3},
 };
@@ -323,7 +323,7 @@ impl TryFrom<ModelParams<'_, ParamsGGML>> for XLoraQLlama {
 }
 
 akin! {
-    let &models_gguf = [QLlama, QPhi, QPhi3, QStarcoder2, QQwen2];
+    let &models_gguf = [QLlama, QPhi, QPhi3, QStarcoder2, QQwen];
 
     impl<R: std::io::Seek + std::io::Read> TryFrom<ModelParams<'_, ParamsGGUF<'_, R>>> for *models_gguf {
         type Error = candle_core::Error;


### PR DESCRIPTION
Hi Eric,

I would like to merge Qwen3 GGUF model support from candle-vllm into mistral.rs. Qwen2 and Qwen3 share a similar structure, with differences mainly in the attention bias and q_norm/k_norm.

Tested case:

```shell
./mistralrs-server gguf -m unsloth/DeepSeek-R1-0528-Qwen3-8B-GGUF -f DeepSeek-R1-0528-Qwen3-8B-Q2_K.gguf
```

Additionally, I found that the **tokenizer built (decoded) from the GGUF file** may not be fully compatible with the latest Qwen3 structure. I may open an issue (or submit a separate PR) to address.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Added support for the Qwen3 model architecture, including optional per-head RMS normalization for improved model compatibility.
- **Refactor**
	- Unified Qwen2 and Qwen3 models under a single Qwen model type for streamlined usage and maintenance.
- **Bug Fixes**
	- Adjusted model loading to conditionally include bias tensors based on architecture, ensuring correct handling for both Qwen2 and Qwen3.
- **Chores**
	- Updated internal naming and import paths to reflect the unified Qwen model structure.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->