### PR TITLE
Fix objc dep when non macos

### DIFF
--- a/README.md
+++ b/README.md
@@ -284,6 +284,8 @@ To enable one or more features, pass them to Cargo. For example:
 cargo build --release --features "cuda flash-attn cudnn"
 ```
 
+> **Note for Linux users:** The `metal` feature is macOS-only and should not be used on Linux. Use `--features "cuda flash-attn cudnn"` for NVIDIA GPUs or `--features mkl` for Intel CPUs instead of `--all-features`.
+
 ## Installation and Build
 
 > Note: You can use our [Docker containers here](https://github.com/EricLBuehler/mistral.rs/pkgs/container/mistral.rs).

--- a/mistralrs-core/Cargo.toml
+++ b/mistralrs-core/Cargo.toml
@@ -78,8 +78,6 @@ as-any.workspace = true
 float8.workspace = true
 llguidance.workspace = true
 toktrie_hf_tokenizers.workspace = true
-objc = { workspace = true, optional = true }
-metal = { workspace = true, optional = true }
 candle-flash-attn-v3 = { workspace = true, optional = true }
 safetensors.workspace = true
 serde-big-array.workspace = true
@@ -104,6 +102,10 @@ symphonia.workspace = true
 mistralrs-audio.workspace = true
 rust-mcp-schema.workspace = true
 mistralrs-mcp = { workspace = true, features = ["utoipa"] }
+
+[target.'cfg(target_os = "macos")'.dependencies]
+objc = { workspace = true, optional = true }
+metal = { workspace = true, optional = true }
 
 [features]
 pyo3_macros = ["pyo3", "mistralrs-mcp/pyo3_macros"]


### PR DESCRIPTION
Fixes #1466.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated the README to clarify that the `metal` feature is exclusive to macOS and provided guidance for Linux users on appropriate feature flags for their hardware.

- **Chores**
  - Scoped certain dependencies to only be included when building for macOS, reducing unnecessary dependencies on other platforms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->