### PR TITLE
Upgrade Metal standard from 3.0 to 3.1

### DIFF
--- a/mistralrs-quant/build.rs
+++ b/mistralrs-quant/build.rs
@@ -252,11 +252,11 @@ fn main() -> Result<(), String> {
             }
 
             fn metal_std(&self) -> &str {
-                // Use Metal 3.0 unified standard for both platforms
+                // Use Metal 3.1 unified standard for both platforms
                 // This fixes Xcode 26+ where the default Metal standard may be too low
                 // https://github.com/EricLBuehler/mistral.rs/issues/1844
                 match self {
-                    Platform::MacOS | Platform::Ios => "metal3.0",
+                    Platform::MacOS | Platform::Ios => "metal3.1",
                 }
             }
         }


### PR DESCRIPTION
## Summary
  Upgrades Metal shader compilation standard from 3.0 to 3.1 to enable bfloat16 support.

  ## Problem
  Models using BF16 dtype fail with error: `Error while loading function: fused_glu_bfloat`

  The `fused_glu_bfloat` shader is [conditionally](https://github.com/EricLBuehler/mistral.rs/blob/master/mistralrs-quant/src/metal_kernels/fused_glu.metal#L74) compiled only when `__METAL_VERSION__ >= 310`, but the build script was using Metal 3.0 standard.

  ## Solution
  Bump Metal standard to 3.1 in `mistralrs-quant/build.rs`.

fix #1859 