### PR TITLE
Update MCP client documentation link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ mistralrs doctor
 **Agentic Features**
 - Integrated [tool calling](docs/TOOL_CALLING.md) with Python/Rust callbacks
 - ⭐ [Web search integration](docs/WEB_SEARCH.md)
-- ⭐ [MCP client](docs/MCP/README.md): Connect to external tools automatically
+- ⭐ [MCP client](docs/MCP/client.md): Connect to external tools automatically
 
 [Full feature documentation](docs/README.md)
 


### PR DESCRIPTION
The old link was 404, I think this should be the new target after https://github.com/EricLBuehler/mistral.rs/pull/1854/changes#diff-a6ed1cf0e722cbdbe115db6e20fb6069c1d1b6194c65bd2615002e96a6ef7a3d