### PR TITLE
chore: `Dockerfile` - Drop runtime rayon thread ENV

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,6 @@ FROM debian:bookworm-slim AS runtime
 ENV HUGGINGFACE_HUB_CACHE=/data \
     PORT=80 \
     MKL_ENABLE_INSTRUCTIONS=AVX512_E4 \
-    RAYON_NUM_THREADS=8 \
     LD_LIBRARY_PATH=/usr/local/lib
 
 # Install only essential runtime dependencies and clean up

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,7 @@
+# syntax=docker/dockerfile:1
+
 # Stage 1: Build environment
 FROM rust:latest AS builder
-
-# Update and install dependencies required for building
-RUN apt-get update && apt-get install -y --no-install-recommends \
-    && rm -rf /var/lib/apt/lists/*
 
 # Set working directory and copy files
 WORKDIR /mistralrs
@@ -22,12 +20,17 @@ ENV HUGGINGFACE_HUB_CACHE=/data \
     LD_LIBRARY_PATH=/usr/local/lib
 
 # Install only essential runtime dependencies and clean up
-RUN apt-get update && apt-get install -y --no-install-recommends \
-    libomp-dev \
-    ca-certificates \
-    libssl-dev \
-    curl \
-    && rm -rf /var/lib/apt/lists/*
+ARG DEBIAN_FRONTEND=noninteractive
+RUN <<HEREDOC
+    apt-get update
+    apt-get install -y --no-install-recommends \
+        libomp-dev \
+        ca-certificates \
+        libssl-dev \
+        curl
+
+    rm -rf /var/lib/apt/lists/*
+HEREDOC
 
 # Copy the built binaries from the builder stage
 COPY --from=builder /mistralrs/target/release/mistralrs-bench /usr/local/bin/

--- a/Dockerfile.cuda-all
+++ b/Dockerfile.cuda-all
@@ -22,6 +22,8 @@ WORKDIR /mistralrs
 
 COPY . .
 
+# Rayon threads are limited to minimize memory requirements in CI, avoiding OOM
+# Rust threads are increased with a nightly feature for faster compilation (single-threaded by default)
 ARG CUDA_COMPUTE_CAP=80
 ARG RAYON_NUM_THREADS=4
 ARG RUST_NUM_THREADS=4
@@ -30,10 +32,8 @@ ARG WITH_FEATURES="cuda,cudnn"
 RUN cargo build --release --workspace --exclude mistralrs-pyo3 --features "${WITH_FEATURES}"
 
 FROM nvidia/cuda:12.4.1-cudnn-runtime-ubuntu22.04 AS base
-ARG RAYON_NUM_THREADS=8
 ENV HUGGINGFACE_HUB_CACHE=/data \
     PORT=80 \
-    RAYON_NUM_THREADS=${RAYON_NUM_THREADS} \ 
     LD_LIBRARY_PATH=/usr/local/cuda/lib64:$LD_LIBRARY_PATH
 
 # Run the script to create symlinks in /usr/local/cuda/lib64

--- a/Dockerfile.cuda-all
+++ b/Dockerfile.cuda-all
@@ -1,3 +1,5 @@
+# syntax=docker/dockerfile:1
+
 FROM nvidia/cuda:12.4.1-cudnn-devel-ubuntu22.04 AS builder
 
 ARG DEBIAN_FRONTEND=noninteractive
@@ -45,13 +47,18 @@ RUN set -eux; \
         fi; \
     done
 
-RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
-    libomp-dev \
-    ca-certificates \
-    libssl-dev \
-    curl \
-    pkg-config \
-    && rm -rf /var/lib/apt/lists/*
+ARG DEBIAN_FRONTEND=noninteractive
+RUN <<HEREDOC
+    apt-get update
+    apt-get install -y --no-install-recommends \
+        libomp-dev \
+        ca-certificates \
+        libssl-dev \
+        curl \
+        pkg-config
+
+    rm -rf /var/lib/apt/lists/*
+HEREDOC
 
 FROM base
 


### PR DESCRIPTION
`ENV RAYON_NUM_THREADS` is not likely important to set a fixed value for for the runtime image. Dropping it as discussed in https://github.com/EricLBuehler/mistral.rs/pull/1458

---

This PR additionally revises `RUN` instructions for `apt-get`, moving `DEBIAN_FRONTEND=noninteractive` to an `ARG` and using HereDoc syntax for easier to grok multi-line sequence of commands.

The CPU `Dockerfile` had a redundant and empty `RUN`, so I've also removed that.
- [Originally introduced to add Python](https://github.com/EricLBuehler/mistral.rs/pull/249)
- [Later removed when Python was not required](https://github.com/EricLBuehler/mistral.rs/pull/303), however that PR left an empty install command since then.

**NOTE:** Presently the CUDA variant of the `Dockerfile` apparently requires Python again due to recent changes, but the actual cause [should be investigated and resolved](https://github.com/EricLBuehler/mistral.rs/pull/1459#issuecomment-2964541535) in future.

---

Some of the runtime image dependencies installed seem odd, I'm lacking time to investigate there but I'm under the impression that quite a few are unnecessary.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated Dockerfiles to improve clarity and maintainability of build and runtime instructions.
  - Refactored package installation steps for better readability and non-interactive builds.
  - Adjusted thread-related environment variables and build arguments for improved configuration in CUDA-enabled images.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->