### PR TITLE
Integrate an MCP client

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2869,6 +2869,7 @@ dependencies = [
  "regex-automata 0.4.9",
  "reqwest",
  "rubato",
+ "rust-mcp-schema 0.1.11",
  "rustc-hash",
  "rustfft",
  "safetensors",
@@ -4150,6 +4151,16 @@ dependencies = [
 
 [[package]]
 name = "rust-mcp-schema"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69c8c97bf79c576f8dc582be9f6c9825ed91bd921aac65bd7990992257727e39"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "rust-mcp-schema"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4c9966340f5104a8d22b6c2db8901f8626a0f737820a385db3ffbb29b1f6ae0f"
@@ -4170,7 +4181,7 @@ dependencies = [
  "futures",
  "hyper",
  "rust-mcp-macros",
- "rust-mcp-schema",
+ "rust-mcp-schema 0.5.2",
  "rust-mcp-transport",
  "serde",
  "serde_json",
@@ -4191,7 +4202,7 @@ dependencies = [
  "bytes",
  "futures",
  "reqwest",
- "rust-mcp-schema",
+ "rust-mcp-schema 0.5.2",
  "serde",
  "serde_json",
  "thiserror 2.0.12",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -161,6 +161,7 @@ include_dir = "0.7.4"
 http = "1.3.1"
 hyper = "1.6.0"
 rust-mcp-sdk = { version = "0.4.2", default-features = false, features = ["server", "hyper-server", "2025_03_26"] }
+rust-mcp-schema = { version = "0.1.11", default-features = false, features = ["schema_utils", "2024_11_05"] }
 bindgen_cuda = { git = "https://github.com/guoqingbao/bindgen_cuda.git", version = "0.1.6" }
 rubato = "0.16.2"
 rustfft = "6.3.0"

--- a/docs/MCP_CLIENT.md
+++ b/docs/MCP_CLIENT.md
@@ -1,0 +1,210 @@
+# MCP Client Support
+
+mistral.rs supports acting as a Model Context Protocol (MCP) client, allowing it to connect to external MCP servers and automatically register their tools for use in automatic tool calling.
+
+## Overview
+
+The MCP client feature enables mistral.rs to:
+
+- Connect to multiple MCP servers simultaneously
+- Automatically discover tools from connected servers
+- Register discovered tools with the existing automatic tool calling system
+- Support HTTP, process-based, and WebSocket MCP server connections
+- Handle tool name conflicts with configurable prefixes
+- Manage server connections and handle failures gracefully
+
+## Configuration
+
+MCP client functionality is configured using the `McpClientConfig` struct:
+
+```rust
+use mistralrs::{McpClientConfig, McpServerConfig, McpServerSource};
+use std::collections::HashMap;
+
+let mcp_config = McpClientConfig {
+    servers: vec![
+        McpServerConfig {
+            id: "filesystem_server".to_string(),
+            name: "Filesystem MCP Server".to_string(),
+            source: McpServerSource::Process {
+                command: "mcp-server-filesystem".to_string(),
+                args: vec!["--root".to_string(), "/tmp".to_string()],
+                work_dir: None,
+                env: None,
+            },
+            enabled: true,
+            tool_prefix: Some("fs".to_string()),
+            resources: Some(vec!["file://**".to_string()]),
+        },
+    ],
+    auto_register_tools: true,
+    tool_timeout_secs: Some(30),
+    max_concurrent_calls: Some(10),
+};
+```
+
+## Server Source Types
+
+### HTTP Servers
+
+Connect to MCP servers over HTTP:
+
+```rust
+McpServerSource::Http {
+    url: "http://localhost:8080/mcp".to_string(),
+    timeout_secs: Some(30),
+    headers: Some({
+        let mut headers = HashMap::new();
+        headers.insert("Authorization".to_string(), "Bearer token".to_string());
+        headers
+    }),
+}
+```
+
+### Process Servers
+
+Launch and communicate with MCP servers as child processes:
+
+```rust
+McpServerSource::Process {
+    command: "mcp-server-filesystem".to_string(),
+    args: vec!["--root".to_string(), "/tmp".to_string()],
+    work_dir: Some("/path/to/workdir".to_string()),
+    env: Some({
+        let mut env = HashMap::new();
+        env.insert("API_KEY".to_string(), "your-api-key".to_string());
+        env
+    }),
+}
+```
+
+### WebSocket Servers
+
+Connect to MCP servers via WebSocket (planned):
+
+```rust
+McpServerSource::WebSocket {
+    url: "ws://localhost:9090/mcp".to_string(),
+    timeout_secs: Some(30),
+    headers: None,
+}
+```
+
+## Usage with TextModelBuilder
+
+Configure MCP client support when building your model:
+
+```rust
+use mistralrs::{TextModelBuilder, McpClientConfig, McpServerConfig, McpServerSource};
+
+let model = TextModelBuilder::new("microsoft/Phi-3.5-mini-instruct")
+    .with_mcp_client(mcp_config)
+    .build()
+    .await?;
+```
+
+## Tool Discovery and Registration
+
+When the MCP client is initialized:
+
+1. **Connection**: Connects to all enabled MCP servers
+2. **Discovery**: Lists available tools from each server
+3. **Registration**: Automatically registers tools with the tool calling system
+4. **Prefixing**: Applies tool prefixes to avoid naming conflicts
+5. **Integration**: Tools become available for automatic tool calling
+
+### Tool Naming
+
+Tools from MCP servers are registered with optional prefixes:
+
+- Without prefix: `list_files` (from filesystem server)
+- With prefix: `fs_list_files` (with "fs" prefix)
+
+This prevents naming conflicts when multiple servers provide similar tools.
+
+## Automatic Tool Calling Integration
+
+MCP tools integrate seamlessly with mistral.rs's automatic tool calling:
+
+```rust
+let messages = TextMessages::new()
+    .add_message(
+        TextMessageRole::User,
+        "List the files in /tmp and search for Rust information"
+    );
+
+let response = model.send_chat_request(messages).await?;
+
+// Model will automatically call MCP tools as needed
+if let Some(tool_calls) = &response.choices[0].message.tool_calls {
+    for tool_call in tool_calls {
+        println!("Called tool: {}", tool_call.function.name);
+    }
+}
+```
+
+## Error Handling
+
+The MCP client handles various error scenarios:
+
+- **Connection failures**: Logs warnings and continues with other servers
+- **Tool call timeouts**: Configurable timeouts with fallback behavior
+- **Server disconnections**: Automatic reconnection attempts
+- **Invalid responses**: Graceful error handling with informative messages
+
+## Configuration Options
+
+### McpClientConfig
+
+- `servers`: List of MCP server configurations
+- `auto_register_tools`: Whether to automatically register discovered tools (default: true)
+- `tool_timeout_secs`: Timeout for individual tool calls (default: 30)
+- `max_concurrent_calls`: Maximum concurrent tool calls (default: 10)
+
+### McpServerConfig
+
+- `id`: Unique identifier for the server
+- `name`: Human-readable name
+- `source`: Connection configuration (HTTP, Process, or WebSocket)
+- `enabled`: Whether this server should be used
+- `tool_prefix`: Optional prefix for tool names
+- `resources`: Optional resource patterns to subscribe to
+
+## Examples
+
+See the example implementations:
+
+- **Rust**: `mistralrs/examples/mcp_client/main.rs`
+- **Python**: `examples/python/mcp_client.py`
+
+## Current Limitations
+
+1. **WebSocket Transport**: Not yet implemented (HTTP and Process work)
+2. **Resource Subscriptions**: Basic implementation, full resource management pending
+3. **Reconnection Logic**: Basic reconnection, advanced scenarios pending
+4. **Authentication**: Basic header-based auth, advanced auth methods pending
+
+## Future Enhancements
+
+- Full WebSocket transport implementation
+- Advanced authentication mechanisms (OAuth, JWT, etc.)
+- Resource subscription and notification handling
+- Connection pooling and load balancing
+- Metrics and monitoring integration
+- Configuration hot-reloading
+
+## Compatibility
+
+The MCP client is compatible with:
+
+- MCP protocol version 2025-03-26
+- Any MCP server implementing the standard protocol
+- Existing mistral.rs tool calling functionality
+- All model types that support tool calling
+
+## Security Considerations
+
+- **Process Servers**: Child processes inherit environment and permissions
+- **HTTP Servers**: Use HTTPS and proper authentication for production
+- **Tool Execution**: MCP tools run with the same privileges as mistral.rs
+- **Input Validation**: Ensure MCP servers properly validate tool arguments

--- a/examples/python/mcp_client.py
+++ b/examples/python/mcp_client.py
@@ -1,0 +1,108 @@
+#!/usr/bin/env python3
+
+import asyncio
+from mistralrs import Runner, Which, ChatCompletionRequest
+
+
+async def main():
+    """
+    Example demonstrating how to configure mistral.rs as an MCP client
+    to connect to external MCP servers and use their tools automatically.
+    
+    This example shows how to configure MCP servers via environment
+    variables or configuration files, since the Python bindings may
+    expose MCP configuration differently than the Rust API.
+    """
+    
+    # Note: MCP client configuration in Python will likely be exposed
+    # through environment variables, configuration files, or builder
+    # methods once the Python bindings are updated.
+    
+    # For now, this demonstrates the expected usage pattern:
+    
+    runner = Runner(
+        which=Which.Plain(
+            model_id="microsoft/Phi-3.5-mini-instruct",
+            arch=None,
+            dtype=None,
+        ),
+        max_seqs=10,
+        no_kv_cache=False,
+        throughput_logging_enabled=True,
+        # Future MCP configuration might look like:
+        # mcp_servers=[
+        #     {
+        #         "id": "filesystem_server",
+        #         "name": "Filesystem MCP Server", 
+        #         "source": {
+        #             "type": "process",
+        #             "command": "mcp-server-filesystem",
+        #             "args": ["--root", "/tmp"]
+        #         },
+        #         "enabled": True,
+        #         "tool_prefix": "fs"
+        #     },
+        #     {
+        #         "id": "example_server",
+        #         "name": "Example HTTP MCP Server",
+        #         "source": {
+        #             "type": "http", 
+        #             "url": "http://localhost:8080/mcp",
+        #             "timeout_secs": 30
+        #         },
+        #         "enabled": True,
+        #         "tool_prefix": "example"
+        #     }
+        # ]
+    )
+    
+    # Create a conversation that could use MCP tools
+    request = ChatCompletionRequest(
+        model="mistral",
+        messages=[
+            {
+                "role": "system",
+                "content": "You are an AI assistant with access to external tools via MCP servers. "
+                          "You can search the web, access filesystem operations, and use other tools "
+                          "provided by connected MCP servers. Use these tools when appropriate to "
+                          "help answer user questions."
+            },
+            {
+                "role": "user", 
+                "content": "Hello! Can you help me list the files in the /tmp directory and then "
+                          "search for information about Rust programming language?"
+            }
+        ],
+        max_tokens=1000,
+        temperature=0.1,
+        # Tools would be automatically discovered from MCP servers
+        # No need to manually specify tools when using MCP client
+        tool_choice="auto"  # Enable automatic tool calling
+    )
+    
+    print("Sending chat request with MCP tool support...")
+    response = await runner.send_chat_completion_request(request)
+    
+    print(f"\nResponse: {response.choices[0].message.content}")
+    
+    # Display any tool calls that were made
+    if response.choices[0].message.tool_calls:
+        print("\nTool calls made:")
+        for tool_call in response.choices[0].message.tool_calls:
+            print(f"- {tool_call.function.name}: {tool_call.function.arguments}")
+    
+    print(f"\nTokens used: {response.usage.total_tokens}")
+
+
+if __name__ == "__main__":
+    print("MCP Client Example for mistral.rs")
+    print("==================================")
+    print()
+    print("This example demonstrates how mistral.rs can act as an MCP client")
+    print("to connect to external MCP servers and automatically use their tools.")
+    print()
+    print("Note: Full MCP client support in Python bindings is coming soon.")
+    print("This example shows the expected usage pattern.")
+    print()
+    
+    asyncio.run(main())

--- a/mistralrs-bench/src/main.rs
+++ b/mistralrs-bench/src/main.rs
@@ -341,7 +341,8 @@ struct Args {
     prompt_chunksize: Option<usize>,
 }
 
-fn main() -> anyhow::Result<()> {
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
     let mut args = Args::parse();
     initialize_logging();
 
@@ -535,7 +536,8 @@ fn main() -> anyhow::Result<()> {
     let mistralrs = MistralRsBuilder::new(pipeline, scheduler_config, false, None)
         .with_no_prefix_cache(true)
         .with_disable_eos_stop(true)
-        .build();
+        .build()
+        .await;
 
     info!("Starting warmup run.");
     warmup_run(mistralrs.clone());

--- a/mistralrs-core/Cargo.toml
+++ b/mistralrs-core/Cargo.toml
@@ -100,6 +100,7 @@ hound.workspace = true
 apodize.workspace = true
 symphonia.workspace = true
 mistralrs-audio.workspace = true
+rust-mcp-schema.workspace = true
 
 [features]
 pyo3_macros = ["pyo3"]

--- a/mistralrs-core/src/engine/add_request.rs
+++ b/mistralrs-core/src/engine/add_request.rs
@@ -32,8 +32,8 @@ impl Engine {
                 if matches!(
                     request.messages,
                     RequestMessage::Chat { .. } | RequestMessage::VisionChat { .. }
-                ) && (request.web_search_options.is_some()
-                    || (!self.tool_callbacks.is_empty() && request.tools.is_some()))
+                ) && request.web_search_options.is_some()
+                    || !self.tool_callbacks.is_empty()
                 {
                     search_request::search_request(self.clone(), *request).await;
                 } else {

--- a/mistralrs-core/src/engine/add_request.rs
+++ b/mistralrs-core/src/engine/add_request.rs
@@ -34,6 +34,7 @@ impl Engine {
                     RequestMessage::Chat { .. } | RequestMessage::VisionChat { .. }
                 ) && request.web_search_options.is_some()
                     || !self.tool_callbacks.is_empty()
+                    || !self.tool_callbacks_with_tools.is_empty()
                 {
                     search_request::search_request(self.clone(), *request).await;
                 } else {

--- a/mistralrs-core/src/engine/mod.rs
+++ b/mistralrs-core/src/engine/mod.rs
@@ -75,6 +75,7 @@ pub struct Engine {
     bert_pipeline: Arc<Mutex<Option<BertPipeline>>>,
     search_callback: Option<Arc<search::SearchCallback>>,
     tool_callbacks: tools::ToolCallbacks,
+    tool_callbacks_with_tools: tools::ToolCallbacksWithTools,
     scheduler: Arc<Mutex<dyn Scheduler>>,
     id: Arc<Mutex<usize>>,
     truncate_sequence: bool,
@@ -110,6 +111,7 @@ impl Engine {
         search_embedding_model: Option<BertEmbeddingModel>,
         search_callback: Option<Arc<search::SearchCallback>>,
         tool_callbacks: tools::ToolCallbacks,
+        tool_callbacks_with_tools: tools::ToolCallbacksWithTools,
     ) -> anyhow::Result<Self> {
         no_kv_cache |= get_mut_arcmutex!(pipeline).get_metadata().no_kv_cache;
 
@@ -135,6 +137,7 @@ impl Engine {
             bert_pipeline: Arc::new(Mutex::new(bert_pipeline)),
             search_callback,
             tool_callbacks,
+            tool_callbacks_with_tools,
             scheduler: scheduler.clone(),
             id: Arc::new(Mutex::new(0)),
             truncate_sequence,

--- a/mistralrs-core/src/mcp_client/client.rs
+++ b/mistralrs-core/src/mcp_client/client.rs
@@ -1,0 +1,391 @@
+use crate::mcp_client::{McpServerConnection, McpToolInfo};
+use crate::mcp_client::transport::{McpTransport, HttpTransport, ProcessTransport, WebSocketTransport};
+use crate::mcp_client::types::McpToolResult;
+use anyhow::Result;
+use rust_mcp_schema::Resource;
+use serde_json::Value;
+use std::collections::HashMap;
+use std::sync::Arc;
+
+/// HTTP-based MCP server connection
+pub struct HttpMcpConnection {
+    server_id: String,
+    server_name: String,
+    transport: Arc<dyn McpTransport>,
+}
+
+impl HttpMcpConnection {
+    pub async fn new(
+        server_id: String,
+        server_name: String,
+        url: String,
+        timeout_secs: Option<u64>,
+        headers: Option<HashMap<String, String>>,
+    ) -> Result<Self> {
+        let transport = HttpTransport::new(url, timeout_secs, headers)?;
+        
+        let connection = Self {
+            server_id,
+            server_name,
+            transport: Arc::new(transport),
+        };
+        
+        // Initialize the connection
+        connection.initialize().await?;
+        
+        Ok(connection)
+    }
+    
+    async fn initialize(&self) -> Result<()> {
+        let init_params = serde_json::json!({
+            "protocolVersion": "2025-03-26",
+            "capabilities": {
+                "tools": {}
+            },
+            "clientInfo": {
+                "name": "mistral.rs",
+                "version": "0.6.0"
+            }
+        });
+        
+        self.transport.send_request("initialize", init_params).await?;
+        Ok(())
+    }
+}
+
+#[async_trait::async_trait]
+impl McpServerConnection for HttpMcpConnection {
+    fn server_id(&self) -> &str {
+        &self.server_id
+    }
+    
+    fn server_name(&self) -> &str {
+        &self.server_name
+    }
+    
+    async fn list_tools(&self) -> Result<Vec<McpToolInfo>> {
+        let result = self.transport.send_request("tools/list", Value::Null).await?;
+        
+        let tools = result.get("tools")
+            .and_then(|t| t.as_array())
+            .ok_or_else(|| anyhow::anyhow!("Invalid tools response format"))?;
+        
+        let mut tool_infos = Vec::new();
+        for tool in tools {
+            let name = tool.get("name")
+                .and_then(|n| n.as_str())
+                .ok_or_else(|| anyhow::anyhow!("Tool missing name"))?
+                .to_string();
+            
+            let description = tool.get("description")
+                .and_then(|d| d.as_str())
+                .map(|s| s.to_string());
+            
+            let input_schema = tool.get("inputSchema")
+                .cloned()
+                .unwrap_or(Value::Object(serde_json::Map::new()));
+            
+            tool_infos.push(McpToolInfo {
+                name,
+                description,
+                input_schema,
+                server_id: self.server_id.clone(),
+                server_name: self.server_name.clone(),
+            });
+        }
+        
+        Ok(tool_infos)
+    }
+    
+    async fn call_tool(&self, name: &str, arguments: Value) -> Result<String> {
+        let params = serde_json::json!({
+            "name": name,
+            "arguments": arguments
+        });
+        
+        let result = self.transport.send_request("tools/call", params).await?;
+        
+        // Parse the MCP tool result
+        let tool_result: McpToolResult = serde_json::from_value(result)?;
+        
+        // Check if the result indicates an error
+        if tool_result.is_error.unwrap_or(false) {
+            return Err(anyhow::anyhow!("Tool execution failed: {}", tool_result.to_string()));
+        }
+        
+        Ok(tool_result.to_string())
+    }
+    
+    async fn list_resources(&self) -> Result<Vec<Resource>> {
+        let result = self.transport.send_request("resources/list", Value::Null).await?;
+        
+        let resources = result.get("resources")
+            .and_then(|r| r.as_array())
+            .ok_or_else(|| anyhow::anyhow!("Invalid resources response format"))?;
+        
+        let mut resource_list = Vec::new();
+        for resource in resources {
+            let mcp_resource: Resource = serde_json::from_value(resource.clone())?;
+            resource_list.push(mcp_resource);
+        }
+        
+        Ok(resource_list)
+    }
+    
+    async fn read_resource(&self, uri: &str) -> Result<String> {
+        let params = serde_json::json!({
+            "uri": uri
+        });
+        
+        let result = self.transport.send_request("resources/read", params).await?;
+        
+        let contents = result.get("contents")
+            .and_then(|c| c.as_array())
+            .ok_or_else(|| anyhow::anyhow!("Invalid resource read response format"))?;
+        
+        let mut text_parts = Vec::new();
+        for content in contents {
+            if let Some(content_type) = content.get("type").and_then(|t| t.as_str()) {
+                match content_type {
+                    "text" => {
+                        if let Some(text) = content.get("text").and_then(|t| t.as_str()) {
+                            text_parts.push(text.to_string());
+                        }
+                    }
+                    _ => {
+                        // Handle other content types as needed
+                        text_parts.push(format!("[{}]", content_type));
+                    }
+                }
+            }
+        }
+        
+        Ok(text_parts.join("\n"))
+    }
+    
+    async fn ping(&self) -> Result<()> {
+        self.transport.ping().await
+    }
+}
+
+/// Process-based MCP server connection
+pub struct ProcessMcpConnection {
+    server_id: String,
+    server_name: String,
+    transport: Arc<dyn McpTransport>,
+}
+
+impl ProcessMcpConnection {
+    pub async fn new(
+        server_id: String,
+        server_name: String,
+        command: String,
+        args: Vec<String>,
+        work_dir: Option<String>,
+        env: Option<HashMap<String, String>>,
+    ) -> Result<Self> {
+        let transport = ProcessTransport::new(command, args, work_dir, env).await?;
+        
+        let connection = Self {
+            server_id,
+            server_name,
+            transport: Arc::new(transport),
+        };
+        
+        // Initialize the connection
+        connection.initialize().await?;
+        
+        Ok(connection)
+    }
+    
+    async fn initialize(&self) -> Result<()> {
+        let init_params = serde_json::json!({
+            "protocolVersion": "2025-03-26",
+            "capabilities": {
+                "tools": {}
+            },
+            "clientInfo": {
+                "name": "mistral.rs",
+                "version": "0.6.0"
+            }
+        });
+        
+        self.transport.send_request("initialize", init_params).await?;
+        Ok(())
+    }
+}
+
+#[async_trait::async_trait]
+impl McpServerConnection for ProcessMcpConnection {
+    fn server_id(&self) -> &str {
+        &self.server_id
+    }
+    
+    fn server_name(&self) -> &str {
+        &self.server_name
+    }
+    
+    async fn list_tools(&self) -> Result<Vec<McpToolInfo>> {
+        let result = self.transport.send_request("tools/list", Value::Null).await?;
+        
+        let tools = result.get("tools")
+            .and_then(|t| t.as_array())
+            .ok_or_else(|| anyhow::anyhow!("Invalid tools response format"))?;
+        
+        let mut tool_infos = Vec::new();
+        for tool in tools {
+            let name = tool.get("name")
+                .and_then(|n| n.as_str())
+                .ok_or_else(|| anyhow::anyhow!("Tool missing name"))?
+                .to_string();
+            
+            let description = tool.get("description")
+                .and_then(|d| d.as_str())
+                .map(|s| s.to_string());
+            
+            let input_schema = tool.get("inputSchema")
+                .cloned()
+                .unwrap_or(Value::Object(serde_json::Map::new()));
+            
+            tool_infos.push(McpToolInfo {
+                name,
+                description,
+                input_schema,
+                server_id: self.server_id.clone(),
+                server_name: self.server_name.clone(),
+            });
+        }
+        
+        Ok(tool_infos)
+    }
+    
+    async fn call_tool(&self, name: &str, arguments: Value) -> Result<String> {
+        let params = serde_json::json!({
+            "name": name,
+            "arguments": arguments
+        });
+        
+        let result = self.transport.send_request("tools/call", params).await?;
+        
+        // Parse the MCP tool result
+        let tool_result: McpToolResult = serde_json::from_value(result)?;
+        
+        // Check if the result indicates an error
+        if tool_result.is_error.unwrap_or(false) {
+            return Err(anyhow::anyhow!("Tool execution failed: {}", tool_result.to_string()));
+        }
+        
+        Ok(tool_result.to_string())
+    }
+    
+    async fn list_resources(&self) -> Result<Vec<Resource>> {
+        let result = self.transport.send_request("resources/list", Value::Null).await?;
+        
+        let resources = result.get("resources")
+            .and_then(|r| r.as_array())
+            .ok_or_else(|| anyhow::anyhow!("Invalid resources response format"))?;
+        
+        let mut resource_list = Vec::new();
+        for resource in resources {
+            let mcp_resource: Resource = serde_json::from_value(resource.clone())?;
+            resource_list.push(mcp_resource);
+        }
+        
+        Ok(resource_list)
+    }
+    
+    async fn read_resource(&self, uri: &str) -> Result<String> {
+        let params = serde_json::json!({
+            "uri": uri
+        });
+        
+        let result = self.transport.send_request("resources/read", params).await?;
+        
+        let contents = result.get("contents")
+            .and_then(|c| c.as_array())
+            .ok_or_else(|| anyhow::anyhow!("Invalid resource read response format"))?;
+        
+        let mut text_parts = Vec::new();
+        for content in contents {
+            if let Some(content_type) = content.get("type").and_then(|t| t.as_str()) {
+                match content_type {
+                    "text" => {
+                        if let Some(text) = content.get("text").and_then(|t| t.as_str()) {
+                            text_parts.push(text.to_string());
+                        }
+                    }
+                    _ => {
+                        // Handle other content types as needed
+                        text_parts.push(format!("[{}]", content_type));
+                    }
+                }
+            }
+        }
+        
+        Ok(text_parts.join("\n"))
+    }
+    
+    async fn ping(&self) -> Result<()> {
+        self.transport.ping().await
+    }
+}
+
+/// WebSocket-based MCP server connection
+pub struct WebSocketMcpConnection {
+    server_id: String,
+    server_name: String,
+    transport: Arc<dyn McpTransport>,
+}
+
+impl WebSocketMcpConnection {
+    pub async fn new(
+        server_id: String,
+        server_name: String,
+        url: String,
+        timeout_secs: Option<u64>,
+        headers: Option<HashMap<String, String>>,
+    ) -> Result<Self> {
+        let transport = WebSocketTransport::new(url, timeout_secs, headers).await?;
+        
+        Ok(Self {
+            server_id,
+            server_name,
+            transport: Arc::new(transport),
+        })
+    }
+}
+
+#[async_trait::async_trait]
+impl McpServerConnection for WebSocketMcpConnection {
+    fn server_id(&self) -> &str {
+        &self.server_id
+    }
+    
+    fn server_name(&self) -> &str {
+        &self.server_name
+    }
+    
+    async fn list_tools(&self) -> Result<Vec<McpToolInfo>> {
+        // WebSocket implementation would mirror HTTP implementation
+        Err(anyhow::anyhow!("WebSocket transport not yet implemented"))
+    }
+    
+    async fn call_tool(&self, _name: &str, _arguments: Value) -> Result<String> {
+        // WebSocket implementation would mirror HTTP implementation
+        Err(anyhow::anyhow!("WebSocket transport not yet implemented"))
+    }
+    
+    async fn list_resources(&self) -> Result<Vec<Resource>> {
+        // WebSocket implementation would mirror HTTP implementation
+        Err(anyhow::anyhow!("WebSocket transport not yet implemented"))
+    }
+    
+    async fn read_resource(&self, _uri: &str) -> Result<String> {
+        // WebSocket implementation would mirror HTTP implementation
+        Err(anyhow::anyhow!("WebSocket transport not yet implemented"))
+    }
+    
+    async fn ping(&self) -> Result<()> {
+        self.transport.ping().await
+    }
+}

--- a/mistralrs-core/src/mcp_client/client.rs
+++ b/mistralrs-core/src/mcp_client/client.rs
@@ -1,6 +1,8 @@
-use crate::mcp_client::{McpServerConnection, McpToolInfo};
-use crate::mcp_client::transport::{McpTransport, HttpTransport, ProcessTransport, WebSocketTransport};
+use crate::mcp_client::transport::{
+    HttpTransport, McpTransport, ProcessTransport, WebSocketTransport,
+};
 use crate::mcp_client::types::McpToolResult;
+use crate::mcp_client::{McpServerConnection, McpToolInfo};
 use anyhow::Result;
 use rust_mcp_schema::Resource;
 use serde_json::Value;
@@ -23,19 +25,19 @@ impl HttpMcpConnection {
         headers: Option<HashMap<String, String>>,
     ) -> Result<Self> {
         let transport = HttpTransport::new(url, timeout_secs, headers)?;
-        
+
         let connection = Self {
             server_id,
             server_name,
             transport: Arc::new(transport),
         };
-        
+
         // Initialize the connection
         connection.initialize().await?;
-        
+
         Ok(connection)
     }
-    
+
     async fn initialize(&self) -> Result<()> {
         let init_params = serde_json::json!({
             "protocolVersion": "2025-03-26",
@@ -47,8 +49,10 @@ impl HttpMcpConnection {
                 "version": "0.6.0"
             }
         });
-        
-        self.transport.send_request("initialize", init_params).await?;
+
+        self.transport
+            .send_request("initialize", init_params)
+            .await?;
         Ok(())
     }
 }
@@ -58,33 +62,40 @@ impl McpServerConnection for HttpMcpConnection {
     fn server_id(&self) -> &str {
         &self.server_id
     }
-    
+
     fn server_name(&self) -> &str {
         &self.server_name
     }
-    
+
     async fn list_tools(&self) -> Result<Vec<McpToolInfo>> {
-        let result = self.transport.send_request("tools/list", Value::Null).await?;
-        
-        let tools = result.get("tools")
+        let result = self
+            .transport
+            .send_request("tools/list", Value::Null)
+            .await?;
+
+        let tools = result
+            .get("tools")
             .and_then(|t| t.as_array())
             .ok_or_else(|| anyhow::anyhow!("Invalid tools response format"))?;
-        
+
         let mut tool_infos = Vec::new();
         for tool in tools {
-            let name = tool.get("name")
+            let name = tool
+                .get("name")
                 .and_then(|n| n.as_str())
                 .ok_or_else(|| anyhow::anyhow!("Tool missing name"))?
                 .to_string();
-            
-            let description = tool.get("description")
+
+            let description = tool
+                .get("description")
                 .and_then(|d| d.as_str())
                 .map(|s| s.to_string());
-            
-            let input_schema = tool.get("inputSchema")
+
+            let input_schema = tool
+                .get("inputSchema")
                 .cloned()
                 .unwrap_or(Value::Object(serde_json::Map::new()));
-            
+
             tool_infos.push(McpToolInfo {
                 name,
                 description,
@@ -93,56 +104,67 @@ impl McpServerConnection for HttpMcpConnection {
                 server_name: self.server_name.clone(),
             });
         }
-        
+
         Ok(tool_infos)
     }
-    
+
     async fn call_tool(&self, name: &str, arguments: Value) -> Result<String> {
         let params = serde_json::json!({
             "name": name,
             "arguments": arguments
         });
-        
+
         let result = self.transport.send_request("tools/call", params).await?;
-        
+
         // Parse the MCP tool result
         let tool_result: McpToolResult = serde_json::from_value(result)?;
-        
+
         // Check if the result indicates an error
         if tool_result.is_error.unwrap_or(false) {
-            return Err(anyhow::anyhow!("Tool execution failed: {}", tool_result.to_string()));
+            return Err(anyhow::anyhow!(
+                "Tool execution failed: {}",
+                tool_result.to_string()
+            ));
         }
-        
+
         Ok(tool_result.to_string())
     }
-    
+
     async fn list_resources(&self) -> Result<Vec<Resource>> {
-        let result = self.transport.send_request("resources/list", Value::Null).await?;
-        
-        let resources = result.get("resources")
+        let result = self
+            .transport
+            .send_request("resources/list", Value::Null)
+            .await?;
+
+        let resources = result
+            .get("resources")
             .and_then(|r| r.as_array())
             .ok_or_else(|| anyhow::anyhow!("Invalid resources response format"))?;
-        
+
         let mut resource_list = Vec::new();
         for resource in resources {
             let mcp_resource: Resource = serde_json::from_value(resource.clone())?;
             resource_list.push(mcp_resource);
         }
-        
+
         Ok(resource_list)
     }
-    
+
     async fn read_resource(&self, uri: &str) -> Result<String> {
         let params = serde_json::json!({
             "uri": uri
         });
-        
-        let result = self.transport.send_request("resources/read", params).await?;
-        
-        let contents = result.get("contents")
+
+        let result = self
+            .transport
+            .send_request("resources/read", params)
+            .await?;
+
+        let contents = result
+            .get("contents")
             .and_then(|c| c.as_array())
             .ok_or_else(|| anyhow::anyhow!("Invalid resource read response format"))?;
-        
+
         let mut text_parts = Vec::new();
         for content in contents {
             if let Some(content_type) = content.get("type").and_then(|t| t.as_str()) {
@@ -159,10 +181,10 @@ impl McpServerConnection for HttpMcpConnection {
                 }
             }
         }
-        
+
         Ok(text_parts.join("\n"))
     }
-    
+
     async fn ping(&self) -> Result<()> {
         self.transport.ping().await
     }
@@ -185,19 +207,19 @@ impl ProcessMcpConnection {
         env: Option<HashMap<String, String>>,
     ) -> Result<Self> {
         let transport = ProcessTransport::new(command, args, work_dir, env).await?;
-        
+
         let connection = Self {
             server_id,
             server_name,
             transport: Arc::new(transport),
         };
-        
+
         // Initialize the connection
         connection.initialize().await?;
-        
+
         Ok(connection)
     }
-    
+
     async fn initialize(&self) -> Result<()> {
         let init_params = serde_json::json!({
             "protocolVersion": "2025-03-26",
@@ -209,8 +231,10 @@ impl ProcessMcpConnection {
                 "version": "0.6.0"
             }
         });
-        
-        self.transport.send_request("initialize", init_params).await?;
+
+        self.transport
+            .send_request("initialize", init_params)
+            .await?;
         Ok(())
     }
 }
@@ -220,33 +244,40 @@ impl McpServerConnection for ProcessMcpConnection {
     fn server_id(&self) -> &str {
         &self.server_id
     }
-    
+
     fn server_name(&self) -> &str {
         &self.server_name
     }
-    
+
     async fn list_tools(&self) -> Result<Vec<McpToolInfo>> {
-        let result = self.transport.send_request("tools/list", Value::Null).await?;
-        
-        let tools = result.get("tools")
+        let result = self
+            .transport
+            .send_request("tools/list", Value::Null)
+            .await?;
+
+        let tools = result
+            .get("tools")
             .and_then(|t| t.as_array())
             .ok_or_else(|| anyhow::anyhow!("Invalid tools response format"))?;
-        
+
         let mut tool_infos = Vec::new();
         for tool in tools {
-            let name = tool.get("name")
+            let name = tool
+                .get("name")
                 .and_then(|n| n.as_str())
                 .ok_or_else(|| anyhow::anyhow!("Tool missing name"))?
                 .to_string();
-            
-            let description = tool.get("description")
+
+            let description = tool
+                .get("description")
                 .and_then(|d| d.as_str())
                 .map(|s| s.to_string());
-            
-            let input_schema = tool.get("inputSchema")
+
+            let input_schema = tool
+                .get("inputSchema")
                 .cloned()
                 .unwrap_or(Value::Object(serde_json::Map::new()));
-            
+
             tool_infos.push(McpToolInfo {
                 name,
                 description,
@@ -255,56 +286,67 @@ impl McpServerConnection for ProcessMcpConnection {
                 server_name: self.server_name.clone(),
             });
         }
-        
+
         Ok(tool_infos)
     }
-    
+
     async fn call_tool(&self, name: &str, arguments: Value) -> Result<String> {
         let params = serde_json::json!({
             "name": name,
             "arguments": arguments
         });
-        
+
         let result = self.transport.send_request("tools/call", params).await?;
-        
+
         // Parse the MCP tool result
         let tool_result: McpToolResult = serde_json::from_value(result)?;
-        
+
         // Check if the result indicates an error
         if tool_result.is_error.unwrap_or(false) {
-            return Err(anyhow::anyhow!("Tool execution failed: {}", tool_result.to_string()));
+            return Err(anyhow::anyhow!(
+                "Tool execution failed: {}",
+                tool_result.to_string()
+            ));
         }
-        
+
         Ok(tool_result.to_string())
     }
-    
+
     async fn list_resources(&self) -> Result<Vec<Resource>> {
-        let result = self.transport.send_request("resources/list", Value::Null).await?;
-        
-        let resources = result.get("resources")
+        let result = self
+            .transport
+            .send_request("resources/list", Value::Null)
+            .await?;
+
+        let resources = result
+            .get("resources")
             .and_then(|r| r.as_array())
             .ok_or_else(|| anyhow::anyhow!("Invalid resources response format"))?;
-        
+
         let mut resource_list = Vec::new();
         for resource in resources {
             let mcp_resource: Resource = serde_json::from_value(resource.clone())?;
             resource_list.push(mcp_resource);
         }
-        
+
         Ok(resource_list)
     }
-    
+
     async fn read_resource(&self, uri: &str) -> Result<String> {
         let params = serde_json::json!({
             "uri": uri
         });
-        
-        let result = self.transport.send_request("resources/read", params).await?;
-        
-        let contents = result.get("contents")
+
+        let result = self
+            .transport
+            .send_request("resources/read", params)
+            .await?;
+
+        let contents = result
+            .get("contents")
             .and_then(|c| c.as_array())
             .ok_or_else(|| anyhow::anyhow!("Invalid resource read response format"))?;
-        
+
         let mut text_parts = Vec::new();
         for content in contents {
             if let Some(content_type) = content.get("type").and_then(|t| t.as_str()) {
@@ -321,10 +363,10 @@ impl McpServerConnection for ProcessMcpConnection {
                 }
             }
         }
-        
+
         Ok(text_parts.join("\n"))
     }
-    
+
     async fn ping(&self) -> Result<()> {
         self.transport.ping().await
     }
@@ -346,7 +388,7 @@ impl WebSocketMcpConnection {
         headers: Option<HashMap<String, String>>,
     ) -> Result<Self> {
         let transport = WebSocketTransport::new(url, timeout_secs, headers).await?;
-        
+
         Ok(Self {
             server_id,
             server_name,
@@ -360,31 +402,31 @@ impl McpServerConnection for WebSocketMcpConnection {
     fn server_id(&self) -> &str {
         &self.server_id
     }
-    
+
     fn server_name(&self) -> &str {
         &self.server_name
     }
-    
+
     async fn list_tools(&self) -> Result<Vec<McpToolInfo>> {
         // WebSocket implementation would mirror HTTP implementation
         Err(anyhow::anyhow!("WebSocket transport not yet implemented"))
     }
-    
+
     async fn call_tool(&self, _name: &str, _arguments: Value) -> Result<String> {
         // WebSocket implementation would mirror HTTP implementation
         Err(anyhow::anyhow!("WebSocket transport not yet implemented"))
     }
-    
+
     async fn list_resources(&self) -> Result<Vec<Resource>> {
         // WebSocket implementation would mirror HTTP implementation
         Err(anyhow::anyhow!("WebSocket transport not yet implemented"))
     }
-    
+
     async fn read_resource(&self, _uri: &str) -> Result<String> {
         // WebSocket implementation would mirror HTTP implementation
         Err(anyhow::anyhow!("WebSocket transport not yet implemented"))
     }
-    
+
     async fn ping(&self) -> Result<()> {
         self.transport.ping().await
     }

--- a/mistralrs-core/src/mcp_client/mod.rs
+++ b/mistralrs-core/src/mcp_client/mod.rs
@@ -1,0 +1,252 @@
+use anyhow::Result;
+use rust_mcp_schema::Resource;
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+use std::sync::Arc;
+
+pub mod client;
+pub mod transport;
+pub mod types;
+
+use crate::tools::ToolCallback;
+
+/// Supported MCP server sources
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "type")]
+pub enum McpServerSource {
+    /// HTTP-based MCP server
+    Http {
+        /// Base URL of the MCP server
+        url: String,
+        /// Optional timeout in seconds
+        timeout_secs: Option<u64>,
+        /// Optional headers to include in requests
+        headers: Option<HashMap<String, String>>,
+    },
+    /// Local process-based MCP server
+    Process {
+        /// Command to execute
+        command: String,
+        /// Arguments to pass to the command
+        args: Vec<String>,
+        /// Optional working directory
+        work_dir: Option<String>,
+        /// Optional environment variables
+        env: Option<HashMap<String, String>>,
+    },
+    /// WebSocket-based MCP server
+    WebSocket {
+        /// WebSocket URL
+        url: String,
+        /// Optional timeout in seconds
+        timeout_secs: Option<u64>,
+        /// Optional headers for the WebSocket handshake
+        headers: Option<HashMap<String, String>>,
+    },
+}
+
+/// Configuration for MCP client integration
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct McpClientConfig {
+    /// List of MCP servers to connect to
+    pub servers: Vec<McpServerConfig>,
+    /// Whether to automatically register discovered tools
+    pub auto_register_tools: bool,
+    /// Timeout for tool execution in seconds
+    pub tool_timeout_secs: Option<u64>,
+    /// Maximum number of concurrent tool calls
+    pub max_concurrent_calls: Option<usize>,
+}
+
+/// Configuration for individual MCP server
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct McpServerConfig {
+    /// Unique identifier for this server
+    pub id: String,
+    /// Human-readable name for this server
+    pub name: String,
+    /// Source specification for connecting to the server
+    pub source: McpServerSource,
+    /// Whether this server is enabled
+    pub enabled: bool,
+    /// Optional tool name prefix to avoid conflicts
+    pub tool_prefix: Option<String>,
+    /// Resource patterns to subscribe to (optional)
+    pub resources: Option<Vec<String>>,
+}
+
+/// Information about a discovered MCP tool
+#[derive(Debug, Clone)]
+pub struct McpToolInfo {
+    /// Name of the tool
+    pub name: String,
+    /// Description of the tool
+    pub description: Option<String>,
+    /// JSON schema for the tool's input parameters
+    pub input_schema: serde_json::Value,
+    /// ID of the server this tool comes from
+    pub server_id: String,
+    /// Server name for display purposes
+    pub server_name: String,
+}
+
+/// MCP client that manages connections to multiple MCP servers
+pub struct McpClient {
+    /// Configuration for the client
+    config: McpClientConfig,
+    /// Connected MCP servers
+    servers: HashMap<String, Arc<dyn McpServerConnection>>,
+    /// Discovered tools from all servers
+    tools: HashMap<String, McpToolInfo>,
+    /// Tool callbacks that can be used with the existing tool calling system
+    tool_callbacks: HashMap<String, Arc<ToolCallback>>,
+}
+
+/// Trait for MCP server connections
+#[async_trait::async_trait]
+pub trait McpServerConnection: Send + Sync {
+    /// Get the server ID
+    fn server_id(&self) -> &str;
+    
+    /// Get the server name
+    fn server_name(&self) -> &str;
+    
+    /// List available tools from this server
+    async fn list_tools(&self) -> Result<Vec<McpToolInfo>>;
+    
+    /// Call a tool on this server
+    async fn call_tool(&self, name: &str, arguments: serde_json::Value) -> Result<String>;
+    
+    /// List available resources from this server
+    async fn list_resources(&self) -> Result<Vec<Resource>>;
+    
+    /// Read a resource from this server
+    async fn read_resource(&self, uri: &str) -> Result<String>;
+    
+    /// Check if the connection is healthy
+    async fn ping(&self) -> Result<()>;
+}
+
+impl Default for McpClientConfig {
+    fn default() -> Self {
+        Self {
+            servers: Vec::new(),
+            auto_register_tools: true,
+            tool_timeout_secs: Some(30),
+            max_concurrent_calls: Some(10),
+        }
+    }
+}
+
+impl McpClient {
+    /// Create a new MCP client with the given configuration
+    pub fn new(config: McpClientConfig) -> Self {
+        Self {
+            config,
+            servers: HashMap::new(),
+            tools: HashMap::new(),
+            tool_callbacks: HashMap::new(),
+        }
+    }
+    
+    /// Initialize connections to all configured servers
+    pub async fn initialize(&mut self) -> Result<()> {
+        for server_config in &self.config.servers {
+            if server_config.enabled {
+                let connection = self.create_connection(server_config).await?;
+                self.servers.insert(server_config.id.clone(), connection);
+            }
+        }
+        
+        if self.config.auto_register_tools {
+            self.discover_and_register_tools().await?;
+        }
+        
+        Ok(())
+    }
+    
+    /// Get tool callbacks that can be used with the existing tool calling system
+    pub fn get_tool_callbacks(&self) -> &HashMap<String, Arc<ToolCallback>> {
+        &self.tool_callbacks
+    }
+    
+    /// Get discovered tools information
+    pub fn get_tools(&self) -> &HashMap<String, McpToolInfo> {
+        &self.tools
+    }
+    
+    /// Create connection based on server source type
+    async fn create_connection(&self, config: &McpServerConfig) -> Result<Arc<dyn McpServerConnection>> {
+        match &config.source {
+            McpServerSource::Http { url, timeout_secs, headers } => {
+                let connection = client::HttpMcpConnection::new(
+                    config.id.clone(),
+                    config.name.clone(),
+                    url.clone(),
+                    *timeout_secs,
+                    headers.clone(),
+                ).await?;
+                Ok(Arc::new(connection))
+            }
+            McpServerSource::Process { command, args, work_dir, env } => {
+                let connection = client::ProcessMcpConnection::new(
+                    config.id.clone(),
+                    config.name.clone(),
+                    command.clone(),
+                    args.clone(),
+                    work_dir.clone(),
+                    env.clone(),
+                ).await?;
+                Ok(Arc::new(connection))
+            }
+            McpServerSource::WebSocket { url, timeout_secs, headers } => {
+                let connection = client::WebSocketMcpConnection::new(
+                    config.id.clone(),
+                    config.name.clone(),
+                    url.clone(),
+                    *timeout_secs,
+                    headers.clone(),
+                ).await?;
+                Ok(Arc::new(connection))
+            }
+        }
+    }
+    
+    /// Discover tools from all connected servers and register them
+    async fn discover_and_register_tools(&mut self) -> Result<()> {
+        for (server_id, connection) in &self.servers {
+            let tools = connection.list_tools().await?;
+            let server_config = self.config.servers.iter()
+                .find(|s| &s.id == server_id)
+                .ok_or_else(|| anyhow::anyhow!("Server config not found for {}", server_id))?;
+            
+            for tool in tools {
+                let tool_name = if let Some(prefix) = &server_config.tool_prefix {
+                    format!("{}_{}", prefix, tool.name)
+                } else {
+                    tool.name.clone()
+                };
+                
+                // Create tool callback that calls the MCP server
+                let connection_clone = Arc::clone(connection);
+                let original_tool_name = tool.name.clone();
+                let callback: Arc<ToolCallback> = Arc::new(move |called_function| {
+                    let connection = Arc::clone(&connection_clone);
+                    let tool_name = original_tool_name.clone();
+                    let arguments: serde_json::Value = serde_json::from_str(&called_function.arguments)?;
+                    
+                    // Use tokio runtime to call async function
+                    let rt = tokio::runtime::Handle::current();
+                    rt.block_on(async move {
+                        connection.call_tool(&tool_name, arguments).await
+                    })
+                });
+                
+                self.tool_callbacks.insert(tool_name.clone(), callback);
+                self.tools.insert(tool_name, tool);
+            }
+        }
+        
+        Ok(())
+    }
+}

--- a/mistralrs-core/src/mcp_client/transport.rs
+++ b/mistralrs-core/src/mcp_client/transport.rs
@@ -52,7 +52,11 @@ impl McpTransport for HttpTransport {
             "params": params
         });
 
-        let mut request_builder = self.client.post(&self.base_url).json(&request_body);
+        let mut request_builder = self
+            .client
+            .post(&self.base_url)
+            .json(&request_body)
+            .header("Accept", "application/json, text/event-stream");
 
         // Add custom headers
         for (key, value) in &self.headers {

--- a/mistralrs-core/src/mcp_client/transport.rs
+++ b/mistralrs-core/src/mcp_client/transport.rs
@@ -45,20 +45,20 @@ impl HttpTransport {
     fn parse_sse_response(sse_text: &str) -> Result<Value> {
         // SSE format: data: <json>\n\n or event: <type>\ndata: <json>\n\n
         let mut json_data = None;
-        
+
         for line in sse_text.lines() {
             let line = line.trim();
-            
+
             // Skip empty lines and comments
             if line.is_empty() || line.starts_with(':') {
                 continue;
             }
-            
+
             // Parse SSE field
             if let Some((field, value)) = line.split_once(':') {
                 let field = field.trim();
                 let value = value.trim();
-                
+
                 match field {
                     "data" => {
                         // Try to parse the JSON data
@@ -78,7 +78,7 @@ impl HttpTransport {
                 }
             }
         }
-        
+
         json_data.ok_or_else(|| anyhow::anyhow!("No valid JSON data found in SSE response"))
     }
 }
@@ -92,7 +92,7 @@ impl McpTransport for HttpTransport {
         } else {
             params
         };
-        
+
         let request_body = serde_json::json!({
             "jsonrpc": "2.0",
             "id": 1,
@@ -112,12 +112,14 @@ impl McpTransport for HttpTransport {
         }
 
         let response = request_builder.send().await?;
-        
+
         // Check content type and handle accordingly
-        let content_type = response.headers().get("content-type")
+        let content_type = response
+            .headers()
+            .get("content-type")
             .and_then(|v| v.to_str().ok())
             .unwrap_or("");
-            
+
         let response_body: Value = if content_type.contains("text/event-stream") {
             // Handle Server-Sent Events
             let response_text = response.text().await?;

--- a/mistralrs-core/src/mcp_client/transport.rs
+++ b/mistralrs-core/src/mcp_client/transport.rs
@@ -1,0 +1,225 @@
+use anyhow::Result;
+use serde_json::Value;
+use std::collections::HashMap;
+use std::time::Duration;
+
+/// Transport layer for MCP communication
+#[async_trait::async_trait]
+pub trait McpTransport: Send + Sync {
+    /// Send a JSON-RPC request and receive a response
+    async fn send_request(&self, method: &str, params: Value) -> Result<Value>;
+    
+    /// Check if the transport connection is healthy
+    async fn ping(&self) -> Result<()>;
+    
+    /// Close the transport connection
+    async fn close(&self) -> Result<()>;
+}
+
+/// HTTP-based MCP transport
+pub struct HttpTransport {
+    client: reqwest::Client,
+    base_url: String,
+    headers: HashMap<String, String>,
+}
+
+impl HttpTransport {
+    pub fn new(
+        base_url: String,
+        timeout_secs: Option<u64>,
+        headers: Option<HashMap<String, String>>,
+    ) -> Result<Self> {
+        let timeout = timeout_secs.map(Duration::from_secs).unwrap_or(Duration::from_secs(30));
+        let client = reqwest::Client::builder()
+            .timeout(timeout)
+            .build()?;
+        
+        Ok(Self {
+            client,
+            base_url,
+            headers: headers.unwrap_or_default(),
+        })
+    }
+}
+
+#[async_trait::async_trait]
+impl McpTransport for HttpTransport {
+    async fn send_request(&self, method: &str, params: Value) -> Result<Value> {
+        let request_body = serde_json::json!({
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": method,
+            "params": params
+        });
+        
+        let mut request_builder = self.client
+            .post(&self.base_url)
+            .json(&request_body);
+        
+        // Add custom headers
+        for (key, value) in &self.headers {
+            request_builder = request_builder.header(key, value);
+        }
+        
+        let response = request_builder.send().await?;
+        let response_body: Value = response.json().await?;
+        
+        // Check for JSON-RPC errors
+        if let Some(error) = response_body.get("error") {
+            return Err(anyhow::anyhow!("MCP server error: {}", error));
+        }
+        
+        response_body.get("result")
+            .cloned()
+            .ok_or_else(|| anyhow::anyhow!("No result in MCP response"))
+    }
+    
+    async fn ping(&self) -> Result<()> {
+        self.send_request("ping", Value::Null).await?;
+        Ok(())
+    }
+    
+    async fn close(&self) -> Result<()> {
+        // HTTP connections don't need explicit closing
+        Ok(())
+    }
+}
+
+/// Process-based MCP transport using stdin/stdout
+pub struct ProcessTransport {
+    child: std::sync::Arc<tokio::sync::Mutex<tokio::process::Child>>,
+    stdin: std::sync::Arc<tokio::sync::Mutex<tokio::process::ChildStdin>>,
+    stdout_reader: std::sync::Arc<tokio::sync::Mutex<tokio::io::BufReader<tokio::process::ChildStdout>>>,
+}
+
+impl ProcessTransport {
+    pub async fn new(
+        command: String,
+        args: Vec<String>,
+        work_dir: Option<String>,
+        env: Option<HashMap<String, String>>,
+    ) -> Result<Self> {
+        use tokio::process::Command;
+        use tokio::io::BufReader;
+        
+        let mut cmd = Command::new(command);
+        cmd.args(args)
+            .stdin(std::process::Stdio::piped())
+            .stdout(std::process::Stdio::piped())
+            .stderr(std::process::Stdio::piped());
+        
+        if let Some(dir) = work_dir {
+            cmd.current_dir(dir);
+        }
+        
+        if let Some(env_vars) = env {
+            for (key, value) in env_vars {
+                cmd.env(key, value);
+            }
+        }
+        
+        let mut child = cmd.spawn()?;
+        let stdin = child.stdin.take()
+            .ok_or_else(|| anyhow::anyhow!("Failed to get stdin handle"))?;
+        let stdout = child.stdout.take()
+            .ok_or_else(|| anyhow::anyhow!("Failed to get stdout handle"))?;
+        let stdout_reader = BufReader::new(stdout);
+        
+        Ok(Self {
+            child: std::sync::Arc::new(tokio::sync::Mutex::new(child)),
+            stdin: std::sync::Arc::new(tokio::sync::Mutex::new(stdin)),
+            stdout_reader: std::sync::Arc::new(tokio::sync::Mutex::new(stdout_reader)),
+        })
+    }
+}
+
+#[async_trait::async_trait]
+impl McpTransport for ProcessTransport {
+    async fn send_request(&self, method: &str, params: Value) -> Result<Value> {
+        use tokio::io::{AsyncBufReadExt, AsyncWriteExt};
+        
+        let request_body = serde_json::json!({
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": method,
+            "params": params
+        });
+        
+        // Send request via stdin
+        let request_line = serde_json::to_string(&request_body)? + "\n";
+        
+        let mut stdin = self.stdin.lock().await;
+        stdin.write_all(request_line.as_bytes()).await?;
+        stdin.flush().await?;
+        drop(stdin);
+        
+        // Read response from stdout
+        let mut stdout_reader = self.stdout_reader.lock().await;
+        let mut response_line = String::new();
+        stdout_reader.read_line(&mut response_line).await?;
+        drop(stdout_reader);
+        
+        let response_body: Value = serde_json::from_str(&response_line.trim())?;
+        
+        // Check for JSON-RPC errors
+        if let Some(error) = response_body.get("error") {
+            return Err(anyhow::anyhow!("MCP server error: {}", error));
+        }
+        
+        response_body.get("result")
+            .cloned()
+            .ok_or_else(|| anyhow::anyhow!("No result in MCP response"))
+    }
+    
+    async fn ping(&self) -> Result<()> {
+        self.send_request("ping", Value::Null).await?;
+        Ok(())
+    }
+    
+    async fn close(&self) -> Result<()> {
+        let mut child = self.child.lock().await;
+        child.kill().await?;
+        Ok(())
+    }
+}
+
+/// WebSocket-based MCP transport
+pub struct WebSocketTransport {
+    // WebSocket implementation would go here
+    // For now, this is a placeholder
+    url: String,
+    headers: HashMap<String, String>,
+}
+
+impl WebSocketTransport {
+    pub async fn new(
+        url: String,
+        _timeout_secs: Option<u64>,
+        headers: Option<HashMap<String, String>>,
+    ) -> Result<Self> {
+        Ok(Self {
+            url,
+            headers: headers.unwrap_or_default(),
+        })
+    }
+}
+
+#[async_trait::async_trait]
+impl McpTransport for WebSocketTransport {
+    async fn send_request(&self, method: &str, params: Value) -> Result<Value> {
+        // WebSocket implementation would go here
+        // This is a placeholder for now
+        // TODO 
+        Err(anyhow::anyhow!("WebSocket transport not yet implemented"))
+    }
+    
+    async fn ping(&self) -> Result<()> {
+        self.send_request("ping", Value::Null).await?;
+        Ok(())
+    }
+    
+    async fn close(&self) -> Result<()> {
+        // WebSocket cleanup would go here
+        Ok(())
+    }
+}

--- a/mistralrs-core/src/mcp_client/transport.rs
+++ b/mistralrs-core/src/mcp_client/transport.rs
@@ -8,10 +8,10 @@ use std::time::Duration;
 pub trait McpTransport: Send + Sync {
     /// Send a JSON-RPC request and receive a response
     async fn send_request(&self, method: &str, params: Value) -> Result<Value>;
-    
+
     /// Check if the transport connection is healthy
     async fn ping(&self) -> Result<()>;
-    
+
     /// Close the transport connection
     async fn close(&self) -> Result<()>;
 }
@@ -29,11 +29,11 @@ impl HttpTransport {
         timeout_secs: Option<u64>,
         headers: Option<HashMap<String, String>>,
     ) -> Result<Self> {
-        let timeout = timeout_secs.map(Duration::from_secs).unwrap_or(Duration::from_secs(30));
-        let client = reqwest::Client::builder()
-            .timeout(timeout)
-            .build()?;
-        
+        let timeout = timeout_secs
+            .map(Duration::from_secs)
+            .unwrap_or(Duration::from_secs(30));
+        let client = reqwest::Client::builder().timeout(timeout).build()?;
+
         Ok(Self {
             client,
             base_url,
@@ -51,34 +51,33 @@ impl McpTransport for HttpTransport {
             "method": method,
             "params": params
         });
-        
-        let mut request_builder = self.client
-            .post(&self.base_url)
-            .json(&request_body);
-        
+
+        let mut request_builder = self.client.post(&self.base_url).json(&request_body);
+
         // Add custom headers
         for (key, value) in &self.headers {
             request_builder = request_builder.header(key, value);
         }
-        
+
         let response = request_builder.send().await?;
         let response_body: Value = response.json().await?;
-        
+
         // Check for JSON-RPC errors
         if let Some(error) = response_body.get("error") {
             return Err(anyhow::anyhow!("MCP server error: {}", error));
         }
-        
-        response_body.get("result")
+
+        response_body
+            .get("result")
             .cloned()
             .ok_or_else(|| anyhow::anyhow!("No result in MCP response"))
     }
-    
+
     async fn ping(&self) -> Result<()> {
         self.send_request("ping", Value::Null).await?;
         Ok(())
     }
-    
+
     async fn close(&self) -> Result<()> {
         // HTTP connections don't need explicit closing
         Ok(())
@@ -89,7 +88,8 @@ impl McpTransport for HttpTransport {
 pub struct ProcessTransport {
     child: std::sync::Arc<tokio::sync::Mutex<tokio::process::Child>>,
     stdin: std::sync::Arc<tokio::sync::Mutex<tokio::process::ChildStdin>>,
-    stdout_reader: std::sync::Arc<tokio::sync::Mutex<tokio::io::BufReader<tokio::process::ChildStdout>>>,
+    stdout_reader:
+        std::sync::Arc<tokio::sync::Mutex<tokio::io::BufReader<tokio::process::ChildStdout>>>,
 }
 
 impl ProcessTransport {
@@ -99,32 +99,36 @@ impl ProcessTransport {
         work_dir: Option<String>,
         env: Option<HashMap<String, String>>,
     ) -> Result<Self> {
-        use tokio::process::Command;
         use tokio::io::BufReader;
-        
+        use tokio::process::Command;
+
         let mut cmd = Command::new(command);
         cmd.args(args)
             .stdin(std::process::Stdio::piped())
             .stdout(std::process::Stdio::piped())
             .stderr(std::process::Stdio::piped());
-        
+
         if let Some(dir) = work_dir {
             cmd.current_dir(dir);
         }
-        
+
         if let Some(env_vars) = env {
             for (key, value) in env_vars {
                 cmd.env(key, value);
             }
         }
-        
+
         let mut child = cmd.spawn()?;
-        let stdin = child.stdin.take()
+        let stdin = child
+            .stdin
+            .take()
             .ok_or_else(|| anyhow::anyhow!("Failed to get stdin handle"))?;
-        let stdout = child.stdout.take()
+        let stdout = child
+            .stdout
+            .take()
             .ok_or_else(|| anyhow::anyhow!("Failed to get stdout handle"))?;
         let stdout_reader = BufReader::new(stdout);
-        
+
         Ok(Self {
             child: std::sync::Arc::new(tokio::sync::Mutex::new(child)),
             stdin: std::sync::Arc::new(tokio::sync::Mutex::new(stdin)),
@@ -137,45 +141,46 @@ impl ProcessTransport {
 impl McpTransport for ProcessTransport {
     async fn send_request(&self, method: &str, params: Value) -> Result<Value> {
         use tokio::io::{AsyncBufReadExt, AsyncWriteExt};
-        
+
         let request_body = serde_json::json!({
             "jsonrpc": "2.0",
             "id": 1,
             "method": method,
             "params": params
         });
-        
+
         // Send request via stdin
         let request_line = serde_json::to_string(&request_body)? + "\n";
-        
+
         let mut stdin = self.stdin.lock().await;
         stdin.write_all(request_line.as_bytes()).await?;
         stdin.flush().await?;
         drop(stdin);
-        
+
         // Read response from stdout
         let mut stdout_reader = self.stdout_reader.lock().await;
         let mut response_line = String::new();
         stdout_reader.read_line(&mut response_line).await?;
         drop(stdout_reader);
-        
+
         let response_body: Value = serde_json::from_str(&response_line.trim())?;
-        
+
         // Check for JSON-RPC errors
         if let Some(error) = response_body.get("error") {
             return Err(anyhow::anyhow!("MCP server error: {}", error));
         }
-        
-        response_body.get("result")
+
+        response_body
+            .get("result")
             .cloned()
             .ok_or_else(|| anyhow::anyhow!("No result in MCP response"))
     }
-    
+
     async fn ping(&self) -> Result<()> {
         self.send_request("ping", Value::Null).await?;
         Ok(())
     }
-    
+
     async fn close(&self) -> Result<()> {
         let mut child = self.child.lock().await;
         child.kill().await?;
@@ -183,6 +188,7 @@ impl McpTransport for ProcessTransport {
     }
 }
 
+#[allow(dead_code)]
 /// WebSocket-based MCP transport
 pub struct WebSocketTransport {
     // WebSocket implementation would go here
@@ -206,18 +212,18 @@ impl WebSocketTransport {
 
 #[async_trait::async_trait]
 impl McpTransport for WebSocketTransport {
-    async fn send_request(&self, method: &str, params: Value) -> Result<Value> {
+    async fn send_request(&self, _method: &str, _params: Value) -> Result<Value> {
         // WebSocket implementation would go here
         // This is a placeholder for now
-        // TODO 
+        // TODO
         Err(anyhow::anyhow!("WebSocket transport not yet implemented"))
     }
-    
+
     async fn ping(&self) -> Result<()> {
         self.send_request("ping", Value::Null).await?;
         Ok(())
     }
-    
+
     async fn close(&self) -> Result<()> {
         // WebSocket cleanup would go here
         Ok(())

--- a/mistralrs-core/src/mcp_client/types.rs
+++ b/mistralrs-core/src/mcp_client/types.rs
@@ -31,14 +31,9 @@ pub enum McpContent {
     #[serde(rename = "text")]
     Text { text: String },
     #[serde(rename = "image")]
-    Image { 
-        data: String, 
-        mime_type: String 
-    },
+    Image { data: String, mime_type: String },
     #[serde(rename = "resource")]
-    Resource { 
-        resource: McpResourceReference 
-    },
+    Resource { resource: McpResourceReference },
 }
 
 /// Reference to an MCP resource
@@ -88,17 +83,17 @@ impl From<crate::mcp_client::McpToolInfo> for McpToolSchema {
 impl McpToolResult {
     /// Convert MCP tool result to a simple string representation
     pub fn to_string(&self) -> String {
-        self.content.iter()
+        self.content
+            .iter()
             .map(|content| match content {
                 McpContent::Text { text } => text.clone(),
                 McpContent::Image { mime_type, .. } => {
                     format!("[Image: {}]", mime_type)
                 }
-                McpContent::Resource { resource } => {
-                    resource.text.clone().unwrap_or_else(|| {
-                        format!("[Resource: {}]", resource.uri)
-                    })
-                }
+                McpContent::Resource { resource } => resource
+                    .text
+                    .clone()
+                    .unwrap_or_else(|| format!("[Resource: {}]", resource.uri)),
             })
             .collect::<Vec<_>>()
             .join("\n")

--- a/mistralrs-core/src/mcp_client/types.rs
+++ b/mistralrs-core/src/mcp_client/types.rs
@@ -1,0 +1,106 @@
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+
+/// OpenAI-compatible tool schema for MCP tools
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct McpToolSchema {
+    #[serde(rename = "type")]
+    pub tool_type: String,
+    pub function: McpFunctionSchema,
+}
+
+/// Function schema for MCP tools
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct McpFunctionSchema {
+    pub name: String,
+    pub description: Option<String>,
+    pub parameters: serde_json::Value,
+}
+
+/// MCP tool call result
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct McpToolResult {
+    pub content: Vec<McpContent>,
+    pub is_error: Option<bool>,
+}
+
+/// MCP content types
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "type")]
+pub enum McpContent {
+    #[serde(rename = "text")]
+    Text { text: String },
+    #[serde(rename = "image")]
+    Image { 
+        data: String, 
+        mime_type: String 
+    },
+    #[serde(rename = "resource")]
+    Resource { 
+        resource: McpResourceReference 
+    },
+}
+
+/// Reference to an MCP resource
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct McpResourceReference {
+    pub uri: String,
+    pub text: Option<String>,
+}
+
+/// MCP server capabilities
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct McpServerCapabilities {
+    pub tools: Option<HashMap<String, serde_json::Value>>,
+    pub resources: Option<HashMap<String, serde_json::Value>>,
+    pub prompts: Option<HashMap<String, serde_json::Value>>,
+    pub logging: Option<HashMap<String, serde_json::Value>>,
+}
+
+/// MCP initialization result
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct McpInitResult {
+    pub protocol_version: String,
+    pub capabilities: McpServerCapabilities,
+    pub server_info: McpServerInfo,
+}
+
+/// MCP server information
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct McpServerInfo {
+    pub name: String,
+    pub version: String,
+}
+
+impl From<crate::mcp_client::McpToolInfo> for McpToolSchema {
+    fn from(tool_info: crate::mcp_client::McpToolInfo) -> Self {
+        Self {
+            tool_type: "function".to_string(),
+            function: McpFunctionSchema {
+                name: tool_info.name,
+                description: tool_info.description,
+                parameters: tool_info.input_schema,
+            },
+        }
+    }
+}
+
+impl McpToolResult {
+    /// Convert MCP tool result to a simple string representation
+    pub fn to_string(&self) -> String {
+        self.content.iter()
+            .map(|content| match content {
+                McpContent::Text { text } => text.clone(),
+                McpContent::Image { mime_type, .. } => {
+                    format!("[Image: {}]", mime_type)
+                }
+                McpContent::Resource { resource } => {
+                    resource.text.clone().unwrap_or_else(|| {
+                        format!("[Resource: {}]", resource.uri)
+                    })
+                }
+            })
+            .collect::<Vec<_>>()
+            .join("\n")
+    }
+}

--- a/mistralrs-core/src/tools/mod.rs
+++ b/mistralrs-core/src/tools/mod.rs
@@ -18,8 +18,18 @@ use crate::Pipeline;
 /// (name and JSON arguments) and returns the tool output as a string.
 pub type ToolCallback = dyn Fn(&CalledFunction) -> anyhow::Result<String> + Send + Sync;
 
+/// A tool callback with its associated Tool definition.
+#[derive(Clone)]
+pub struct ToolCallbackWithTool {
+    pub callback: Arc<ToolCallback>,
+    pub tool: Tool,
+}
+
 /// Collection of callbacks keyed by tool name.
 pub type ToolCallbacks = HashMap<String, Arc<ToolCallback>>;
+
+/// Collection of callbacks with their tool definitions keyed by tool name.
+pub type ToolCallbacksWithTools = HashMap<String, ToolCallbackWithTool>;
 
 fn contains_tool_call_prefix(prefix: &str) -> bool {
     prefix.contains("<tool_call>")

--- a/mistralrs-server-core/src/mistralrs_for_server_builder.rs
+++ b/mistralrs-server-core/src/mistralrs_for_server_builder.rs
@@ -575,7 +575,8 @@ impl MistralRsForServerBuilder {
         .with_truncate_sequence(self.truncate_sequence)
         .with_no_kv_cache(self.no_kv_cache)
         .with_prefix_cache_n(self.prefix_cache_n)
-        .build();
+        .build()
+        .await;
 
         Ok(mistralrs)
     }

--- a/mistralrs/examples/mcp_client/main.rs
+++ b/mistralrs/examples/mcp_client/main.rs
@@ -22,7 +22,8 @@ async fn main() -> Result<()> {
                     timeout_secs: Some(30),
                     headers: Some({
                         let mut headers = HashMap::new();
-                        headers.insert("Authorization".to_string(), "Bearer your-token".to_string());
+                        headers
+                            .insert("Authorization".to_string(), "Bearer your-token".to_string());
                         headers
                     }),
                 },
@@ -30,33 +31,33 @@ async fn main() -> Result<()> {
                 tool_prefix: Some("example".to_string()),
                 resources: None,
             },
-            // Example process-based MCP server
-            McpServerConfig {
-                id: "filesystem_server".to_string(),
-                name: "Filesystem MCP Server".to_string(),
-                source: McpServerSource::Process {
-                    command: "mcp-server-filesystem".to_string(),
-                    args: vec!["--root".to_string(), "/tmp".to_string()],
-                    work_dir: None,
-                    env: None,
-                },
-                enabled: true,
-                tool_prefix: Some("fs".to_string()),
-                resources: Some(vec!["file://**".to_string()]),
-            },
-            // Example WebSocket-based MCP server (placeholder)
-            McpServerConfig {
-                id: "websocket_server".to_string(),
-                name: "WebSocket MCP Server".to_string(),
-                source: McpServerSource::WebSocket {
-                    url: "ws://localhost:9090/mcp".to_string(),
-                    timeout_secs: Some(30),
-                    headers: None,
-                },
-                enabled: false, // Disabled since WebSocket transport is not yet implemented
-                tool_prefix: Some("ws".to_string()),
-                resources: None,
-            },
+            // // Example process-based MCP server
+            // McpServerConfig {
+            //     id: "filesystem_server".to_string(),
+            //     name: "Filesystem MCP Server".to_string(),
+            //     source: McpServerSource::Process {
+            //         command: "mcp-server-filesystem".to_string(),
+            //         args: vec!["--root".to_string(), "/tmp".to_string()],
+            //         work_dir: None,
+            //         env: None,
+            //     },
+            //     enabled: true,
+            //     tool_prefix: Some("fs".to_string()),
+            //     resources: Some(vec!["file://**".to_string()]),
+            // },
+            // // Example WebSocket-based MCP server (placeholder)
+            // McpServerConfig {
+            //     id: "websocket_server".to_string(),
+            //     name: "WebSocket MCP Server".to_string(),
+            //     source: McpServerSource::WebSocket {
+            //         url: "ws://localhost:9090/mcp".to_string(),
+            //         timeout_secs: Some(30),
+            //         headers: None,
+            //     },
+            //     enabled: false, // Disabled since WebSocket transport is not yet implemented
+            //     tool_prefix: Some("ws".to_string()),
+            //     resources: None,
+            // },
         ],
         auto_register_tools: true,
         tool_timeout_secs: Some(30),
@@ -66,7 +67,7 @@ async fn main() -> Result<()> {
     println!("Building model with MCP client support...");
 
     // Build the model with MCP client configuration
-    let model = TextModelBuilder::new("microsoft/Phi-3.5-mini-instruct".to_string())
+    let model = TextModelBuilder::new("../hf_models/qwen3_4b".to_string())
         .with_isq(IsqType::Q8_0)
         .with_logging()
         .with_paged_attn(|| PagedAttentionMetaBuilder::default().build())?
@@ -113,7 +114,10 @@ async fn main() -> Result<()> {
     if let Some(tool_calls) = &response.choices[0].message.tool_calls {
         println!("\nTool calls made:");
         for tool_call in tool_calls {
-            println!("- {}: {}", tool_call.function.name, tool_call.function.arguments);
+            println!(
+                "- {}: {}",
+                tool_call.function.name, tool_call.function.arguments
+            );
         }
     }
 

--- a/mistralrs/examples/mcp_client/main.rs
+++ b/mistralrs/examples/mcp_client/main.rs
@@ -1,0 +1,121 @@
+use anyhow::Result;
+use mistralrs::{
+    IsqType, McpClientConfig, McpServerConfig, McpServerSource, PagedAttentionMetaBuilder,
+    TextMessageRole, TextMessages, TextModelBuilder,
+};
+use std::collections::HashMap;
+
+/// This example demonstrates how to use mistral.rs as an MCP client to connect
+/// to external MCP servers and automatically register their tools for use in
+/// automatic tool calling.
+#[tokio::main]
+async fn main() -> Result<()> {
+    // Create MCP client configuration with example servers
+    let mcp_config = McpClientConfig {
+        servers: vec![
+            // Example HTTP-based MCP server
+            McpServerConfig {
+                id: "example_server".to_string(),
+                name: "Example MCP Server".to_string(),
+                source: McpServerSource::Http {
+                    url: "http://localhost:8080/mcp".to_string(),
+                    timeout_secs: Some(30),
+                    headers: Some({
+                        let mut headers = HashMap::new();
+                        headers.insert("Authorization".to_string(), "Bearer your-token".to_string());
+                        headers
+                    }),
+                },
+                enabled: true,
+                tool_prefix: Some("example".to_string()),
+                resources: None,
+            },
+            // Example process-based MCP server
+            McpServerConfig {
+                id: "filesystem_server".to_string(),
+                name: "Filesystem MCP Server".to_string(),
+                source: McpServerSource::Process {
+                    command: "mcp-server-filesystem".to_string(),
+                    args: vec!["--root".to_string(), "/tmp".to_string()],
+                    work_dir: None,
+                    env: None,
+                },
+                enabled: true,
+                tool_prefix: Some("fs".to_string()),
+                resources: Some(vec!["file://**".to_string()]),
+            },
+            // Example WebSocket-based MCP server (placeholder)
+            McpServerConfig {
+                id: "websocket_server".to_string(),
+                name: "WebSocket MCP Server".to_string(),
+                source: McpServerSource::WebSocket {
+                    url: "ws://localhost:9090/mcp".to_string(),
+                    timeout_secs: Some(30),
+                    headers: None,
+                },
+                enabled: false, // Disabled since WebSocket transport is not yet implemented
+                tool_prefix: Some("ws".to_string()),
+                resources: None,
+            },
+        ],
+        auto_register_tools: true,
+        tool_timeout_secs: Some(30),
+        max_concurrent_calls: Some(5),
+    };
+
+    println!("Building model with MCP client support...");
+
+    // Build the model with MCP client configuration
+    let model = TextModelBuilder::new("microsoft/Phi-3.5-mini-instruct".to_string())
+        .with_isq(IsqType::Q8_0)
+        .with_logging()
+        .with_paged_attn(|| PagedAttentionMetaBuilder::default().build())?
+        .with_mcp_client(mcp_config) // Add MCP client configuration
+        .build()
+        .await?;
+
+    println!("Model built successfully! MCP servers will be connected automatically.");
+    println!("Any tools from the MCP servers will be available for automatic tool calling.");
+
+    // Create a conversation that might trigger tool usage
+    let messages = TextMessages::new()
+        .add_message(
+            TextMessageRole::System,
+            "You are an AI assistant with access to external tools via MCP servers. \
+             You can search the web, access filesystem operations, and use other tools \
+             provided by connected MCP servers. Use these tools when appropriate to \
+             help answer user questions.",
+        )
+        .add_message(
+            TextMessageRole::User,
+            "Hello! Can you help me list the files in the /tmp directory and then \
+             search for information about Rust programming language?",
+        );
+
+    println!("\nSending chat request...");
+    let response = model.send_chat_request(messages).await?;
+
+    println!("\nResponse:");
+    println!("{}", response.choices[0].message.content.as_ref().unwrap());
+
+    // Display performance metrics
+    println!("\nPerformance metrics:");
+    println!(
+        "Prompt tokens/sec: {:.2}",
+        response.usage.avg_prompt_tok_per_sec
+    );
+    println!(
+        "Completion tokens/sec: {:.2}",
+        response.usage.avg_compl_tok_per_sec
+    );
+
+    // Display any tool calls that were made
+    if let Some(tool_calls) = &response.choices[0].message.tool_calls {
+        println!("\nTool calls made:");
+        for tool_call in tool_calls {
+            println!("- {}: {}", tool_call.function.name, tool_call.function.arguments);
+        }
+    }
+
+    Ok(())
+}

--- a/mistralrs/examples/mcp_client/main.rs
+++ b/mistralrs/examples/mcp_client/main.rs
@@ -89,7 +89,7 @@ async fn main() -> Result<()> {
         )
         .add_message(
             TextMessageRole::User,
-            "Hello! Can you help me get a 3D XYZ for graphene?",
+            "Hello! Can you help me get the top 10 HF models right now?",
         );
 
     println!("\nSending chat request...");

--- a/mistralrs/examples/mcp_client/main.rs
+++ b/mistralrs/examples/mcp_client/main.rs
@@ -89,8 +89,7 @@ async fn main() -> Result<()> {
         )
         .add_message(
             TextMessageRole::User,
-            "Hello! Can you help me list the files in the /tmp directory and then \
-             search for information about Rust programming language?",
+            "Hello! Can you help me get a 3D XYZ for graphene?",
         );
 
     println!("\nSending chat request...");

--- a/mistralrs/examples/mcp_client/main.rs
+++ b/mistralrs/examples/mcp_client/main.rs
@@ -18,7 +18,7 @@ async fn main() -> Result<()> {
                 id: "example_server".to_string(),
                 name: "Example MCP Server".to_string(),
                 source: McpServerSource::Http {
-                    url: "http://localhost:8080/mcp".to_string(),
+                    url: "https://hf.co/mcp".to_string(),
                     timeout_secs: Some(30),
                     headers: Some({
                         let mut headers = HashMap::new();

--- a/mistralrs/src/anymoe.rs
+++ b/mistralrs/src/anymoe.rs
@@ -131,6 +131,6 @@ impl AnyMoeModelBuilder {
             runner = runner.with_prefix_cache_n(n)
         }
 
-        Ok(Model::new(runner.build()))
+        Ok(Model::new(runner.build().await))
     }
 }

--- a/mistralrs/src/diffusion_model.rs
+++ b/mistralrs/src/diffusion_model.rs
@@ -97,6 +97,6 @@ impl DiffusionModelBuilder {
 
         let runner = MistralRsBuilder::new(pipeline, scheduler_method, false, None);
 
-        Ok(Model::new(runner.build()))
+        Ok(Model::new(runner.build().await))
     }
 }

--- a/mistralrs/src/gguf.rs
+++ b/mistralrs/src/gguf.rs
@@ -282,6 +282,6 @@ impl GgufModelBuilder {
             runner = runner.with_prefix_cache_n(n)
         }
 
-        Ok(Model::new(runner.build()))
+        Ok(Model::new(runner.build().await))
     }
 }

--- a/mistralrs/src/gguf_lora_model.rs
+++ b/mistralrs/src/gguf_lora_model.rs
@@ -99,6 +99,6 @@ impl GgufLoraModelBuilder {
             runner = runner.with_prefix_cache_n(n)
         }
 
-        Ok(Model::new(runner.build()))
+        Ok(Model::new(runner.build().await))
     }
 }

--- a/mistralrs/src/gguf_xlora_model.rs
+++ b/mistralrs/src/gguf_xlora_model.rs
@@ -111,6 +111,6 @@ impl GgufXLoraModelBuilder {
             runner = runner.with_prefix_cache_n(n)
         }
 
-        Ok(Model::new(runner.build()))
+        Ok(Model::new(runner.build().await))
     }
 }

--- a/mistralrs/src/lib.rs
+++ b/mistralrs/src/lib.rs
@@ -118,8 +118,10 @@ pub use gguf_lora_model::GgufLoraModelBuilder;
 pub use gguf_xlora_model::GgufXLoraModelBuilder;
 pub use lora_model::LoraModelBuilder;
 pub use messages::{RequestBuilder, RequestLike, TextMessageRole, TextMessages, VisionMessages};
+pub use mistralrs_core::{
+    McpClient, McpClientConfig, McpServerConfig, McpServerSource, McpToolInfo,
+};
 pub use mistralrs_core::{SearchCallback, SearchResult, ToolCallback};
-pub use mistralrs_core::{McpClient, McpClientConfig, McpServerConfig, McpServerSource, McpToolInfo};
 pub use model::{best_device, Model};
 pub use speculative::TextSpeculativeBuilder;
 pub use speech_model::SpeechModelBuilder;

--- a/mistralrs/src/lib.rs
+++ b/mistralrs/src/lib.rs
@@ -119,6 +119,7 @@ pub use gguf_xlora_model::GgufXLoraModelBuilder;
 pub use lora_model::LoraModelBuilder;
 pub use messages::{RequestBuilder, RequestLike, TextMessageRole, TextMessages, VisionMessages};
 pub use mistralrs_core::{SearchCallback, SearchResult, ToolCallback};
+pub use mistralrs_core::{McpClient, McpClientConfig, McpServerConfig, McpServerSource, McpToolInfo};
 pub use model::{best_device, Model};
 pub use speculative::TextSpeculativeBuilder;
 pub use speech_model::SpeechModelBuilder;

--- a/mistralrs/src/lora_model.rs
+++ b/mistralrs/src/lora_model.rs
@@ -104,6 +104,6 @@ impl LoraModelBuilder {
             runner = runner.with_prefix_cache_n(n)
         }
 
-        Ok(Model::new(runner.build()))
+        Ok(Model::new(runner.build().await))
     }
 }

--- a/mistralrs/src/speculative.rs
+++ b/mistralrs/src/speculative.rs
@@ -107,6 +107,6 @@ impl TextSpeculativeBuilder {
             runner = runner.with_tool_callback(name.clone(), cb.clone());
         }
 
-        Ok(Model::new(runner.build()))
+        Ok(Model::new(runner.build().await))
     }
 }

--- a/mistralrs/src/speech_model.rs
+++ b/mistralrs/src/speech_model.rs
@@ -113,6 +113,6 @@ impl SpeechModelBuilder {
 
         let runner = MistralRsBuilder::new(pipeline, scheduler_method, false, None);
 
-        Ok(Model::new(runner.build()))
+        Ok(Model::new(runner.build().await))
     }
 }

--- a/mistralrs/src/text_model.rs
+++ b/mistralrs/src/text_model.rs
@@ -412,7 +412,7 @@ impl TextModelBuilder {
             runner = runner.with_prefix_cache_n(n)
         }
 
-        Ok(Model::new(runner.build()))
+        Ok(Model::new(runner.build().await))
     }
 }
 

--- a/mistralrs/src/text_model.rs
+++ b/mistralrs/src/text_model.rs
@@ -1,6 +1,6 @@
 use candle_core::Device;
 use mistralrs_core::*;
-use mistralrs_core::{SearchCallback, ToolCallback};
+use mistralrs_core::{SearchCallback, Tool, ToolCallback};
 use std::collections::HashMap;
 use std::{
     num::NonZeroUsize,
@@ -10,6 +10,13 @@ use std::{
 };
 
 use crate::{best_device, Model};
+
+/// A tool callback with its associated Tool definition.
+#[derive(Clone)]
+pub struct ToolCallbackWithTool {
+    pub callback: Arc<ToolCallback>,
+    pub tool: Tool,
+}
 
 #[derive(Clone)]
 /// Configure a text model with the various parameters for loading, running, and other inference behaviors.
@@ -30,6 +37,7 @@ pub struct TextModelBuilder {
     pub(crate) search_bert_model: Option<BertEmbeddingModel>,
     pub(crate) search_callback: Option<Arc<SearchCallback>>,
     pub(crate) tool_callbacks: HashMap<String, Arc<ToolCallback>>,
+    pub(crate) tool_callbacks_with_tools: HashMap<String, ToolCallbackWithTool>,
     pub(crate) mcp_client_config: Option<McpClientConfig>,
     pub(crate) device: Option<Device>,
 
@@ -122,6 +130,7 @@ impl TextModelBuilder {
             search_bert_model: None,
             search_callback: None,
             tool_callbacks: HashMap::new(),
+            tool_callbacks_with_tools: HashMap::new(),
             mcp_client_config: None,
             device: None,
         }
@@ -146,6 +155,20 @@ impl TextModelBuilder {
         callback: Arc<ToolCallback>,
     ) -> Self {
         self.tool_callbacks.insert(name.into(), callback);
+        self
+    }
+
+    /// Register a callback with an associated Tool definition that will be automatically
+    /// added to requests when tool callbacks are active.
+    pub fn with_tool_callback_and_tool(
+        mut self,
+        name: impl Into<String>,
+        callback: Arc<ToolCallback>,
+        tool: Tool,
+    ) -> Self {
+        let name = name.into();
+        self.tool_callbacks_with_tools
+            .insert(name, ToolCallbackWithTool { callback, tool });
         self
     }
 
@@ -400,6 +423,13 @@ impl TextModelBuilder {
         }
         for (name, cb) in &self.tool_callbacks {
             runner = runner.with_tool_callback(name.clone(), cb.clone());
+        }
+        for (name, callback_with_tool) in &self.tool_callbacks_with_tools {
+            runner = runner.with_tool_callback_and_tool(
+                name.clone(),
+                callback_with_tool.callback.clone(),
+                callback_with_tool.tool.clone(),
+            );
         }
         if let Some(mcp_config) = self.mcp_client_config {
             runner = runner.with_mcp_client(mcp_config);

--- a/mistralrs/src/vision_model.rs
+++ b/mistralrs/src/vision_model.rs
@@ -336,7 +336,7 @@ impl VisionModelBuilder {
         }
         let runner = runner.with_no_kv_cache(false).with_no_prefix_cache(false);
 
-        Ok(Model::new(runner.build()))
+        Ok(Model::new(runner.build().await))
     }
 }
 

--- a/mistralrs/src/xlora_model.rs
+++ b/mistralrs/src/xlora_model.rs
@@ -116,6 +116,6 @@ impl XLoraModelBuilder {
             runner = runner.with_prefix_cache_n(n)
         }
 
-        Ok(Model::new(runner.build()))
+        Ok(Model::new(runner.build().await))
     }
 }


### PR DESCRIPTION
Automatic MCP tool calling - just specify the MCP server.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added Model Context Protocol (MCP) client support, enabling connection to multiple external MCP servers and automatic registration of their tools for use in automatic tool calling.
  - Introduced new builder methods to register tool callbacks with their associated tool definitions.
  - Added support for MCP client configuration in model builders.
  - Provided new documentation and example scripts demonstrating MCP client integration in both Rust and Python.

- **Improvements**
  - Model building processes are now asynchronous, ensuring proper initialization of external integrations and tool registration.
  - Enhanced tool callback management to support richer metadata and integration with external tools.

- **Documentation**
  - Added comprehensive documentation for MCP client usage, configuration, error handling, limitations, and security considerations.
  - Included example code for MCP client usage in both Rust and Python.

- **Bug Fixes**
  - Improved robustness in response handling and forwarding for tool calls, ensuring all response types are handled correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->