### PR TITLE
docs(triage): add Gemma3 repeated-token repro notes

### DIFF
--- a/docs/triage/issue-1248-gemma3-repeat-repro-notes.md
+++ b/docs/triage/issue-1248-gemma3-repeat-repro-notes.md
@@ -1,0 +1,16 @@
+# Issue #1248 Repro Notes
+
+## Scope
+Investigate repeated/garbled token generation with Gemma 3 at larger contexts.
+
+## What was attempted locally
+- Static review of Gemma 3 model, inputs processor, and sampling paths.
+- Searched for obvious logic regressions tied to long-context position handling or repetition penalties.
+
+## Findings
+- No single low-risk code change was identified from static inspection alone.
+- A reliable runtime repro with the target model/workload is required before making a behavioral fix.
+
+## Next step
+- Run the issue's end-to-end server repro on a suitable GPU environment.
+- Capture logits/sequence traces around degeneration onset and patch based on measured failure mode.


### PR DESCRIPTION
## Summary
- add investigation notes for issue #1248 in `docs/triage/issue-1248-gemma3-repeat-repro-notes.md`
- document current status and concrete next-step repro plan

## Related
- Refs #1248

## Notes
- This draft PR intentionally captures triage work; no behavior change is included yet.

Supersedes closed draft #1921 (rebased from upstream master).
