### PR TITLE
fix(build): enable vendored Swagger UI for offline compilation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7065,8 +7065,15 @@ dependencies = [
  "serde_json",
  "url",
  "utoipa",
+ "utoipa-swagger-ui-vendored",
  "zip 3.0.0",
 ]
+
+[[package]]
+name = "utoipa-swagger-ui-vendored"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2eebbbfe4093922c2b6734d7c679ebfebd704a0d7e56dfcb0d05818ce28977d"
 
 [[package]]
 name = "uuid"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -165,7 +165,7 @@ directories = "6.0.0"
 # Need to keep rustyline at 15.0.0 as 16.0.0 has a breaking change that conficts with `ctrlc`'s handling
 rustyline = { version = "15.0.0", default-features = false, features = ["with-file-history"] }
 tower-http = "0.6.8"
-utoipa-swagger-ui = { version = "9.0.2", features = ["axum"] }
+utoipa-swagger-ui = { version = "9.0.2", features = ["axum", "vendored"] }
 futures-util = "0.3.31"
 axum_static = "1.8.6"
 mime_guess = "2.0.5"


### PR DESCRIPTION
Building without internet access (sandboxed environments, air-gapped machines, flaky connections) fails because utoipa-swagger-ui's build script attempts to
download Swagger UI from GitHub at compile time:

```
curl: (28) SSL connection timeout
thread 'main' panicked at 'failed to download Swagger UI'
```