### PR TITLE
Hotfix: Remove fastmath from candle-kernels

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -639,7 +639,7 @@ checksum = "ade8366b8bd5ba243f0a58f036cc0ca8a2f069cff1a2351ef1cac6b083e16fc0"
 [[package]]
 name = "candle-core"
 version = "0.9.2-alpha.2"
-source = "git+https://github.com/huggingface/candle.git?rev=f2d30fb#f2d30fbd15eb5fe8ba77a7cfc3c996d00b3d03bb"
+source = "git+https://github.com/huggingface/candle.git?rev=aaf5c86#aaf5c86ffaf77850166a61bb4eeee0cdf7b5861f"
 dependencies = [
  "accelerate-src",
  "byteorder",
@@ -670,7 +670,7 @@ dependencies = [
 [[package]]
 name = "candle-flash-attn"
 version = "0.9.2-alpha.2"
-source = "git+https://github.com/huggingface/candle.git?rev=f2d30fb#f2d30fbd15eb5fe8ba77a7cfc3c996d00b3d03bb"
+source = "git+https://github.com/huggingface/candle.git?rev=aaf5c86#aaf5c86ffaf77850166a61bb4eeee0cdf7b5861f"
 dependencies = [
  "anyhow",
  "bindgen_cuda 0.1.5",
@@ -682,7 +682,7 @@ dependencies = [
 [[package]]
 name = "candle-flash-attn-build"
 version = "0.9.2-alpha.2"
-source = "git+https://github.com/huggingface/candle.git?rev=f2d30fb#f2d30fbd15eb5fe8ba77a7cfc3c996d00b3d03bb"
+source = "git+https://github.com/huggingface/candle.git?rev=aaf5c86#aaf5c86ffaf77850166a61bb4eeee0cdf7b5861f"
 dependencies = [
  "anyhow",
 ]
@@ -690,7 +690,7 @@ dependencies = [
 [[package]]
 name = "candle-flash-attn-v3"
 version = "0.9.2-alpha.2"
-source = "git+https://github.com/huggingface/candle.git?rev=f2d30fb#f2d30fbd15eb5fe8ba77a7cfc3c996d00b3d03bb"
+source = "git+https://github.com/huggingface/candle.git?rev=aaf5c86#aaf5c86ffaf77850166a61bb4eeee0cdf7b5861f"
 dependencies = [
  "anyhow",
  "candle-core",
@@ -703,7 +703,7 @@ dependencies = [
 [[package]]
 name = "candle-kernels"
 version = "0.9.2-alpha.2"
-source = "git+https://github.com/huggingface/candle.git?rev=f2d30fb#f2d30fbd15eb5fe8ba77a7cfc3c996d00b3d03bb"
+source = "git+https://github.com/huggingface/candle.git?rev=aaf5c86#aaf5c86ffaf77850166a61bb4eeee0cdf7b5861f"
 dependencies = [
  "bindgen_cuda 0.1.7",
 ]
@@ -711,7 +711,7 @@ dependencies = [
 [[package]]
 name = "candle-metal-kernels"
 version = "0.9.2-alpha.2"
-source = "git+https://github.com/huggingface/candle.git?rev=f2d30fb#f2d30fbd15eb5fe8ba77a7cfc3c996d00b3d03bb"
+source = "git+https://github.com/huggingface/candle.git?rev=aaf5c86#aaf5c86ffaf77850166a61bb4eeee0cdf7b5861f"
 dependencies = [
  "half",
  "objc2",
@@ -725,7 +725,7 @@ dependencies = [
 [[package]]
 name = "candle-nn"
 version = "0.9.2-alpha.2"
-source = "git+https://github.com/huggingface/candle.git?rev=f2d30fb#f2d30fbd15eb5fe8ba77a7cfc3c996d00b3d03bb"
+source = "git+https://github.com/huggingface/candle.git?rev=aaf5c86#aaf5c86ffaf77850166a61bb4eeee0cdf7b5861f"
 dependencies = [
  "accelerate-src",
  "candle-core",
@@ -744,7 +744,7 @@ dependencies = [
 [[package]]
 name = "candle-ug"
 version = "0.9.2-alpha.2"
-source = "git+https://github.com/huggingface/candle.git?rev=f2d30fb#f2d30fbd15eb5fe8ba77a7cfc3c996d00b3d03bb"
+source = "git+https://github.com/huggingface/candle.git?rev=aaf5c86#aaf5c86ffaf77850166a61bb4eeee0cdf7b5861f"
 dependencies = [
  "ug",
  "ug-cuda",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,11 +33,11 @@ rust-version = "1.86"
 # candle-flash-attn-v3 = { version = "0.9.2-alpha.2" }
 # candle-flash-attn = { version = "0.9.2-alpha.2" }
 # candle-metal-kernels = { version = "0.9.2-alpha.2" }
-candle-core = { git = "https://github.com/huggingface/candle.git", version = "0.9.2-alpha.2", rev = "f2d30fb" }
-candle-nn = { git = "https://github.com/huggingface/candle.git", version = "0.9.2-alpha.2", rev = "f2d30fb" }
-candle-flash-attn-v3 = { git = "https://github.com/huggingface/candle.git", version = "0.9.2-alpha.2", rev = "f2d30fb" }
-candle-flash-attn = { git = "https://github.com/huggingface/candle.git", version = "0.9.2-alpha.2", rev = "f2d30fb" }
-candle-metal-kernels = { git = "https://github.com/huggingface/candle.git", version = "0.9.2-alpha.2", rev = "f2d30fb" }
+candle-core = { git = "https://github.com/huggingface/candle.git", version = "0.9.2-alpha.2", rev = "aaf5c86" }
+candle-nn = { git = "https://github.com/huggingface/candle.git", version = "0.9.2-alpha.2", rev = "aaf5c86" }
+candle-flash-attn-v3 = { git = "https://github.com/huggingface/candle.git", version = "0.9.2-alpha.2", rev = "aaf5c86" }
+candle-flash-attn = { git = "https://github.com/huggingface/candle.git", version = "0.9.2-alpha.2", rev = "aaf5c86" }
+candle-metal-kernels = { git = "https://github.com/huggingface/candle.git", version = "0.9.2-alpha.2", rev = "aaf5c86" }
 # candle-core = { path = "../candle/candle-core" }
 # candle-nn = { path = "../candle/candle-nn" }
 # candle-flash-attn-v3 = { path = "../candle/candle-flash-attn-v3" }


### PR DESCRIPTION
Fix fastmath usage in candle-kernels introduced in https://github.com/huggingface/candle/pull/3221.

See: https://github.com/huggingface/candle/pull/3309.

This causes accuracy regressions (to the point of NaNs or garbage logits) in many models.

Fixes #1806.