### PR TITLE
Fix streaming OpenResponses with store=true not persisted (#1946)

### DIFF
--- a/mistralrs-core/src/vision_models/clip.rs
+++ b/mistralrs-core/src/vision_models/clip.rs
@@ -303,7 +303,7 @@ impl ClipVisionTransformer {
     /// where (for example) `.pp("embeddings")` is valid.
     pub fn new(vb: ShardedVarBuilder, c: &ClipConfig) -> Result<Self> {
         let embeddings = ClipVisionEmbeddings::new(vb.pp("embeddings"), c)?;
-        let pre_layer_norm = layers::layer_norm(c.hidden_size, 1e-5, vb.pp("pre_layrnorm"))?;
+        let pre_layer_norm = layers::layer_norm(c.hidden_size, 1e-5, vb.pp("pre_layernorm"))?;
         let encoder = ClipEncoder::new(vb.pp("encoder"), c)?;
         let final_layer_norm = layers::layer_norm(c.hidden_size, 1e-5, vb.pp("post_layernorm"))?;
         Ok(Self {
@@ -330,7 +330,7 @@ impl ClipVisionTransformer {
     pub fn residual_tensors(&self) -> Vec<(String, Tensor)> {
         let uvb = UnVarBuilder::new();
 
-        uvb.pp("pre_layrnorm").add(&self.pre_layer_norm);
+        uvb.pp("pre_layernorm").add(&self.pre_layer_norm);
         uvb.pp("post_layernorm").add(&self.final_layer_norm);
 
         // vision embeddings

--- a/mistralrs-core/src/vision_models/clip.rs
+++ b/mistralrs-core/src/vision_models/clip.rs
@@ -303,7 +303,7 @@ impl ClipVisionTransformer {
     /// where (for example) `.pp("embeddings")` is valid.
     pub fn new(vb: ShardedVarBuilder, c: &ClipConfig) -> Result<Self> {
         let embeddings = ClipVisionEmbeddings::new(vb.pp("embeddings"), c)?;
-        let pre_layer_norm = layers::layer_norm(c.hidden_size, 1e-5, vb.pp("pre_layernorm"))?;
+        let pre_layer_norm = layers::layer_norm(c.hidden_size, 1e-5, vb.pp("pre_layrnorm"))?;
         let encoder = ClipEncoder::new(vb.pp("encoder"), c)?;
         let final_layer_norm = layers::layer_norm(c.hidden_size, 1e-5, vb.pp("post_layernorm"))?;
         Ok(Self {
@@ -330,7 +330,7 @@ impl ClipVisionTransformer {
     pub fn residual_tensors(&self) -> Vec<(String, Tensor)> {
         let uvb = UnVarBuilder::new();
 
-        uvb.pp("pre_layernorm").add(&self.pre_layer_norm);
+        uvb.pp("pre_layrnorm").add(&self.pre_layer_norm);
         uvb.pp("post_layernorm").add(&self.final_layer_norm);
 
         // vision embeddings

--- a/mistralrs-server-core/src/responses.rs
+++ b/mistralrs-server-core/src/responses.rs
@@ -753,6 +753,8 @@ pub struct OpenResponsesStreamer {
     events: Vec<OpenResponsesStreamEvent>,
     /// Request context for echoing back request parameters
     request_context: RequestContext,
+    /// Final response resource for storage
+    final_response: Option<ResponseResource>,
 }
 
 impl OpenResponsesStreamer {
@@ -789,6 +791,7 @@ impl OpenResponsesStreamer {
             on_done: None,
             events: Vec::new(),
             request_context,
+            final_response: None,
         }
     }
 
@@ -873,10 +876,10 @@ impl futures::Stream for OpenResponsesStreamer {
                 return Poll::Ready(Some(Ok(Event::default().data("[DONE]"))));
             }
             DoneState::Done => {
-                // Store conversation history if needed
+                // Store conversation history and response if needed
                 if self.store {
+                    let cache = get_response_cache();
                     if let Some(history) = self.conversation_history.take() {
-                        let cache = get_response_cache();
                         let mut history = history;
 
                         // Add assistant's response
@@ -895,6 +898,12 @@ impl futures::Stream for OpenResponsesStreamer {
                         let _ = cache.store_conversation_history(
                             self.streaming_state.response_id.clone(),
                             history,
+                        );
+                    }
+                    if let Some(response) = self.final_response.take() {
+                        let _ = cache.store_response(
+                            self.streaming_state.response_id.clone(),
+                            response,
                         );
                     }
                 }
@@ -1104,6 +1113,8 @@ impl futures::Stream for OpenResponsesStreamer {
                             ));
                         }
 
+                        self.final_response = Some(response.clone());
+
                         events_to_emit.push(OpenResponsesStreamEvent::ResponseCompleted {
                             sequence_number: seq,
                             response,
@@ -1138,6 +1149,9 @@ impl futures::Stream for OpenResponsesStreamer {
                         self.metadata.clone(),
                         &self.request_context,
                     );
+
+                    self.final_response = Some(response.clone());
+
                     let event = OpenResponsesStreamEvent::ResponseCompleted {
                         sequence_number: seq,
                         response,

--- a/mistralrs-server-core/src/responses.rs
+++ b/mistralrs-server-core/src/responses.rs
@@ -901,10 +901,8 @@ impl futures::Stream for OpenResponsesStreamer {
                         );
                     }
                     if let Some(response) = self.final_response.take() {
-                        let _ = cache.store_response(
-                            self.streaming_state.response_id.clone(),
-                            response,
-                        );
+                        let _ = cache
+                            .store_response(self.streaming_state.response_id.clone(), response);
                     }
                 }
 


### PR DESCRIPTION
Superseded by #2342. The useful one-file fix was rebuilt on current `master`, hardened to persist before the terminal stream event, regression-tested, and published as a new ready-for-review PR because GitHub would not permit this closed draft to be reopened after its stale branch was replaced.