### PR TITLE
Fix offline cache issue for gguf models

### DIFF
--- a/mistralrs-core/src/pipeline/loaders/diffusion_loaders.rs
+++ b/mistralrs-core/src/pipeline/loaders/diffusion_loaders.rs
@@ -133,7 +133,7 @@ pub struct FluxLoader {
 impl DiffusionModelLoader for FluxLoader {
     fn get_model_paths(&self, api: &ApiRepo, model_id: &Path) -> Result<Vec<PathBuf>> {
         let regex = Regex::new(r"^flux\d+-(schnell|dev)\.safetensors$")?;
-        let flux_name = api_dir_list!(api, model_id)
+        let flux_name = api_dir_list!(api, model_id, true)
             .filter(|x| regex.is_match(x))
             .nth(0)
             .with_context(|| "Expected at least 1 .safetensors file matching the FLUX regex, please raise an issue.")?;

--- a/mistralrs-core/src/pipeline/normal.rs
+++ b/mistralrs-core/src/pipeline/normal.rs
@@ -1128,7 +1128,9 @@ impl AnyMoePipelineMixin for NormalPipeline {
             ));
 
             let mut filenames = vec![];
-            for rfilename in api_dir_list!(api, model_id).filter(|x| x.ends_with(".safetensors")) {
+            for rfilename in
+                api_dir_list!(api, model_id, true).filter(|x| x.ends_with(".safetensors"))
+            {
                 filenames.push(api_get_file!(api, &rfilename, model_id));
             }
 
@@ -1184,7 +1186,9 @@ impl AnyMoePipelineMixin for NormalPipeline {
             ));
 
             let mut gate_filenames = vec![];
-            for rfilename in api_dir_list!(api, model_id).filter(|x| x.ends_with(".safetensors")) {
+            for rfilename in
+                api_dir_list!(api, model_id, true).filter(|x| x.ends_with(".safetensors"))
+            {
                 gate_filenames.push(api_get_file!(api, &rfilename, model_id));
             }
             assert_eq!(

--- a/mistralrs-core/src/pipeline/paths.rs
+++ b/mistralrs-core/src/pipeline/paths.rs
@@ -80,7 +80,7 @@ pub fn get_xlora_paths(
             let model_id = Path::new(&xlora_id);
 
             // Get the path for the xlora classifier
-            let xlora_classifier = &api_dir_list!(api, model_id)
+            let xlora_classifier = &api_dir_list!(api, model_id, true)
                 .filter(|x| x.contains("xlora_classifier.safetensors"))
                 .collect::<Vec<_>>();
             if xlora_classifier.len() > 1 {
@@ -94,7 +94,7 @@ pub fn get_xlora_paths(
 
             // Get the path for the xlora config by checking all for valid versions.
             // NOTE(EricLBuehler): Remove this functionality because all configs should be deserializable
-            let xlora_configs = &api_dir_list!(api, model_id)
+            let xlora_configs = &api_dir_list!(api, model_id, true)
                 .filter(|x| x.contains("xlora_config.json"))
                 .collect::<Vec<_>>();
             if xlora_configs.len() > 1 {
@@ -135,7 +135,7 @@ pub fn get_xlora_paths(
             });
 
             // If there are adapters in the ordering file, get their names and remote paths
-            let adapter_files = api_dir_list!(api, model_id)
+            let adapter_files = api_dir_list!(api, model_id, true)
                 .filter_map(|name| {
                     if let Some(ref adapters) = xlora_order.adapters {
                         for adapter_name in adapters {
@@ -208,7 +208,7 @@ pub fn get_xlora_paths(
                     let mut output = HashMap::new();
                     for adapter in preload_adapters {
                         // Get the names and remote paths of the files associated with this adapter
-                        let adapter_files = api_dir_list!(api, &adapter.adapter_model_id)
+                        let adapter_files = api_dir_list!(api, &adapter.adapter_model_id, true)
                             .filter_map(|f| {
                                 if f.contains(&adapter.name) {
                                     Some((f, adapter.name.clone()))
@@ -348,7 +348,7 @@ pub fn get_model_paths(
             let pickle_match = Regex::new(PICKLE_MATCH)?;
 
             let mut filenames = vec![];
-            let listing = api_dir_list!(api, model_id).filter(|x| {
+            let listing = api_dir_list!(api, model_id, true).filter(|x| {
                 safetensor_match.is_match(x)
                     || pickle_match.is_match(x)
                     || quant_safetensor_match.is_match(x)

--- a/mistralrs-core/src/pipeline/vision.rs
+++ b/mistralrs-core/src/pipeline/vision.rs
@@ -961,7 +961,9 @@ impl AnyMoePipelineMixin for VisionPipeline {
             ));
 
             let mut filenames = vec![];
-            for rfilename in api_dir_list!(api, model_id).filter(|x| x.ends_with(".safetensors")) {
+            for rfilename in
+                api_dir_list!(api, model_id, true).filter(|x| x.ends_with(".safetensors"))
+            {
                 filenames.push(api_get_file!(api, &rfilename, model_id));
             }
 
@@ -1017,7 +1019,9 @@ impl AnyMoePipelineMixin for VisionPipeline {
             ));
 
             let mut gate_filenames = vec![];
-            for rfilename in api_dir_list!(api, model_id).filter(|x| x.ends_with(".safetensors")) {
+            for rfilename in
+                api_dir_list!(api, model_id, true).filter(|x| x.ends_with(".safetensors"))
+            {
                 gate_filenames.push(api_get_file!(api, &rfilename, model_id));
             }
             assert_eq!(


### PR DESCRIPTION
This PR addresses the issue where GGUF-cached models cannot be loaded when **offline** or when there is a connection issue with Hugging Face #1449. While the Hugging Face `api.get` function works correctly in offline mode if the cache path is provided, the `api_list_dir` function requires an internet connection and will panic even if the GGUF files are already cached locally.

This PR makes the `panic` behavior in api_list_dir optional, allowing the workflow to continue and enabling other dependencies to be loaded from the local GGUF cache.

Tested Case:

Ensure you are disconnected from huggingface.co. When the program attempts to connect and times out, it will now continue executing the rest of the workflow using the locally cached files.

```shell
cargo run --features metal -- -i gguf -m unsloth/DeepSeek-R1-0528-Qwen3-8B-GGUF -f DeepSeek-R1-0528-Qwen3-8B-Q2_K.gguf
```


```shell
Running `target/debug/mistralrs-server -i gguf -m unsloth/DeepSeek-R1-0528-Qwen3-8B-GGUF -f DeepSeek-R1-0528-Qwen3-8B-Q2_K.gguf`
2025-06-09T13:54:57.645341Z  INFO mistralrs_server_core::mistralrs_for_server_builder: avx: false, neon: true, simd128: false, f16c: false
2025-06-09T13:54:57.645425Z  INFO mistralrs_server_core::mistralrs_for_server_builder: Sampling method: penalties -> temperature -> topk -> topp -> minp -> multinomial
2025-06-09T13:54:57.645513Z  INFO mistralrs_server_core::mistralrs_for_server_builder: Model kind is: gguf quantized from gguf (no adapters)
2025-06-09T13:54:57.645741Z  INFO mistralrs_core::utils::tokens: Could not load token at "/Users/bobking/.cache/huggingface/token", using no HF token.
2025-06-09T13:54:57.646060Z  INFO mistralrs_core::utils::tokens: Could not load token at "/Users/bobking/.cache/huggingface/token", using no HF token.
2025-06-09T13:54:57.646393Z  INFO mistralrs_core::pipeline::gguf: GGUF file(s) ["/Users/bobking/.cache/huggingface/hub/models--unsloth--DeepSeek-R1-0528-Qwen3-8B-GGUF/snapshots/bacf989729d563d2040798faf7ef19ac45c078bf/DeepSeek-R1-0528-Qwen3-8B-Q2_K.gguf"]
2025-06-09T13:55:20.178844Z  WARN mistralrs_core::pipeline::gguf: Could not get directory listing from API: RequestError(Transport(Transport { kind: ConnectionFailed, message: Some("Connect error"), url: Some(Url { scheme: "https", cannot_be_a_base: false, username: "", password: None, host: Some(Domain("huggingface.co")), port: None, path: "/api/models/unsloth/DeepSeek-R1-0528-Qwen3-8B-GGUF/revision/main", query: None, fragment: None }), source: Some(Error { kind: TimedOut, message: "connection timed out" }) }))
2025-06-09T13:55:20.179552Z  INFO mistralrs_core::pipeline::gguf: Prompt chunk size is 1024.
2025-06-09T13:55:20.469253Z  INFO mistralrs_core::gguf::content: Model config:
general.architecture: qwen3
general.base_model.0.name: DeepSeek R1 0528 Qwen3 8B
general.base_model.0.organization: Deepseek Ai
general.base_model.0.repo_url: https://huggingface.co/deepseek-ai/DeepSeek-R1-0528-Qwen3-8B
general.base_model.count: 1
general.basename: Deepseek-R1-0528-Qwen3-8B
general.file_type: 10
general.license: mit
general.name: Deepseek-R1-0528-Qwen3-8B
general.quantization_version: 2
general.quantized_by: Unsloth
general.repo_url: https://huggingface.co/unsloth
general.size_label: 8B
general.tags: unsloth
general.type: model
quantize.imatrix.chunks_count: 713
quantize.imatrix.dataset: unsloth_calibration_DeepSeek-R1-0528-Qwen3-8B.txt
quantize.imatrix.entries_count: 252
quantize.imatrix.file: DeepSeek-R1-0528-Qwen3-8B-GGUF/imatrix_unsloth.dat
qwen3.attention.head_count: 32
qwen3.attention.head_count_kv: 8
qwen3.attention.key_length: 128
qwen3.attention.layer_norm_rms_epsilon: 0.000001
qwen3.attention.value_length: 128
qwen3.block_count: 36
qwen3.context_length: 131072
qwen3.embedding_length: 4096
qwen3.feed_forward_length: 12288
qwen3.rope.freq_base: 1000000
qwen3.rope.scaling.factor: 4
qwen3.rope.scaling.original_context_length: 32768
qwen3.rope.scaling.type: yarn
2025-06-09T13:55:20.472658Z  INFO mistralrs_core::utils::normal: DType selected is BF16.
2025-06-09T13:55:20.475453Z  INFO mistralrs_core::pipeline::loaders::auto_device_map: Using automatic device mapping parameters: text[max_seq_len: 4096, max_batch_size: 1].
2025-06-09T13:55:20.475574Z  INFO mistralrs_quant::utils::log: Model has 36 repeating layers.
2025-06-09T13:55:20.475601Z  INFO mistralrs_quant::utils::log: Loading model according to the following repeating layer mappings:
2025-06-09T13:55:20.475671Z  INFO mistralrs_quant::utils::log: Layers 0-35: metal[4294968381] (11 GB)
2025-06-09T13:55:20.618306Z  INFO mistralrs_core::gguf::gguf_tokenizer: GGUF tokenizer model is `gpt2`, kind: `Bpe`, num tokens: 151936, num special tokens 293, num added tokens: 0, num merges: 151387, num scores: 0
2025-06-09T13:55:20.630674Z  INFO mistralrs_core::gguf::chat_template: Discovered and using GGUF chat template: `{% if not add_generation_prompt is defined %}{% set add_generation_prompt = false %}{% endif %}{% set ns = namespace(is_first=false, is_tool=false, is_output_first=true, system_prompt='', is_first_sp=true, is_last_user=false) %}{%- for message in messages %}{%- if message['role'] == 'system' %}{%- if ns.is_first_sp %}{% set ns.system_prompt = ns.system_prompt + message['content'] %}{% set ns.is_first_sp = false %}{%- else %}{% set ns.system_prompt = ns.system_prompt + '\n\n' + message['content'] %}{%- endif %}{%- endif %}{%- endfor %}{{ bos_token }}{{ ns.system_prompt }}{%- for message in messages %}{% set content = message['content'] %}{%- if message['role'] == 'user' %}{%- set ns.is_tool = false -%}{%- set ns.is_first = false -%}{%- set ns.is_last_user = true -%}{{'<｜User｜>' + content + '<｜Assistant｜>'}}{%- endif %}{%- if message['role'] == 'assistant' %}{% if '</think>' in content %}{% set content = content.split('</think>')[-1] %}{% endif %}{% endif %}{%- if message['role'] == 'assistant' and message['tool_calls'] is defined and message['tool_calls'] is not none %}{%- set ns.is_last_user = false -%}{%- if ns.is_tool %}{{'<｜tool▁outputs▁end｜>'}}{%- endif %}{%- set ns.is_first = false %}{%- set ns.is_tool = false -%}{%- set ns.is_output_first = true %}{%- for tool in message['tool_calls'] %}{%- if not ns.is_first %}{%- if content is none %}{{'<｜tool▁calls▁begin｜><｜tool▁call▁begin｜>' + tool['type'] + '<｜tool▁sep｜>' + tool['function']['name'] + '\n' + '```json' + '\n' + tool['function']['arguments'] + '\n' + '```' + '<｜tool▁call▁end｜>'}}{%- else %}{{content + '<｜tool▁calls▁begin｜><｜tool▁call▁begin｜>' + tool['type'] + '<｜tool▁sep｜>' + tool['function']['name'] + '\n' + '```json' + '\n' + tool['function']['arguments'] + '\n' + '```' + '<｜tool▁call▁end｜>'}}{%- endif %}{%- set ns.is_first = true -%}{%- else %}{{'\n' + '<｜tool▁call▁begin｜>' + tool['type'] + '<｜tool▁sep｜>' + tool['function']['name'] + '\n' + '```json' + '\n' + tool['function']['arguments'] + '\n' + '```' + '<｜tool▁call▁end｜>'}}{%- endif %}{%- endfor %}{{'<｜tool▁calls▁end｜><｜end▁of▁sentence｜>'}}{%- endif %}{%- if message['role'] == 'assistant' and (message['tool_calls'] is not defined or message['tool_calls'] is none)%}{%- set ns.is_last_user = false -%}{%- if ns.is_tool %}{{'<｜tool▁outputs▁end｜>' + content + '<｜end▁of▁sentence｜>'}}{%- set ns.is_tool = false -%}{%- else %}{{content + '<｜end▁of▁sentence｜>'}}{%- endif %}{%- endif %}{%- if message['role'] == 'tool' %}{%- set ns.is_last_user = false -%}{%- set ns.is_tool = true -%}{%- if ns.is_output_first %}{{'<｜tool▁outputs▁begin｜><｜tool▁output▁begin｜>' + content + '<｜tool▁output▁end｜>'}}{%- set ns.is_output_first = false %}{%- else %}{{'\n<｜tool▁output▁begin｜>' + content + '<｜tool▁output▁end｜>'}}{%- endif %}{%- endif %}{%- endfor -%}{% if ns.is_tool %}{{'<｜tool▁outputs▁end｜>'}}{% endif %}{% if add_generation_prompt and not ns.is_last_user and not ns.is_tool %}{{'<｜Assistant｜>'}}{% endif %}`
2025-06-09T13:55:20.632232Z  INFO mistralrs_core::utils::normal: DType selected is BF16.
2025-06-09T13:55:22.563302Z  INFO mistralrs_core::pipeline::paths: Using literal chat template.
2025-06-09T13:55:23.038123Z  INFO mistralrs_core::pipeline::chat_template: bos_toks = "<｜begin▁of▁sentence｜>", eos_toks = "<｜end▁of▁sentence｜>", unk_tok = `None`
2025-06-09T13:55:23.046254Z  INFO mistralrs_server_core::mistralrs_for_server_builder: Model loaded.
2025-06-09T13:55:23.046555Z  INFO mistralrs_core: Beginning dummy run.
2025-06-09T13:55:23.046668Z  INFO mistralrs_core::prefix_cacher: PrefixCacherV2 is enabled. Expect higher multi-turn throughput for both text and multimodal.
2025-06-09T13:55:23.358234Z  INFO mistralrs_core: Dummy run completed in 0.311649584s.
2025-06-09T13:55:23.358581Z  INFO mistralrs_server::interactive_mode: Starting interactive loop with sampling params: SamplingParams { temperature: Some(0.1), top_k: Some(32), top_p: Some(0.1), min_p: Some(0.05), top_n_logprobs: 0, frequency_penalty: Some(0.1), presence_penalty: Some(0.1), stop_toks: None, max_len: None, logits_bias: None, n_choices: 1, dry_params: Some(DrySamplingParams { sequence_breakers: ["\n", ":", "\"", "*"], multiplier: 0.0, base: 1.75, allowed_length: 2 }) }
====================
Welcome to interactive mode! Because this model is a text model, you can enter prompts and chat with the model.

Commands:
- `\help`: Display this message.
- `\exit`: Quit interactive mode.
- `\system <system message here>`:
    Add a system message to the chat without running the model.
    Ex: `\system Always respond as a pirate.`
- `\clear`: Clear the chat history.
- `\temperature <float>`: Set sampling temperature (0.0 to 2.0).
- `\topk <int>`: Set top-k sampling value (>0).
- `\topp <float>`: Set top-p sampling value in (0.0 to 1.0).
====================
> 
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Improved error handling and logging when listing files from remote directories, reducing unnecessary failures and redundant API calls.
- **Chores**
	- Updated internal processes for file retrieval to enhance reliability and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->