### PR TITLE
Fix Phi3.5 Moe device mismatch

### DIFF
--- a/mistralrs-core/src/models/phi3_5_moe.rs
+++ b/mistralrs-core/src/models/phi3_5_moe.rs
@@ -319,6 +319,10 @@ impl Mlp {
         })
     }
 
+    fn device(&self) -> Device {
+        self.w1.dtype_and_device().1
+    }
+
     fn forward(&self, xs: &Tensor) -> Result<Tensor> {
         let original_dtype = xs.dtype();
         let mut xs = xs.clone();
@@ -465,7 +469,7 @@ impl MoeMlp {
                 .index_select(&top_x, 0)?
                 .gather(&idx.unsqueeze(1)?.contiguous()?, 1)?;
             let exp_out = expert
-                .forward(&current_state.to_device(xs_dev)?)?
+                .forward(&current_state.to_device(&expert.device())?)?
                 .to_device(&Device::Cpu)?;
 
             let current_hidden_states = exp_out.broadcast_mul(&current_routing_weights)?;


### PR DESCRIPTION
## Summary
- ensure Phi3.5 MoE experts receive tensors on their device

## Testing
- `cargo fmt --all`
- `cargo test -p mistralrs-core -p mistralrs-quant -p mistralrs-vision` *(failed: compilation interrupted due to environment limits)*

------
https://chatgpt.com/codex/tasks/task_e_68471ad0727883229e37d40af3ce1bcc

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved device handling to ensure computations run on the correct hardware, enhancing stability and compatibility across different devices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->