### PR TITLE
Fix MCP doc test

### DIFF
--- a/mistralrs-mcp/src/lib.rs
+++ b/mistralrs-mcp/src/lib.rs
@@ -53,7 +53,8 @@
 //!                 name: "Hugging Face MCP Server".to_string(),
 //!                 source: McpServerSource::Http {
 //!                     url: "https://hf.co/mcp".to_string(),
-//!                     ..Default::default()
+//!                     timeout_secs: None,
+//!                     headers: None,
 //!                 },
 //!                 bearer_token: Some("hf_xxx".to_string()),
 //!                 ..Default::default()


### PR DESCRIPTION
Fixes the `mistralrs-mcp/src/lib.rs` doctest:

```
---- mistralrs-mcp/src/lib.rs - (line 43) stdout ----
error[E0436]: functional record update syntax requires a struct
  --> mistralrs-mcp/src/lib.rs:57:23
   |
16 |                     ..Default::default()
   |                       ^^^^^^^^^^^^^^^^^^

error[E0277]: the trait bound `McpServerSource: Default` is not satisfied
  --> mistralrs-mcp/src/lib.rs:57:23
   |
16 |                     ..Default::default()
   |                       ^^^^^^^^^^^^^^^^^^ the trait `Default` is not implemented for `McpServerSource`

error: aborting due to 2 previous errors
```
