### PR TITLE
Fix hang and performance drop with Metal

### DIFF
--- a/mistralrs-core/src/sampler.rs
+++ b/mistralrs-core/src/sampler.rs
@@ -844,16 +844,16 @@ impl Sampler {
         sample_speculative: bool,
         multiple_sequences: bool,
     ) -> Result<Logprobs> {
-        // if cfg!(feature = "metal") && !multiple_sequences {
-        //     return self.sample_fast(
-        //         logits,
-        //         context,
-        //         return_logprobs,
-        //         self.top_k,
-        //         self.top_p,
-        //         self.min_p,
-        //     );
-        // }
+        if cfg!(feature = "metal") && !multiple_sequences {
+            return self.sample_fast(
+                logits,
+                context,
+                return_logprobs,
+                self.top_k,
+                self.top_p,
+                self.min_p,
+            );
+        }
 
         let logits = logits.to_vec1()?;
         let mut logits = self.apply_penalties(logits, context)?;


### PR DESCRIPTION
I discovered that the dummy run always hangs with Metal. Even if that is worked around, the output tokens-per-second is half of what it used to be with older builds.

`git bisect` pointed to a change in #1580 as the likely cause. Reverting the commented code fixes both issues.

- Fixes #1660
- Fixes #1661