### PR TITLE
fix(stream): emit  field in tool-call deltas for schema compliance

### DIFF
--- a/mistralrs-core/src/tools/mod.rs
+++ b/mistralrs-core/src/tools/mod.rs
@@ -203,6 +203,7 @@ impl ToolCallingMatcher {
         if let Ok(deser) = serde_json::from_str::<CalledFunctionParameters>(&message) {
             let id = format!("call-{}", Uuid::new_v4());
             Ok(vec![ToolCallResponse {
+                index: 0,
                 id,
                 tp: ToolCallType::Function,
                 function: CalledFunction {
@@ -213,9 +214,11 @@ impl ToolCallingMatcher {
         } else if let Ok(deser) = serde_json::from_str::<Vec<CalledFunctionParameters>>(&message) {
             Ok(deser
                 .into_iter()
-                .map(|deser| {
+                .enumerate()
+                .map(|(idx, deser)| {
                     let id = format!("call-{}", Uuid::new_v4());
                     Ok(ToolCallResponse {
+                        index: idx,
                         id,
                         tp: ToolCallType::Function,
                         function: CalledFunction {

--- a/mistralrs-core/src/tools/response.rs
+++ b/mistralrs-core/src/tools/response.rs
@@ -20,8 +20,30 @@ use mistralrs_mcp::CalledFunction;
 #[cfg_attr(feature = "pyo3_macros", pyo3(get_all))]
 #[derive(Clone, Debug, serde::Serialize)]
 pub struct ToolCallResponse {
+    pub index: usize,
     pub id: String,
     #[serde(rename = "type")]
     pub tp: ToolCallType,
     pub function: CalledFunction,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn serializes_index_field() {
+        let resp = ToolCallResponse {
+            index: 0,
+            id: "call-1".to_string(),
+            tp: ToolCallType::Function,
+            function: CalledFunction {
+                name: "foo".to_string(),
+                arguments: "{}".to_string(),
+            },
+        };
+
+        let json = serde_json::to_value(&resp).unwrap();
+        assert_eq!(json.get("index").and_then(|v| v.as_u64()), Some(0));
+    }
 }


### PR DESCRIPTION
## Context

While running Qwen2.5-3B-Instruct behind mistral.rs' OpenAI-compatible server, discovered that streamed tool-call deltas do not include the mandatory index field

## What actually breaks and why  

### 1.  Streaming layers inside `openai-python`

| layer | public surface | key file | what it does | tolerant to `index = null`? |
|-------|----------------|-------------------|--------------|-----------------------------|
| **A** | `AsyncStream[ChatCompletionChunk]` returned by `client.chat.completions.create(..., stream=True)` | `openai/_streaming.py` | raw Server-Sent-Events → `ChatCompletionChunk` objects | **yes** – values are just dataclasses |
| **B** | `AsyncChatCompletionStreamManager / ChatCompletionStreamState` | `openai/lib/streaming/chat/_completions.py` | merges deltas into higher-level events | **no** – dereferences `tool_call_chunk.index` |
| **C** | wrappers that call (B) for you – Logfire, pydantic-ai, LangChain, etc. | pydantic-ai: `logfire/_internal/.../openai.py` | instrumentation / convenience | inherits layer-B requirements |

`_build_events()` (layer B) shows the contract:

```python
# openai/lib/streaming/chat/_completions.py
tool_call_snapshot = (choice_snapshot.message.tool_calls or [])[tool_call_chunk.index]        # ← index must be int
```
Reference : 
https://github.com/openai/openai-python/blob/main/src/openai/lib/streaming/chat/_completions.py#L450

If `index` is `None`, Python raises  
`TypeError: list indices must be integers or slices, not NoneType`.

### 2.  Issue reproduction

```python
from openai import AsyncOpenAI, NOT_GIVEN
from openai.lib.streaming.chat._completions import AsyncChatCompletionStreamManager

client = AsyncOpenAI(base_url=EP, api_key="not needed")

async def repro():
    chunk_stream = await client.chat.completions.create(
        model=MODEL,
        messages=[{"role": "user", "content": "…"}],
        tools=[{...}],           # any tool so the model produces a call
        stream=True,
    )

    async with AsyncChatCompletionStreamManager(
        api_request=chunk_stream,
        input_tools=NOT_GIVEN,
        response_format=NOT_GIVEN,
    ) as events:
        async for _ in events:           # crashes here if `index` is null
            pass
```

### 3.  OpenAPI spec excerpt 

```yaml
components:
  schemas:
    ChatCompletionMessageToolCallChunk:
      ...
      required:
        - index 
```

Source: <https://github.com/openai/openai-openapi/blob/manual_spec/openapi.yaml#L17781>

### 4.  What Mistral-RS must emit

Streaming tool-call delta **per chunk**

```jsonc
{
  "choices": [
    {
      "delta": {
        "tool_calls": [
          {
            "index": 0,                       // required int
            "id": "call-<uuid>",
            "type": "function",
            "function": { "name": "run_python", "arguments": "{\"code\":\"…\"}" }
          }
        ]
      },
      "finish_reason": "tool_calls"
    }
  ]
}
```

For multi-call replies, the first chunk carries `index:0`, the second
`index:1`, … – identical to the non-streaming `message.tool_calls` order.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Tool call responses now include an explicit index to indicate their order.

- **Tests**
  - Added a test to verify the correct serialization of the index field in tool call responses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->