### PR TITLE
fix(core): handle missing BOS token in calibration path

### DIFF
--- a/mistralrs-core/src/pipeline/vision.rs
+++ b/mistralrs-core/src/pipeline/vision.rs
@@ -684,10 +684,10 @@ impl Loader for VisionLoader {
                 calibration_file.display(),
                 tokens.len()
             );
-            let bos_toks = chat_template.bos_tok().map(|b| vec![b]).unwrap_or_default();
-            let bos_tok_id = tokenizer
-                .token_to_id(&bos_toks[0])
-                .expect("Somehow the bos token is not present.");
+            let bos_tok_id = chat_template
+                .bos_tok()
+                .as_deref()
+                .and_then(|tok| tokenizer.token_to_id(tok));
 
             // NOTE: We ONLY calibrate the text bits of these models!!
             // So only those should be tracked!
@@ -700,7 +700,10 @@ impl Loader for VisionLoader {
             let n_chunks: usize = tokens.len().div_ceil(CHUNK_SIZE);
             let start = Instant::now();
             for (i, chunk) in tokens.chunks(CHUNK_SIZE).enumerate() {
-                let chunk = [vec![bos_tok_id], chunk.to_vec()].concat();
+                let mut chunk = chunk.to_vec();
+                if let Some(bos_tok_id) = bos_tok_id {
+                    chunk.insert(0, bos_tok_id);
+                }
                 let chunk_len = chunk.len();
 
                 let start = Instant::now();


### PR DESCRIPTION
## Summary
- fix calibration/imatrix token chunking to avoid indexing into an empty BOS token list
- make BOS insertion optional for both normal and vision pipelines
- preserve existing behavior when BOS exists and is tokenized

## Before and After Validation

### Before (old behavior, empty BOS token list)
```text
thread 'main' panicked at /tmp/issue1773_validation.rs:3:24:
index out of bounds: the len is 0 but the index is 0
before_panicked=true
```

### After (new behavior)
```text
after_no_bos=[1, 2, 3]
after_with_bos=[42, 1, 2, 3]
```

Attempts to fix #1773
