### PR TITLE
fix(docker): install git in CUDA builders for flash-attn-v3 CUTLASS fetch

### DIFF
--- a/Dockerfile.cuda-13.0-ubi9
+++ b/Dockerfile.cuda-13.0-ubi9
@@ -1,5 +1,6 @@
 FROM nvidia/cuda:13.0.2-cudnn-devel-ubi9 AS builder
 
+RUN dnf install -y git
 RUN curl https://sh.rustup.rs -sSf | bash -s -- -y
 ENV PATH="/root/.cargo/bin:${PATH}"
 RUN rustup update nightly && rustup default nightly

--- a/Dockerfile.cuda-all
+++ b/Dockerfile.cuda-all
@@ -9,6 +9,7 @@ RUN <<HEREDOC
     apt-get update
     apt-get install -y --no-install-recommends \
         curl \
+        git \
         libssl-dev \
         pkg-config
 


### PR DESCRIPTION
## Summary

Fix Docker CUDA builder images that fail when `flash-attn-v3` is enabled because `candle-flash-attn-v3` shells out to `git clone` to fetch CUTLASS at build time.

This adds `git` to builder dependencies in:

- `[redacted local path]`
- `[redacted local path]`

Attempts to fix #1810

## Repro

Before this change, enabling `flash-attn-v3` failed with:

- `cargo::warning=Cloning cutlass from https://github.com/NVIDIA/cutlass.git`
- `Error: Failed to clone cutlass repository`
- `Caused by: No such file or directory (os error 2)`

## Validation

- `cargo check -p mistralrs-core` passes locally.
- Docker build with `flash-attn-v3` now proceeds past CUTLASS clone/check-out.
- Build then fails later at expected hardware gate (`Compute capability must be 90 (90a)`), confirming clone failure is resolved.