### PR TITLE
[Granite Hybrid] Fix Mamba softplus NaNs, GPU mismatches, paged_attn

### DIFF
--- a/mistralrs-core/src/models/granite.rs
+++ b/mistralrs-core/src/models/granite.rs
@@ -1054,7 +1054,9 @@ impl MambaLayer {
 
         for t in 0..seq_len {
             let dt_t = dt.i((.., t, ..))?.unsqueeze(2)?.expand((
-                batch_size, self.num_heads, self.head_dim
+                batch_size,
+                self.num_heads,
+                self.head_dim,
             ))?;
             let x_t = hidden_states.i((.., t, .., ..))?;
             let b_t = b.i((.., t, .., ..))?;


### PR DESCRIPTION
related: PR: #1731, Issues:  #1726 #1741 #1737

```
//tested with:
cargo run -r -F cuda --bin mistralrs-server --  -i plain -m  ibm-granite/granite-4.0-h-micro`
// avoid issue:
// ERROR mistralrs_server::interactive_mode: Got an internal error: A weight is negative, too large or not a valid number`


//tested with:
cargo run -r -F cuda --bin mistralrs-server --  -i  --isq 8 run -m  ibm-granite/granite-4.0-h-micro`
// avoid issue:
// ERROR mistralrs_core::engine: step - Model failed with error: device mismatch in matmul, lhs: Cuda { gpu_id: 0 }, rhs: Cpu
```
