### PR TITLE
chore: `Dockerfile.cuda-all` - Merge `RUN` for `apt-get install`

### DIFF
--- a/Dockerfile.cuda-all
+++ b/Dockerfile.cuda-all
@@ -1,11 +1,17 @@
 FROM nvidia/cuda:12.4.1-cudnn-devel-ubuntu22.04 AS builder
 
-RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
-    curl \
-    libssl-dev \
-    pkg-config \
-    && rm -rf /var/lib/apt/lists/*
-RUN apt-get update && apt-get install -y python3 python3-pip
+ARG DEBIAN_FRONTEND=noninteractive
+RUN <<HEREDOC
+    apt-get update
+    apt-get install -y --no-install-recommends \
+        curl \
+        libssl-dev \
+        pkg-config \
+        python3 \
+        python3-pip
+
+    rm -rf /var/lib/apt/lists/*
+HEREDOC
 
 RUN curl https://sh.rustup.rs -sSf | bash -s -- -y
 ENV PATH="/root/.cargo/bin:${PATH}"


### PR DESCRIPTION
A [recent "fix"](https://github.com/EricLBuehler/mistral.rs/commit/a5c4eda28da6946a5c01782572d25a04e0dbc56a) for a CI failure was to add Python deps into the `builder` stage. This was a direct commit with minimal context.

No point in the separate `RUN` instruction, I've merged it into the previous one and for added clarity leveraged the [HereDoc syntax feature](https://docs.docker.com/reference/dockerfile/#here-documents).

I don't think this is a proper way to fix the CI issue however. That was introduced by [this June 2025 PR](https://github.com/EricLBuehler/mistral.rs/pull/1438) because the crate `mistralrs-pyo3` had it's [build dependency migrated to a workspace](https://github.com/EricLBuehler/mistral.rs/commit/3d1b29b55682fad6cd5150bfae97dfdb07bb4e4a#diff-9170355ecc927233d7e8c4d51230769ad3f37d489f9022a1fd2cdeb03e0d11e0L39) which presumably [lost the feature guard](https://github.com/EricLBuehler/mistral.rs/commit/3d1b29b55682fad6cd5150bfae97dfdb07bb4e4a#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542R149).

In April 2024 this concern was tackled, and appears it was [a bit more thorough for runtime support](https://github.com/EricLBuehler/mistral.rs/pull/249). It was then [tackled in May 2024](https://github.com/EricLBuehler/mistral.rs/pull/303) (_and [this June 2024 follow-up PR](https://github.com/EricLBuehler/mistral.rs/pull/440)_).

---

I'm not too familiar with the workspace feature, but the `--exclude mistralrs-pyo3` provided to `cargo build` in the image clearly isn't able to opt-out of that now I guess as the crate dep is now implicitly added/built due to being in the workspace without opt-in? (_even though `mistralrs-pyo3` is the only consumer of it I assume_)

That said the [CPU `Dockerfile`](https://github.com/EricLBuehler/mistral.rs/blob/a5c4eda28da6946a5c01782572d25a04e0dbc56a/Dockerfile) has no such workaround involved. So something specific to the CUDA one is bringing it in?

## Reference

[This is the failing workflow run](https://github.com/EricLBuehler/mistral.rs/actions/runs/15572393589/job/43850807208#step:8:1844) and the relevant build error which motivated [bringing Python back into the CUDA image](https://github.com/EricLBuehler/mistral.rs/commit/a5c4eda28da6946a5c01782572d25a04e0dbc56a) as a build workaround:

> ![image](https://github.com/user-attachments/assets/c5f5ab0a-53f5-4eba-9e4f-6a73afb6234b)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Improved Dockerfile build process for better efficiency and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->