### PR TITLE
Fixing idx position bug in Qwen Vision Models

### DIFF
--- a/mistralrs-core/src/vision_models/qwen2_5_vl/mod.rs
+++ b/mistralrs-core/src/vision_models/qwen2_5_vl/mod.rs
@@ -357,6 +357,7 @@ impl Qwen2_5VLModel {
             )?);
         }
         let ropeidx_attn_mask = Tensor::stack(&ropeidx_attn_mask_bs, 0)?;
+
         let mut ropeidx_attn_mask_indices_bs = Vec::new();
         for len in seqlens.iter() {
             ropeidx_attn_mask_indices_bs.push(Tensor::from_vec(
@@ -367,11 +368,24 @@ impl Qwen2_5VLModel {
         }
         let ropeidx_attn_mask_indices = Tensor::stack(&ropeidx_attn_mask_indices_bs, 0)?;
 
-        let ropeidx_input_ids = if attention_mask.is_some() {
+        // For position calculation, we need a tensor with the actual sequence length from seqlens
+        // During completion, input_ids is just [1, 1] (the new token), but seqlens reflects
+        // the full sequence length including KV cache
+        let ropeidx_input_ids_tensor;
+        let ropeidx_input_ids = if seqlens.len() == 1 && seqlens[0] != input_ids.dim(1)? {
+            // Completion mode: create a dummy tensor with the right length for position calculation
+            ropeidx_input_ids_tensor = Tensor::zeros(
+                (input_ids.dim(0)?, seqlens[0]),
+                input_ids.dtype(),
+                input_ids.device(),
+            )?;
+            &ropeidx_input_ids_tensor
+        } else if attention_mask.is_some() {
             input_ids
         } else {
             input_ids_full
         };
+
         let (position_ids, mrope_position_deltas) = self.get_rope_index(
             ropeidx_input_ids,
             image_grid_thw.as_ref(),


### PR DESCRIPTION
### Problem: Qwen2.5-VL models (like olmOCR) were failing during completion with:
```
ERROR mistralrs_core::engine: completion step - Model failed with error: 
shape mismatch in where_cond, lhs: [3, 1624], rhs: [3, 1623]
```

### Root Cause: 
During completion, input_ids contains only the new token (shape [1, 1]), but seqlens contains the full sequence length including KV cache. The position calculation in get_rope_index was using the small input_ids tensor, causing a mismatch with the attention mask created from seqlens. Fix:
1. Added completion mode detection (lines 390-402): When seqlens doesn't match input_ids dimensions, create a dummy tensor with the correct sequence length for position calculation

If there is a more elegant way to do this than creating a dummy tensor please let me know.

Fixes: https://github.com/EricLBuehler/mistral.rs/issues/1786