### PR TITLE
feat(cuda): add opt-in legacy BF16 and FP8

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -634,8 +634,7 @@ checksum = "ade8366b8bd5ba243f0a58f036cc0ca8a2f069cff1a2351ef1cac6b083e16fc0"
 [[package]]
 name = "candle-core"
 version = "0.10.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6bd9895436c1ba5dc1037a19935d084b838db066ff4e15ef7dded020b7c12a4a"
+source = "git+https://github.com/haricot/candle.git?rev=e1f418a#e1f418a32dd568277e44d31af8d3bc09d4d1414f"
 dependencies = [
  "accelerate-src",
  "byteorder",
@@ -667,8 +666,7 @@ dependencies = [
 [[package]]
 name = "candle-flash-attn"
 version = "0.10.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12512cf8e706744642e9a8579305a6ed1e44a0c636ce20c416cd5c519de19b7d"
+source = "git+https://github.com/haricot/candle.git?rev=e1f418a#e1f418a32dd568277e44d31af8d3bc09d4d1414f"
 dependencies = [
  "anyhow",
  "candle-core",
@@ -679,8 +677,7 @@ dependencies = [
 [[package]]
 name = "candle-flash-attn-v3"
 version = "0.10.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8da1101859e200bd6cbd8fe58e9ff45882257a136697fa2fe086684577f5926"
+source = "git+https://github.com/haricot/candle.git?rev=e1f418a#e1f418a32dd568277e44d31af8d3bc09d4d1414f"
 dependencies = [
  "anyhow",
  "candle-core",
@@ -693,8 +690,7 @@ dependencies = [
 [[package]]
 name = "candle-kernels"
 version = "0.10.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "742e2ac226b777134436e9e692f44e77c278b8a7abb1554dc10e44dc911b349f"
+source = "git+https://github.com/haricot/candle.git?rev=e1f418a#e1f418a32dd568277e44d31af8d3bc09d4d1414f"
 dependencies = [
  "cudaforge",
 ]
@@ -702,8 +698,7 @@ dependencies = [
 [[package]]
 name = "candle-metal-kernels"
 version = "0.10.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b6b5a4cae6b4e1ab0efcee4dc05272d11b374a3d1ba121b3a961e36be54ab60"
+source = "git+https://github.com/haricot/candle.git?rev=e1f418a#e1f418a32dd568277e44d31af8d3bc09d4d1414f"
 dependencies = [
  "half",
  "objc2",
@@ -717,8 +712,7 @@ dependencies = [
 [[package]]
 name = "candle-nn"
 version = "0.10.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9317a09d6530b758990ed7f625ac69ff43653bc9ee28b0464644ad1169ada87"
+source = "git+https://github.com/haricot/candle.git?rev=e1f418a#e1f418a32dd568277e44d31af8d3bc09d4d1414f"
 dependencies = [
  "accelerate-src",
  "candle-core",
@@ -737,8 +731,7 @@ dependencies = [
 [[package]]
 name = "candle-ug"
 version = "0.10.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca0fc3167cbc99c8ec1be618cb620aa21dca95038f118c3579a79370e3dc5f77"
+source = "git+https://github.com/haricot/candle.git?rev=e1f418a#e1f418a32dd568277e44d31af8d3bc09d4d1414f"
 dependencies = [
  "ug",
  "ug-cuda",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -192,6 +192,14 @@ mistralrs-audio = { path = "mistralrs-audio", version = "0.8.1" }
 mistralrs-mcp = { path = "mistralrs-mcp", version = "0.8.1" }
 mistralrs-macros = { path = "mistralrs-macros", version = "0.8.1" }
 
+[patch.crates-io]
+candle-core = { git = "https://github.com/haricot/candle.git", rev = "e1f418a" }
+candle-nn = { git = "https://github.com/haricot/candle.git", rev = "e1f418a" }
+candle-flash-attn-v3 = { git = "https://github.com/haricot/candle.git", rev = "e1f418a" }
+candle-flash-attn = { git = "https://github.com/haricot/candle.git", rev = "e1f418a" }
+candle-metal-kernels = { git = "https://github.com/haricot/candle.git", rev = "e1f418a" }
+candle-kernels = { git = "https://github.com/haricot/candle.git", rev = "e1f418a" }
+
 [profile.release-with-debug]
 inherits = "release"
 debug = true

--- a/mistralrs-core/build.rs
+++ b/mistralrs-core/build.rs
@@ -8,6 +8,7 @@ fn main() {
     {
         use std::path::PathBuf;
         println!("cargo:rerun-if-changed=build.rs");
+        println!("cargo:rerun-if-env-changed=ALLOW_LEGACY");
         let build_dir = PathBuf::from(std::env::var("OUT_DIR").unwrap());
 
         let mut builder = cudaforge::KernelBuilder::new()
@@ -26,12 +27,22 @@ fn main() {
             .arg("--compiler-options")
             .arg("-fPIC");
 
+        let allow_legacy = std::env::var("ALLOW_LEGACY").unwrap_or_default();
+        let allow_legacy_bf16 = allow_legacy == "all"
+            || allow_legacy
+                .split(',')
+                .map(str::trim)
+                .any(|value| value == "bf16");
+
         // Check if CUDA_COMPUTE_CAP < 80 and disable bf16 kernels if so.
         // bf16 WMMA operations and certain bf16 intrinsics are only available on sm_80+.
         if let Some(compute_cap) = builder.get_compute_cap() {
-            if compute_cap < 80 {
+            if compute_cap < 80 && !allow_legacy_bf16 {
                 builder = builder.arg("-DNO_BF16_KERNEL");
             }
+        }
+        if allow_legacy_bf16 {
+            builder = builder.arg("-DALLOW_LEGACY_BF16");
         }
 
         // https://github.com/EricLBuehler/mistral.rs/issues/286

--- a/mistralrs-core/src/cuda/ffi.rs
+++ b/mistralrs-core/src/cuda/ffi.rs
@@ -116,6 +116,7 @@ extern "C" {
     );
 
     // for unquntized models (decoding)
+    #[link_name = "mistralrs_moe_gemm"]
     pub fn moe_gemm(
         input: *const c_void,   // input [size_m, size_k]
         weights: *const c_void, // weights [num_experts, size_n, size_k]
@@ -133,6 +134,7 @@ extern "C" {
     );
 
     // for unquntized models (prefill)
+    #[link_name = "mistralrs_moe_gemm_wmma"]
     pub fn moe_gemm_wmma(
         input: *const c_void,         // device pointer [size_m, size_k]
         weights: *const c_void,       // device pointer [num_experts, size_n, size_k]
@@ -148,8 +150,26 @@ extern "C" {
         dtype: i32, // 0=float16, 1=bf16 (for input/output)
         stream: i64,
     );
+    #[link_name = "mistralrs_moe_gemm_hfma2"]
+    pub fn moe_gemm_hfma2(
+        input: *const c_void,         // device pointer [size_m, size_k]
+        weights: *const c_void,       // device pointer [num_experts, size_n, size_k]
+        sorted_token_ids: *const i32, // device pointer [size_m]
+        expert_ids: *const i32,       // host array [size_m] (expert id per sorted token)
+        topk_weights: *const f32,
+        output: *mut c_void, // device pointer [size_m, size_n]
+        expert_offsets: *mut i32,
+        num_experts: i32,
+        topk: i32,
+        size_m: i32,
+        size_n: i32,
+        size_k: i32,
+        dtype: i32, // 0=float16, 1=bf16 (for input/output)
+        stream: i64,
+    );
 
     // for unquntized models (decoding) with transposed weights [num_experts, size_k, size_n]
+    #[link_name = "mistralrs_moe_gemm_transposed"]
     pub fn moe_gemm_transposed(
         input: *const c_void,   // input [size_m, size_k]
         weights: *const c_void, // weights [num_experts, size_k, size_n] - transposed layout
@@ -167,6 +187,7 @@ extern "C" {
     );
 
     // for unquntized models (prefill) with transposed weights [num_experts, size_k, size_n]
+    #[link_name = "mistralrs_moe_gemm_wmma_transposed"]
     pub fn moe_gemm_wmma_transposed(
         input: *const c_void,         // device pointer [size_m, size_k]
         weights: *const c_void, // device pointer [num_experts, size_k, size_n] - transposed layout
@@ -184,6 +205,7 @@ extern "C" {
     );
 
     // MoE GEMV for decode phase (optimized for small batch sizes M <= 8)
+    #[link_name = "mistralrs_moe_gemv"]
     pub fn moe_gemv(
         input: *const c_void,   // input [size_m or size_m / topk, size_k]
         weights: *const c_void, // weights [num_experts, size_n, size_k]
@@ -201,6 +223,7 @@ extern "C" {
     );
 
     // MoE GEMV for decode phase with transposed weights [num_experts, size_k, size_n]
+    #[link_name = "mistralrs_moe_gemv_transposed"]
     pub fn moe_gemv_transposed(
         input: *const c_void,   // input [size_m or size_m / topk, size_k]
         weights: *const c_void, // weights [num_experts, size_k, size_n] - transposed layout

--- a/mistralrs-core/src/cuda/moe.rs
+++ b/mistralrs-core/src/cuda/moe.rs
@@ -1,6 +1,16 @@
 use candle_core::{Result, Tensor};
 
 #[cfg(feature = "cuda")]
+fn supports_wmma(dev: &candle_core::cuda_backend::CudaDevice) -> Result<bool> {
+    let (major, _) = dev
+        .cuda_stream()
+        .context()
+        .compute_capability()
+        .map_err(|err| candle_core::Error::Msg(err.to_string()))?;
+    Ok(major >= 7)
+}
+
+#[cfg(feature = "cuda")]
 pub fn moe_gemm(
     input: &Tensor,
     weights: &Tensor,
@@ -92,7 +102,7 @@ pub fn moe_gemm(
 
         let output = unsafe { dev.alloc::<T>(size_m * size_n) }?;
 
-        let stream = dev.cuda_stream().cu_stream() as i64;
+        let stream = input.stream().cu_stream() as i64;
         use core::ffi::c_void;
 
         // Threshold for using GEMV kernel (optimized for small batch sizes)
@@ -108,8 +118,27 @@ pub fn moe_gemm(
         // - Prefill (larger batches): use WMMA-based kernel for tensor core acceleration
         // - Decode with small M (<=8): use GEMV kernel optimized for warp reductions
         // - Decode with larger M: use standard moe_gemm kernel
+        let use_wmma = supports_wmma(dev)?;
         let moe_func = if is_prefill {
-            crate::cuda::ffi::moe_gemm_wmma
+            if use_wmma {
+                crate::cuda::ffi::moe_gemm_wmma
+            } else {
+                return launch_hfma2::<T>(
+                    dev,
+                    input,
+                    weights,
+                    topk_weights_ptr,
+                    sorted_token_ids,
+                    experts_ids,
+                    num_experts,
+                    topk,
+                    size_m,
+                    size_n,
+                    size_k,
+                    data_type,
+                    stream,
+                );
+            }
         } else if size_m_i32 <= GEMV_THRESHOLD {
             crate::cuda::ffi::moe_gemv
         } else {
@@ -284,7 +313,7 @@ pub fn moe_gemm_transposed(
 
         let output = unsafe { dev.alloc::<T>(size_m * size_n) }?;
 
-        let stream = dev.cuda_stream().cu_stream() as i64;
+        let stream = input.stream().cu_stream() as i64;
         use core::ffi::c_void;
 
         // Threshold for using GEMV kernel (optimized for small batch sizes)
@@ -300,8 +329,13 @@ pub fn moe_gemm_transposed(
         // - Prefill (larger batches): use WMMA-based kernel for tensor core acceleration
         // - Decode with small M (<=8): use GEMV kernel optimized for warp reductions
         // - Decode with larger M: use standard moe_gemm_transposed kernel
+        let use_wmma = supports_wmma(dev)?;
         let moe_func = if is_prefill {
-            crate::cuda::ffi::moe_gemm_wmma_transposed
+            if use_wmma {
+                crate::cuda::ffi::moe_gemm_wmma_transposed
+            } else {
+                crate::cuda::ffi::moe_gemm_transposed
+            }
         } else if size_m_i32 <= GEMV_THRESHOLD {
             crate::cuda::ffi::moe_gemv_transposed
         } else {
@@ -378,4 +412,60 @@ pub fn moe_gemm_transposed(
     _: bool,
 ) -> Result<Tensor> {
     candle_core::bail!("moe_gemm_transposed is not implemented on this platform!")
+}
+
+#[cfg(feature = "cuda")]
+fn launch_hfma2<
+    T: candle_core::cuda_backend::CudaDType + candle_core::cuda_backend::cudarc::driver::DeviceRepr,
+>(
+    dev: &candle_core::cuda_backend::CudaDevice,
+    input: &candle_core::cuda_backend::cudarc::driver::CudaSlice<T>,
+    weights: &candle_core::cuda_backend::cudarc::driver::CudaSlice<T>,
+    topk_weights_ptr: *const f32,
+    sorted_token_ids: &candle_core::cuda_backend::cudarc::driver::CudaSlice<u32>,
+    experts_ids: &candle_core::cuda_backend::cudarc::driver::CudaSlice<u32>,
+    num_experts: usize,
+    topk: usize,
+    size_m: usize,
+    size_n: usize,
+    size_k: usize,
+    data_type: i32,
+    stream: i64,
+) -> Result<Tensor> {
+    use candle_core::cuda_backend::cudarc::driver::DevicePtr;
+    use candle_core::CudaStorage;
+
+    let num_experts_i32 = i32::try_from(num_experts).expect("num_experts too large for i32");
+    let topk_i32 = i32::try_from(topk).expect("topk too large for i32");
+    let size_m_i32 = i32::try_from(size_m).expect("size_m too large for i32");
+    let size_n_i32 = i32::try_from(size_n).expect("size_n too large for i32");
+    let size_k_i32 = i32::try_from(size_k).expect("size_k too large for i32");
+
+    let expert_offsets = unsafe { dev.alloc::<i32>(num_experts + 1) }?;
+    let output = unsafe { dev.alloc::<T>(size_m * size_n) }?;
+
+    unsafe {
+        crate::cuda::ffi::moe_gemm_hfma2(
+            input.device_ptr(input.stream()).0 as *const std::ffi::c_void,
+            weights.device_ptr(weights.stream()).0 as *const std::ffi::c_void,
+            sorted_token_ids.device_ptr(sorted_token_ids.stream()).0 as *const i32,
+            experts_ids.device_ptr(experts_ids.stream()).0 as *const i32,
+            topk_weights_ptr,
+            output.device_ptr(output.stream()).0 as *mut std::ffi::c_void,
+            expert_offsets.device_ptr(expert_offsets.stream()).0 as *mut i32,
+            num_experts_i32,
+            topk_i32,
+            size_m_i32,
+            size_n_i32,
+            size_k_i32,
+            data_type,
+            stream,
+        );
+    }
+
+    let output = CudaStorage::wrap_cuda_slice(output, dev.clone());
+    Ok(Tensor::from((
+        candle_core::Storage::Cuda(output),
+        (size_m, size_n),
+    )))
 }

--- a/mistralrs-core/src/cuda/moe_gemm.cu
+++ b/mistralrs-core/src/cuda/moe_gemm.cu
@@ -57,16 +57,35 @@ template <> struct LoadVecSize<nv_bfloat16> {
 
 inline __device__ void zero(__nv_bfloat162 &dst) {
 #if defined(__CUDA_ARCH__) && __CUDA_ARCH__ < 800
-  assert(false);
+  dst.x = __float2bfloat16(0.0f);
+  dst.y = dst.x;
 #else
   dst.x = __ushort_as_bfloat16((unsigned short)0x0000U);
   dst.y = dst.x;
 #endif
 }
+inline __device__ void zero(float2 &dst) {
+  dst.x = 0.0f;
+  dst.y = 0.0f;
+}
 inline __device__ void zero(half2 &dst) {
   dst.x = __half_as_ushort(__float2half(0));
   dst.y = __half_as_ushort(__float2half(0));
 }
+
+template <typename ComputeT, typename AccumT>
+inline __device__ AccumT hfma2_wrapper(ComputeT a, ComputeT b, AccumT c) {
+  return __hfma2(a, b, c);
+}
+
+#if defined(__CUDA_ARCH__) && __CUDA_ARCH__ < 800
+template <>
+inline __device__ float2 hfma2_wrapper(nv_bfloat162 a, nv_bfloat162 b,
+                                       float2 c) {
+  return float2{__bfloat162float(a.x) * __bfloat162float(b.x) + c.x,
+                __bfloat162float(a.y) * __bfloat162float(b.y) + c.y};
+}
+#endif
 
 } // namespace vllm_rs
 
@@ -86,8 +105,8 @@ inline __device__ void zero(half2 &dst) {
  * @param N                 Output dimension per expert.
  * @param K                 Input dimension per expert.
  */
-template <typename T, typename VecT, int BLOCK_N_TILE, int BLOCK_K_TILE,
-          int BLOCK_K_THREADS>
+template <typename T, typename VecT, typename AccumT, int BLOCK_N_TILE,
+          int BLOCK_K_TILE, int BLOCK_K_THREADS>
 __global__ void moe_gemm_vectorized_kernel(
     const T *__restrict__ input,                  // [M, K]
     const T *__restrict__ weights,                // [num_experts, N, K]
@@ -137,9 +156,10 @@ __global__ void moe_gemm_vectorized_kernel(
   // s_weights: Caches the [N, K] weight matrix tile
   // Layout: [BLOCK_N_TILE][BLOCK_K_TILE] for coalesced compute
   __shared__ T s_weights[BLOCK_N_TILE][BLOCK_K_TILE];
+  __shared__ float s_acc[BLOCK_N_TILE][BLOCK_K_THREADS];
 
   // This thread's accumulator
-  VecT acc;
+  AccumT acc;
   vllm_rs::zero(acc);
   LoadVecT zero_vec;
   zero_vec.x = zero_vec.y = zero_vec.z = zero_vec.w = 0.0f;
@@ -186,22 +206,37 @@ __global__ void moe_gemm_vectorized_kernel(
     VecT *input_vec = reinterpret_cast<VecT *>(s_input);
     VecT *weight_vec = reinterpret_cast<VecT *>(s_weights[tid_n]);
 #pragma unroll
-    for (int k_vec = 0; k_vec < k_compute_vec_tile_size; ++k_vec) {
-      acc = __hfma2(input_vec[k_vec], weight_vec[k_vec], acc);
+    for (int k_vec = tid_k; k_vec < k_compute_vec_tile_size;
+         k_vec += BLOCK_K_THREADS) {
+      acc = vllm_rs::hfma2_wrapper(input_vec[k_vec], weight_vec[k_vec], acc);
     }
   }
 
+  float thread_sum;
+  if constexpr (std::is_same_v<AccumT, float2>) {
+    thread_sum = acc.x + acc.y;
+  } else {
+    thread_sum = vllm::to_float(__hadd(acc.x, acc.y));
+  }
+  s_acc[tid_n][tid_k] = thread_sum;
   __syncthreads();
 
-  // Finalize and Write Output
-  if (topk_weights) {
-    // Apply top-k weight scaling
-    T output_val;
-    vllm::from_float(output_val, vllm::to_float(__hadd(acc.x, acc.y)) *
-                                     topk_weights[token_id]);
-    output[token_id * N + n] = output_val;
-  } else {
-    output[token_id * N + n] = __hadd(acc.x, acc.y);
+  if (tid_k == 0) {
+    float final_sum = 0.0f;
+#pragma unroll
+    for (int i = 0; i < BLOCK_K_THREADS; ++i) {
+      final_sum += s_acc[tid_n][i];
+    }
+
+    if (topk_weights) {
+      T output_val;
+      vllm::from_float(output_val, final_sum * topk_weights[token_id]);
+      output[token_id * N + n] = output_val;
+    } else {
+      T output_val;
+      vllm::from_float(output_val, final_sum);
+      output[token_id * N + n] = output_val;
+    }
   }
 }
 
@@ -223,8 +258,8 @@ __global__ void moe_gemm_vectorized_kernel(
  * @param N                 Output dimension per expert.
  * @param K                 Input dimension per expert.
  */
-template <typename T, typename VecT, int BLOCK_N_TILE, int BLOCK_K_TILE,
-          int BLOCK_K_THREADS>
+template <typename T, typename VecT, typename AccumT, int BLOCK_N_TILE,
+          int BLOCK_K_TILE, int BLOCK_K_THREADS>
 __global__ void moe_gemm_transposed_kernel(
     const T *__restrict__ input,   // [M, K]
     const T *__restrict__ weights, // [num_experts, K, N] - transposed layout
@@ -274,9 +309,10 @@ __global__ void moe_gemm_transposed_kernel(
   // s_weights: Caches the [N, K] weight matrix tile (conceptually transposed
   // from global) Layout: [BLOCK_N_TILE][BLOCK_K_TILE] for coalesced compute
   __shared__ T s_weights[BLOCK_N_TILE][BLOCK_K_TILE];
+  __shared__ float s_acc[BLOCK_N_TILE][BLOCK_K_THREADS];
 
   // This thread's accumulator
-  VecT acc;
+  AccumT acc;
   vllm_rs::zero(acc);
   LoadVecT zero_vec;
   zero_vec.x = zero_vec.y = zero_vec.z = zero_vec.w = 0.0f;
@@ -324,34 +360,49 @@ __global__ void moe_gemm_transposed_kernel(
     VecT *input_vec = reinterpret_cast<VecT *>(s_input);
     VecT *weight_vec = reinterpret_cast<VecT *>(s_weights[tid_n]);
 #pragma unroll
-    for (int k_vec = 0; k_vec < k_compute_vec_tile_size; ++k_vec) {
-      acc = __hfma2(input_vec[k_vec], weight_vec[k_vec], acc);
+    for (int k_vec = tid_k; k_vec < k_compute_vec_tile_size;
+         k_vec += BLOCK_K_THREADS) {
+      acc = vllm_rs::hfma2_wrapper(input_vec[k_vec], weight_vec[k_vec], acc);
     }
   }
 
+  float thread_sum;
+  if constexpr (std::is_same_v<AccumT, float2>) {
+    thread_sum = acc.x + acc.y;
+  } else {
+    thread_sum = vllm::to_float(__hadd(acc.x, acc.y));
+  }
+  s_acc[tid_n][tid_k] = thread_sum;
   __syncthreads();
 
-  // Finalize and Write Output
-  if (topk_weights) {
-    // Apply top-k weight scaling
-    T output_val;
-    vllm::from_float(output_val, vllm::to_float(__hadd(acc.x, acc.y)) *
-                                     topk_weights[token_id]);
-    output[token_id * N + n] = output_val;
-  } else {
-    output[token_id * N + n] = __hadd(acc.x, acc.y);
+  if (tid_k == 0) {
+    float final_sum = 0.0f;
+#pragma unroll
+    for (int i = 0; i < BLOCK_K_THREADS; ++i) {
+      final_sum += s_acc[tid_n][i];
+    }
+
+    if (topk_weights) {
+      T output_val;
+      vllm::from_float(output_val, final_sum * topk_weights[token_id]);
+      output[token_id * N + n] = output_val;
+    } else {
+      T output_val;
+      vllm::from_float(output_val, final_sum);
+      output[token_id * N + n] = output_val;
+    }
   }
 }
 
 extern "C" void
-moe_gemm(const void *input,   // input [size_m or size_m / topk, size_k]
-         const void *weights, // weights [num_experts, size_n, size_k]
-         const int32_t *sorted_token_ids, const int32_t *expert_ids,
-         const float *topk_weights, // device ptr or nullptr
-         void *output,              // output [size_m, size_n]
-         int num_experts, int topk, int size_m, int size_n, int size_k,
-         int dtype, // 0=float16, 1=bf16
-         cudaStream_t stream) {
+mistralrs_moe_gemm(const void *input,   // input [size_m or size_m / topk, size_k]
+                   const void *weights, // weights [num_experts, size_n, size_k]
+                   const int32_t *sorted_token_ids, const int32_t *expert_ids,
+                   const float *topk_weights, // device ptr or nullptr
+                   void *output,              // output [size_m, size_n]
+                   int num_experts, int topk, int size_m, int size_n, int size_k,
+                   int dtype, // 0=float16, 1=bf16
+                   cudaStream_t stream) {
 
   // These tile sizes can be tuned based on GPU architecture and problem size
   constexpr int BLOCK_N_TILE = 64;
@@ -378,7 +429,7 @@ moe_gemm(const void *input,   // input [size_m or size_m / topk, size_k]
   // cudaMemsetAsync(output, 0, output_bytes, stream);
 
   if (dtype == 0) {
-    moe_gemm_vectorized_kernel<half, half2, BLOCK_N_TILE, BLOCK_K_TILE,
+    moe_gemm_vectorized_kernel<half, half2, half2, BLOCK_N_TILE, BLOCK_K_TILE,
                                BLOCK_K_THREADS><<<grids, blocks, 0, stream>>>(
         reinterpret_cast<const half *>(input),
         reinterpret_cast<const half *>(weights), sorted_token_ids, expert_ids,
@@ -387,13 +438,23 @@ moe_gemm(const void *input,   // input [size_m or size_m / topk, size_k]
   }
 #ifndef NO_BF16_KERNEL
   else if (dtype == 1) {
-    moe_gemm_vectorized_kernel<nv_bfloat16, nv_bfloat162, BLOCK_N_TILE,
-                               BLOCK_K_TILE, BLOCK_K_THREADS>
+#if defined(ALLOW_LEGACY_BF16)
+    moe_gemm_vectorized_kernel<nv_bfloat16, nv_bfloat162, float2,
+                               BLOCK_N_TILE, BLOCK_K_TILE, BLOCK_K_THREADS>
         <<<grids, blocks, 0, stream>>>(
             reinterpret_cast<const nv_bfloat16 *>(input),
             reinterpret_cast<const nv_bfloat16 *>(weights), sorted_token_ids,
             expert_ids, topk_weights, reinterpret_cast<nv_bfloat16 *>(output),
             num_experts, topk, size_m, size_n, size_k);
+#else
+    moe_gemm_vectorized_kernel<nv_bfloat16, nv_bfloat162, nv_bfloat162,
+                               BLOCK_N_TILE, BLOCK_K_TILE, BLOCK_K_THREADS>
+        <<<grids, blocks, 0, stream>>>(
+            reinterpret_cast<const nv_bfloat16 *>(input),
+            reinterpret_cast<const nv_bfloat16 *>(weights), sorted_token_ids,
+            expert_ids, topk_weights, reinterpret_cast<nv_bfloat16 *>(output),
+            num_experts, topk, size_m, size_n, size_k);
+#endif
   }
 #endif
   else {
@@ -403,7 +464,7 @@ moe_gemm(const void *input,   // input [size_m or size_m / topk, size_k]
 
 // Transposed weight variant: weights are [num_experts, size_k, size_n] instead
 // of [num_experts, size_n, size_k]
-extern "C" void moe_gemm_transposed(
+extern "C" void mistralrs_moe_gemm_transposed(
     const void *input, // input [size_m or size_m / topk, size_k]
     const void
         *weights, // weights [num_experts, size_k, size_n] - transposed layout
@@ -431,7 +492,7 @@ extern "C" void moe_gemm_transposed(
                "size_k must be divisible by vector size (2 for fp16/bf16)");
 
   if (dtype == 0) {
-    moe_gemm_transposed_kernel<half, half2, BLOCK_N_TILE, BLOCK_K_TILE,
+    moe_gemm_transposed_kernel<half, half2, half2, BLOCK_N_TILE, BLOCK_K_TILE,
                                BLOCK_K_THREADS><<<grids, blocks, 0, stream>>>(
         reinterpret_cast<const half *>(input),
         reinterpret_cast<const half *>(weights), sorted_token_ids, expert_ids,
@@ -440,13 +501,23 @@ extern "C" void moe_gemm_transposed(
   }
 #ifndef NO_BF16_KERNEL
   else if (dtype == 1) {
-    moe_gemm_transposed_kernel<nv_bfloat16, nv_bfloat162, BLOCK_N_TILE,
+#if defined(ALLOW_LEGACY_BF16)
+    moe_gemm_transposed_kernel<nv_bfloat16, nv_bfloat162, float2, BLOCK_N_TILE,
                                BLOCK_K_TILE, BLOCK_K_THREADS>
         <<<grids, blocks, 0, stream>>>(
             reinterpret_cast<const nv_bfloat16 *>(input),
             reinterpret_cast<const nv_bfloat16 *>(weights), sorted_token_ids,
             expert_ids, topk_weights, reinterpret_cast<nv_bfloat16 *>(output),
             num_experts, topk, size_m, size_n, size_k);
+#else
+    moe_gemm_transposed_kernel<nv_bfloat16, nv_bfloat162, nv_bfloat162,
+                               BLOCK_N_TILE, BLOCK_K_TILE, BLOCK_K_THREADS>
+        <<<grids, blocks, 0, stream>>>(
+            reinterpret_cast<const nv_bfloat16 *>(input),
+            reinterpret_cast<const nv_bfloat16 *>(weights), sorted_token_ids,
+            expert_ids, topk_weights, reinterpret_cast<nv_bfloat16 *>(output),
+            num_experts, topk, size_m, size_n, size_k);
+#endif
   }
 #endif
   else {

--- a/mistralrs-core/src/cuda/moe_gemm_hfma2.cu
+++ b/mistralrs-core/src/cuda/moe_gemm_hfma2.cu
@@ -1,0 +1,235 @@
+/**
+ * @brief CUDA kernel for Mixture-of-Experts (MoE) GEMM using half2/bf162
+ * vectorized arithmetic as a fallback for WMMA.
+ *
+ * Adapted from candle-kernels for mistral.rs
+ */
+
+#include "moe_utils.h"
+#include <cstdint>
+#include <cstdio>
+#include <type_traits>
+
+namespace vllm_rs {
+
+#define CEILDIV(x, y) (((x) + (y) - 1) / (y))
+
+constexpr int M_BLK = 32;
+constexpr int N_BLK = 32;
+constexpr int K_BLK = 16;
+constexpr int BLOCK_THREADS = 128;
+constexpr int THREADS_PER_GROUP = 16;
+
+template <typename T2>
+static __device__ __forceinline__ float hfma2_dot2(T2 a, T2 b) {
+#if defined(__CUDA_ARCH__) && __CUDA_ARCH__ >= 800
+  if constexpr (std::is_same_v<T2, nv_bfloat162>) {
+    nv_bfloat162 res = __hmul2(a, b);
+    return __bfloat162float(res.x) + __bfloat162float(res.y);
+  }
+#endif
+#if defined(__CUDA_ARCH__) && __CUDA_ARCH__ >= 530
+  if constexpr (std::is_same_v<T2, half2>) {
+    half2 res = __hmul2(a, b);
+    return __half2float(res.x) + __half2float(res.y);
+  }
+#endif
+
+  if constexpr (std::is_same_v<T2, nv_bfloat162>) {
+    return __bfloat162float(a.x) * __bfloat162float(b.x) +
+           __bfloat162float(a.y) * __bfloat162float(b.y);
+  } else {
+    return vllm::to_float(a.x) * vllm::to_float(b.x) +
+           vllm::to_float(a.y) * vllm::to_float(b.y);
+  }
+}
+
+template <typename T, typename T2>
+__global__ void moe_gemm_hfma2_kernel(
+    const T *__restrict__ input,                  // [num_tokens, size_k]
+    const T *__restrict__ weights,                // [num_experts, size_n, size_k]
+    const int32_t *__restrict__ sorted_token_ids, // [size_m]
+    const int32_t *__restrict__ expert_offsets,   // [num_experts + 1]
+    const float *__restrict__ topk_weights,       // [size_m]
+    T *__restrict__ output,                       // [size_m, size_n]
+    const int num_experts, const int topk, const int32_t size_m,
+    const int32_t size_n, const int32_t size_k) {
+  const int expert_id = blockIdx.x;
+  const int n_tile_idx = blockIdx.y;
+  if (expert_id >= num_experts)
+    return;
+
+  const int segment_start = expert_offsets[expert_id];
+  const int segment_end = expert_offsets[expert_id + 1];
+  const int num_rows_in_segment = segment_end - segment_start;
+  if (num_rows_in_segment <= 0)
+    return;
+
+  const int n_base = n_tile_idx * N_BLK;
+  if (n_base >= size_n)
+    return;
+
+  const T *expert_w =
+      weights + (size_t)expert_id * (size_t)size_n * (size_t)size_k;
+
+  constexpr int K_PAD = K_BLK + 2;
+  extern __shared__ uint8_t smem_bytes[];
+  T *A_sh = reinterpret_cast<T *>(smem_bytes);
+  T *B_sh = reinterpret_cast<T *>(A_sh + M_BLK * K_PAD);
+
+  const int tid = threadIdx.x;
+
+  for (int m_base = 0; m_base < num_rows_in_segment; m_base += M_BLK) {
+    float acc[8] = {0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f};
+
+    for (int k_base = 0; k_base < size_k; k_base += K_BLK) {
+      constexpr int A_ELEMS = M_BLK * K_BLK;
+      for (int i = tid; i < A_ELEMS / 2; i += BLOCK_THREADS) {
+        int idx = i * 2;
+        int m_local = idx / K_BLK;
+        int k_local = idx % K_BLK;
+        int m_seg = m_base + m_local;
+        int k_global = k_base + k_local;
+
+        T *dest = &A_sh[m_local * K_PAD + k_local];
+        T2 val;
+
+        if (m_seg < num_rows_in_segment && (k_global + 1) < size_k) {
+          int token_pair_index = segment_start + m_seg;
+          int token_index = sorted_token_ids[token_pair_index];
+          int input_index = topk_weights ? token_index : (token_index / topk);
+          val = *reinterpret_cast<const T2 *>(
+              &input[(size_t)input_index * size_k + k_global]);
+        } else if (m_seg < num_rows_in_segment && k_global < size_k) {
+          reinterpret_cast<T *>(&val)[0] =
+              input[(size_t)(topk_weights ? sorted_token_ids[segment_start + m_seg]
+                                          : (sorted_token_ids[segment_start + m_seg] / topk)) *
+                        size_k +
+                    k_global];
+          reinterpret_cast<T *>(&val)[1] = T(0.0f);
+        } else {
+          val = T2{T(0.0f), T(0.0f)};
+        }
+        *reinterpret_cast<T2 *>(dest) = val;
+      }
+
+      constexpr int B_ELEMS = N_BLK * K_BLK;
+      for (int i = tid; i < B_ELEMS / 2; i += BLOCK_THREADS) {
+        int idx = i * 2;
+        int n_local = idx / K_BLK;
+        int k_local = idx % K_BLK;
+        int n_global = n_base + n_local;
+        int k_global = k_base + k_local;
+
+        T *dest = &B_sh[n_local * K_PAD + k_local];
+        T2 val;
+
+        if (n_global < size_n && (k_global + 1) < size_k) {
+          val = *reinterpret_cast<const T2 *>(
+              &expert_w[(size_t)n_global * size_k + k_global]);
+        } else if (n_global < size_n && k_global < size_k) {
+          reinterpret_cast<T *>(&val)[0] =
+              expert_w[(size_t)n_global * size_k + k_global];
+          reinterpret_cast<T *>(&val)[1] = T(0.0f);
+        } else {
+          val = T2{T(0.0f), T(0.0f)};
+        }
+        *reinterpret_cast<T2 *>(dest) = val;
+      }
+      __syncthreads();
+
+      const int group_id = tid / THREADS_PER_GROUP;
+      const int lane_id = tid % THREADS_PER_GROUP;
+      const int m_start = group_id * 4;
+      const int n_start = lane_id * 2;
+
+      const T2 *A2_sh = reinterpret_cast<const T2 *>(A_sh);
+      const T2 *B2_sh = reinterpret_cast<const T2 *>(B_sh);
+
+      for (int k2 = 0; k2 < K_BLK / 2; ++k2) {
+        T2 a2[4];
+        for (int r = 0; r < 4; ++r) {
+          a2[r] = A2_sh[(m_start + r) * (K_PAD / 2) + k2];
+        }
+
+        T2 b2[2];
+        for (int c = 0; c < 2; ++c) {
+          b2[c] = B2_sh[(n_start + c) * (K_PAD / 2) + k2];
+        }
+
+        for (int r = 0; r < 4; ++r) {
+          for (int c = 0; c < 2; ++c) {
+            acc[r * 2 + c] += hfma2_dot2(a2[r], b2[c]);
+          }
+        }
+      }
+      __syncthreads();
+    }
+
+    const int group_id = tid / THREADS_PER_GROUP;
+    const int lane_id = tid % THREADS_PER_GROUP;
+    const int m_start = group_id * 4;
+    const int n_start = lane_id * 2;
+
+    for (int r = 0; r < 4; ++r) {
+      int m_seg = m_base + m_start + r;
+      if (m_seg >= num_rows_in_segment)
+        continue;
+
+      int token_pair_index = segment_start + m_seg;
+      int token_index = sorted_token_ids[token_pair_index];
+
+      for (int c = 0; c < 2; ++c) {
+        int n_global = n_base + n_start + c;
+        if (n_global >= size_n)
+          continue;
+
+        float val = acc[r * 2 + c];
+        if (topk_weights) {
+          val *= topk_weights[token_index];
+        }
+        vllm::from_float(output[(size_t)token_index * size_n + n_global], val);
+      }
+    }
+  }
+}
+
+} // namespace vllm_rs
+
+extern "C" void mistralrs_moe_gemm_hfma2(
+    const void *input, const void *weights, const int32_t *sorted_token_ids,
+    const int32_t *expert_ids, const float *topk_weights, void *output,
+    int32_t *expert_offsets, int num_experts, int topk, int size_m, int size_n,
+    int size_k, int data_type, cudaStream_t stream) {
+  using namespace vllm_rs;
+
+  calculate_expert_offsets(expert_ids, size_m, expert_offsets, num_experts,
+                           stream);
+
+  int grid_n = CEILDIV(size_n, N_BLK);
+  dim3 grid(num_experts, grid_n, 1);
+  dim3 block(BLOCK_THREADS, 1, 1);
+
+  constexpr int K_PAD = K_BLK + 2;
+  size_t smem_bytes =
+      (M_BLK * K_PAD + N_BLK * K_PAD) * 2; // sizeof(half) or sizeof(bfloat16)
+
+  if (data_type == 0) {
+    moe_gemm_hfma2_kernel<half, half2><<<grid, block, smem_bytes, stream>>>(
+        reinterpret_cast<const half *>(input),
+        reinterpret_cast<const half *>(weights), sorted_token_ids,
+        expert_offsets, topk_weights, reinterpret_cast<half *>(output),
+        num_experts, topk, size_m, size_n, size_k);
+  }
+#ifndef NO_BF16_KERNEL
+  else if (data_type == 1) {
+    moe_gemm_hfma2_kernel<nv_bfloat16, nv_bfloat162>
+        <<<grid, block, smem_bytes, stream>>>(
+            reinterpret_cast<const nv_bfloat16 *>(input),
+            reinterpret_cast<const nv_bfloat16 *>(weights), sorted_token_ids,
+            expert_offsets, topk_weights,
+            reinterpret_cast<nv_bfloat16 *>(output), num_experts, topk, size_m,
+            size_n, size_k);
+  }
+#endif
+}

--- a/mistralrs-core/src/cuda/moe_gemm_wmma.cu
+++ b/mistralrs-core/src/cuda/moe_gemm_wmma.cu
@@ -28,12 +28,15 @@
 #include <cstring>
 #include <cuda.h>
 #include <cuda_runtime.h>
+#if !defined(__CUDA_ARCH__) || __CUDA_ARCH__ >= 700
 #include <mma.h>
-#include <vector>
 using namespace nvcuda::wmma;
+#endif
+#include <vector>
 
 #define CEILDIV(x, y) (((x) + (y) - 1) / (y))
 
+#if !defined(__CUDA_ARCH__) || __CUDA_ARCH__ >= 700
 constexpr int WMMA_M = 16;
 constexpr int WMMA_N = 16;
 constexpr int WMMA_K = 16;
@@ -52,6 +55,13 @@ constexpr int BLOCK_THREADS = WARPS_PER_BLOCK * 32; // 128 threads
 constexpr int M_BLK = WARPS_M * WMMA_M; // 32
 constexpr int N_BLK = WARPS_N * WMMA_N; // 32
 constexpr int K_BLK = WMMA_K;           // 16
+#else
+using VecT = float4;
+constexpr int BLOCK_THREADS = 128;
+constexpr int M_BLK = 32;
+constexpr int N_BLK = 32;
+constexpr int K_BLK = 16;
+#endif
 
 /**
  *  @brief  WMMA-based grouped MoE GEMM kernel.
@@ -85,6 +95,7 @@ __global__ void moe_gemm_grouped_kernel(
     T *__restrict__ output, // [size_m, size_n] (Zero-initialized)
     const int num_experts, const int topk, const int32_t size_m,
     const int32_t size_n, const int32_t size_k) {
+#if !defined(__CUDA_ARCH__) || __CUDA_ARCH__ >= 700
   // Get Segment and N-Tile for this Block
   const int expert_id = blockIdx.x;
   const int n_tile_idx = blockIdx.y;
@@ -236,6 +247,7 @@ __global__ void moe_gemm_grouped_kernel(
       }
     }
   } // end m_base loop
+#endif
 }
 
 /**
@@ -271,6 +283,7 @@ __global__ void moe_gemm_grouped_transposed_kernel(
     T *__restrict__ output, // [size_m, size_n] (Zero-initialized)
     const int num_experts, const int topk, const int32_t size_m,
     const int32_t size_n, const int32_t size_k) {
+#if !defined(__CUDA_ARCH__) || __CUDA_ARCH__ >= 700
   // Get Segment and N-Tile for this Block
   const int expert_id = blockIdx.x;
   const int n_tile_idx = blockIdx.y;
@@ -421,18 +434,19 @@ __global__ void moe_gemm_grouped_transposed_kernel(
       }
     }
   } // end m_base loop
+#endif
 }
 
 extern "C" void
-moe_gemm_wmma(const void *input,               // [size_m, size_k]
-              const void *weights,             // [num_experts, size_n, size_k]
-              const int32_t *sorted_token_ids, // [size_m] (Device)
-              const int32_t *expert_ids,       // [size_m * topk]
-              const float *topk_weights, // [size_m] (Device, can be nullptr)
-              void *output,              // [size_m, size_n]
-              int num_experts, int topk, int size_m, int size_n, int size_k,
-              int data_type, // 0 = half, 1 = bfloat16
-              cudaStream_t stream) {
+mistralrs_moe_gemm_wmma(const void *input,               // [size_m, size_k]
+                        const void *weights,             // [num_experts, size_n, size_k]
+                        const int32_t *sorted_token_ids, // [size_m] (Device)
+                        const int32_t *expert_ids,       // [size_m * topk]
+                        const float *topk_weights, // [size_m] (Device, can be nullptr)
+                        void *output,              // [size_m, size_n]
+                        int num_experts, int topk, int size_m, int size_n, int size_k,
+                        int data_type, // 0 = half, 1 = bfloat16
+                        cudaStream_t stream) {
   int32_t *expert_offsets;
   cudaMallocAsync(&expert_offsets, (num_experts + 1) * sizeof(int32_t), stream);
   calculate_expert_offsets(expert_ids, size_m, expert_offsets, num_experts,
@@ -471,7 +485,7 @@ moe_gemm_wmma(const void *input,               // [size_m, size_k]
 
 // Transposed weight variant: weights are [num_experts, size_k, size_n] instead
 // of [num_experts, size_n, size_k]
-extern "C" void moe_gemm_wmma_transposed(
+extern "C" void mistralrs_moe_gemm_wmma_transposed(
     const void *input,   // [size_m, size_k]
     const void *weights, // [num_experts, size_k, size_n] - transposed layout
     const int32_t *sorted_token_ids, // [size_m] (Device)

--- a/mistralrs-core/src/cuda/moe_gemv.cu
+++ b/mistralrs-core/src/cuda/moe_gemv.cu
@@ -126,10 +126,8 @@ __global__ void moe_gemv_kernel(
         half2 prod = __hmul2(in_v2[i], w_v2[i]);
         sum += __low2float(prod) + __high2float(prod);
       } else {
-        // For BF16, convert each element to float and accumulate
-        // Note: __hmul2 doesn't work with bfloat162 on older CUDA versions
-        sum += vllm::to_float(in_v2[i].x) * vllm::to_float(w_v2[i].x);
-        sum += vllm::to_float(in_v2[i].y) * vllm::to_float(w_v2[i].y);
+        sum += __bfloat162float(in_v2[i].x) * __bfloat162float(w_v2[i].x);
+        sum += __bfloat162float(in_v2[i].y) * __bfloat162float(w_v2[i].y);
       }
     }
   }
@@ -259,14 +257,14 @@ __global__ void moe_gemv_transposed_kernel(
 }
 
 extern "C" void
-moe_gemv(const void *input,   // input [size_m or size_m / topk, size_k]
-         const void *weights, // weights [num_experts, size_n, size_k]
-         const int32_t *sorted_token_ids, const int32_t *expert_ids,
-         const float *topk_weights, // device ptr or nullptr
-         void *output,              // output [size_m, size_n]
-         int num_experts, int topk, int size_m, int size_n, int size_k,
-         int dtype, // 0=float16, 1=bf16
-         cudaStream_t stream) {
+mistralrs_moe_gemv(const void *input,   // input [size_m or size_m / topk, size_k]
+                   const void *weights, // weights [num_experts, size_n, size_k]
+                   const int32_t *sorted_token_ids, const int32_t *expert_ids,
+                   const float *topk_weights, // device ptr or nullptr
+                   void *output,              // output [size_m, size_n]
+                   int num_experts, int topk, int size_m, int size_n, int size_k,
+                   int dtype, // 0=float16, 1=bf16
+                   cudaStream_t stream) {
 
   constexpr int BLOCK_SIZE = 256;
 
@@ -295,7 +293,7 @@ moe_gemv(const void *input,   // input [size_m or size_m / topk, size_k]
   }
 }
 
-extern "C" void moe_gemv_transposed(
+extern "C" void mistralrs_moe_gemv_transposed(
     const void *input, // input [size_m or size_m / topk, size_k]
     const void
         *weights, // weights [num_experts, size_k, size_n] - transposed layout

--- a/mistralrs-core/src/cuda/moe_utils.h
+++ b/mistralrs-core/src/cuda/moe_utils.h
@@ -51,6 +51,10 @@ inline __device__ float to_float(__nv_bfloat16 u) {
   return __bfloat162float(u);
 }
 
+inline __device__ float to_float(float f) {
+  return f;
+}
+
 } // namespace vllm
 
 #define ASSERT_THROW(cond, msg)                                                \

--- a/mistralrs-paged-attn/build.rs
+++ b/mistralrs-paged-attn/build.rs
@@ -11,6 +11,7 @@ fn main() -> Result<()> {
     println!("cargo::rustc-check-cfg=cfg(has_fp8)");
 
     println!("cargo:rerun-if-changed=build.rs");
+    println!("cargo:rerun-if-env-changed=ALLOW_LEGACY");
     println!("cargo:rerun-if-changed=src/cuda/pagedattention.cuh");
     println!("cargo:rerun-if-changed=src/cuda/copy_blocks_kernel.cu");
     println!("cargo:rerun-if-changed=src/cuda/reshape_and_cache_kernel.cu");
@@ -51,10 +52,20 @@ fn main() -> Result<()> {
         .arg("--compiler-options")
         .arg("-fPIC");
 
+    let allow_legacy = std::env::var("ALLOW_LEGACY").unwrap_or_default();
+    let allow_legacy_fp8 = allow_legacy == "all"
+        || allow_legacy
+            .split(',')
+            .map(str::trim)
+            .any(|value| value == "fp8");
+
     let compute_cap = builder.get_compute_cap().unwrap_or(80);
-    // Enable FP8 if compute capability >= 8.0 (Ampere and newer)
-    let using_fp8 = if compute_cap >= 80 {
+    // Enable FP8 on Ampere+ by default, or opt-in on older cards.
+    let using_fp8 = if compute_cap >= 80 || allow_legacy_fp8 {
         builder = builder.arg("-DENABLE_FP8");
+        if allow_legacy_fp8 {
+            builder = builder.arg("-DALLOW_LEGACY_FP8");
+        }
         true
     } else {
         false

--- a/mistralrs-paged-attn/src/cuda/attention/dtype_bfloat16.cuh
+++ b/mistralrs-paged-attn/src/cuda/attention/dtype_bfloat16.cuh
@@ -88,7 +88,10 @@ struct FloatVec<bf16_8_t> {
 // Utility functions for type conversions.
 inline __device__ float2 bf1622float2(const __nv_bfloat162 val) {
 #if defined(__CUDA_ARCH__) && __CUDA_ARCH__ < 800
-  assert(false);
+  float2 res;
+  res.x = __bfloat162float(val.x);
+  res.y = __bfloat162float(val.y);
+  return res;
 #else
   return __bfloat1622float2(val);
 #endif
@@ -96,7 +99,7 @@ inline __device__ float2 bf1622float2(const __nv_bfloat162 val) {
 
 inline __device__ __nv_bfloat162 bf162bf162(const __nv_bfloat16 val) {
 #if defined(__CUDA_ARCH__) && __CUDA_ARCH__ < 800
-  assert(false);
+  return __nv_bfloat162{val, val};
 #else
   return __bfloat162bfloat162(val);
 #endif
@@ -105,7 +108,7 @@ inline __device__ __nv_bfloat162 bf162bf162(const __nv_bfloat16 val) {
 // Vector addition.
 inline __device__ __nv_bfloat16 add(__nv_bfloat16 a, __nv_bfloat16 b) {
 #if defined(__CUDA_ARCH__) && __CUDA_ARCH__ < 800
-  assert(false);
+  return __float2bfloat16(__bfloat162float(a) + __bfloat162float(b));
 #else
   #ifndef USE_ROCM
     return a + b;
@@ -117,7 +120,8 @@ inline __device__ __nv_bfloat16 add(__nv_bfloat16 a, __nv_bfloat16 b) {
 
 inline __device__ __nv_bfloat162 add(__nv_bfloat162 a, __nv_bfloat162 b) {
 #if defined(__CUDA_ARCH__) && __CUDA_ARCH__ < 800
-  assert(false);
+  return __nv_bfloat162{__float2bfloat16(__bfloat162float(a.x) + __bfloat162float(b.x)),
+                        __float2bfloat16(__bfloat162float(a.y) + __bfloat162float(b.y))};
 #else
   return __hadd2(a, b);
 #endif
@@ -164,7 +168,7 @@ inline __device__ Float8_ add(bf16_8_t a, Float8_ fb) {
 template<>
 inline __device__ __nv_bfloat16 mul(__nv_bfloat16 a, __nv_bfloat16 b) {
 #if defined(__CUDA_ARCH__) && __CUDA_ARCH__ < 800
-  assert(false);
+  return __float2bfloat16(__bfloat162float(a) * __bfloat162float(b));
 #else
   return __hmul(a, b);
 #endif
@@ -173,7 +177,8 @@ inline __device__ __nv_bfloat16 mul(__nv_bfloat16 a, __nv_bfloat16 b) {
 template<>
 inline __device__ __nv_bfloat162 mul(__nv_bfloat162 a, __nv_bfloat162 b) {
 #if defined(__CUDA_ARCH__) && __CUDA_ARCH__ < 800
-  assert(false);
+  return __nv_bfloat162{__float2bfloat16(__bfloat162float(a.x) * __bfloat162float(b.x)),
+                        __float2bfloat16(__bfloat162float(a.y) * __bfloat162float(b.y))};
 #else
   return __hmul2(a, b);
 #endif
@@ -282,7 +287,9 @@ inline __device__ Float8_ mul(__nv_bfloat16 a, bf16_8_t b) {
 // Vector fused multiply-add.
 inline __device__ __nv_bfloat162 fma(__nv_bfloat162 a, __nv_bfloat162 b, __nv_bfloat162 c) {
 #if defined(__CUDA_ARCH__) && __CUDA_ARCH__ < 800
-  assert(false);
+  return __nv_bfloat162{
+      __float2bfloat16(__bfloat162float(a.x) * __bfloat162float(b.x) + __bfloat162float(c.x)),
+      __float2bfloat16(__bfloat162float(a.y) * __bfloat162float(b.y) + __bfloat162float(c.y))};
 #else
   return __hfma2(a, b, c);
 #endif
@@ -290,7 +297,7 @@ inline __device__ __nv_bfloat162 fma(__nv_bfloat162 a, __nv_bfloat162 b, __nv_bf
 
 inline __device__ __nv_bfloat162 fma(__nv_bfloat16 a, __nv_bfloat162 b, __nv_bfloat162 c) {
 #if defined(__CUDA_ARCH__) && __CUDA_ARCH__ < 800
-  assert(false);
+  return fma(bf162bf162(a), b, c);
 #else
   return __hfma2(bf162bf162(a), b, c);
 #endif
@@ -407,7 +414,8 @@ inline __device__ void from_float(__nv_bfloat16& dst, float src) {
 
 inline __device__ void from_float(__nv_bfloat162& dst, float2 src) {
 #if defined(__CUDA_ARCH__) && __CUDA_ARCH__ < 800
-  assert(false);
+  dst.x = __float2bfloat16(src.x);
+  dst.y = __float2bfloat16(src.y);
 #else
   dst = __float22bfloat162_rn(src);
 #endif
@@ -415,7 +423,8 @@ inline __device__ void from_float(__nv_bfloat162& dst, float2 src) {
 
 inline __device__ void from_float(bf16_4_t& dst, Float4_ src) {
 #if defined(__CUDA_ARCH__) && __CUDA_ARCH__ < 800
-  assert(false);
+  from_float(dst.x, src.x);
+  from_float(dst.y, src.y);
 #else
   dst.x = __float22bfloat162_rn(src.x);
   dst.y = __float22bfloat162_rn(src.y);
@@ -424,7 +433,10 @@ inline __device__ void from_float(bf16_4_t& dst, Float4_ src) {
 
 inline __device__ void from_float(bf16_8_t& dst, Float8_ src) {
 #if defined(__CUDA_ARCH__) && __CUDA_ARCH__ < 800
-  assert(false);
+  from_float(dst.x, src.x);
+  from_float(dst.y, src.y);
+  from_float(dst.z, src.z);
+  from_float(dst.w, src.w);
 #else
   dst.x = __float22bfloat162_rn(src.x);
   dst.y = __float22bfloat162_rn(src.y);
@@ -441,7 +453,7 @@ inline __device__ float to_float(__nv_bfloat16 u) {
 // Zero-out a variable.
 inline __device__ void zero(__nv_bfloat16& dst) {
 #if defined(__CUDA_ARCH__) && __CUDA_ARCH__ < 800
-  assert(false);
+  dst = __float2bfloat16(0.0f);
 #else
   // Same as CUDART_ZERO_BF16 introduced in CUDA 12.2.
   dst = __ushort_as_bfloat16((unsigned short)0x0000U);

--- a/mistralrs-paged-attn/src/cuda/backend/paged_attention.rs
+++ b/mistralrs-paged-attn/src/cuda/backend/paged_attention.rs
@@ -130,7 +130,7 @@ impl PagedAttention {
             std::ptr::null()
         };
 
-        let (k_scale_ptr, v_scale_ptr) =
+        let (k_scale_ptr, v_scale_ptr) = if cache_dtype == 3 {
             if let (Some(k_scale), Some(v_scale)) = (&self.k_scale, &self.v_scale) {
                 if !crate::cuda::USE_FP8 {
                     candle::bail!("FP8 is not supported on this system.");
@@ -155,7 +155,10 @@ impl PagedAttention {
                 (ks as *const f32, vs as *const f32)
             } else {
                 (std::ptr::null(), std::ptr::null())
-            };
+            }
+        } else {
+            (std::ptr::null(), std::ptr::null())
+        };
 
         let sinks_ptr = if let Some(sinks) = self.sinks.as_ref() {
             let (s, s_l) = sinks.storage_and_layout();
@@ -513,28 +516,32 @@ fn update_cache<
     let v = v.slice(v_l.start_offset()..);
     let s = s.slice(s_l.start_offset()..);
 
-    let (k_scale_ptr, v_scale_ptr) = if let (Some(k_scale), Some(v_scale)) = (k_scale, v_scale) {
-        if !crate::cuda::USE_FP8 {
-            candle::bail!("FP8 is not supported on this system.");
+    let (k_scale_ptr, v_scale_ptr) = if cache_dtype == 3 {
+        if let (Some(k_scale), Some(v_scale)) = (k_scale, v_scale) {
+            if !crate::cuda::USE_FP8 {
+                candle::bail!("FP8 is not supported on this system.");
+            }
+
+            let (ks, ks_l) = k_scale.storage_and_layout();
+            let ks = match &*ks {
+                Storage::Cuda(ks) => ks,
+                _ => candle::bail!("k_scale must be a cuda tensor"),
+            };
+            let ks = ks.as_cuda_slice::<f32>()?;
+            let (ks, _ks_guard) = slice_ptr(ks, ks_l.start_offset());
+
+            let (vs, vs_l) = v_scale.storage_and_layout();
+            let vs = match &*vs {
+                Storage::Cuda(vs) => vs,
+                _ => candle::bail!("v_scale must be a cuda tensor"),
+            };
+            let vs = vs.as_cuda_slice::<f32>()?;
+            let (vs, _vs_guard) = slice_ptr(vs, vs_l.start_offset());
+
+            (ks as *const f32, vs as *const f32)
+        } else {
+            (std::ptr::null(), std::ptr::null())
         }
-
-        let (ks, ks_l) = k_scale.storage_and_layout();
-        let ks = match &*ks {
-            Storage::Cuda(ks) => ks,
-            _ => candle::bail!("k_scale must be a cuda tensor"),
-        };
-        let ks = ks.as_cuda_slice::<f32>()?;
-        let (ks, _ks_guard) = slice_ptr(ks, ks_l.start_offset());
-
-        let (vs, vs_l) = v_scale.storage_and_layout();
-        let vs = match &*vs {
-            Storage::Cuda(vs) => vs,
-            _ => candle::bail!("v_scale must be a cuda tensor"),
-        };
-        let vs = vs.as_cuda_slice::<f32>()?;
-        let (vs, _vs_guard) = slice_ptr(vs, vs_l.start_offset());
-
-        (ks as *const f32, vs as *const f32)
     } else {
         (std::ptr::null(), std::ptr::null())
     };

--- a/mistralrs-paged-attn/src/cuda/flashinfer/utils.cuh
+++ b/mistralrs-paged-attn/src/cuda/flashinfer/utils.cuh
@@ -27,6 +27,11 @@
 #include <type_traits>
 #include <vector>
 
+#if defined(__CUDA_ARCH__) && (__CUDA_ARCH__ < 700)
+#undef __grid_constant__
+#define __grid_constant__
+#endif
+
 #include "exception.h"
 
 #define STR_HELPER(x) #x

--- a/mistralrs-paged-attn/src/cuda/quantization/fp8/nvidia/quant_utils.cuh
+++ b/mistralrs-paged-attn/src/cuda/quantization/fp8/nvidia/quant_utils.cuh
@@ -197,14 +197,9 @@ template <>
 __inline__ __device__ uint8_t scaled_vec_conversion<uint8_t, __nv_bfloat16>(
     const __nv_bfloat16& a, const float scale,
     const __nv_fp8_interpretation_t fp8_type) {
-    #if defined(__CUDA_ARCH__) && __CUDA_ARCH__ < 800
-  assert(false);
-    #else
   __nv_fp8_storage_t res = __nv_cvt_float_to_fp8(__bfloat162float(a) / scale,
                                                  __NV_SATFINITE, fp8_type);
   return (uint8_t)res;
-    #endif
-  __builtin_unreachable();  // Suppress missing return statement warning
 }
 
 // float -> fp8

--- a/mistralrs-quant/build.rs
+++ b/mistralrs-quant/build.rs
@@ -49,6 +49,7 @@ fn main() -> Result<(), String> {
     println!("cargo::rustc-check-cfg=cfg(has_vector_fp8_kernels)");
     println!("cargo::rustc-check-cfg=cfg(has_mxfp4_kernels)");
     println!("cargo::rustc-check-cfg=cfg(has_mxfp4_wmma_kernels)");
+    println!("cargo::rustc-check-cfg=cfg(allow_legacy_bf16)");
 
     #[cfg(feature = "cuda")]
     {
@@ -56,6 +57,7 @@ fn main() -> Result<(), String> {
         const CUDA_NVCC_FLAGS: Option<&'static str> = option_env!("CUDA_NVCC_FLAGS");
 
         println!("cargo:rerun-if-changed=build.rs");
+        println!("cargo:rerun-if-env-changed=ALLOW_LEGACY");
         let build_dir = PathBuf::from(std::env::var("OUT_DIR").unwrap());
 
         let mut builder = cudaforge::KernelBuilder::new()
@@ -73,6 +75,17 @@ fn main() -> Result<(), String> {
             .arg("--verbose")
             .arg("--compiler-options")
             .arg("-fPIC");
+
+        let allow_legacy = std::env::var("ALLOW_LEGACY").unwrap_or_default();
+        let allow_legacy_bf16 = allow_legacy == "all"
+            || allow_legacy
+                .split(',')
+                .map(str::trim)
+                .any(|value| value == "bf16");
+        if allow_legacy_bf16 {
+            builder = builder.arg("-DALLOW_LEGACY_BF16");
+            println!("cargo:rustc-cfg=allow_legacy_bf16");
+        }
 
         let compute_cap = builder.get_compute_cap().unwrap_or(80);
         // ======== Handle optional kernel compilation via rustc-cfg flags

--- a/mistralrs-quant/build.rs
+++ b/mistralrs-quant/build.rs
@@ -50,6 +50,7 @@ fn main() -> Result<(), String> {
     println!("cargo::rustc-check-cfg=cfg(has_mxfp4_kernels)");
     println!("cargo::rustc-check-cfg=cfg(has_mxfp4_wmma_kernels)");
     println!("cargo::rustc-check-cfg=cfg(allow_legacy_bf16)");
+    println!("cargo::rustc-check-cfg=cfg(allow_legacy_fp8)");
 
     #[cfg(feature = "cuda")]
     {
@@ -82,28 +83,42 @@ fn main() -> Result<(), String> {
                 .split(',')
                 .map(str::trim)
                 .any(|value| value == "bf16");
+        let allow_legacy_fp8 = allow_legacy == "all"
+            || allow_legacy
+                .split(',')
+                .map(str::trim)
+                .any(|value| value == "fp8");
         if allow_legacy_bf16 {
             builder = builder.arg("-DALLOW_LEGACY_BF16");
             println!("cargo:rustc-cfg=allow_legacy_bf16");
+        }
+        if allow_legacy_fp8 {
+            builder = builder.arg("-DALLOW_LEGACY_FP8");
+            println!("cargo:rustc-cfg=allow_legacy_fp8");
         }
 
         let compute_cap = builder.get_compute_cap().unwrap_or(80);
         // ======== Handle optional kernel compilation via rustc-cfg flags
         let cc_over_80 = compute_cap >= 80;
+        let enable_legacy_fp8 = cc_over_80 || allow_legacy_fp8;
 
         if cc_over_80 {
             println!("cargo:rustc-cfg=has_marlin_kernels");
+            // WMMA tensor core MXFP4 kernel (FP16/BF16 WMMA requires SM >= 80)
+            println!("cargo:rustc-cfg=has_mxfp4_wmma_kernels");
+        }
+        if enable_legacy_fp8 {
             println!("cargo:rustc-cfg=has_blockwise_fp8_kernels");
             println!("cargo:rustc-cfg=has_scalar_fp8_kernels");
             println!("cargo:rustc-cfg=has_vector_fp8_kernels");
-            // WMMA tensor core MXFP4 kernel (FP16/BF16 WMMA requires SM >= 80)
-            println!("cargo:rustc-cfg=has_mxfp4_wmma_kernels");
         }
         // MXFP4 is always enabled with CUDA (uses LUT-based dequantization)
         println!("cargo:rustc-cfg=has_mxfp4_kernels");
 
         let excluded_files = if cc_over_80 {
             vec!["dummy_*.cu", "*_dummy.cu"]
+        } else if allow_legacy_fp8 {
+            vec!["dummy_*.cu", "*_dummy.cu", "marlin_*.cu", "*_wmma.cu"]
         } else {
             vec!["marlin_*.cu", "*_fp8.cu", "*_fp8_gemm.cu", "*_wmma.cu"]
         };

--- a/mistralrs-quant/kernels/afq/afq.cu
+++ b/mistralrs-quant/kernels/afq/afq.cu
@@ -148,7 +148,7 @@ __device__ void compute_scale_bias_warp(const T *w, int group_start, int cols,
       } else if constexpr (std::is_same_v<T, __half>) {
         val = __half2float(w[col]);
       }
-#if __CUDA_ARCH__ >= 800
+#if __CUDA_ARCH__ >= 800 || defined(ALLOW_LEGACY_BF16)
       else if constexpr (std::is_same_v<T, __nv_bfloat16>) {
         val = __bfloat162float(w[col]);
       }
@@ -213,7 +213,7 @@ afq_quantize_kernel(const T *__restrict__ w, uint32_t *__restrict__ w_q,
       scales[row * groups_per_row + group_idx] = __float2half(final_scale);
       biases[row * groups_per_row + group_idx] = __float2half(bias);
     }
-#if __CUDA_ARCH__ >= 800
+#if __CUDA_ARCH__ >= 800 || defined(ALLOW_LEGACY_BF16)
     else if constexpr (std::is_same_v<T, __nv_bfloat16>) {
       scales[row * groups_per_row + group_idx] = __float2bfloat16(final_scale);
       biases[row * groups_per_row + group_idx] = __float2bfloat16(bias);
@@ -235,7 +235,7 @@ afq_quantize_kernel(const T *__restrict__ w, uint32_t *__restrict__ w_q,
     } else if constexpr (std::is_same_v<T, __half>) {
       val = __half2float(row_w[col]);
     }
-#if __CUDA_ARCH__ >= 800
+#if __CUDA_ARCH__ >= 800 || defined(ALLOW_LEGACY_BF16)
     else if constexpr (std::is_same_v<T, __nv_bfloat16>) {
       val = __bfloat162float(row_w[col]);
     }

--- a/mistralrs-quant/kernels/afq/afq_gemm.cu
+++ b/mistralrs-quant/kernels/afq/afq_gemm.cu
@@ -96,7 +96,7 @@ afq_qmv_kernel(const T *__restrict__ x, const uint32_t *__restrict__ w_q,
     } else if constexpr (std::is_same_v<T, __half>) {
       x_val = __half2float(x_row[k]);
     }
-#if __CUDA_ARCH__ >= 800
+#if __CUDA_ARCH__ >= 800 || defined(ALLOW_LEGACY_BF16)
     else if constexpr (std::is_same_v<T, __nv_bfloat16>) {
       x_val = __bfloat162float(x_row[k]);
     }
@@ -115,7 +115,7 @@ afq_qmv_kernel(const T *__restrict__ x, const uint32_t *__restrict__ w_q,
     } else if constexpr (std::is_same_v<T, __half>) {
       y[m * N + n] = __float2half(acc);
     }
-#if __CUDA_ARCH__ >= 800
+#if __CUDA_ARCH__ >= 800 || defined(ALLOW_LEGACY_BF16)
     else if constexpr (std::is_same_v<T, __nv_bfloat16>) {
       y[m * N + n] = __float2bfloat16(acc);
     }
@@ -161,7 +161,7 @@ afq_qmv_3bit_kernel(const T *__restrict__ x, const uint8_t *__restrict__ w_q,
       scale = __half2float(scales_row[group_idx]);
       bias = __half2float(biases_row[group_idx]);
     }
-#if __CUDA_ARCH__ >= 800
+#if __CUDA_ARCH__ >= 800 || defined(ALLOW_LEGACY_BF16)
     else if constexpr (std::is_same_v<T, __nv_bfloat16>) {
       scale = __bfloat162float(scales_row[group_idx]);
       bias = __bfloat162float(biases_row[group_idx]);
@@ -176,7 +176,7 @@ afq_qmv_3bit_kernel(const T *__restrict__ x, const uint8_t *__restrict__ w_q,
     } else if constexpr (std::is_same_v<T, __half>) {
       x_val = __half2float(x_row[k]);
     }
-#if __CUDA_ARCH__ >= 800
+#if __CUDA_ARCH__ >= 800 || defined(ALLOW_LEGACY_BF16)
     else if constexpr (std::is_same_v<T, __nv_bfloat16>) {
       x_val = __bfloat162float(x_row[k]);
     }
@@ -193,7 +193,7 @@ afq_qmv_3bit_kernel(const T *__restrict__ x, const uint8_t *__restrict__ w_q,
     } else if constexpr (std::is_same_v<T, __half>) {
       y[m * N + n] = __float2half(acc);
     }
-#if __CUDA_ARCH__ >= 800
+#if __CUDA_ARCH__ >= 800 || defined(ALLOW_LEGACY_BF16)
     else if constexpr (std::is_same_v<T, __nv_bfloat16>) {
       y[m * N + n] = __float2bfloat16(acc);
     }
@@ -239,7 +239,7 @@ afq_qmv_6bit_kernel(const T *__restrict__ x, const uint8_t *__restrict__ w_q,
       scale = __half2float(scales_row[group_idx]);
       bias = __half2float(biases_row[group_idx]);
     }
-#if __CUDA_ARCH__ >= 800
+#if __CUDA_ARCH__ >= 800 || defined(ALLOW_LEGACY_BF16)
     else if constexpr (std::is_same_v<T, __nv_bfloat16>) {
       scale = __bfloat162float(scales_row[group_idx]);
       bias = __bfloat162float(biases_row[group_idx]);
@@ -254,7 +254,7 @@ afq_qmv_6bit_kernel(const T *__restrict__ x, const uint8_t *__restrict__ w_q,
     } else if constexpr (std::is_same_v<T, __half>) {
       x_val = __half2float(x_row[k]);
     }
-#if __CUDA_ARCH__ >= 800
+#if __CUDA_ARCH__ >= 800 || defined(ALLOW_LEGACY_BF16)
     else if constexpr (std::is_same_v<T, __nv_bfloat16>) {
       x_val = __bfloat162float(x_row[k]);
     }
@@ -271,7 +271,7 @@ afq_qmv_6bit_kernel(const T *__restrict__ x, const uint8_t *__restrict__ w_q,
     } else if constexpr (std::is_same_v<T, __half>) {
       y[m * N + n] = __float2half(acc);
     }
-#if __CUDA_ARCH__ >= 800
+#if __CUDA_ARCH__ >= 800 || defined(ALLOW_LEGACY_BF16)
     else if constexpr (std::is_same_v<T, __nv_bfloat16>) {
       y[m * N + n] = __float2bfloat16(acc);
     }
@@ -320,7 +320,7 @@ afq_qmm_kernel(const T *__restrict__ x, const uint32_t *__restrict__ w_q,
       } else if constexpr (std::is_same_v<T, __half>) {
         x_tile[ty][tx] = __half2float(x[m_idx * K + k_idx]);
       }
-#if __CUDA_ARCH__ >= 800
+#if __CUDA_ARCH__ >= 800 || defined(ALLOW_LEGACY_BF16)
       else if constexpr (std::is_same_v<T, __nv_bfloat16>) {
         x_tile[ty][tx] = __bfloat162float(x[m_idx * K + k_idx]);
       }
@@ -346,7 +346,7 @@ afq_qmm_kernel(const T *__restrict__ x, const uint32_t *__restrict__ w_q,
         scale = __half2float(scales[n_idx * groups_per_row + group_idx]);
         bias = __half2float(biases[n_idx * groups_per_row + group_idx]);
       }
-#if __CUDA_ARCH__ >= 800
+#if __CUDA_ARCH__ >= 800 || defined(ALLOW_LEGACY_BF16)
       else if constexpr (std::is_same_v<T, __nv_bfloat16>) {
         scale = __bfloat162float(scales[n_idx * groups_per_row + group_idx]);
         bias = __bfloat162float(biases[n_idx * groups_per_row + group_idx]);
@@ -378,7 +378,7 @@ afq_qmm_kernel(const T *__restrict__ x, const uint32_t *__restrict__ w_q,
     } else if constexpr (std::is_same_v<T, __half>) {
       y[m_out * N + n_out] = __float2half(acc);
     }
-#if __CUDA_ARCH__ >= 800
+#if __CUDA_ARCH__ >= 800 || defined(ALLOW_LEGACY_BF16)
     else if constexpr (std::is_same_v<T, __nv_bfloat16>) {
       y[m_out * N + n_out] = __float2bfloat16(acc);
     }

--- a/mistralrs-quant/kernels/afq/afq_utils.cuh
+++ b/mistralrs-quant/kernels/afq/afq_utils.cuh
@@ -91,17 +91,26 @@ __device__ __forceinline__ float dequant_value<float>(uint32_t q, float scale,
 template <>
 __device__ __forceinline__ __half dequant_value<__half>(uint32_t q, __half scale,
                                                          __half bias) {
+#if __CUDA_ARCH__ >= 700
   return __hfma(__uint2half_rn(q), scale, bias);
+#else
+  return __float2half_rn(fmaf(static_cast<float>(q), __half2float(scale),
+                              __half2float(bias)));
+#endif
 }
 
-#if __CUDA_ARCH__ >= 800
 template <>
 __device__ __forceinline__ __nv_bfloat16
 dequant_value<__nv_bfloat16>(uint32_t q, __nv_bfloat16 scale,
                               __nv_bfloat16 bias) {
+#if __CUDA_ARCH__ >= 800
   return __hfma(__uint2bfloat16_rn(q), scale, bias);
-}
+#else
+  return __float2bfloat16_rn(
+      fmaf(static_cast<float>(q), __bfloat162float(scale),
+           __bfloat162float(bias)));
 #endif
+}
 
 // ============================================================================
 // Quantization helpers (round((w - bias) / scale))

--- a/mistralrs-quant/src/unquantized/mod.rs
+++ b/mistralrs-quant/src/unquantized/mod.rs
@@ -24,6 +24,17 @@ pub struct UnquantLinear {
     stats: Option<ImatrixLayerStats>,
 }
 
+fn use_legacy_bf16_fallback(a: &Tensor) -> bool {
+    cfg!(feature = "cuda")
+        && cfg!(allow_legacy_bf16)
+        && a.device().is_cuda()
+        && a.dtype() == DType::BF16
+}
+
+fn bf16_safe_matmul(a: &Tensor, b: &Tensor) -> Result<Tensor> {
+    a.matmul(b)
+}
+
 impl QuantMethod for UnquantLinear {
     fn new(method: QuantMethodConfig) -> candle_core::Result<Self>
     where
@@ -55,10 +66,11 @@ impl QuantMethod for UnquantLinear {
     fn forward(&self, a: &Tensor) -> Result<Tensor> {
         // Batch matrix multiplication
         maybe_init_cublas_lt_wrapper(a.device().clone());
+        let use_legacy_bf16_fallback = use_legacy_bf16_fallback(a);
 
         // Try custom GEMV for single-token decode (batch_size=1)
         #[cfg(feature = "cuda")]
-        if crate::gemv::should_use_gemv(a, &self.w) {
+        if !use_legacy_bf16_fallback && crate::gemv::should_use_gemv(a, &self.w) {
             return crate::gemv::gemv(a, &self.w, self.b.as_ref());
         }
 
@@ -80,27 +92,32 @@ impl QuantMethod for UnquantLinear {
             match a.device().location() {
                 DeviceLocation::Cuda { .. } => {
                     // Try to use cublaslt, otherwise fallback to gemm
-                    if let (Device::Cuda(_), Some(cublaslt)) =
-                        (a.device(), CUBLASLT_CONTROLLER.get_for_device(a.device()))
-                    {
-                        cublaslt
-                            .batch_matmul(
-                                a,
-                                &w,
-                                Some(&b.t()?.contiguous()?),
-                                None,
-                                Some(1.0),
-                                None,
-                                None,
-                            )?
-                            .t()
+                    if !use_legacy_bf16_fallback {
+                        if let (Device::Cuda(_), Some(cublaslt)) =
+                            (a.device(), CUBLASLT_CONTROLLER.get_for_device(a.device()))
+                        {
+                            cublaslt
+                                .batch_matmul(
+                                    a,
+                                    &w,
+                                    Some(&b.t()?.contiguous()?),
+                                    None,
+                                    Some(1.0),
+                                    None,
+                                    None,
+                                )?
+                                .t()
+                        } else {
+                            let matmul_result = bf16_safe_matmul(a, &w.t()?)?;
+                            matmul_result.broadcast_add(&b)
+                        }
                     } else {
-                        let matmul_result = a.matmul(&w.t()?)?;
+                        let matmul_result = bf16_safe_matmul(a, &w.t()?)?;
                         matmul_result.broadcast_add(&b)
                     }
                 }
                 DeviceLocation::Metal { .. } => {
-                    let matmul_result = a.matmul(&w.t()?)?;
+                    let matmul_result = bf16_safe_matmul(a, &w.t()?)?;
                     matmul_result.broadcast_add(&b)
                 }
                 DeviceLocation::Cpu => {
@@ -125,22 +142,26 @@ impl QuantMethod for UnquantLinear {
         } else {
             match a.device().location() {
                 DeviceLocation::Cuda { .. } => {
-                    if let (Device::Cuda(_), Some(cublaslt)) =
-                        (a.device(), CUBLASLT_CONTROLLER.get_for_device(a.device()))
-                    {
-                        // cuBLAS batch_matmul requires 3D tensors, fall back to regular matmul for 2D.
-                        if a.rank() >= 3 && w.rank() >= 3 {
-                            cublaslt
-                                .batch_matmul(a, &w, None, None, None, None, None)?
-                                .t()
+                    if !use_legacy_bf16_fallback {
+                        if let (Device::Cuda(_), Some(cublaslt)) =
+                            (a.device(), CUBLASLT_CONTROLLER.get_for_device(a.device()))
+                        {
+                            // cuBLAS batch_matmul requires 3D tensors, fall back to regular matmul for 2D.
+                            if a.rank() >= 3 && w.rank() >= 3 {
+                                cublaslt
+                                    .batch_matmul(a, &w, None, None, None, None, None)?
+                                    .t()
+                            } else {
+                                bf16_safe_matmul(a, &w.t()?)
+                            }
                         } else {
-                            a.matmul(&w.t()?)
+                            bf16_safe_matmul(a, &w.t()?)
                         }
                     } else {
-                        a.matmul(&w.t()?)
+                        bf16_safe_matmul(a, &w.t()?)
                     }
                 }
-                DeviceLocation::Metal { .. } => a.matmul(&w.t()?),
+                DeviceLocation::Metal { .. } => bf16_safe_matmul(a, &w.t()?),
                 DeviceLocation::Cpu => {
                     #[cfg(feature = "accelerate")]
                     {
@@ -191,10 +212,9 @@ impl QuantMethod for UnquantLinear {
                     .reshape((b_size * seq_len * num_experts_per_tok, hidden_dim))?;
 
                 // Matmul: [b*s*k, hidden_dim] @ [b*s*k, hidden_dim, out_features] -> [b*s*k, out_features]
-                let result = a_expanded
-                    .unsqueeze(1)?
-                    .matmul(&selected_w.transpose(1, 2)?)?
-                    .squeeze(1)?;
+                let result =
+                    bf16_safe_matmul(&a_expanded.unsqueeze(1)?, &selected_w.transpose(1, 2)?)?
+                        .squeeze(1)?;
 
                 // Reshape back to [b, s, k, out_features]
                 result.reshape((b_size, seq_len, num_experts_per_tok, out_features))
@@ -215,10 +235,9 @@ impl QuantMethod for UnquantLinear {
                     .reshape((num_tokens * num_experts_per_tok, hidden_dim))?;
 
                 // Matmul: [n*k, hidden] @ [n*k, hidden, out] -> [n*k, out]
-                let result = a_expanded
-                    .unsqueeze(1)?
-                    .matmul(&selected_w.transpose(1, 2)?)?
-                    .squeeze(1)?;
+                let result =
+                    bf16_safe_matmul(&a_expanded.unsqueeze(1)?, &selected_w.transpose(1, 2)?)?
+                        .squeeze(1)?;
 
                 // Reshape to [n, k, out]
                 result.reshape((num_tokens, num_experts_per_tok, out_features))
@@ -551,5 +570,116 @@ impl QuantizedSerde for UnquantLinear {
             }),
             b,
         ))
+    }
+}
+
+#[cfg(test)]
+#[cfg(feature = "cuda")]
+mod tests {
+    use std::sync::{LazyLock, Mutex};
+
+    use candle_core::{DType, Device, Result, Tensor};
+    use candle_nn::Linear;
+
+    use super::*;
+    use crate::GEMV_CONTROLLER;
+
+    static CUDA_FALLBACK_TEST_LOCK: LazyLock<Mutex<()>> = LazyLock::new(|| Mutex::new(()));
+
+    struct FallbackControllerGuard {
+        gemv_was_enabled: bool,
+    }
+
+    impl FallbackControllerGuard {
+        fn force_candle_matmul() -> Self {
+            let guard = Self {
+                gemv_was_enabled: GEMV_CONTROLLER.is_enabled(),
+            };
+            GEMV_CONTROLLER.set_enabled(false);
+            CUBLASLT_CONTROLLER.set_inhibit(true);
+            guard
+        }
+    }
+
+    impl Drop for FallbackControllerGuard {
+        fn drop(&mut self) {
+            GEMV_CONTROLLER.set_enabled(self.gemv_was_enabled);
+            CUBLASLT_CONTROLLER.set_inhibit(false);
+        }
+    }
+
+    fn assert_close(lhs: &Tensor, rhs: &Tensor, max_abs_diff: f32) -> Result<()> {
+        let max_diff = (lhs.to_dtype(DType::F32)? - rhs.to_dtype(DType::F32)?)?
+            .abs()?
+            .max_all()?
+            .to_vec0::<f32>()?;
+        assert!(
+            max_diff <= max_abs_diff,
+            "max abs diff {max_diff} exceeded tolerance {max_abs_diff}"
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn test_forward_bf16_without_bias_falls_back_to_candle_matmul_when_specialized_paths_are_off(
+    ) -> Result<()> {
+        let _lock = CUDA_FALLBACK_TEST_LOCK.lock().unwrap();
+        let device = Device::new_cuda(0)?;
+        maybe_init_cublas_lt_wrapper(device.clone());
+
+        let input = Tensor::randn(0., 1., (1, 8), &device)?
+            .to_dtype(DType::BF16)?
+            .contiguous()?;
+        let weight = Tensor::randn(0., 1., (6, 8), &device)?
+            .to_dtype(DType::BF16)?
+            .contiguous()?;
+        assert!(crate::gemv::should_use_gemv(&input, &weight));
+
+        let layer = UnquantLinear::new(QuantMethodConfig::Unquantized(Linear::new(
+            weight.clone(),
+            None,
+        )))?;
+
+        let _controllers = FallbackControllerGuard::force_candle_matmul();
+        let actual = layer.forward(&input)?;
+        let expected = input.matmul(&weight.t()?)?;
+
+        assert_eq!(actual.dtype(), DType::BF16);
+        assert_close(&actual, &expected, 1e-2)?;
+        Ok(())
+    }
+
+    #[test]
+    fn test_forward_bf16_with_bias_falls_back_to_candle_matmul_when_specialized_paths_are_off(
+    ) -> Result<()> {
+        let _lock = CUDA_FALLBACK_TEST_LOCK.lock().unwrap();
+        let device = Device::new_cuda(0)?;
+        maybe_init_cublas_lt_wrapper(device.clone());
+
+        let input = Tensor::randn(0., 1., (1, 1, 8), &device)?
+            .to_dtype(DType::BF16)?
+            .contiguous()?;
+        let weight = Tensor::randn(0., 1., (6, 8), &device)?
+            .to_dtype(DType::BF16)?
+            .contiguous()?;
+        let bias = Tensor::randn(0., 1., 6, &device)?
+            .to_dtype(DType::BF16)?
+            .contiguous()?;
+        assert!(crate::gemv::should_use_gemv(&input, &weight));
+
+        let layer = UnquantLinear::new(QuantMethodConfig::Unquantized(Linear::new(
+            weight.clone(),
+            Some(bias.clone()),
+        )))?;
+
+        let _controllers = FallbackControllerGuard::force_candle_matmul();
+        let actual = layer.forward(&input)?;
+        let expected = input
+            .matmul(&weight.broadcast_left(1)?.t()?)?
+            .broadcast_add(&bias)?;
+
+        assert_eq!(actual.dtype(), DType::BF16);
+        assert_close(&actual, &expected, 1e-2)?;
+        Ok(())
     }
 }


### PR DESCRIPTION
## Goal

Support older NVIDIA GPUs in the CUDA backend by avoiding BF16 and FP8 paths that rely on newer hardware features.

The goal of the `allow_old_card` branch is compatibility: keep existing CUDA functionality usable on legacy cards by falling back to kernels and helpers that are supported on older architectures.

## What this PR changes

- add opt-in legacy CUDA flags for BF16 and FP8 paths
- add MoE fallback kernels when WMMA or native BF16 paths are unavailable
- route quantized BF16 handling through supported CUDA implementations
- emulate BF16 helpers used by paged attention on legacy CUDA
- enable opt-in legacy FP8 paths in `mistralrs-quant` and `mistralrs-paged-attn`
- remove older-card FP8 gating that prevented these compatible paths from being used
- pin the Candle fork required by these compatibility changes
- switch to Candle `0.10.2`

## Scope

This PR is focused on compatibility for older cards.
It intentionally avoids unrelated model or pipeline changes.

## Notes

- this is a compatibility change, not a performance improvement
- newer GPUs should keep using the existing fast paths
- the Candle fork carries the changes from https://github.com/huggingface/candle/pull/2704

## Validation

Validated locally with:

```bash
CUDA_COMPUTE_CAP=61 ALLOW_LEGACY="bf16,fp8" cargo build -r -F cuda --bin mistralrs
ALLOW_LEGACY="bf16,fp8" cargo run -r -F cuda --bin mistralrs run -m ibm-granite/granite-4.0-h-micro --pa-context-len 512 --dtype bf16
