### PR TITLE
mistralrs-quant: Fix build when `feature=+cuda -ring`.

### DIFF
--- a/mistralrs-quant/src/distributed/mod.rs
+++ b/mistralrs-quant/src/distributed/mod.rs
@@ -70,7 +70,7 @@ pub fn get_global_tp_size_from_devices() -> Result<usize> {
         Ok(config.world_size)
     }
 
-    #[cfg(not(any(feature = "cuda", feature = "ring")))]
+    #[cfg(not(feature = "ring"))]
     Ok(1)
 }
 


### PR DESCRIPTION
I'm otherwise getting an error:

```
error[E0308]: mismatched types
  --> /home/ryan/.cargo/git/checkouts/mistral.rs-d7a5d833e16ad691/c91ac73/mistralrs-quant/src/distributed/mod.rs:59:45
   |
59 | pub fn get_global_tp_size_from_devices() -> Result<usize> {
   |        -------------------------------      ^^^^^^^^^^^^^ expected `Result<usize, Error>`, found `()`
   |        |
   |        implicitly returns `()` as its body has no tail or `return` expression
   |
   = note:   expected enum `Result<usize, candle_core::Error>`
           found unit type `()`

For more information about this error, try `rustc --explain E0308`.
error: could not compile `mistralrs-quant` (lib) due to 1 previous error
```