### PR TITLE
Switch to cudarc 0.19, fix d2d cuda copies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3467,7 +3467,7 @@ dependencies = [
  "rust-mcp-schema 0.1.11",
  "rustc-hash 2.1.1",
  "rustfft",
- "safetensors 0.6.2",
+ "safetensors 0.7.0",
  "schemars 0.8.22",
  "scraper",
  "serde",
@@ -3587,13 +3587,13 @@ dependencies = [
  "paste",
  "rayon",
  "regex",
- "safetensors 0.6.2",
+ "safetensors 0.7.0",
  "serde",
  "serde_json",
  "thiserror 2.0.17",
  "tokio",
  "tracing",
- "yoke 0.7.5",
+ "yoke 0.8.1",
 ]
 
 [[package]]
@@ -5320,16 +5320,6 @@ name = "safetensors"
 version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "44560c11236a6130a46ce36c836a62936dc81ebf8c36a37947423571be0e55b6"
-dependencies = [
- "serde",
- "serde_json",
-]
-
-[[package]]
-name = "safetensors"
-version = "0.6.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "172dd94c5a87b5c79f945c863da53b2ebc7ccef4eca24ac63cca66a41aab2178"
 dependencies = [
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -92,7 +92,7 @@ float8 = "0.6.0"
 regex = "1.11.1"
 objc2-metal = "0.3.1"
 objc2-foundation = "0.3.1"
-safetensors = "0.6.0"
+safetensors = "0.7.0"
 toml = "0.8.22"
 hf-hub = { version = "0.4.2", default-features = false, features = [
     "ureq",
@@ -155,7 +155,7 @@ symphonia = { version = "0.5.4", default-features = false, features = ["mp3", "f
 lazy_static = "1.5"
 paste = "1.0.15"
 byteorder = "1.5.0"
-yoke = "0.7.5"
+yoke = { version = "0.8.1", features = ["derive"] }
 memmap2 = "0.9.5"
 pyo3-build-config = "0.25.0"
 ctrlc = "3.4.7"


### PR DESCRIPTION
Kudos to @krampenschiesser for https://github.com/huggingface/candle/pull/3312 (based on: https://github.com/chelsea0x3b/cudarc/pull/520) which fixes several multi-GPU issues surrounding mismanaged CUDA device contexts and lack of `d2d` copy support.

Bumps to the related git rev and float8 version.