### PR TITLE
Docs: Clarify correct GPU arch for FlashAttention 

### DIFF
--- a/docs/FLASH_ATTENTION.md
+++ b/docs/FLASH_ATTENTION.md
@@ -5,14 +5,14 @@ Mistral.rs supports FlashAttention V2 and V3 on CUDA devices (V3 is only support
 > Note: If compiled with FlashAttention and [PagedAttention](PAGED_ATTENTION.md) is enabled, then FlashAttention will be used in tandem to accelerate
 the prefill phase.
 
-## Using FlashAttention V2/V3
+## GPU Architecture Compatibility
 
-To use FlashAttention V2/V3, compile with the following feature flags.
-
-|FlashAttention|Feature flag|
-|--|--|
-|V2 (CC < 9.0)| `--features flash-attn` |
-|V3 (CC >= 9.0)| `--features flash-attn-v3` |
+| Architecture | Compute Capability | Example GPUs | Feature Flag |
+|--------------|-------------------|--------------|--------------|
+| Ampere | 8.0, 8.6 | RTX 30*, A100, A40 | `--features flash-attn` |
+| Ada Lovelace | 8.9 | RTX 40*, L40S | `--features flash-attn` |
+| Hopper | 9.0 | H100, H800 | `--features flash-attn-v3` |
+| Blackwell | 10.0, 12.0 | RTX 50* | `--features flash-attn` |
 
 > Note: FlashAttention V2 and V3 are mutually exclusive
 > Note: To use FlashAttention in the Python API, [compile from source](../mistralrs-pyo3/README.md).


### PR DESCRIPTION
**Add GPU architecture compatibility table for FlashAttention**

Fixes unclear documentation that led to compilation errors when users selected the wrong FlashAttention version for their GPU architecture. The previous docs used confusing compute capability ranges (e.g., "V3 (CC >= 9.0)") which incorrectly suggested newer architectures like Blackwell should use FlashAttention V3.

This PR adds a clear compatibility table showing:
- **Architecture**: Ampere, Ada Lovelace, Hopper, Blackwell
- **Compute Capability**: Specific versions (8.0/8.6, 8.9, 9.0, 10.0/12.0)
- **Example GPUs**: RTX 30*/40*/50* series, datacenter GPUs
- **Feature Flag**: Exact `--features` flag to use for compilation

Key clarification: FlashAttention V3 is **Hopper-only** (H100/H800), not for all CC >= 9.0 GPUs. Blackwell GPUs should use V2.

**Sources:**
- [FlashAttention V3 Hopper requirements](https://github.com/Dao-AILab/flash-attention)
- [NVIDIA Blackwell compute capability documentation](https://docs.nvidia.com/cuda/blackwell-compatibility-guide/index.html)