### PR TITLE
Runtime CUDA Memory Expanding to OOM

### DIFF
--- a/mistralrs-core/src/paged_attention/scheduler.rs
+++ b/mistralrs-core/src/paged_attention/scheduler.rs
@@ -440,6 +440,20 @@ impl PagedAttentionScheduler {
         self.running
             .retain(|seq| !get_mut_arcmutex!(seq).is_finished_paged_attn());
 
+        // Remove aborted/finished sequences from waiting
+        self.waiting.retain(|seq| {
+            let seq_guard = get_mut_arcmutex!(seq);
+            if seq_guard.is_finished_paged_attn() {
+                let id = *seq_guard.id();
+                let tokens = seq_guard.get_toks().to_vec();
+                let mm_features = seq_guard.mm_features().to_vec();
+                finished.push((id, tokens, mm_features));
+                false
+            } else {
+                true
+            }
+        });
+
         // Cache and free blocks for finished sequences
         if self.prefix_caching_enabled {
             for (id, tokens, mm_features) in &finished {

--- a/mistralrs-core/src/scheduler/default_scheduler.rs
+++ b/mistralrs-core/src/scheduler/default_scheduler.rs
@@ -18,6 +18,7 @@ pub trait FcfsBacker: Default {
     fn into_iter(self) -> impl Iterator<Item = Sequence>;
     fn len(&self) -> usize;
     fn sort_ascending_ids(&mut self);
+    fn retain(&mut self, f: impl FnMut(&Sequence) -> bool);
 }
 
 impl FcfsBacker for VecDeque<Sequence> {
@@ -36,6 +37,9 @@ impl FcfsBacker for VecDeque<Sequence> {
     }
     fn len(&self) -> usize {
         VecDeque::len(self)
+    }
+    fn retain(&mut self, f: impl FnMut(&Sequence) -> bool) {
+        VecDeque::retain(self, f)
     }
 }
 
@@ -333,6 +337,7 @@ impl Scheduler for DefaultScheduler<VecDeque<Sequence>> {
     fn free_finished_sequence_groups(&mut self) {
         // Remove finished sequences
         self.running.retain(|seq| !seq.is_finished_paged_attn());
+        self.waiting.retain(|seq| !seq.is_finished_paged_attn());
     }
     fn get_finished_recurrent_indices(&self) -> Vec<usize> {
         self.running


### PR DESCRIPTION
Resolves #1589. Resolves #1637.

## Problem

When sequences were preempted or aborted, they were removed from the `running` queue but not from the `waiting` queue. Orphaned sequences in `waiting` continued to hold their KV block allocations, causing VRAM usage to grow monotonically over time.

This affected both the PagedAttention scheduler and the DefaultScheduler.

## Fix

**PagedAttentionScheduler (`paged_attention/scheduler.rs`):** Call `retain()` inside `free_finished_sequence_groups()` to purge any sequences in `self.waiting` that have already reached a finished state before they are scheduled.

**DefaultScheduler (`scheduler/default_scheduler.rs`):** Add a `retain()` method to the `FcfsBacker` trait and implement it for both `VecDeque`-backed and `Heap`-backed queues. Call it from `free_finished_sequence_groups()`.

## Branch isolation

This branch was rebased directly onto `origin/master` to remove a hidden dependency on commit `1d15838a` from PR #2043 (`fix-paged-attention-deadlock-1470`) that had been included as the branch base. The two fixes are logically independent and can be reviewed and merged without #2043.

## Files changed

- `mistralrs-core/src/paged_attention/scheduler.rs`
- `mistralrs-core/src/scheduler/default_scheduler.rs`