### PR TITLE
Target generic CPUs when building Python package

### DIFF
--- a/mistralrs-pyo3/generate_wheels.sh
+++ b/mistralrs-pyo3/generate_wheels.sh
@@ -24,9 +24,9 @@ maturin build -o wheels-accelerate -m mistralrs-pyo3/Cargo.toml --interpreter py
 # WINDOWS: x86_64 Manylinux, Windows
 
 docker build -t wheelmaker:latest -f Dockerfile.manylinux .
-docker run --rm -v .:/io wheelmaker build --release -o wheels-cpu -m mistralrs-pyo3/Cargo.toml --interpreter python3.10
-docker run --rm -v .:/io wheelmaker build --release -o wheels-cpu -m mistralrs-pyo3/Cargo.toml --interpreter python3.11
-docker run --rm -v .:/io wheelmaker build --release -o wheels-cpu -m mistralrs-pyo3/Cargo.toml --interpreter python3.12
+docker run -e RUSTFLAGS="-C target-cpu=generic" --rm -v .:/io wheelmaker build --release -o wheels-cpu -m mistralrs-pyo3/Cargo.toml --interpreter python3.10
+docker run -e RUSTFLAGS="-C target-cpu=generic" --rm -v .:/io wheelmaker build --release -o wheels-cpu -m mistralrs-pyo3/Cargo.toml --interpreter python3.11
+docker run -e RUSTFLAGS="-C target-cpu=generic" --rm -v .:/io wheelmaker build --release -o wheels-cpu -m mistralrs-pyo3/Cargo.toml --interpreter python3.12
 
 maturin build -o wheels-cpu -m mistralrs-pyo3/Cargo.toml --interpreter python3.10
 maturin build -o wheels-cpu -m mistralrs-pyo3/Cargo.toml --interpreter python3.11


### PR DESCRIPTION
This change adjusts the `mistralrs` Python package builds to target baseline "generic" CPUs on Linux rather than the native CPU of the build system. This should produce wheels with maximum CPU compatibility.

Prior to this change, CPUs lacking features found on the build system would not run the Python package properly and fail with an "Illegal Instruction" error message.

I have confirmed that this change fixes #1269 for me by building and installing the Python package from the current main branch using:

```sh
docker run --rm -v .:/io wheelmaker build --release -o wheels-cpu -m mistralrs-pyo3/Cargo.toml --interpreter python3.10
pip3 uninstall mistralrs
pip3 install wheels-cpu/mistralrs-0.6.0-cp310-cp310-manylinux_2_35_x86_64.whl
```

This fails with an "Illegal Instruction" error message. Repeating this process with this patched build command produces a working Python package for me.

While this change does provide maximum compatibility for the Python package, it has the potential to be a performance regression on more modern CPUs. It should be possible to have another version of this package (e.g. mistralrs-avx2) that includes more advanced CPU features in the future if that is valuable. The Rust crate itself is not impacted by this change.

I experimented with modifying the root .cargo/config.toml file to build on generic CPUs, but that didn't seem like a good solution as it would likely negatively impact performance of the Rust package. I also tried adding a mistralrs-pyo3/.cargo/config.toml file to accomplish this, but that did not seem to work as I expected, so I landed on using an environment variable along with the build command.

I do not have systems handy to test the Windows and Mac Python packages, but a similar environment variable could be added on these systems to potentially enhance compatibility there as well. On Mac, `avx` and `avx2` are [already disabled via the Cargo configuration](https://github.com/EricLBuehler/mistral.rs/blob/a637d8f09dd33d35fda2a91fa444abc7398ccc22/.cargo/config.toml#L13), so this issue may already be addressed on that platform.