### PR TITLE
Small fix for Voxtral: load params.json before config.json if present

### DIFF
--- a/mistralrs-core/src/pipeline/macros.rs
+++ b/mistralrs-core/src/pipeline/macros.rs
@@ -66,10 +66,7 @@ macro_rules! get_paths {
             info!("Loading `tokenizer.json` at `{}`", $this.model_id);
             $crate::api_get_file!(api, "tokenizer.json", model_id)
         };
-        let config_filename = if dir_list.contains(&"config.json".to_string()) {
-            info!("Loading `config.json` at `{}`", $this.model_id);
-            $crate::api_get_file!(api, "config.json", model_id)
-        } else if dir_list.contains(&"params.json".to_string()) {
+        let config_filename = if dir_list.contains(&"params.json".to_string()) {
             info!(
                 "Loading `params.json` (Mistral config) at `{}`",
                 $this.model_id


### PR DESCRIPTION
Currently, we never attempt to load params.json because Voxtral's repo also contains a config.json. Fixed a small logic error here to make sure we load params if present and fallback to config if not