### PR TITLE
Send the mcp server an initialization notification to let it know the client is done initializing plus finish off making all 3 supported mcp transports properly increment their request ids

### DIFF
--- a/mistralrs-mcp/src/client.rs
+++ b/mistralrs-mcp/src/client.rs
@@ -366,6 +366,7 @@ impl HttpMcpConnection {
         self.transport
             .send_request("initialize", init_params)
             .await?;
+        self.transport.send_initialization_notification().await?;
         Ok(())
     }
 }
@@ -534,6 +535,7 @@ impl ProcessMcpConnection {
         self.transport
             .send_request("initialize", init_params)
             .await?;
+        self.transport.send_initialization_notification().await?;
         Ok(())
     }
 }
@@ -701,6 +703,7 @@ impl WebSocketMcpConnection {
         self.transport
             .send_request("initialize", init_params)
             .await?;
+        self.transport.send_initialization_notification().await?;
         Ok(())
     }
 }


### PR DESCRIPTION
According to the MCP specification, the client needs to send this. Not sending this was keeping some mcp servers from working with mistral.rs.  Also finished off all 3 supported mcp transports properly increment their request ids