### PR TITLE
feat: Remove ram limits for CPU

### DIFF
--- a/mistralrs-core/src/pipeline/loaders/auto_device_map.rs
+++ b/mistralrs-core/src/pipeline/loaders/auto_device_map.rs
@@ -256,9 +256,15 @@ pub fn get_device_layers(
             .pop()
             .context("No more devices to map to. The model does not fit on this system.")?;
 
-        // All usage of 90% of the memory as a maximum.
+        // For CPU: effectively unlimited capacity since it can use swap memory
+        // For GPU/accelerators: use 90% of available memory as maximum
         #[allow(clippy::cast_possible_truncation, clippy::cast_precision_loss)]
-        let cap = (cap as f64 * 0.90) as usize;
+        let cap = if dev.is_cpu() {
+            // Allow unlimited capacity for CPU - swap will handle it
+            usize::MAX
+        } else {
+            (cap as f64 * 0.90) as usize
+        };
 
         // Algorithm is to check the following:
         // 1) (no mapping) if *everything* fits on the first dev (non mapped and mapped)


### PR DESCRIPTION
In practice, it can be fine to use the CPU even when there's not enough RAM because modern hardware and operating systems are really good at swapping. In fact, I would guess the average Apple user is probably at 100% ram utilization nearly 100% of the time. The issue is that this makes it essentially impossible for such people to use the CPU executor, because it will always report that they have zero megabytes of ram remaining (and their model will of course require more than that). Despite that, it would actually work fine if the code simply didn't have this check. So, this PR removes it for CPU targets.