### PR TITLE
chore: Dockerfile - Remove redundant symlink creation + ENV

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,9 +15,7 @@ FROM debian:bookworm-slim AS runtime
 
 # Set environment variables
 ENV HUGGINGFACE_HUB_CACHE=/data \
-    PORT=80 \
-    MKL_ENABLE_INSTRUCTIONS=AVX512_E4 \
-    LD_LIBRARY_PATH=/usr/local/lib
+    PORT=80
 
 # Install only essential runtime dependencies and clean up
 ARG DEBIAN_FRONTEND=noninteractive

--- a/Dockerfile.cuda-all
+++ b/Dockerfile.cuda-all
@@ -36,15 +36,6 @@ ENV HUGGINGFACE_HUB_CACHE=/data \
     PORT=80 \
     LD_LIBRARY_PATH=/usr/local/cuda/lib64:$LD_LIBRARY_PATH
 
-# Run the script to create symlinks in /usr/local/cuda/lib64
-RUN set -eux; \
-    for lib in $(ls /usr/local/cuda/lib64); do \
-        base=$(echo $lib | sed -r 's/(.+)\.so\..+/\1.so/'); \
-        if [ "$lib" != "$base" ]; then \
-            ln -sf "/usr/local/cuda/lib64/$lib" "/usr/local/cuda/lib64/$base"; \
-        fi; \
-    done
-
 ARG DEBIAN_FRONTEND=noninteractive
 RUN <<HEREDOC
     apt-get update

--- a/Dockerfile.cuda-all
+++ b/Dockerfile.cuda-all
@@ -33,8 +33,7 @@ RUN cargo build --release --workspace --exclude mistralrs-pyo3 --features "${WIT
 
 FROM nvidia/cuda:12.4.1-cudnn-runtime-ubuntu22.04 AS base
 ENV HUGGINGFACE_HUB_CACHE=/data \
-    PORT=80 \
-    LD_LIBRARY_PATH=/usr/local/cuda/lib64:$LD_LIBRARY_PATH
+    PORT=80
 
 ARG DEBIAN_FRONTEND=noninteractive
 RUN <<HEREDOC


### PR DESCRIPTION
Introduced by [this PR](https://github.com/EricLBuehler/mistral.rs/pull/302) ( May 2024 via @LLukas22 ), no context was provided in the issue description or reference to known issues.

## Removing unversioned symlinks from runtime image

With dynamic linking, these symlinks should not be relevant at runtime, the binary executed should be linked to the correct versioned SONAME and will ignore such symlinks.

~~This was presumably a workaround for `cudarc` at the time with `dynamic-loading`?~~ (_**EDIT:** Seems unlikely_). Typically unversioned symlinks to libraries is only relevant when building for the linker to search for the libraries to link and resolve via the library `DT_SONAME` entry.

---

## Removing `LD_LIBRARY_PATH` ENV modification from runtime image

Additionally the runtime ENV change is redundant:

```console
$ docker run --rm -it nvidia/cuda:12.8.0-cudnn-runtime-ubuntu24.04

$ echo $LD_LIBRARY_PATH
/usr/local/nvidia/lib:/usr/local/nvidia/lib64

# These paths populate `/etc/ld.so.cache` for runtime resolution, similar to `LD_LIBRARY_PATH`:
$ cat /etc/ld.so.conf.d/*
/usr/local/cuda/targets/x86_64-linux/lib
/usr/local/cuda-12/targets/x86_64-linux/lib
/usr/local/cuda-12.8/targets/x86_64-linux/lib
# libc default configuration
/usr/local/lib
/usr/local/nvidia/lib
/usr/local/nvidia/lib64
# Multiarch support
/usr/local/lib/x86_64-linux-gnu
/lib/x86_64-linux-gnu
/usr/lib/x86_64-linux-gnu


# `/usr/local/cuda` is a symlink, as is it's `lib64` folder,
# `/usr/local/cuda/lib64` => `/usr/local/cuda-12.8/targets/x86_64-linux/lib`
$ readlink -f /usr/local/cuda/lib64
/usr/local/cuda-12.8/targets/x86_64-linux/lib


# Check if `/etc/ld.so.cache` has expected entries:
$ ldconfig --print-cache | grep libcuda
        libcudart.so.12 (libc6,x86-64) => /usr/local/cuda/targets/x86_64-linux/lib/libcudart.so.12

$ ldconfig --print-cache | grep -F 'libnvrtc.so'
        libnvrtc.so.12 (libc6,x86-64) => /usr/local/cuda/targets/x86_64-linux/lib/libnvrtc.so.12

$ ldconfig --print-cache | grep libnccl
        libnccl.so.2 (libc6,x86-64) => /lib/x86_64-linux-gnu/libnccl.so.2
```

The only reason you'd need to modify `LD_LIBRARY_PATH` to prepend `/usr/local/cuda/lib64` would be if you needed to raise priority of that search path, or because `/etc/ld.so.cache` has not been updated by running `ldconfig`, which as can be seen above is working as expected.

The `dynamic-loading` feature for `cudarc` may not have leveraged that cache, nor encoded the `DT_SONAME` when it would search for libraries.

- `cudarc` [provides `libloading` many variations](https://github.com/coreylowman/cudarc/blob/62e92bdf1d690d6c9c25171bfab55372e89189f0/src/lib.rs#L104-L145) for library file names to search, which typically shouldn't be necessary 🤔 (_likely misconfiguration on user systems_)
- https://github.com/nagisa/rust_libloading/issues/76#issuecomment-688452825 (_the `libloading` crate [calls `dlopen`](https://github.com/nagisa/rust_libloading/blob/83f08b8779f4ba41777c41218398df4a2977d340/src/os/unix/mod.rs#L190), thus it would be capable of resolving libs like `dynamic-linking`_)

### `LD_LIBRARY_PATH` for non-cuda image

This is lacking context for why `/usr/local/lib` is important to add here?

Similar concern for the MKL ENV which is specific to Intel? Without information about it's inclusion I'm not sure if it was intentional/understood or just copy/pasted from somewhere?

The [original PR for the `Dockerfile`](https://github.com/EricLBuehler/mistral.rs/pull/56) (April 2024) references TEI, but it had [no equivalent for this in it's `Dockerfile` until Nov 2024](https://github.com/huggingface/text-embeddings-inference/blob/1193add354e425f2a6af76813ebbdcc414c84f7e/Dockerfile#L78-L81) (_from [this PR](https://github.com/huggingface/text-embeddings-inference/pull/440), which [seems to be a mistake](https://github.com/huggingface/text-embeddings-inference/issues/611#issuecomment-2907553442) given the Intel optimized image TEI introduced in Jan 2025_).

Without context for their relevance I've opted to drop them.

---

Back in May 2024, none of the referenced `cudarc` fallbacks were present, those [began from the end of May 2024](https://github.com/coreylowman/cudarc/commit/1fa82db37352ab6d4e21e72527e66c235f6eb9b7), so it should have been working like `LD_LIBRARY_PATH` already?

Without additional context for why the runtime image was given these symlinks and `LD_LIBRARY_PATH` ENV change, I cannot grok why they were necessary in the first place 🤷‍♂️

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Simplified environment variable settings in Docker images by removing unnecessary variables and scripts related to library paths and CUDA shared libraries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->