### PR TITLE
chore: Dockerfile - Add `SHELL` instruction

### DIFF
--- a/Dockerfile.cuda-all
+++ b/Dockerfile.cuda-all
@@ -1,6 +1,8 @@
 # syntax=docker/dockerfile:1
 
+# Stage 1: Build environment
 FROM nvidia/cuda:12.4.1-cudnn-devel-ubuntu22.04 AS builder
+SHELL ["/bin/bash", "-e", "-o", "pipefail", "-c"]
 
 ARG DEBIAN_FRONTEND=noninteractive
 RUN <<HEREDOC
@@ -15,11 +17,9 @@ HEREDOC
 
 RUN curl https://sh.rustup.rs -sSf | bash -s -- -y
 ENV PATH="/root/.cargo/bin:${PATH}"
-RUN rustup update nightly
-RUN rustup default nightly
+RUN rustup update nightly && rustup default nightly
 
 WORKDIR /mistralrs
-
 COPY . .
 
 # Rayon threads are limited to minimize memory requirements in CI, avoiding OOM
@@ -31,9 +31,10 @@ ARG RUSTFLAGS="-Z threads=${RUST_NUM_THREADS}"
 ARG WITH_FEATURES="cuda,cudnn"
 RUN cargo build --release --workspace --exclude mistralrs-pyo3 --features "${WITH_FEATURES}"
 
-FROM nvidia/cuda:12.4.1-cudnn-runtime-ubuntu22.04 AS base
-ENV HUGGINGFACE_HUB_CACHE=/data \
-    PORT=80
+
+# Stage 2: Minimal runtime environment
+FROM nvidia/cuda:12.4.1-cudnn-runtime-ubuntu22.04 AS runtime
+SHELL ["/bin/bash", "-e", "-o", "pipefail", "-c"]
 
 ARG DEBIAN_FRONTEND=noninteractive
 RUN <<HEREDOC
@@ -48,14 +49,11 @@ RUN <<HEREDOC
     rm -rf /var/lib/apt/lists/*
 HEREDOC
 
-FROM base
-
-COPY --from=builder /mistralrs/target/release/mistralrs-bench /usr/local/bin/mistralrs-bench
-RUN chmod +x /usr/local/bin/mistralrs-bench
-COPY --from=builder /mistralrs/target/release/mistralrs-server /usr/local/bin/mistralrs-server
-RUN chmod +x /usr/local/bin/mistralrs-server
-COPY --from=builder /mistralrs/target/release/mistralrs-web-chat /usr/local/bin/mistralrs-web-chat
-RUN chmod +x /usr/local/bin/mistralrs-web-chat
-
+COPY --chmod=755 --from=builder /mistralrs/target/release/mistralrs-bench /usr/local/bin/mistralrs-bench
+COPY --chmod=755 --from=builder /mistralrs/target/release/mistralrs-server /usr/local/bin/mistralrs-server
+COPY --chmod=755 --from=builder /mistralrs/target/release/mistralrs-web-chat /usr/local/bin/mistralrs-web-chat
 # Copy chat templates for users running models which may not include them
 COPY --from=builder /mistralrs/chat_templates /chat_templates
+
+ENV HUGGINGFACE_HUB_CACHE=/data \
+    PORT=80


### PR DESCRIPTION
This adds the `SHELL` instruction to change the default `/bin/sh -c` value to use bash with flags `-e` (_fail early when encountering a non-zero exit status_) and `-o pipefail` (_forward exit status through pipe operator `|`, rather than status of the final command_).

Prior to introducing HereDoc with `RUN`, a `RUN` either had a single command or sequence chained with `&&` which with exception of the rustup install `RUN` using a pipe, would have failed more clearly.

As the usage of the HereDoc strings are effectively running multi-line shell scripts now, these will continue on to the next command in the same `RUN` which is undesirable if a failure occurred. By using `bash -e` to run these commands instead, they'll bail early when an issue occurs (_eg: disk space or network connectivity issues causing `curl` / `apt` to unexpectedly fail_).

This was a problem that @sempervictus [experienced with a recent build attempt](https://github.com/EricLBuehler/mistral.rs/pull/1468#discussion_r2250188396).

There is one slight caveat with the usage of `SHELL`. It's not standardized by OCI, so tools like Podman which have an opt-in option to their build command to support it would need to be used if building the image locally without Dockers buildx. These `Dockerfile`s are primarily serving CI build and publishing AFAIK for official image releases, so this should be a non-issue in practice?

---

Unrelated are some minor changes to both `Dockerfile` + `Dockerfile.cuda-all` for consistency / tidy-up.

- Use `--chmod` from `COPY` instruction instead of depending upon subsequent `RUN` instruction(s) to set an executable bit (_AFAIK these would be executable by default from the builder itself though_).
- Move `ENV` instruction to the end as it has no relevance to earlier instructions, nor should changing it invalidate those layers.
- The CUDA `Dockerfile` variant also has had a [redundant `FROM base` stage since the file was contributed](https://github.com/EricLBuehler/mistral.rs/pull/56), so I've dropped that and renamed the earlier `base` stage to `runtime` to align with the non-CUDA `Dockerfile`.