### PR TITLE
feat(server): add configurable concurrency limit to router builder

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -165,6 +165,7 @@ ctrlc = "3.5.1"
 directories = "6.0.0"
 # Need to keep rustyline at 15.0.0 as 16.0.0 has a breaking change that conficts with `ctrlc`'s handling
 rustyline = { version = "15.0.0", default-features = false, features = ["with-file-history"] }
+tower = { version = "0.5", features = ["limit"] }
 tower-http = "0.6.8"
 utoipa-swagger-ui = { version = "9.0.2", features = ["axum", "vendored"] }
 futures-util = "0.3.31"

--- a/mistralrs-server-core/Cargo.toml
+++ b/mistralrs-server-core/Cargo.toml
@@ -30,6 +30,7 @@ reqwest.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 tokio.workspace = true
+tower = { workspace = true, features = ["limit"] }
 tower-http = { workspace = true, features = ["cors"] }
 tracing.workspace = true
 url.workspace = true

--- a/mistralrs-server-core/src/mistralrs_server_router_builder.rs
+++ b/mistralrs-server-core/src/mistralrs_server_router_builder.rs
@@ -7,6 +7,8 @@ use axum::{
     routing::{get, post},
     Router,
 };
+use tower::ServiceBuilder;
+use tower::limit::ConcurrencyLimitLayer;
 use tower_http::cors::{AllowOrigin, CorsLayer};
 #[cfg(feature = "swagger-ui")]
 use utoipa_swagger_ui::SwaggerUi;
@@ -74,6 +76,13 @@ pub struct MistralRsServerRouterBuilder {
     allowed_origins: Option<Vec<String>>,
     /// Optional axum default request body limit
     max_body_limit: Option<usize>,
+    /// Optional maximum number of in-flight requests.
+    ///
+    /// LLM inference is memory-intensive; without a concurrency cap a burst of
+    /// simultaneous requests can exhaust GPU/CPU memory and cause OOM.  When
+    /// set, requests beyond the limit are queued by the Tower `ConcurrencyLimitLayer`
+    /// until a slot opens rather than being rejected outright.
+    max_concurrency: Option<usize>,
 }
 
 impl Default for MistralRsServerRouterBuilder {
@@ -87,6 +96,7 @@ impl Default for MistralRsServerRouterBuilder {
             base_path: None,
             allowed_origins: None,
             max_body_limit: None,
+            max_concurrency: None,
         }
     }
 }
@@ -150,6 +160,22 @@ impl MistralRsServerRouterBuilder {
         self
     }
 
+    /// Sets the maximum number of requests that may be in-flight simultaneously.
+    ///
+    /// LLM inference is memory-intensive — a burst of concurrent requests can
+    /// exhaust VRAM/RAM and cause OOM.  This wraps the router with Tower's
+    /// [`ConcurrencyLimitLayer`], which queues excess requests rather than
+    /// rejecting them, providing back-pressure without dropping traffic.
+    ///
+    /// A reasonable starting value is `num_gpus * 4` or the batch size your
+    /// model uses, e.g. `8` for a single-GPU deployment.
+    ///
+    /// [`ConcurrencyLimitLayer`]: tower::limit::ConcurrencyLimitLayer
+    pub fn with_max_concurrency(mut self, max_concurrency: usize) -> Self {
+        self.max_concurrency = Some(max_concurrency);
+        self
+    }
+
     /// Builds the configured axum router.
     ///
     /// ### Examples
@@ -168,7 +194,7 @@ impl MistralRsServerRouterBuilder {
         })?;
 
         #[allow(unused_mut)]
-        let mut router = init_router(mistralrs, self.allowed_origins, self.max_body_limit)?;
+        let mut router = init_router(mistralrs, self.allowed_origins, self.max_body_limit, self.max_concurrency)?;
 
         #[cfg(feature = "swagger-ui")]
         if self.include_swagger_routes {
@@ -192,6 +218,7 @@ fn init_router(
     state: SharedMistralRsState,
     allowed_origins: Option<Vec<String>>,
     max_body_limit: Option<usize>,
+    max_concurrency: Option<usize>,
 ) -> Result<Router> {
     let allow_origin = if let Some(origins) = allowed_origins {
         let parsed_origins: Result<Vec<_>, _> = origins.into_iter().map(|o| o.parse()).collect();
@@ -236,6 +263,16 @@ fn init_router(
         .layer(cors_layer)
         .layer(DefaultBodyLimit::max(router_max_body_limit))
         .with_state(state);
+
+    let router = if let Some(limit) = max_concurrency {
+        router.layer(
+            ServiceBuilder::new()
+                .layer(ConcurrencyLimitLayer::new(limit))
+                .into_inner(),
+        )
+    } else {
+        router
+    };
 
     Ok(router)
 }


### PR DESCRIPTION
## Motivation

LLM inference is uniquely memory-intensive — a single request can hold gigabytes of KV-cache in VRAM/RAM for the duration of the stream.  When many requests arrive simultaneously the server can:

- **OOM-kill** the process (GPU or CPU), causing a complete outage
- Thrash between contexts, degrading throughput for all users
- Trigger CUDA out-of-memory errors with no clean recovery path

Today `mistralrs-server` exposes no mechanism to bound the number of in-flight requests.

## Change

Add `with_max_concurrency(n: usize)` to `MistralRsServerRouterBuilder`.  When set, the axum router is wrapped with Tower's [`ConcurrencyLimitLayer`](https://docs.rs/tower/latest/tower/limit/struct.ConcurrencyLimitLayer.html) which **queues** requests beyond the limit rather than rejecting them — providing back-pressure without dropping traffic.

```rust
let router = MistralRsServerRouterBuilder::new()
    .with_mistralrs(state)
    .with_max_concurrency(8)   // cap at 8 simultaneous in-flight requests
    .build()
    .await?;
```

The feature is **opt-in** — omitting `with_max_concurrency` leaves the existing behaviour unchanged.

## Implementation

- Adds `tower = { version = "0.5", features = ["limit"] }` to the workspace and `mistralrs-server-core` Cargo manifests (`tower-http` was already present).
- Threads `max_concurrency: Option<usize>` through the builder → `init_router`.
- Applies `ConcurrencyLimitLayer` at the outermost router layer (after CORS and body-limit) so it covers all endpoints uniformly.

## Testing

The change is additive; existing tests continue to pass.  Manual smoke test with `with_max_concurrency(2)` confirms that a third concurrent request queues until one of the first two completes.