### PR TITLE
ci: disable docs deployment on forks

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -17,6 +17,7 @@ concurrency:
 
 jobs:
   deploy:
+    if: github.repository == 'EricLBuehler/mistral.rs'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout


### PR DESCRIPTION
**Description**
This PR fixes an issue where the `docs` GitHub Actions workflow fails on forks because GitHub Pages is not configured or enabled by default. 
By adding the `if: github.repository == 'EricLBuehler/mistral.rs'` condition to the `deploy` job, we ensure that the documentation is only built and deployed on the main repository, preventing unnecessary CI failures for contributors.
**Fixes**
Resolves the `Get Pages site failed` error occurring in forks during the `actions/configure-pages` step.