### PR TITLE
feat(loaders): accept BitNet HF architecture aliases

### DIFF
--- a/mistralrs-core/src/pipeline/loaders/normal_loaders.rs
+++ b/mistralrs-core/src/pipeline/loaders/normal_loaders.rs
@@ -197,7 +197,7 @@ impl NormalLoaderType {
             "Gemma2ForCausalLM" => Ok(Self::Gemma2),
             "PhiForCausalLM" => Ok(Self::Phi2),
             "Phi3ForCausalLM" => Ok(Self::Phi3),
-            "LlamaForCausalLM" => Ok(Self::Llama),
+            "LlamaForCausalLM" | "BitnetForCausalLM" | "BitNetForCausalLM" => Ok(Self::Llama),
             "Qwen2ForCausalLM" => Ok(Self::Qwen2),
             "Starcoder2ForCausalLM" => Ok(Self::Starcoder2),
             "PhiMoEForCausalLM" => Ok(Self::Phi3_5MoE),


### PR DESCRIPTION
## Summary
- route `BitNetForCausalLM` / `BitnetForCausalLM` architecture aliases through existing llama loader autodetection path
- provide a minimal compatibility bridge while fuller BitNet support is evaluated

## Related
- Refs #1013

Supersedes closed draft #1923 (rebased from upstream master).
