### PR TITLE
Use smaller model in streaming example

### DIFF
--- a/examples/python/streaming.py
+++ b/examples/python/streaming.py
@@ -2,9 +2,9 @@ from mistralrs import Runner, Which, ChatCompletionRequest
 
 runner = Runner(
     which=Which.GGUF(
-        tok_model_id="mistralai/Mistral-7B-Instruct-v0.1",
-        quantized_model_id="TheBloke/Mistral-7B-Instruct-v0.1-GGUF",
-        quantized_filename="mistral-7b-instruct-v0.1.Q4_K_M.gguf",
+        tok_model_id="Qwen/Qwen3-0.6B",
+        quantized_model_id="unsloth/Qwen3-0.6B-GGUF",
+        quantized_filename="Qwen3-0.6B-Q4_K_M.gguf",
     )
 )
 


### PR DESCRIPTION
This change adjusts the streaming example to use a more modern and much smaller model. The example will still produce a coherent response, but it should be roughly 10x faster and require downloading one tenth as much model data.