### PR TITLE
fix: memory limit constants for 32-bit targets in attention and ISQ

### DIFF
--- a/mistralrs-core/src/attention/backends/naive.rs
+++ b/mistralrs-core/src/attention/backends/naive.rs
@@ -10,7 +10,11 @@ use crate::attention::{chunked_attention, SdpaParams};
 /// Not *really* sure why this is necessary but it is.
 pub(crate) fn maybe_synchronize(device: &Device) -> Result<()> {
     // If less that 4 GB available, synchronize
-    if MemoryUsage.get_memory_available(device)? < 4 * 1024 * (1024 * 1024) {
+    #[cfg(target_pointer_width = "64")]
+    const FOUR_GIB: usize = 4 * 1024 * 1024 * 1024;
+    #[cfg(not(target_pointer_width = "64"))]
+    const FOUR_GIB: usize = usize::MAX;
+    if MemoryUsage.get_memory_available(device)? < FOUR_GIB {
         device.synchronize()?;
     }
     Ok(())

--- a/mistralrs-core/src/pipeline/isq.rs
+++ b/mistralrs-core/src/pipeline/isq.rs
@@ -13,7 +13,7 @@ use std::{
 ///
 /// *Purpose*: lets us pass raw byte buffers to
 /// `safetensors::serialize_to_file` without cloning them into a `Vec<u8>` or
-/// converting to a higher‑level tensor type.  
+/// converting to a higher‑level tensor type.
 /// We expose the buffer as a 1‑D `u8` tensor of shape `[len]`.
 #[derive(Clone)]
 pub struct CowBytesView<'a> {
@@ -72,7 +72,10 @@ use crate::{
 
 pub(crate) const UQFF_RESIDUAL_SAFETENSORS: &str = "residual.safetensors";
 // 10 GB max per file
+#[cfg(target_pointer_width = "64")]
 const MAX_UQFF_SIZE_BYTES: usize = 10 * 1024 * 1024 * 1024;
+#[cfg(not(target_pointer_width = "64"))]
+const MAX_UQFF_SIZE_BYTES: usize = usize::MAX;
 pub const UQFF_MULTI_FILE_DELIMITER: &str = ";";
 
 /// Parse ISQ value.


### PR DESCRIPTION
Building for `armv7-linux-androideabi` failed with overflow error:

```
error[E0080]: attempt to compute `10485760_usize * 1024_usize`, which would overflow
  --> /Users/setoelkahfi/Repositories/mistral.rs/mistralrs-core/src/pipeline/isq.rs:75:36
   |LE
75 | const MAX_UQFF_SIZE_BYTES: usize = 10 * 1024 * 1024 * 1024;
   |                                    ^^^^^^^^^^^^^^^^^^^^^^^ evaluation of `pipeline::isq::MAX_UQFF_SIZE_BYTES` failed here

error: this arithmetic operation will overflow
  --> /Users/setoelkahfi/Repositories/mistral.rs/mistralrs-core/src/attention/backends/naive.rs:13:52
   |LE
13 |     if MemoryUsage.get_memory_available(device)? < 4 * 1024 * (1024 * 1024) {
   |                                                    ^^^^^^^^^^^^^^^^^^^^^^^^ attempt to compute `4096_usize * 1048576_usize`, which would overflow
   |LE
   = note: `#[deny(arithmetic_overflow)]` on by default

note: erroneous constant encountereds]
   --> /Users/setoelkahfi/Repositories/mistral.rs/mistralrs-core/src/pipeline/isq.rs:752:59
    |E
752 |                         && current_bytes + tensor_bytes > MAX_UQFF_SIZE_BYTES
    |                                                           ^^^^^^^^^^^^^^^^^^^

For more information about this error, try `rustc --explain E0080`.
error: could not compile `mistralrs-core` (lib) due to 2 previous errors
       Error failed to build Android app: `Failed to run `cargo build`: command ["cargo", "build", "--package", "app", "--manifest-path", "/Users/setoelkahfi/Repositories/splitfire/frontend/reimagen/src-tauri/Cargo.toml", "--target", "armv7-linux-androideabi", "--features", "tauri/custom-protocol tauri/custom-protocol", "--lib", "--release"] exited with code 101
```
