### PR TITLE
fix(gguf): `verify_arch_any` used AND logic instead of OR

### DIFF
--- a/mistralrs-core/src/utils/gguf_metadata.rs
+++ b/mistralrs-core/src/utils/gguf_metadata.rs
@@ -150,10 +150,19 @@ impl ContentMetadata<'_> {
         Ok(())
     }
 
-    pub fn verify_arch_any(&self, expected_arch: &[&str]) -> Result<()> {
-        expected_arch
-            .iter()
-            .try_for_each(|arch| self.verify_arch(arch))
+    pub fn verify_arch_any(&self, expected_archs: &[&str]) -> Result<()> {
+        let actual_arch: String = self
+            .metadata
+            .get("general.architecture")
+            .cloned()
+            .try_value_into()?;
+
+        anyhow::ensure!(
+            expected_archs.iter().any(|arch| *arch == actual_arch),
+            "Expected one of `{expected_archs:?}` architectures, got `{actual_arch}`."
+        );
+
+        Ok(())
     }
 }
 


### PR DESCRIPTION
## Summary
- `verify_arch_any` used `try_for_each` which requires ALL architectures to match (AND), instead of matching ANY one (OR)
- This caused GGUF models with `llama` architecture to fail with `Expected "mistral3" architecture, got "llama"` when the loader accepts both `["llama", "mistral3"]`
- Replace with `any()` check so matching one expected architecture suffices

## Test plan
- [x] Load a Llama 3.1 8B GGUF (architecture: `llama`) through the quantized_llama loader which calls `verify_arch_any(&["llama", "mistral3"])`
- [ ] Verify Mistral3 GGUF models still load correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)