### PR TITLE
fix(ci): add Metal and CUDA+NCCL compile checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,21 @@ jobs:
         with:
           command: check
 
+  check-metal:
+    name: Check (metal)
+    runs-on: macOS-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+      - uses: actions-rs/cargo@v1
+        with:
+          command: check
+          args: --workspace --features metal
+
   test:
     name: Test Suite
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/ci_cuda.yaml
+++ b/.github/workflows/ci_cuda.yaml
@@ -6,16 +6,26 @@ on:
 
 jobs:
   test-cuda:
+    name: CI / cuda (${{ matrix.name }})
+
     # For security, only run automatically for:
     # - PRs from the same repo (not forks)
     # - manual workflow dispatch
     if: ${{ github.event_name == 'workflow_dispatch' || github.event.pull_request.head.repo.full_name == github.event.pull_request.base.repo.full_name }}
 
     concurrency:
-      group: ${{ github.workflow }}-${{ github.job }}-${{ github.head_ref || github.run_id }}
+      group: ${{ github.workflow }}-${{ matrix.name }}-${{ github.head_ref || github.run_id }}
       cancel-in-progress: true
 
     runs-on: [self-hosted, Linux, ARM64, gpu, cuda]
+
+    strategy:
+      matrix:
+        include:
+          - name: cuda
+            features: cuda
+          - name: cuda+nccl
+            features: cuda,nccl
 
     steps:
       - name: Checkout repository
@@ -34,8 +44,8 @@ jobs:
           nvidia-smi || true
           nvcc --version || true
 
-      - name: Clippy (cuda)
-        run: cargo clippy --features cuda
+      - name: Clippy
+        run: cargo clippy --features ${{ matrix.features }}
 
-      - name: Test (cuda)
-        run: cargo test --features cuda
+      - name: Test
+        run: cargo test --features ${{ matrix.features }}


### PR DESCRIPTION
Resolves https://github.com/EricLBuehler/mistral.rs/issues/1902.

- Add cargo check --workspace --features metal on macOS to catch Metal build regressions at PR time 
- Expand CUDA CI matrix to also compile-check cuda,nccl alongside the existing cuda-only pass