### PR TITLE
chore: `Dockerfile.cuda-all` configurable threads

### DIFF
--- a/Dockerfile.cuda-all
+++ b/Dockerfile.cuda-all
@@ -17,16 +17,17 @@ WORKDIR /mistralrs
 COPY . .
 
 ARG CUDA_COMPUTE_CAP=80
-ENV CUDA_COMPUTE_CAP=${CUDA_COMPUTE_CAP}
-ARG FEATURES="cuda cudnn"
-ENV RAYON_NUM_THREADS=4
-RUN RUSTFLAGS="-Z threads=4" cargo build --release --workspace --exclude mistralrs-pyo3 --features "${FEATURES}"
+ARG RAYON_NUM_THREADS=4
+ARG RUST_NUM_THREADS=4
+ARG RUSTFLAGS="-Z threads=${RUST_NUM_THREADS}"
+ARG WITH_FEATURES="cuda,cudnn"
+RUN cargo build --release --workspace --exclude mistralrs-pyo3 --features "${WITH_FEATURES}"
 
 FROM nvidia/cuda:12.4.1-cudnn-runtime-ubuntu22.04 AS base
-
+ARG RAYON_NUM_THREADS=8
 ENV HUGGINGFACE_HUB_CACHE=/data \
     PORT=80 \
-    RAYON_NUM_THREADS=8 \ 
+    RAYON_NUM_THREADS=${RAYON_NUM_THREADS} \ 
     LD_LIBRARY_PATH=/usr/local/cuda/lib64:$LD_LIBRARY_PATH
 
 # Run the script to create symlinks in /usr/local/cuda/lib64


### PR DESCRIPTION
This applies changes referenced from https://github.com/EricLBuehler/mistral.rs/pull/913#issuecomment-2486996032 ( PR author @sammcj ), it seems they did not get around to restoring their original contribution.

There was an error in their original PR for `RAYON_NUM_THREADS` as it referenced an ARG that wasn't defined in the `base` stage (_where the default also differs_). I'm not sure how useful it is to have `RAYON_NUM_THREADS` preconfigured as an ENV in the `base` stage, given that a user could override this at runtime? Only seems relevant as an ARG for controlling number of threads at build-time?

[`RAYON_NUM_THREADS` will default](https://github.com/rayon-rs/rayon/blob/main/FAQ.md#how-many-threads-will-rayon-spawn) to the number of logical threads available. The origin of this ENV when contributed to `mistral.rs` comes from another project that only cared about lowering the threads used for builds in CI due to memory overhead involved compiling many CUDA kernels concurrently. It seems safe/preferrable to be consistent with how `mistral.rs` would work outside of a container and avoid configuring this ENV in the runtime image?

Meanwhile nightly is used for building with rust compiler itself to use 4 threads instead of the default single-threaded build. Not sure how important that is justify building without a stable rust release, but [this issue](https://github.com/rust-lang/rust-project-goals/issues/121) tracks when the feature will eventually stabilize.

---

The other contribution from the referenced PR was already handled differently [here](https://github.com/EricLBuehler/mistral.rs/pull/944) for build-time requirement of inferring compute cap (if ENV is unset) via `nvidia-smi` when available.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Improved handling of environment variables for threading and feature flags in the Docker build and runtime stages.
  - Updated feature selection to use comma-separated values.
  - Made the number of threads configurable at runtime.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->