### PR TITLE
Simplify streaming example output

### DIFF
--- a/examples/python/streaming.py
+++ b/examples/python/streaming.py
@@ -22,4 +22,4 @@ res = runner.send_chat_completion_request(
     )
 )
 for chunk in res:
-    print(chunk)
+    print(chunk.choices[0].delta.content, end="", flush=True)


### PR DESCRIPTION
This change simplifies the Python streaming example output to display only the output as it is generated rather than printing the complete data structure returned along with each token.

For me, this change better aligns with my expectations of what output streaming from and LLM should look like in my terminal.