### PR TITLE
chore(deps): update candle revision

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -211,28 +211,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "async-stream"
-version = "0.3.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b5a71a6f37880a80d1d7f19efd781e4b5de42c88f0722cc13bcb6cc2cfe8476"
-dependencies = [
- "async-stream-impl",
- "futures-core",
- "pin-project-lite",
-]
-
-[[package]]
-name = "async-stream-impl"
-version = "0.3.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7c24de15d275a1ecfd47a380fb4d5ec9bfe0933f309ed5e705b775596a3574d"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.113",
-]
-
-[[package]]
 name = "async-trait"
 version = "0.1.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -661,7 +639,7 @@ checksum = "ade8366b8bd5ba243f0a58f036cc0ca8a2f069cff1a2351ef1cac6b083e16fc0"
 [[package]]
 name = "candle-core"
 version = "0.9.2-alpha.2"
-source = "git+https://github.com/huggingface/candle.git?rev=a4ad7c7#a4ad7c79666958c38b9afc0e0c3e3499ab8991d8"
+source = "git+https://github.com/huggingface/candle.git?rev=fd8448d#fd8448d2c7fe2098c60bb88f48d5878845bb08c0"
 dependencies = [
  "accelerate-src",
  "byteorder",
@@ -692,7 +670,7 @@ dependencies = [
 [[package]]
 name = "candle-flash-attn"
 version = "0.9.2-alpha.2"
-source = "git+https://github.com/huggingface/candle.git?rev=a4ad7c7#a4ad7c79666958c38b9afc0e0c3e3499ab8991d8"
+source = "git+https://github.com/huggingface/candle.git?rev=fd8448d#fd8448d2c7fe2098c60bb88f48d5878845bb08c0"
 dependencies = [
  "anyhow",
  "bindgen_cuda 0.1.5",
@@ -704,7 +682,7 @@ dependencies = [
 [[package]]
 name = "candle-flash-attn-build"
 version = "0.9.2-alpha.2"
-source = "git+https://github.com/huggingface/candle.git?rev=a4ad7c7#a4ad7c79666958c38b9afc0e0c3e3499ab8991d8"
+source = "git+https://github.com/huggingface/candle.git?rev=fd8448d#fd8448d2c7fe2098c60bb88f48d5878845bb08c0"
 dependencies = [
  "anyhow",
 ]
@@ -712,7 +690,7 @@ dependencies = [
 [[package]]
 name = "candle-flash-attn-v3"
 version = "0.9.2-alpha.2"
-source = "git+https://github.com/huggingface/candle.git?rev=a4ad7c7#a4ad7c79666958c38b9afc0e0c3e3499ab8991d8"
+source = "git+https://github.com/huggingface/candle.git?rev=fd8448d#fd8448d2c7fe2098c60bb88f48d5878845bb08c0"
 dependencies = [
  "anyhow",
  "candle-core",
@@ -725,7 +703,7 @@ dependencies = [
 [[package]]
 name = "candle-kernels"
 version = "0.9.2-alpha.2"
-source = "git+https://github.com/huggingface/candle.git?rev=a4ad7c7#a4ad7c79666958c38b9afc0e0c3e3499ab8991d8"
+source = "git+https://github.com/huggingface/candle.git?rev=fd8448d#fd8448d2c7fe2098c60bb88f48d5878845bb08c0"
 dependencies = [
  "bindgen_cuda 0.1.7",
 ]
@@ -733,7 +711,7 @@ dependencies = [
 [[package]]
 name = "candle-metal-kernels"
 version = "0.9.2-alpha.2"
-source = "git+https://github.com/huggingface/candle.git?rev=a4ad7c7#a4ad7c79666958c38b9afc0e0c3e3499ab8991d8"
+source = "git+https://github.com/huggingface/candle.git?rev=fd8448d#fd8448d2c7fe2098c60bb88f48d5878845bb08c0"
 dependencies = [
  "half",
  "objc2",
@@ -747,7 +725,7 @@ dependencies = [
 [[package]]
 name = "candle-nn"
 version = "0.9.2-alpha.2"
-source = "git+https://github.com/huggingface/candle.git?rev=a4ad7c7#a4ad7c79666958c38b9afc0e0c3e3499ab8991d8"
+source = "git+https://github.com/huggingface/candle.git?rev=fd8448d#fd8448d2c7fe2098c60bb88f48d5878845bb08c0"
 dependencies = [
  "accelerate-src",
  "candle-core",
@@ -766,7 +744,7 @@ dependencies = [
 [[package]]
 name = "candle-ug"
 version = "0.9.2-alpha.2"
-source = "git+https://github.com/huggingface/candle.git?rev=a4ad7c7#a4ad7c79666958c38b9afc0e0c3e3499ab8991d8"
+source = "git+https://github.com/huggingface/candle.git?rev=fd8448d#fd8448d2c7fe2098c60bb88f48d5878845bb08c0"
 dependencies = [
  "ug",
  "ug-cuda",
@@ -2229,9 +2207,9 @@ checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
 
 [[package]]
 name = "h2"
-version = "0.4.12"
+version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3c0b69cfcb4e1b9f1bf2f53f95f766e4661169728ec61cd3fe5a0166f2d1386"
+checksum = "2f44da3a8150a6703ed5d34e164b875fd14c2cdab9af1252a9a1020bde2bdc54"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -4209,9 +4187,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.104"
+version = "1.0.105"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9695f8df41bb4f3d222c95a67532365f569318332d03d5f3f67f37b20e6ebdf0"
+checksum = "535d180e0ecab6268a3e718bb9fd44db66bbbc256257165fc699dadf70d16fe7"
 dependencies = [
  "unicode-ident",
 ]
@@ -4428,9 +4406,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.42"
+version = "1.0.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a338cc41d27e6cc6dce6cefc13a0729dfbb81c262b1f519331575dd80ef3067f"
+checksum = "dc74d9a594b72ae6656596548f56f667211f8a97b3d4c3d467150794690dc40a"
 dependencies = [
  "proc-macro2",
 ]
@@ -5054,9 +5032,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.35"
+version = "0.23.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "533f54bc6a7d4f647e46ad909549eda97bf5afc1585190ef692b4286b198bd8f"
+checksum = "c665f33d38cea657d9614f766881e4d510e0eda4239891eea56b4cadcf01801b"
 dependencies = [
  "aws-lc-rs",
  "log",
@@ -6252,9 +6230,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-stream"
-version = "0.1.17"
+version = "0.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eca58d7bba4a75707817a2c44174253f9236b2d5fbd055602e9d5c07c139a047"
+checksum = "32da49809aab5c3bc678af03902d4ccddea2a87d028d86392a4b1560c6906c70"
 dependencies = [
  "futures-core",
  "pin-project-lite",
@@ -6263,12 +6241,10 @@ dependencies = [
 
 [[package]]
 name = "tokio-test"
-version = "0.4.4"
+version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2468baabc3311435b55dd935f702f42cd1b8abb7e754fb7dfb16bd36aa88f9f7"
+checksum = "3f6d24790a10a7af737693a3e8f1d03faef7e6ca0cc99aae5066f533766de545"
 dependencies = [
- "async-stream",
- "bytes",
  "futures-core",
  "tokio",
  "tokio-stream",
@@ -6300,9 +6276,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.7.17"
+version = "0.7.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2efa149fe76073d6e8fd97ef4f4eca7b67f599660115591483572e406e165594"
+checksum = "9ae9cec805b01e8fc3fd2fe289f89149a9b66dd16786abd8b19cfa7b48cb0098"
 dependencies = [
  "bytes",
  "futures-core",
@@ -6727,9 +6703,9 @@ dependencies = [
 
 [[package]]
 name = "url"
-version = "2.5.7"
+version = "2.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08bc136a29a3d1758e07a9cca267be308aeebf5cfd5a10f3f67ab2097683ef5b"
+checksum = "ff67a8a4397373c3ef660812acab3268222035010ab8680ec4215f38ba3d0eed"
 dependencies = [
  "form_urlencoded",
  "idna",
@@ -7675,9 +7651,9 @@ checksum = "40990edd51aae2c2b6907af74ffb635029d5788228222c4bb811e9351c0caad3"
 
 [[package]]
 name = "zmij"
-version = "1.0.10"
+version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30e0d8dffbae3d840f64bda38e28391faef673a7b5a6017840f2a106c8145868"
+checksum = "2fc5a66a20078bf1251bde995aa2fdcc4b800c70b5d92dd2c62abc5c60f679f8"
 
 [[package]]
 name = "zopfli"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,11 +32,11 @@ rust-version = "1.86"
 # candle-flash-attn-v3 = { version = "0.9.2-alpha.2" }
 # candle-flash-attn = { version = "0.9.2-alpha.2" }
 # candle-metal-kernels = { version = "0.9.2-alpha.2" }
-candle-core = { git = "https://github.com/huggingface/candle.git", version = "0.9.2-alpha.2", rev = "a4ad7c7" }
-candle-nn = { git = "https://github.com/huggingface/candle.git", version = "0.9.2-alpha.2", rev = "a4ad7c7" }
-candle-flash-attn-v3 = { git = "https://github.com/huggingface/candle.git", version = "0.9.2-alpha.2", rev = "a4ad7c7" }
-candle-flash-attn = { git = "https://github.com/huggingface/candle.git", version = "0.9.2-alpha.2", rev = "a4ad7c7" }
-candle-metal-kernels = { git = "https://github.com/huggingface/candle.git", version = "0.9.2-alpha.2", rev = "a4ad7c7" }
+candle-core = { git = "https://github.com/huggingface/candle.git", version = "0.9.2-alpha.2", rev = "fd8448d" }
+candle-nn = { git = "https://github.com/huggingface/candle.git", version = "0.9.2-alpha.2", rev = "fd8448d" }
+candle-flash-attn-v3 = { git = "https://github.com/huggingface/candle.git", version = "0.9.2-alpha.2", rev = "fd8448d" }
+candle-flash-attn = { git = "https://github.com/huggingface/candle.git", version = "0.9.2-alpha.2", rev = "fd8448d" }
+candle-metal-kernels = { git = "https://github.com/huggingface/candle.git", version = "0.9.2-alpha.2", rev = "fd8448d" }
 # candle-core = { path = "../candle/candle-core" }
 # candle-nn = { path = "../candle/candle-nn" }
 # candle-flash-attn-v3 = { path = "../candle/candle-flash-attn-v3" }


### PR DESCRIPTION
this fix is required for compiling candle on windows with cuda backend.