### PR TITLE
Fix inverted logic bug in DRY sampler sequence breaker encoding

### DIFF
--- a/mistralrs-core/src/sampler.rs
+++ b/mistralrs-core/src/sampler.rs
@@ -133,9 +133,9 @@ impl DrySamplingParamsInner {
                             .map(|enc| {
                                 let ids = enc.get_ids();
                                 if !ids.is_empty() {
-                                    None
-                                } else {
                                     Some(ids[ids.len() - 1])
+                                } else {
+                                    None
                                 }
                             })
                     })


### PR DESCRIPTION
Fixed a critical logic error in DrySamplingParamsInner::from() where the condition checking if token IDs were empty was inverted. The original code would return None when IDs were present and attempt to access ids[len-1] when the vector was empty, causing an index out of bounds panic.

The fix ensures:
- When token IDs are present (!ids.is_empty()), return Some(ids[len-1])
- When token IDs are empty, return None

This bug was in the workaround code for sequence breaker encoding that prefixes 'a' to get correct tokenization (referenced in koboldcpp#982).