### PR TITLE
fix(paged-attn): resolve scheduler queue loop deadlock under memory pressure

### DIFF
--- a/.typos.toml
+++ b/.typos.toml
@@ -5,6 +5,7 @@ extend-exclude = [
     "examples/server/phi3_duckduckgo_mistral.rs.ipynb",
     "mistralrs-web-chat/static/",
     "mistralrs-cli/static/",
+    "mistralrs-quant/kernels/mmq_gguf/",
     "CLAUDE.md",
 ]
 ignore-hidden = false
@@ -12,6 +13,7 @@ ignore-hidden = false
 [default]
 extend-ignore-re = [
     "cudaDevAttrMaxSharedMemoryPerBlockOptin",
+    "CU_DEVICE_ATTRIBUTE_MAX_SHARED_MEMORY_PER_BLOCK_OPTIN",
     '"tese"',
     "setp\\.ne\\.b32",
     # metal_kernels

--- a/mistralrs-core/src/paged_attention/scheduler.rs
+++ b/mistralrs-core/src/paged_attention/scheduler.rs
@@ -181,9 +181,10 @@ impl PagedAttentionScheduler {
         let mut for_waiting_again: VecDeque<Arc<Mutex<Sequence>>> = VecDeque::new();
         while !self.waiting.is_empty() {
             let mut did_ignore = false;
-            let seq = self.waiting.front().unwrap().clone();
+            let seq = self.waiting.pop_front().unwrap();
 
             if self.running.len() >= self.config.max_num_seqs {
+                self.waiting.push_front(seq);
                 break;
             }
 
@@ -263,6 +264,7 @@ impl PagedAttentionScheduler {
                             did_ignore = true;
                         }
                     } else {
+                        self.waiting.push_front(seq);
                         break;
                     }
                 }
@@ -278,7 +280,6 @@ impl PagedAttentionScheduler {
                     kv_mgr.free(seq_id);
                     drop(kv_mgr);
                 }
-                let seq = self.waiting.pop_front().unwrap();
                 for_waiting_again.push_back(seq);
                 continue;
             }
@@ -289,7 +290,6 @@ impl PagedAttentionScheduler {
                 get_mut_arcmutex!(seq).set_prefix_cache_len(num_computed);
             }
 
-            let seq = self.waiting.pop_front().unwrap();
             if did_ignore {
                 // Sequence is terminal (FinishedIgnored), do NOT add to running queue.
                 // Clean up associated state and free any allocated blocks.

--- a/mistralrs-quant/src/distributed/layers.rs
+++ b/mistralrs-quant/src/distributed/layers.rs
@@ -1432,7 +1432,7 @@ impl PackedExperts {
             let mut us = Vec::new();
             let mut ds = Vec::new();
             for ((mut gate_proj, mut up_proj), mut down_proj) in
-                gc.into_iter().zip(uc.into_iter()).zip(dc.into_iter())
+                gc.into_iter().zip(uc).zip(dc)
             {
                 gate_proj = gate_proj.squeeze(0)?;
                 up_proj = up_proj.squeeze(0)?;
@@ -2036,9 +2036,7 @@ pub fn compute_n_kv_groups(
     } else {
         1
     };
-    if kv_replicate != 0 {
-        (num_attention_heads / total_num_kv_heads) / kv_replicate
-    } else {
-        num_attention_heads / total_num_kv_heads
-    }
+    (num_attention_heads / total_num_kv_heads)
+        .checked_div(kv_replicate)
+        .unwrap_or(num_attention_heads / total_num_kv_heads)
 }

--- a/mistralrs-server-core/src/openapi_doc.rs
+++ b/mistralrs-server-core/src/openapi_doc.rs
@@ -6,7 +6,7 @@ use crate::{
     chat_completion::__path_chatcompletions,
     completions::__path_completions,
     embeddings::__path_embeddings,
-    handlers::{ReIsqRequest, __path_health, __path_models, __path_re_isq},
+    handlers::{__path_health, __path_models, __path_re_isq, ReIsqRequest},
     image_generation::__path_image_generation,
     openai::{
         AudioResponseFormat, ChatCompletionRequest, CompletionRequest, EmbeddingData,


### PR DESCRIPTION
### Description
This PR addresses a deadlock issue in `PagedAttentionScheduler` where the inference engine could hang during preemption under heavy KV cache memory pressure (resolves #1470).

Previously, when a sequence was preempted in the `schedule` method via `_preempt()`, it was pushed to the front of the `self.waiting` queue. Because the main starvation loop iterated over the queue non-destructively using `self.waiting.front()`, the newly preempted sequence was immediately targeted for re-evaluation. This caused an infinite loop of preemption and failed allocations.

### Changes
* Refactored the `waiting` sequence queue iteration in `scheduler.rs` to proactively `pop_front()` the sequence before checking its allocation status.
* If the scheduling loop must break early (due to `max_num_seqs` caps or unresolvable starvation conditions requiring a later retry), the sequence is safely re-inserted via `self.waiting.push_front(seq)`.

### Testing
* Reproduced the deadlock condition under a heavy simulated workload (30 concurrent requests) on a `g2-standard-32` instance.
* Verified that the patched logic properly filters preempted sequences to the next pipeline tick, maintaining stable throughput without triggering the infinite `WARN` log cycle.

#### Blast Radius Verification
To verify the structural integrity of the scheduler state, we ran a concurrent barrage of large Qwen2.5-3B completions on a strictly bounded 4096-token KV cache environment specifically designed to exhaust the BlockPool.

**Before (Unpatched):** 
The engine immediately hit the KV cache bottleneck and permanently hung at `0.00 T/s` as it recursively thrashed the preemption loop safely catching `AllocStatus::Later`:
```text
2026-03-30T23:52:01.962646Z  WARN mistralrs_core::paged_attention::scheduler: Sequence 5 with length of 351 tokens still exceeds KV cache size even after evicting another sequence.
2026-03-30T23:52:01.962654Z  WARN mistralrs_core::paged_attention::scheduler: Sequence 5 with length of 351 tokens still exceeds KV cache size even after evicting another sequence.
... <Infinitely spammed leading to 42MB deadlocked dump> ...
```

**After (Patched):**
Under identical `aiohttp` saturation tests, the sequence correctly stepped down onto the `waiting` queue and advanced the scheduler, letting independent completions securely evaluate until block space was liberated. The load successfully finished while keeping interval processing cleanly between 1.6K ~ 2.0K T/s:
```text
2026-03-31T00:05:18.231240Z  INFO mistralrs_core::engine::logger: Throughput (T/s) 1328.40, Prefix cache hitrate 0.00%, 4 running, 26 waiting
2026-03-31T00:05:23.231414Z  INFO mistralrs_core::engine::logger: Throughput (T/s) 1558.40, Prefix cache hitrate 0.00%, 15 running, 15 waiting
2026-03-31T00:05:38.231924Z  INFO mistralrs_core::engine::logger: Throughput (T/s) 1848.60, Prefix cache hitrate 0.00%, 15 running, 15 waiting
... <Gracefully finishes execution> ...
```