### PR TITLE
fix(core): qwen2(.5)-vl drift handling + adversarial alignment tests

### DIFF
--- a/mistralrs-core/src/vision_models/qwen2_5_vl/mod.rs
+++ b/mistralrs-core/src/vision_models/qwen2_5_vl/mod.rs
@@ -788,4 +788,40 @@ mod tests {
         );
         Ok(())
     }
+
+    #[test]
+    fn best_align_subtle_extra_at_start_prefers_tail() -> Result<()> {
+        let dev = &Device::Cpu;
+        let reference = Tensor::from_vec(
+            vec![0i64, 1, 2, 3, 4, 0, 1, 2, 3, 4, 0, 1, 2, 3, 4],
+            (3, 5),
+            dev,
+        )?;
+        let candidate = Tensor::from_vec(
+            vec![0i64, 0, 1, 2, 3, 4, 0, 0, 1, 2, 3, 4, 0, 0, 1, 2, 3, 4],
+            (3, 6),
+            dev,
+        )?;
+        let aligned = best_align_to_seq_len(&candidate, &reference, 5, "test")?;
+        assert_eq!(aligned.to_vec2::<i64>()?, reference.to_vec2::<i64>()?);
+        Ok(())
+    }
+
+    #[test]
+    fn best_align_subtle_extra_at_end_prefers_head() -> Result<()> {
+        let dev = &Device::Cpu;
+        let reference = Tensor::from_vec(
+            vec![0i64, 1, 2, 3, 4, 0, 1, 2, 3, 4, 0, 1, 2, 3, 4],
+            (3, 5),
+            dev,
+        )?;
+        let candidate = Tensor::from_vec(
+            vec![0i64, 1, 2, 3, 4, 4, 0, 1, 2, 3, 4, 4, 0, 1, 2, 3, 4, 4],
+            (3, 6),
+            dev,
+        )?;
+        let aligned = best_align_to_seq_len(&candidate, &reference, 5, "test")?;
+        assert_eq!(aligned.to_vec2::<i64>()?, reference.to_vec2::<i64>()?);
+        Ok(())
+    }
 }

--- a/mistralrs-core/src/vision_models/qwen2vl/mod.rs
+++ b/mistralrs-core/src/vision_models/qwen2vl/mod.rs
@@ -788,4 +788,40 @@ mod tests {
         );
         Ok(())
     }
+
+    #[test]
+    fn best_align_subtle_extra_at_start_prefers_tail() -> Result<()> {
+        let dev = &Device::Cpu;
+        let reference = Tensor::from_vec(
+            vec![0i64, 1, 2, 3, 4, 0, 1, 2, 3, 4, 0, 1, 2, 3, 4],
+            (3, 5),
+            dev,
+        )?;
+        let candidate = Tensor::from_vec(
+            vec![0i64, 0, 1, 2, 3, 4, 0, 0, 1, 2, 3, 4, 0, 0, 1, 2, 3, 4],
+            (3, 6),
+            dev,
+        )?;
+        let aligned = best_align_to_seq_len(&candidate, &reference, 5, "test")?;
+        assert_eq!(aligned.to_vec2::<i64>()?, reference.to_vec2::<i64>()?);
+        Ok(())
+    }
+
+    #[test]
+    fn best_align_subtle_extra_at_end_prefers_head() -> Result<()> {
+        let dev = &Device::Cpu;
+        let reference = Tensor::from_vec(
+            vec![0i64, 1, 2, 3, 4, 0, 1, 2, 3, 4, 0, 1, 2, 3, 4],
+            (3, 5),
+            dev,
+        )?;
+        let candidate = Tensor::from_vec(
+            vec![0i64, 1, 2, 3, 4, 4, 0, 1, 2, 3, 4, 4, 0, 1, 2, 3, 4, 4],
+            (3, 6),
+            dev,
+        )?;
+        let aligned = best_align_to_seq_len(&candidate, &reference, 5, "test")?;
+        assert_eq!(aligned.to_vec2::<i64>()?, reference.to_vec2::<i64>()?);
+        Ok(())
+    }
 }


### PR DESCRIPTION
Issue: https://github.com/EricLBuehler/mistral.rs/issues/1786
Fixes #1786
Attempts to fix #1786
Supersedes closed PR #1929.

## Summary
Carries forward the Qwen2-VL/Qwen2.5-VL position-drift handling changes and adds subtle adversarial unit tests for head/tail alignment selection.

## Branch convention
- Head branch: `fix/1929-qwen-vl-drift-adversarial` (PR-numbered branch as requested)

## Before / After test output
### Before (prior to this commit on same branch)
Command:
`cargo test -p mistralrs-core --lib best_align_`
Output summary:
- `running 6 tests`
- `test result: ok. 6 passed; 0 failed; 0 ignored; 0 measured; 95 filtered out`

### After (this commit)
Command:
`cargo test -p mistralrs-core --lib best_align_`
Output summary:
- `running 10 tests`
- `test result: ok. 10 passed; 0 failed; 0 ignored; 0 measured; 95 filtered out`

New adversarial tests added in both modules:
- `best_align_subtle_extra_at_start_prefers_tail`
- `best_align_subtle_extra_at_end_prefers_head`

Touched files:
- `mistralrs-core/src/vision_models/qwen2vl/mod.rs`
- `mistralrs-core/src/vision_models/qwen2_5_vl/mod.rs`
