### PR TITLE
fix(core): use unix seconds for streaming chunk created timestamp

### DIFF
--- a/mistralrs-core/src/sequence.rs
+++ b/mistralrs-core/src/sequence.rs
@@ -1562,7 +1562,7 @@ impl SequenceGroup {
                 .send(Response::Chunk(ChatCompletionChunkResponse {
                     id: seq.id.to_string(),
                     choices: swap_streaming_chunks,
-                    created: seq.timestamp,
+                    created: seq.creation_time() as u128,
                     model: model.clone(),
                     system_fingerprint: SYSTEM_FINGERPRINT.to_string(),
                     object: "chat.completion.chunk".to_string(),
@@ -1581,7 +1581,7 @@ impl SequenceGroup {
                 .send(Response::CompletionChunk(CompletionChunkResponse {
                     id: seq.id.to_string(),
                     choices: swap_streaming_chunks,
-                    created: seq.timestamp,
+                    created: seq.creation_time() as u128,
                     model: model.clone(),
                     system_fingerprint: SYSTEM_FINGERPRINT.to_string(),
                     object: "text_completion".to_string(),


### PR DESCRIPTION
## Summary
This PR attempts to fix OpenAI compatibility for streaming responses by ensuring the `created` field is emitted in Unix **seconds** (not milliseconds).

## Problem
In streaming paths, `created` was set from `seq.timestamp`, which is initialized with `now.as_millis()`.
OpenAI-compatible `created` values should be Unix epoch seconds.

## Changes
- Updated streaming chat chunk response:
  - `created: seq.timestamp` -> `created: seq.creation_time() as u128`
- Updated streaming completion chunk response:
  - `created: seq.timestamp` -> `created: seq.creation_time() as u128`

File changed:
- `mistralrs-core/src/sequence.rs`

## Why this is correct
- `seq.creation_time()` is set from `SystemTime::now().duration_since(UNIX_EPOCH).as_secs()` at sequence creation.
- Non-streaming response paths already use second-based creation timestamps, so this makes behavior consistent across streaming and non-streaming APIs.

## Validation
- Ran:
  - `cargo check -p mistralrs-core`
- Result:
  - Passed

## References
- Attempts to fix #1805
- OpenAI API docs (streaming/completions `created` is Unix seconds)
