### PR TITLE
Support max_completion_tokens alias

### DIFF
--- a/mistralrs-server-core/src/openai.rs
+++ b/mistralrs-server-core/src/openai.rs
@@ -566,6 +566,7 @@ pub struct CompletionRequest {
     #[schema(example = json!(Option::None::<usize>))]
     pub logprobs: Option<usize>,
     #[schema(example = 16)]
+    #[serde(alias = "max_completion_tokens")]
     pub max_tokens: Option<usize>,
     #[serde(rename = "n")]
     #[serde(default = "default_1usize")]


### PR DESCRIPTION
## Summary
- add serde alias so the completions endpoint accepts `max_completion_tokens`

## Testing
- `cargo fmt --all`
- `cargo test --workspace` *(fails: compile timed out)*

------
https://chatgpt.com/codex/tasks/task_e_68458a04d1bc83228d94f11aa0ec6e53

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved compatibility by allowing requests to specify either "max_tokens" or "max_completion_tokens" for completion settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->