### PR TITLE
Update ISQ Python example

### DIFF
--- a/docs/ISQ.md
+++ b/docs/ISQ.md
@@ -63,10 +63,8 @@ Check out the [imatrix docs](IMATRIX.md).
 ## Python Example
 ```python
 runner = Runner(
-    which=Which.GGUF(
-        tok_model_id="mistralai/Mistral-7B-Instruct-v0.1",
-        quantized_model_id="TheBloke/Mistral-7B-Instruct-v0.1-GGUF",
-        quantized_filename="mistral-7b-instruct-v0.1.Q4_K_M.gguf",
+    which=Which.Plain(
+        model_id="Qwen/Qwen3-0.6B",
     ),
     in_situ_quant="4",
 )


### PR DESCRIPTION
This change updates the Python ISQ example in the docs to load a non-quantized model. When running the current example, I get the following error message:

> ValueError: You are trying to in-situ quantize a GGUF model. This
> will not do anything.

This updated example works correctly for me.