### PR TITLE
Downgrade rustyline 16.0.0 -> 15.0.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -931,7 +931,7 @@ version = "3.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "46f93780a459b7d656ef7f071fe699c4d3d2cb201c4b24d085b6ddc505276e73"
 dependencies = [
- "nix",
+ "nix 0.30.1",
  "windows-sys 0.59.0",
 ]
 
@@ -3007,6 +3007,18 @@ dependencies = [
 
 [[package]]
 name = "nix"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46"
+dependencies = [
+ "bitflags 2.9.1",
+ "cfg-if",
+ "cfg_aliases",
+ "libc",
+]
+
+[[package]]
+name = "nix"
 version = "0.30.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "74523f3a35e05aba87a1d978330aef40f67b0304ac79c1c00b294c9830543db6"
@@ -4013,9 +4025,9 @@ checksum = "8a0d197bd2c9dc6e53b84da9556a69ba4cdfab8619eb41a8bd1cc2027a0f6b1d"
 
 [[package]]
 name = "rustyline"
-version = "16.0.0"
+version = "15.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62fd9ca5ebc709e8535e8ef7c658eb51457987e48c98ead2be482172accc408d"
+checksum = "2ee1e066dc922e513bda599c6ccb5f3bb2b0ea5870a579448f2622993f0a9a2f"
 dependencies = [
  "bitflags 2.9.1",
  "cfg-if",
@@ -4024,7 +4036,7 @@ dependencies = [
  "libc",
  "log",
  "memchr",
- "nix",
+ "nix 0.29.0",
  "unicode-segmentation",
  "unicode-width 0.2.0",
  "utf8parse",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -148,7 +148,8 @@ memmap2 = "0.9.5"
 pyo3-build-config = "0.25.0"
 ctrlc = "3.4.7"
 directories = "6.0.0"
-rustyline = { version = "16.0.0", default-features = false, features = ["with-file-history"] }
+# Need to keep rustyline at 15.0.0 as 16.0.0 has a breaking change that conficts with `ctrlc`'s handling
+rustyline = { version = "15.0.0", default-features = false, features = ["with-file-history"] }
 tower-http = "0.6.6"
 utoipa-swagger-ui = { version = "9.0.2", features = ["axum"] }
 futures-util = "0.3.31"


### PR DESCRIPTION
Fixes an issue in interactive mode.

Need to keep rustyline at 15.0.0 as 16.0.0 has a breaking change that conficts with `ctrlc`'s handling.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated internal dependencies to improve compatibility and stability. No user-facing changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->