### PR TITLE
Add utils.metal include to fused_glu.metal

### DIFF
--- a/mistralrs-quant/src/metal_kernels/fused_glu.metal
+++ b/mistralrs-quant/src/metal_kernels/fused_glu.metal
@@ -1,4 +1,5 @@
 #include <metal_stdlib>
+#include "utils.metal"
 using namespace metal;
 
 // Activation types matching Rust GluActivationType enum


### PR DESCRIPTION
this is required in order to get the metal files compiled.