### PR TITLE
Fix swapped width/height in Qwen VL preprocessor

### DIFF
--- a/mistralrs-core/src/vision_models/qwen2_5_vl/inputs_processor.rs
+++ b/mistralrs-core/src/vision_models/qwen2_5_vl/inputs_processor.rs
@@ -533,8 +533,8 @@ impl Qwen2_5VLImageProcessor {
 
         for mut image in images {
             image = image.resize_exact(
-                height,
                 width,
+                height,
                 config
                     .resampling
                     .map(|resample| Some(resample).to_filter())

--- a/mistralrs-core/src/vision_models/qwen2vl/inputs_processor.rs
+++ b/mistralrs-core/src/vision_models/qwen2vl/inputs_processor.rs
@@ -530,8 +530,8 @@ impl Qwen2VLImageProcessor {
 
         for mut image in images {
             image = image.resize_exact(
-                height,
                 width,
+                height,
                 config
                     .resampling
                     .map(|resample| Some(resample).to_filter())

--- a/mistralrs-core/src/vision_models/qwen3_vl/inputs_processor.rs
+++ b/mistralrs-core/src/vision_models/qwen3_vl/inputs_processor.rs
@@ -502,8 +502,8 @@ impl Qwen3VLImageProcessor {
 
         for mut image in images {
             image = image.resize_exact(
-                height,
                 width,
+                height,
                 config
                     .resampling
                     .map(|resample| Some(resample).to_filter())


### PR DESCRIPTION
resize_exact expects width then height, but was being passed height/width. This would get corrected, but not before degrading image quality (by first downsizing, then upsizing), causing subtle systemic spatial reasoning issues.

Affects Qwen2-VL, Qwen2.5-VL, and Qwen3-VL preprocessors. 