### PR TITLE
feat(gguf): add Qwen3.5 (qwen3-next) hybrid MoE GGUF loader

### DIFF
--- a/mistralrs-core/src/gguf/mod.rs
+++ b/mistralrs-core/src/gguf/mod.rs
@@ -29,6 +29,9 @@ pub enum GGUFArchitecture {
     Qwen2,
     Qwen3,
     Qwen3MoE,
+    Qwen35,
+    #[strum(serialize = "qwen35moe")]
+    Qwen35Moe,
     Mistral3,
 }
 

--- a/mistralrs-core/src/models/deltanet.rs
+++ b/mistralrs-core/src/models/deltanet.rs
@@ -521,11 +521,12 @@ impl GatedDeltaNet {
         )?;
 
         let projection = if world_size > 1 {
-            let merged_qkv = mistralrs_quant::ColumnParallelLayer::new_merged_chunks(
+            let merged_qkv = mistralrs_quant::ColumnParallelLayer::new_merged(
                 cfg.hidden_size(),
                 qkv_out_global,
-                vec![key_dim_global, key_dim_global, value_dim_global],
+                3,
                 cfg.quantization_config(),
+                false,
                 comm,
                 vb_la.pp("in_proj_qkv"),
             )?;

--- a/mistralrs-core/src/models/deltanet.rs
+++ b/mistralrs-core/src/models/deltanet.rs
@@ -1,0 +1,1005 @@
+#![allow(clippy::cast_possible_truncation, clippy::cast_precision_loss)]
+
+//! Shared GatedDeltaNet (linear attention) layer used by Qwen3Next, Qwen3.5, and Qwen3.5-MoE.
+//!
+//! This module provides the core DeltaNet recurrence and causal conv1d primitives that are common
+//! across all Qwen3 hybrid-attention models.
+
+use candle_core::{DType, Device, IndexOp, Result, Tensor, D};
+use mistralrs_quant::{QuantMethod, QuantizedConfig, RowParallelLayer, ShardedVarBuilder};
+use std::sync::Arc;
+
+use crate::device_map::DeviceMapper;
+
+// ====================== DeltaNet Config Trait ======================
+
+/// Trait to abstract DeltaNet-relevant config fields from model-specific Config structs.
+pub trait DeltaNetConfig {
+    fn hidden_size(&self) -> usize;
+    fn rms_norm_eps(&self) -> f64;
+    fn linear_num_key_heads(&self) -> usize;
+    fn linear_num_value_heads(&self) -> usize;
+    fn linear_key_head_dim(&self) -> usize;
+    fn linear_value_head_dim(&self) -> usize;
+    fn linear_conv_kernel_dim(&self) -> usize;
+    fn quantization_config(&self) -> &Option<QuantizedConfig>;
+
+    /// Total key dimension = num_key_heads * key_head_dim
+    fn linear_key_dim(&self) -> usize {
+        self.linear_num_key_heads() * self.linear_key_head_dim()
+    }
+
+    /// Total value dimension = num_value_heads * value_head_dim
+    fn linear_value_dim(&self) -> usize {
+        self.linear_num_value_heads() * self.linear_value_head_dim()
+    }
+
+    /// Conv dim for GDN = key_dim * 2 + value_dim (q, k, v before split)
+    fn linear_conv_dim(&self) -> usize {
+        self.linear_key_dim() * 2 + self.linear_value_dim()
+    }
+}
+
+// ====================== RMSNorm Gated (for GDN output) ======================
+
+/// RMSNorm with gating: `rms_norm(x) * weight * silu(gate)`
+pub struct RmsNormGated {
+    pub weight: Tensor,
+    pub eps: f64,
+}
+
+impl RmsNormGated {
+    pub fn new(
+        size: usize,
+        eps: f64,
+        vb: ShardedVarBuilder,
+        isq_target_device: Option<&Device>,
+    ) -> Result<Self> {
+        let mut weight = vb.get(size, "weight")?;
+        if let Some(target_dev) = isq_target_device {
+            weight = weight.to_device(target_dev)?;
+        }
+        Ok(Self { weight, eps })
+    }
+
+    pub fn forward(&self, x: &Tensor, gate: &Tensor) -> Result<Tensor> {
+        let dtype = x.dtype();
+        let x = x.to_dtype(DType::F32)?;
+        let gate = candle_nn::ops::silu(&gate.to_dtype(DType::F32)?)?;
+        let variance = x.sqr()?.mean_keepdim(D::Minus1)?;
+        let normed = x.broadcast_div(&(variance + self.eps)?.sqrt()?)?;
+        let out = normed
+            .broadcast_mul(&self.weight.to_dtype(DType::F32)?)?
+            .broadcast_mul(&gate)?;
+        out.to_dtype(dtype)
+    }
+}
+
+// ====================== GDN layer cache ======================
+
+#[derive(Debug)]
+pub struct GdnLayerCache {
+    /// Conv state: (batch, conv_dim, kernel_size)
+    pub conv_state: Tensor,
+    /// Recurrent state: (batch, num_v_heads, head_k_dim, head_v_dim)
+    pub recurrent_state: Tensor,
+    pub seqlen_offset: usize,
+}
+
+impl GdnLayerCache {
+    pub fn new(
+        cfg: &dyn DeltaNetConfig,
+        dtype: DType,
+        device: &Device,
+        world_size: usize,
+    ) -> Result<Self> {
+        let conv_dim = cfg.linear_conv_dim() / world_size;
+        let conv_state = Tensor::zeros((1, conv_dim, cfg.linear_conv_kernel_dim()), dtype, device)?;
+        let recurrent_state = Tensor::zeros(
+            (
+                1,
+                (cfg.linear_num_value_heads() / world_size).max(1),
+                cfg.linear_key_head_dim(),
+                cfg.linear_value_head_dim(),
+            ),
+            dtype,
+            device,
+        )?;
+        Ok(Self {
+            conv_state,
+            recurrent_state,
+            seqlen_offset: 0,
+        })
+    }
+
+    pub fn reset(&mut self) -> Result<()> {
+        self.conv_state = self.conv_state.zeros_like()?;
+        self.recurrent_state = self.recurrent_state.zeros_like()?;
+        self.seqlen_offset = 0;
+        Ok(())
+    }
+}
+
+impl Clone for GdnLayerCache {
+    fn clone(&self) -> Self {
+        Self {
+            conv_state: self.conv_state.clone(),
+            recurrent_state: self.recurrent_state.clone(),
+            seqlen_offset: self.seqlen_offset,
+        }
+    }
+}
+
+// ====================== GDN math functions ======================
+
+pub fn l2_norm(x: &Tensor, eps: f64) -> Result<Tensor> {
+    let inv_norm = x
+        .sqr()?
+        .sum_keepdim(D::Minus1)?
+        .broadcast_add(&Tensor::new(eps as f32, x.device())?.to_dtype(x.dtype())?)?
+        .sqrt()?
+        .recip()?;
+    x.broadcast_mul(&inv_norm)
+}
+
+pub fn softplus(x: &Tensor) -> Result<Tensor> {
+    (Tensor::ones_like(x)? + x.exp()?)?.log()
+}
+
+/// Recurrent gated delta rule (CPU/Metal fallback).
+///
+/// q, k: (batch, seq, num_v_heads, head_k_dim)
+/// v:    (batch, seq, num_v_heads, head_v_dim)
+/// g:    (batch, seq, num_v_heads)
+/// beta: (batch, seq, num_v_heads)
+/// state: (batch, num_v_heads, head_k_dim, head_v_dim)
+///
+/// Returns: (batch, seq, num_v_heads, head_v_dim)
+pub fn gated_delta_rule_recurrence(
+    q: &Tensor,
+    k: &Tensor,
+    v: &Tensor,
+    g: &Tensor,
+    beta: &Tensor,
+    state: &mut Tensor,
+) -> Result<Tensor> {
+    let dtype = q.dtype();
+    let k_head_dim = q.dim(D::Minus1)?;
+    let scale = 1.0 / (k_head_dim as f64).sqrt();
+
+    let q = (q.transpose(1, 2)?.contiguous()?.to_dtype(DType::F32)? * scale)?;
+    let k = k.transpose(1, 2)?.contiguous()?.to_dtype(DType::F32)?;
+    let v = v.transpose(1, 2)?.contiguous()?.to_dtype(DType::F32)?;
+    let g = g.transpose(1, 2)?.contiguous()?.to_dtype(DType::F32)?;
+    let beta = beta.transpose(1, 2)?.contiguous()?.to_dtype(DType::F32)?;
+
+    let seq_len = q.dim(2)?;
+    let mut s = state.to_dtype(DType::F32)?;
+    let mut outputs = Vec::with_capacity(seq_len);
+
+    for i in 0..seq_len {
+        let q_t = q.i((.., .., i, ..))?;
+        let k_t = k.i((.., .., i, ..))?;
+        let v_t = v.i((.., .., i, ..))?;
+        let g_t = g.i((.., .., i))?;
+        let beta_t = beta.i((.., .., i))?;
+
+        let k_exp = k_t.unsqueeze(D::Minus1)?;
+        let kv_mem = s.broadcast_mul(&k_exp)?.sum(2)?;
+
+        let decay = g_t.exp()?.unsqueeze(D::Minus1)?.unsqueeze(D::Minus1)?;
+        s = s.broadcast_mul(&decay)?;
+
+        let beta_exp = beta_t.unsqueeze(D::Minus1)?;
+        let delta = (v_t - kv_mem)?.broadcast_mul(&beta_exp)?;
+
+        let outer = k_exp.broadcast_mul(&delta.unsqueeze(2)?)?;
+        s = (s + outer)?;
+
+        let q_exp = q_t.unsqueeze(D::Minus1)?;
+        let y_t = s.broadcast_mul(&q_exp)?.sum(2)?;
+
+        outputs.push(y_t);
+    }
+
+    *state = s.to_dtype(state.dtype())?;
+
+    let out = Tensor::stack(&outputs, 2)?;
+    out.transpose(1, 2)?.contiguous()?.to_dtype(dtype)
+}
+
+// ====================== GDN Projection variants ======================
+
+/// Projection strategy for GDN input. Qwen3Next and Qwen3.5 differ in how they pack weights.
+#[allow(dead_code)]
+pub enum GdnProjection {
+    /// Qwen3Next: fused in_proj_qkvz (key_dim*2 + value_dim*2) + in_proj_ba (num_v_heads*2)
+    FusedQkvzBa {
+        in_proj_qkvz: Arc<dyn QuantMethod>,
+        in_proj_ba: Arc<dyn QuantMethod>,
+    },
+    /// Qwen3.5: split in_proj_qkv (key_dim*2 + value_dim) + in_proj_z (value_dim) + in_proj_b (num_v_heads) + in_proj_a (num_v_heads)
+    SplitQkvZa {
+        in_proj_qkv: Arc<dyn QuantMethod>,
+        in_proj_z: Arc<dyn QuantMethod>,
+        in_proj_b: Arc<dyn QuantMethod>,
+        in_proj_a: Arc<dyn QuantMethod>,
+    },
+    /// Qwen3.5 TP-safe split for packed in_proj_qkv [q|k|v].
+    SplitQkvZaMerged {
+        in_proj_q: Arc<dyn QuantMethod>,
+        in_proj_k: Arc<dyn QuantMethod>,
+        in_proj_v: Arc<dyn QuantMethod>,
+        in_proj_z: Arc<dyn QuantMethod>,
+        in_proj_b: Arc<dyn QuantMethod>,
+        in_proj_a: Arc<dyn QuantMethod>,
+    },
+}
+
+// ====================== Gated Delta Net layer ======================
+
+/// Projected outputs from the GDN input projections.
+/// z is 4D (batch, seq, num_v_heads, head_v_dim), others are flat for conv.
+struct GdnProjected {
+    /// (batch, seq, key_dim)
+    q: Tensor,
+    /// (batch, seq, key_dim)
+    k: Tensor,
+    /// (batch, seq, value_dim)
+    v_flat: Tensor,
+    /// (batch, seq, num_v_heads, head_v_dim) — gating signal for norm
+    z: Tensor,
+    /// (batch, seq, num_v_heads)
+    b: Tensor,
+    /// (batch, seq, num_v_heads)
+    a: Tensor,
+}
+
+pub struct GatedDeltaNet {
+    pub projection: GdnProjection,
+    pub conv1d_weight: Tensor,
+    pub dt_bias: Tensor,
+    pub a_log: Tensor,
+    pub norm: RmsNormGated,
+    pub out_proj: Arc<dyn QuantMethod>,
+    pub num_k_heads: usize,
+    pub num_v_heads: usize,
+    pub head_k_dim: usize,
+    pub head_v_dim: usize,
+    pub conv_kernel_size: usize,
+    pub key_dim: usize,
+    pub value_dim: usize,
+    /// If true, V-head expansion uses tiled layout [K0..K15, K0..K15].
+    /// If false, uses interleaved layout [K0, K0, K1, K1, ...].
+    /// MoE models use tiled; dense models use interleaved.
+    pub tiled_v_heads: bool,
+}
+
+impl GatedDeltaNet {
+    /// Load GDN layer with fused Qwen3Next projection (in_proj_qkvz + in_proj_ba).
+    #[allow(dead_code)]
+    pub fn load_qwen3next(
+        vb: ShardedVarBuilder,
+        cfg: &dyn DeltaNetConfig,
+        mapper: &dyn DeviceMapper,
+        layer_idx: usize,
+        loading_isq: bool,
+        comm: &Arc<mistralrs_quant::Comm>,
+    ) -> Result<Self> {
+        let isq_target_device = if loading_isq {
+            mapper.device_for(layer_idx, false).cloned()
+        } else {
+            None
+        };
+
+        let world_size = comm.world_size();
+        let num_k_heads_global = cfg.linear_num_key_heads();
+        let num_v_heads_global = cfg.linear_num_value_heads();
+
+        if !num_v_heads_global.is_multiple_of(world_size)
+            || !num_k_heads_global.is_multiple_of(world_size)
+        {
+            candle_core::bail!(
+                "linear attention heads must be divisible by tensor parallel world_size (num_v_heads={}, num_k_heads={}, world_size={})",
+                num_v_heads_global,
+                num_k_heads_global,
+                world_size
+            );
+        }
+
+        let num_k_heads = num_k_heads_global / world_size;
+        let num_v_heads = num_v_heads_global / world_size;
+
+        let head_k_dim = cfg.linear_key_head_dim();
+        let head_v_dim = cfg.linear_value_head_dim();
+        let key_dim = num_k_heads * head_k_dim;
+        let value_dim = num_v_heads * head_v_dim;
+
+        let key_dim_global = num_k_heads_global * head_k_dim;
+        let value_dim_global = num_v_heads_global * head_v_dim;
+
+        let conv_kernel_size = cfg.linear_conv_kernel_dim();
+
+        let vb_la = mapper.set_device(layer_idx, vb.pp("linear_attn"), loading_isq);
+
+        let qkvz_out_global = key_dim_global * 2 + value_dim_global * 2;
+        let in_proj_qkvz = mistralrs_quant::ColumnParallelLayer::new(
+            cfg.hidden_size(),
+            qkvz_out_global,
+            cfg.quantization_config(),
+            false,
+            comm,
+            vb_la.pp("in_proj_qkvz"),
+        )?;
+        let in_proj_ba = mistralrs_quant::ColumnParallelLayer::new(
+            cfg.hidden_size(),
+            num_v_heads_global * 2,
+            cfg.quantization_config(),
+            false,
+            comm,
+            vb_la.pp("in_proj_ba"),
+        )?;
+
+        let conv_dim_global = key_dim_global * 2 + value_dim_global;
+        let mut conv1d_weight =
+            vb_la.get((conv_dim_global, 1, conv_kernel_size), "conv1d.weight")?;
+
+        let sd = mistralrs_quant::Shard::Simple {
+            dim: 0,
+            rank: comm.rank(),
+            world_size: comm.world_size(),
+        };
+        let mut dt_bias = vb_la.get_with_hints((num_v_heads_global,), "dt_bias", sd)?;
+        let mut a_log = vb_la.get_with_hints((num_v_heads_global,), "A_log", sd)?;
+
+        let rank = comm.rank();
+        let q_start = rank * key_dim;
+        let k_start = key_dim_global + rank * key_dim;
+        let v_start = key_dim_global * 2 + rank * value_dim;
+        let q_w = conv1d_weight.narrow(0, q_start, key_dim)?;
+        let k_w = conv1d_weight.narrow(0, k_start, key_dim)?;
+        let v_w = conv1d_weight.narrow(0, v_start, value_dim)?;
+        conv1d_weight = candle_core::Tensor::cat(&[&q_w, &k_w, &v_w], 0)?;
+
+        if let Some(ref target_dev) = isq_target_device {
+            conv1d_weight = conv1d_weight.to_device(target_dev)?;
+            dt_bias = dt_bias.to_device(target_dev)?;
+            a_log = a_log.to_device(target_dev)?;
+        }
+
+        let norm = RmsNormGated::new(
+            head_v_dim,
+            cfg.rms_norm_eps(),
+            vb_la.pp("norm"),
+            isq_target_device.as_ref(),
+        )?;
+
+        let out_proj = RowParallelLayer::new(
+            value_dim,
+            cfg.hidden_size(),
+            cfg.quantization_config(),
+            false,
+            comm,
+            vb_la.pp("out_proj"),
+        )?;
+
+        Ok(Self {
+            projection: GdnProjection::FusedQkvzBa {
+                in_proj_qkvz,
+                in_proj_ba,
+            },
+            conv1d_weight,
+            dt_bias,
+            a_log,
+            norm,
+            out_proj,
+            num_k_heads,
+            num_v_heads,
+            head_k_dim,
+            head_v_dim,
+            conv_kernel_size,
+            key_dim,
+            value_dim,
+            // HF/safetensor FusedQkvzBa path uses interleaved layout
+            tiled_v_heads: false,
+        })
+    }
+
+    /// Load GDN layer with split Qwen3.5 projection (in_proj_qkv + in_proj_z + in_proj_b + in_proj_a).
+    pub fn load_qwen3_5(
+        vb: ShardedVarBuilder,
+        cfg: &dyn DeltaNetConfig,
+        mapper: &dyn DeviceMapper,
+        layer_idx: usize,
+        loading_isq: bool,
+        comm: &Arc<mistralrs_quant::Comm>,
+    ) -> Result<Self> {
+        let isq_target_device = if loading_isq {
+            mapper.device_for(layer_idx, false).cloned()
+        } else {
+            None
+        };
+
+        let world_size = comm.world_size();
+        let num_k_heads_global = cfg.linear_num_key_heads();
+        let num_v_heads_global = cfg.linear_num_value_heads();
+
+        if !num_v_heads_global.is_multiple_of(world_size)
+            || !num_k_heads_global.is_multiple_of(world_size)
+        {
+            candle_core::bail!(
+                "linear attention heads must be divisible by tensor parallel world_size (num_v_heads={}, num_k_heads={}, world_size={})",
+                num_v_heads_global,
+                num_k_heads_global,
+                world_size
+            );
+        }
+
+        let num_k_heads = num_k_heads_global / world_size;
+        let num_v_heads = num_v_heads_global / world_size;
+
+        let head_k_dim = cfg.linear_key_head_dim();
+        let head_v_dim = cfg.linear_value_head_dim();
+        let key_dim = num_k_heads * head_k_dim;
+        let value_dim = num_v_heads * head_v_dim;
+
+        let key_dim_global = num_k_heads_global * head_k_dim;
+        let value_dim_global = num_v_heads_global * head_v_dim;
+
+        let conv_kernel_size = cfg.linear_conv_kernel_dim();
+
+        let vb_la = mapper.set_device(layer_idx, vb.pp("linear_attn"), loading_isq);
+
+        let qkv_out_global = key_dim_global * 2 + value_dim_global;
+        let in_proj_z = mistralrs_quant::ColumnParallelLayer::new(
+            cfg.hidden_size(),
+            value_dim_global,
+            cfg.quantization_config(),
+            false,
+            comm,
+            vb_la.pp("in_proj_z"),
+        )?;
+        let in_proj_b = mistralrs_quant::ColumnParallelLayer::new(
+            cfg.hidden_size(),
+            num_v_heads_global,
+            cfg.quantization_config(),
+            false,
+            comm,
+            vb_la.pp("in_proj_b"),
+        )?;
+        let in_proj_a = mistralrs_quant::ColumnParallelLayer::new(
+            cfg.hidden_size(),
+            num_v_heads_global,
+            cfg.quantization_config(),
+            false,
+            comm,
+            vb_la.pp("in_proj_a"),
+        )?;
+
+        let conv_dim_global = key_dim_global * 2 + value_dim_global;
+        let mut conv1d_weight =
+            vb_la.get((conv_dim_global, 1, conv_kernel_size), "conv1d.weight")?;
+
+        // Learned GDN parameters ()
+        let sd = mistralrs_quant::Shard::Simple {
+            dim: 0,
+            rank: comm.rank(),
+            world_size: comm.world_size(),
+        };
+        let mut dt_bias = vb_la.get_with_hints((num_v_heads_global,), "dt_bias", sd)?;
+        let mut a_log = vb_la.get_with_hints((num_v_heads_global,), "A_log", sd)?;
+
+        let rank = comm.rank();
+        let q_start = rank * key_dim;
+        let k_start = key_dim_global + rank * key_dim;
+        let v_start = key_dim_global * 2 + rank * value_dim;
+        let q_w = conv1d_weight.narrow(0, q_start, key_dim)?;
+        let k_w = conv1d_weight.narrow(0, k_start, key_dim)?;
+        let v_w = conv1d_weight.narrow(0, v_start, value_dim)?;
+        conv1d_weight = candle_core::Tensor::cat(&[&q_w, &k_w, &v_w], 0)?;
+
+        if let Some(ref target_dev) = isq_target_device {
+            conv1d_weight = conv1d_weight.to_device(target_dev)?;
+            dt_bias = dt_bias.to_device(target_dev)?;
+            a_log = a_log.to_device(target_dev)?;
+        }
+
+        let norm = RmsNormGated::new(
+            head_v_dim,
+            cfg.rms_norm_eps(),
+            vb_la.pp("norm"),
+            isq_target_device.as_ref(),
+        )?;
+
+        let out_proj = RowParallelLayer::new(
+            value_dim,
+            cfg.hidden_size(),
+            cfg.quantization_config(),
+            false,
+            comm,
+            vb_la.pp("out_proj"),
+        )?;
+
+        let projection = if world_size > 1 {
+            let merged_qkv = mistralrs_quant::ColumnParallelLayer::new_merged_chunks(
+                cfg.hidden_size(),
+                qkv_out_global,
+                vec![key_dim_global, key_dim_global, value_dim_global],
+                cfg.quantization_config(),
+                comm,
+                vb_la.pp("in_proj_qkv"),
+            )?;
+            if merged_qkv.len() != 3 {
+                candle_core::bail!(
+                    "Expected 3 merged chunks for in_proj_qkv, got {}",
+                    merged_qkv.len()
+                );
+            }
+            GdnProjection::SplitQkvZaMerged {
+                in_proj_q: merged_qkv[0].clone(),
+                in_proj_k: merged_qkv[1].clone(),
+                in_proj_v: merged_qkv[2].clone(),
+                in_proj_z,
+                in_proj_b,
+                in_proj_a,
+            }
+        } else {
+            let in_proj_qkv = mistralrs_quant::ColumnParallelLayer::new(
+                cfg.hidden_size(),
+                qkv_out_global,
+                cfg.quantization_config(),
+                false,
+                comm,
+                vb_la.pp("in_proj_qkv"),
+            )?;
+            GdnProjection::SplitQkvZa {
+                in_proj_qkv,
+                in_proj_z,
+                in_proj_b,
+                in_proj_a,
+            }
+        };
+
+        Ok(Self {
+            projection,
+            conv1d_weight,
+            dt_bias,
+            a_log,
+            norm,
+            out_proj,
+            num_k_heads,
+            num_v_heads,
+            head_k_dim,
+            head_v_dim,
+            conv_kernel_size,
+            key_dim,
+            value_dim,
+            // HF/safetensor path uses interleaved layout
+            tiled_v_heads: false,
+        })
+    }
+
+    /// Project inputs and unpack into (q, k, v_flat, z, b, a) based on projection variant.
+    fn project_inputs(&self, x: &Tensor) -> Result<GdnProjected> {
+        let (batch_size, seq_len, _) = x.dims3()?;
+        let v_per_group = self.num_v_heads / self.num_k_heads;
+
+        match &self.projection {
+            GdnProjection::FusedQkvzBa {
+                in_proj_qkvz,
+                in_proj_ba,
+            } => {
+                // Use forward_autocast to handle GGUF dtype (F32 matmul → restore original dtype).
+                // For safetensor/ISQ weights, quantized_act_type() is None so this is a no-op.
+                let mixed_qkvz = in_proj_qkvz.forward_autocast(x)?;
+                let mixed_ba = in_proj_ba.forward_autocast(x)?;
+
+                let group_size_qkvz = 2 * self.head_k_dim + 2 * v_per_group * self.head_v_dim;
+                let mixed_qkvz =
+                    mixed_qkvz.reshape((batch_size, seq_len, self.num_k_heads, group_size_qkvz))?;
+
+                let group_size_ba = 2 * v_per_group;
+                let mixed_ba =
+                    mixed_ba.reshape((batch_size, seq_len, self.num_k_heads, group_size_ba))?;
+
+                let mut offset = 0;
+                let q = mixed_qkvz.narrow(D::Minus1, offset, self.head_k_dim)?;
+                offset += self.head_k_dim;
+                let k = mixed_qkvz.narrow(D::Minus1, offset, self.head_k_dim)?;
+                offset += self.head_k_dim;
+                let v = mixed_qkvz.narrow(D::Minus1, offset, v_per_group * self.head_v_dim)?;
+                offset += v_per_group * self.head_v_dim;
+                let z = mixed_qkvz.narrow(D::Minus1, offset, v_per_group * self.head_v_dim)?;
+
+                let b = mixed_ba.narrow(D::Minus1, 0, v_per_group)?;
+                let a = mixed_ba.narrow(D::Minus1, v_per_group, v_per_group)?;
+
+                // Reshape to per-head
+                let v = v.reshape((batch_size, seq_len, self.num_v_heads, self.head_v_dim))?;
+                let z = z.reshape((batch_size, seq_len, self.num_v_heads, self.head_v_dim))?;
+                let b = b.reshape((batch_size, seq_len, self.num_v_heads))?;
+                let a = a.reshape((batch_size, seq_len, self.num_v_heads))?;
+
+                let q = q.reshape((batch_size, seq_len, self.key_dim))?;
+                let k = k.reshape((batch_size, seq_len, self.key_dim))?;
+                let v_flat = v.reshape((batch_size, seq_len, self.value_dim))?;
+
+                Ok(GdnProjected {
+                    q,
+                    k,
+                    v_flat,
+                    z,
+                    b,
+                    a,
+                })
+            }
+            GdnProjection::SplitQkvZa {
+                in_proj_qkv,
+                in_proj_z,
+                in_proj_b,
+                in_proj_a,
+            } => {
+                let proj_qkv = in_proj_qkv.forward_autocast(x)?;
+                let z_full = in_proj_z.forward_autocast(x)?;
+                let b = in_proj_b.forward_autocast(x)?;
+                let a = in_proj_a.forward_autocast(x)?;
+
+                let q = proj_qkv.narrow(D::Minus1, 0, self.key_dim)?;
+                let k = proj_qkv.narrow(D::Minus1, self.key_dim, self.key_dim)?;
+                let v_flat = proj_qkv.narrow(D::Minus1, self.key_dim * 2, self.value_dim)?;
+
+                let z = z_full.reshape((batch_size, seq_len, self.num_v_heads, self.head_v_dim))?;
+
+                Ok(GdnProjected {
+                    q,
+                    k,
+                    v_flat,
+                    z,
+                    b,
+                    a,
+                })
+            }
+            GdnProjection::SplitQkvZaMerged {
+                in_proj_q,
+                in_proj_k,
+                in_proj_v,
+                in_proj_z,
+                in_proj_b,
+                in_proj_a,
+            } => {
+                let q = in_proj_q.forward_autocast(x)?;
+                let k = in_proj_k.forward_autocast(x)?;
+                let v_flat = in_proj_v.forward_autocast(x)?;
+                let z_full = in_proj_z.forward_autocast(x)?;
+                let b = in_proj_b.forward_autocast(x)?;
+                let a = in_proj_a.forward_autocast(x)?;
+
+                let z = z_full.reshape((batch_size, seq_len, self.num_v_heads, self.head_v_dim))?;
+
+                Ok(GdnProjected {
+                    q,
+                    k,
+                    v_flat,
+                    z,
+                    b,
+                    a,
+                })
+            }
+        }
+    }
+
+    /// Run the full GDN forward pass.
+    pub fn forward(&self, x: &Tensor, cache: &mut GdnLayerCache) -> Result<Tensor> {
+        let (batch_size, seq_len, _hidden) = x.dims3()?;
+        let dtype = x.dtype();
+        let v_per_group = self.num_v_heads / self.num_k_heads;
+
+        // 1. Project input
+        let projected = self.project_inputs(x)
+            .map_err(|e| candle_core::Error::Msg(format!("gdn project_inputs: {e}")))?;
+        let GdnProjected {
+            q,
+            k,
+            v_flat,
+            z,
+            b,
+            a,
+        } = projected;
+
+        // 2. Concatenate q, k, v for conv1d: (batch, seq, conv_dim)
+        let mixed_qkv = Tensor::cat(&[&q, &k, &v_flat], D::Minus1)?;
+
+        // 3. Apply causal conv1d (includes silu activation)
+        let mixed_qkv = if cache.seqlen_offset > 0 && seq_len == 1 {
+            self.causal_conv1d_update(&mixed_qkv, cache)
+                .map_err(|e| candle_core::Error::Msg(format!("gdn conv1d_update: {e}")))?
+        } else {
+            self.causal_conv1d_full(&mixed_qkv, cache)
+                .map_err(|e| candle_core::Error::Msg(format!("gdn conv1d_full(seq={seq_len}): {e}")))?
+        };
+        // 4. Split back after conv and reshape to per-head
+        let q = mixed_qkv.narrow(D::Minus1, 0, self.key_dim)?;
+        let k = mixed_qkv.narrow(D::Minus1, self.key_dim, self.key_dim)?;
+        let v = mixed_qkv.narrow(D::Minus1, self.key_dim * 2, self.value_dim)?;
+
+        let q = q.reshape((batch_size, seq_len, self.num_k_heads, self.head_k_dim))?;
+        let k = k.reshape((batch_size, seq_len, self.num_k_heads, self.head_k_dim))?;
+        let v = v.reshape((batch_size, seq_len, self.num_v_heads, self.head_v_dim))?;
+
+        // 5. Compute beta and g (3D: batch, seq, num_v_heads)
+        let (beta, g) = self.compute_gating(&b, &a, dtype)
+            .map_err(|e| candle_core::Error::Msg(format!("gdn compute_gating: {e}")))?;
+        // 6. If num_v_heads > num_k_heads, expand q and k to match V-head count.
+        // Layout depends on GGUF weight ordering:
+        //   Tiled:       [K0..K15, K0..K15] → unsqueeze(2) before num_k_heads
+        //   Interleaved: [K0,K0, K1,K1,...] → unsqueeze(3) after num_k_heads
+        let (q, k) = if v_per_group > 1 {
+            let (q, k) = if self.tiled_v_heads {
+                let q = q
+                    .unsqueeze(2)?
+                    .broadcast_as((batch_size, seq_len, v_per_group, self.num_k_heads, self.head_k_dim))?
+                    .reshape((batch_size, seq_len, self.num_v_heads, self.head_k_dim))?;
+                let k = k
+                    .unsqueeze(2)?
+                    .broadcast_as((batch_size, seq_len, v_per_group, self.num_k_heads, self.head_k_dim))?
+                    .reshape((batch_size, seq_len, self.num_v_heads, self.head_k_dim))?;
+                (q, k)
+            } else {
+                let q = q
+                    .unsqueeze(3)?
+                    .broadcast_as((batch_size, seq_len, self.num_k_heads, v_per_group, self.head_k_dim))?
+                    .reshape((batch_size, seq_len, self.num_v_heads, self.head_k_dim))?;
+                let k = k
+                    .unsqueeze(3)?
+                    .broadcast_as((batch_size, seq_len, self.num_k_heads, v_per_group, self.head_k_dim))?
+                    .reshape((batch_size, seq_len, self.num_v_heads, self.head_k_dim))?;
+                (q, k)
+            };
+            (q, k)
+        } else {
+            (q, k)
+        };
+
+        // 7. L2-normalize q and k
+        let q = l2_norm(&q, 1e-6)?;
+        let k = l2_norm(&k, 1e-6)?;
+
+        // 8. Apply recurrence
+        let y = self.apply_recurrence(&q, &k, &v, &g, &beta, batch_size, seq_len, dtype, cache)?;
+
+        cache.seqlen_offset += seq_len;
+
+        // 9. Apply RMSNormGated: flatten to 2D, apply norm with z as gate, reshape back
+        let z_shape = z.shape().clone();
+        let y = y.reshape(((), self.head_v_dim))?;
+        let z = z.reshape(((), self.head_v_dim))?;
+        let y = self.norm.forward(&y, &z)?;
+        let y = y.reshape(z_shape)?;
+        let y = y.reshape((batch_size, seq_len, self.value_dim))?;
+
+        // 10. Output projection
+        let res = self.out_proj.forward_autocast(&y)?;
+        Ok(res)
+    }
+
+    /// Compute beta (sigmoid of b) and g (gating decay from a, A_log, dt_bias).
+    fn compute_gating(&self, b: &Tensor, a: &Tensor, dtype: DType) -> Result<(Tensor, Tensor)> {
+        #[cfg(feature = "cuda")]
+        {
+            if b.device().is_cuda() {
+                let b_flat = b.contiguous()?.flatten_all()?;
+                let a_flat = a.contiguous()?.flatten_all()?;
+                let a_log_f32 = self.a_log.to_dtype(DType::F32)?.contiguous()?;
+                let dt_bias_f32 = self.dt_bias.to_dtype(DType::F32)?.contiguous()?;
+                let (beta_flat, g_flat) = crate::cuda::gdn::fused_gdn_gating_cuda(
+                    &b_flat,
+                    &a_flat,
+                    &a_log_f32,
+                    &dt_bias_f32,
+                )?;
+                let shape = b.shape();
+                return Ok((beta_flat.reshape(shape)?, g_flat.reshape(shape)?));
+            }
+        }
+        let beta = candle_nn::ops::sigmoid(b)?;
+        let a_f = a.to_dtype(DType::F32)?;
+        let dt_bias_expanded = self
+            .dt_bias
+            .to_dtype(DType::F32)?
+            .unsqueeze(0)?
+            .unsqueeze(0)?;
+        let g = self
+            .a_log
+            .to_dtype(DType::F32)?
+            .exp()?
+            .neg()?
+            .unsqueeze(0)?
+            .unsqueeze(0)?
+            .broadcast_mul(&softplus(&a_f.broadcast_add(&dt_bias_expanded)?)?)?
+            .to_dtype(dtype)?;
+        Ok((beta, g))
+    }
+
+    /// Apply recurrence (CUDA or CPU/Metal fallback).
+    #[allow(clippy::too_many_arguments, unused_variables)]
+    fn apply_recurrence(
+        &self,
+        q: &Tensor,
+        k: &Tensor,
+        v: &Tensor,
+        g: &Tensor,
+        beta: &Tensor,
+        batch_size: usize,
+        seq_len: usize,
+        dtype: DType,
+        cache: &mut GdnLayerCache,
+    ) -> Result<Tensor> {
+        #[cfg(feature = "cuda")]
+        {
+            if q.device().is_cuda() {
+                let num_heads = self.num_v_heads;
+                let k_head = self.head_k_dim;
+                let v_head = self.head_v_dim;
+                let scale = 1.0 / (k_head as f64).sqrt();
+
+                let q_bh = (q.transpose(1, 2)?.contiguous()?.to_dtype(DType::F32)? * scale)?
+                    .reshape((batch_size * num_heads, seq_len, k_head))?
+                    .contiguous()?;
+                let k_bh = k
+                    .transpose(1, 2)?
+                    .contiguous()?
+                    .to_dtype(DType::F32)?
+                    .reshape((batch_size * num_heads, seq_len, k_head))?
+                    .contiguous()?;
+                let v_bh = v
+                    .transpose(1, 2)?
+                    .contiguous()?
+                    .to_dtype(DType::F32)?
+                    .reshape((batch_size * num_heads, seq_len, v_head))?
+                    .contiguous()?;
+                let g_bh = g
+                    .to_dtype(DType::F32)?
+                    .transpose(1, 2)?
+                    .contiguous()?
+                    .reshape((batch_size * num_heads, seq_len))?
+                    .contiguous()?;
+                let beta_bh = beta
+                    .to_dtype(DType::F32)?
+                    .transpose(1, 2)?
+                    .contiguous()?
+                    .reshape((batch_size * num_heads, seq_len))?
+                    .contiguous()?;
+
+                let mut state_flat = cache
+                    .recurrent_state
+                    .to_dtype(DType::F32)?
+                    .reshape((batch_size * num_heads, k_head, v_head))?
+                    .contiguous()?;
+
+                let out_bh = crate::cuda::gdn::gated_delta_rule_recurrence_cuda(
+                    &q_bh,
+                    &k_bh,
+                    &v_bh,
+                    &g_bh,
+                    &beta_bh,
+                    &mut state_flat,
+                )?;
+
+                cache.recurrent_state = state_flat
+                    .reshape((batch_size, num_heads, k_head, v_head))?
+                    .to_dtype(cache.recurrent_state.dtype())?;
+
+                return out_bh
+                    .reshape((batch_size, num_heads, seq_len, v_head))?
+                    .transpose(1, 2)?
+                    .contiguous()?
+                    .to_dtype(dtype);
+            }
+        }
+
+        gated_delta_rule_recurrence(q, k, v, g, beta, &mut cache.recurrent_state)
+    }
+
+    /// Single-step causal conv1d update for decode.
+    fn causal_conv1d_update(&self, x: &Tensor, cache: &mut GdnLayerCache) -> Result<Tensor> {
+        let (_batch, seq_len, _conv_dim) = x.dims3()?;
+        let x_t = x.transpose(1, 2)?.contiguous()?;
+
+        #[cfg(feature = "cuda")]
+        if x_t.device().is_cuda() {
+            let weight = self
+                .conv1d_weight
+                .squeeze(1)?
+                .to_dtype(x_t.dtype())?
+                .contiguous()?;
+            let conv_state = cache.conv_state.contiguous()?;
+            let (output, new_conv_state) = crate::cuda::gdn::causal_conv1d_cuda(
+                &x_t,
+                &weight,
+                &conv_state,
+                self.conv_kernel_size,
+                true,
+            )?;
+            cache.conv_state = new_conv_state;
+            return output.transpose(1, 2);
+        }
+
+        let state_len = cache.conv_state.dim(2)?;
+        let hidden_new = Tensor::cat(&[cache.conv_state.clone(), x_t], 2)?;
+        let new_len = hidden_new.dim(2)?;
+        cache.conv_state = hidden_new.narrow(2, new_len - state_len, state_len)?;
+
+        let weight = self
+            .conv1d_weight
+            .squeeze(1)?
+            .to_dtype(hidden_new.dtype())?;
+        let mut conv_outputs = Vec::with_capacity(seq_len);
+        let total_len = hidden_new.dim(2)?;
+        for i in (total_len - seq_len)..total_len {
+            let window =
+                hidden_new.narrow(2, i + 1 - self.conv_kernel_size, self.conv_kernel_size)?;
+            let out = (window * weight.unsqueeze(0)?)?.sum(D::Minus1)?;
+            conv_outputs.push(out);
+        }
+        let out = Tensor::stack(&conv_outputs, 2)?;
+        let out = candle_nn::ops::silu(&out)?;
+        out.transpose(1, 2)
+    }
+
+    /// Full sequence causal conv1d for prefill.
+    fn causal_conv1d_full(&self, x: &Tensor, cache: &mut GdnLayerCache) -> Result<Tensor> {
+        let (batch_size, seq_len, conv_dim) = x.dims3()?;
+        let x_t = x.transpose(1, 2)?.contiguous()?;
+
+        #[cfg(feature = "cuda")]
+        if x_t.device().is_cuda() {
+            let weight = self
+                .conv1d_weight
+                .squeeze(1)?
+                .to_dtype(x_t.dtype())?
+                .contiguous()?;
+            let (output, new_conv_state) = crate::cuda::gdn::causal_conv1d_cuda(
+                &x_t,
+                &weight,
+                &cache.conv_state,
+                self.conv_kernel_size,
+                false,
+            )?;
+            cache.conv_state = new_conv_state;
+            return output.transpose(1, 2);
+        }
+
+        let pad_width = self.conv_kernel_size.saturating_sub(seq_len);
+        cache.conv_state = if pad_width > 0 {
+            let zeros =
+                Tensor::zeros((batch_size, conv_dim, pad_width), x_t.dtype(), x_t.device())?;
+            Tensor::cat(&[zeros, x_t.clone()], 2)?
+        } else {
+            x_t.narrow(2, seq_len - self.conv_kernel_size, self.conv_kernel_size)?
+        };
+
+        let padded_t = Tensor::cat(
+            &[
+                Tensor::zeros(
+                    (batch_size, conv_dim, self.conv_kernel_size - 1),
+                    x_t.dtype(),
+                    x_t.device(),
+                )?,
+                x_t,
+            ],
+            2,
+        )?;
+
+        let weight = self.conv1d_weight.squeeze(1)?.to_dtype(padded_t.dtype())?;
+
+        let mut conv_outputs = Vec::with_capacity(seq_len);
+        for i in 0..seq_len {
+            let window = padded_t.narrow(2, i, self.conv_kernel_size)?;
+            let out = (window * weight.unsqueeze(0)?)?.sum(D::Minus1)?;
+            conv_outputs.push(out);
+        }
+        let out = Tensor::stack(&conv_outputs, 2)?;
+        let out = candle_nn::ops::silu(&out)?;
+        out.transpose(1, 2)
+    }
+}

--- a/mistralrs-core/src/models/mod.rs
+++ b/mistralrs-core/src/models/mod.rs
@@ -1,6 +1,7 @@
 pub(crate) mod deepseek2;
 pub(crate) mod deepseek3;
 pub(crate) mod deltanet;
+pub(crate) mod gdn;
 pub(crate) mod gemma;
 pub(crate) mod gemma2;
 pub(crate) mod glm4;

--- a/mistralrs-core/src/models/mod.rs
+++ b/mistralrs-core/src/models/mod.rs
@@ -1,6 +1,6 @@
 pub(crate) mod deepseek2;
 pub(crate) mod deepseek3;
-pub(crate) mod gdn;
+pub(crate) mod deltanet;
 pub(crate) mod gemma;
 pub(crate) mod gemma2;
 pub(crate) mod glm4;
@@ -20,6 +20,7 @@ pub(crate) mod quantized_phi3;
 pub(crate) mod quantized_qwen;
 pub(crate) mod quantized_qwen3;
 pub(crate) mod quantized_qwen3_moe;
+pub(crate) mod quantized_qwen3_next;
 pub(crate) mod quantized_starcoder2;
 pub(crate) mod qwen2;
 pub(crate) mod qwen3;

--- a/mistralrs-core/src/models/quantized_qwen3_next.rs
+++ b/mistralrs-core/src/models/quantized_qwen3_next.rs
@@ -1,0 +1,867 @@
+#![allow(clippy::cast_possible_truncation, clippy::cast_precision_loss)]
+
+//! GGUF loader for Qwen3.5 (Qwen3-Next) hybrid MoE models.
+//!
+//! Qwen3.5 uses a hybrid architecture:
+//! - 75% of layers use Gated Delta Networks (linear attention, O(n))
+//! - 25% of layers use standard multi-head attention with output gating
+//! - All layers use Sparse MoE with shared experts
+//!
+//! This loader reads GGUF files with architecture "qwen35moe" and constructs
+//! the model using the shared `deltanet::GatedDeltaNet` module for GDN layers.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use crate::attention::SdpaParams;
+use crate::device_map::{DeviceMappedMask, DeviceMapper};
+use crate::gguf::Content;
+use crate::layers::{CausalMasker, QRmsNorm, RotaryEmbedding, Sdpa};
+use crate::layers_masker::PastKvLenCache;
+use crate::models::deltanet::{GatedDeltaNet, GdnLayerCache, GdnProjection, RmsNormGated};
+use crate::ops::{TopKLastDimOp, TopKOutput};
+use crate::paged_attention::{AttentionImplementation, PagedAttention};
+use crate::pipeline::text_models_inputs_processor::PagedAttentionInputMetadata;
+use crate::pipeline::{extract_logits, EitherCache, KvCache, NormalCache};
+use crate::utils::gguf_metadata::ContentMetadata;
+use crate::utils::model_config as ModelConfig;
+use crate::utils::progress::{new_multi_progress, NiceProgressBar};
+use candle_core::quantized::QMatMul;
+use candle_core::{DType, Device, Result, Tensor, D};
+use candle_nn::{Embedding, Module};
+use mistralrs_quant::{GgufMatMul, QuantMethod, QuantMethodConfig};
+
+const DEFAULT_MAX_SEQ_LEN: u32 = 4096;
+const FULL_ATTENTION_INTERVAL: usize = 4;
+
+fn is_full_attention_layer(layer_idx: usize) -> bool {
+    (layer_idx + 1) % FULL_ATTENTION_INTERVAL == 0
+}
+
+// ====================== MoE ======================
+
+struct FusedMoe {
+    gate: QMatMul,
+    gate_experts: QMatMul,
+    up_experts: QMatMul,
+    down_experts: QMatMul,
+    norm_topk_prob: bool,
+    num_experts_per_tok: usize,
+}
+
+impl FusedMoe {
+    fn forward(&self, xs: &Tensor) -> Result<Tensor> {
+        let (batch, seq_len, hidden_dim) = xs.dims3()?;
+        let xs = xs.reshape(((), hidden_dim))?;
+        let original_dtype = xs.dtype();
+        let (num_tokens, hidden_dim) = xs.dims2()?;
+        let router_logits = self.gate.forward(&xs.to_dtype(DType::F32)?)?;
+        let routing_weights = candle_nn::ops::softmax_last_dim(&router_logits)?;
+
+        let TopKOutput {
+            values: mut scores,
+            indices,
+        } = routing_weights.topk(self.num_experts_per_tok)?;
+
+        if self.norm_topk_prob {
+            scores = scores.broadcast_div(&scores.sum_keepdim(D::Minus1)?)?;
+        }
+
+        let ys = {
+            let xs = xs.to_dtype(DType::F32)?.reshape((num_tokens, 1, hidden_dim))?;
+            let gate = self.gate_experts.indexed_moe_forward(&xs, &indices)?;
+            let up = self.up_experts.indexed_moe_forward(&xs, &indices)?;
+            let activated = crate::ops::mul_and_act(&gate, &up, crate::layers::Activation::Silu)?;
+            self.down_experts
+                .indexed_moe_forward(&activated, &indices)?
+        };
+        ys.broadcast_mul(&scores.unsqueeze(D::Minus1)?)?
+            .sum(D::Minus2)?
+            .reshape((batch, seq_len, hidden_dim))?
+            .to_dtype(original_dtype)
+    }
+}
+
+struct SharedExpert {
+    gate_proj: Arc<dyn QuantMethod>,
+    up_proj: Arc<dyn QuantMethod>,
+    down_proj: Arc<dyn QuantMethod>,
+    shared_gate: candle_nn::Linear,
+}
+
+impl SharedExpert {
+    fn forward(&self, xs: &Tensor) -> Result<Tensor> {
+        let gate = self.gate_proj.forward_autocast(xs)?;
+        let up = self.up_proj.forward_autocast(xs)?;
+        let mlp_out = crate::ops::mul_and_act(&gate, &up, crate::layers::Activation::Silu)?;
+        let mlp_out = self.down_proj.forward_autocast(&mlp_out)?;
+        // Sigmoid gating — shared_gate is [1, hidden] linear, outputs scalar per token
+        let gate_val = candle_nn::ops::sigmoid(&self.shared_gate.forward(&xs.to_dtype(self.shared_gate.weight().dtype())?)?)?;
+        gate_val.to_dtype(mlp_out.dtype())?.broadcast_mul(&mlp_out)
+    }
+}
+
+struct MoeBlock {
+    sparse_moe: FusedMoe,
+    shared_expert: SharedExpert,
+}
+
+impl MoeBlock {
+    fn forward(&self, xs: &Tensor) -> Result<Tensor> {
+        let sparse_out = self.sparse_moe.forward(xs)?;
+        let shared_out = self.shared_expert.forward(xs)?;
+        sparse_out + shared_out
+    }
+}
+
+/// Dense SwiGLU MLP (used by non-MoE Qwen3.5 variants like the 9B dense model).
+struct DenseMlp {
+    gate_proj: Arc<dyn QuantMethod>,
+    up_proj: Arc<dyn QuantMethod>,
+    down_proj: Arc<dyn QuantMethod>,
+}
+
+impl DenseMlp {
+    fn forward(&self, xs: &Tensor) -> Result<Tensor> {
+        let gate = self.gate_proj.forward_autocast(xs)?;
+        let up = self.up_proj.forward_autocast(xs)?;
+        let activated = crate::ops::mul_and_act(&gate, &up, crate::layers::Activation::Silu)?;
+        self.down_proj.forward_autocast(&activated)
+    }
+}
+
+/// Feed-forward block — either MoE (sparse + shared expert) or dense MLP.
+enum FfnBlock {
+    Moe(MoeBlock),
+    Dense(DenseMlp),
+}
+
+impl FfnBlock {
+    fn forward(&self, xs: &Tensor) -> Result<Tensor> {
+        match self {
+            FfnBlock::Moe(moe) => moe.forward(xs),
+            FfnBlock::Dense(mlp) => mlp.forward(xs),
+        }
+    }
+}
+
+// ====================== Full attention layer (with output gate) ======================
+
+struct FullAttentionLayer {
+    attention_wq: Arc<dyn QuantMethod>,
+    attention_wk: Arc<dyn QuantMethod>,
+    attention_wv: Arc<dyn QuantMethod>,
+    attention_wo: Arc<dyn QuantMethod>,
+    q_norm: Option<QRmsNorm>,
+    k_norm: Option<QRmsNorm>,
+    n_head: usize,
+    n_kv_head: usize,
+    head_dim: usize,
+    /// Qwen3.5 Q projection outputs 2*head_dim; second half is sigmoid gate for attention output.
+    has_output_gate: bool,
+    rotary: Arc<RotaryEmbedding>,
+    paged_attn: Option<PagedAttention>,
+    sdpa_params: SdpaParams,
+    dtype: DType,
+}
+
+impl FullAttentionLayer {
+    fn forward(
+        &self,
+        x: &Tensor,
+        mask: Option<&Tensor>,
+        start_offsets: &[usize],
+        kv_cache: &mut KvCache,
+        metadata: Option<((Tensor, Tensor), &PagedAttentionInputMetadata)>,
+    ) -> Result<Tensor> {
+        let (b_sz, seq_len, _) = x.dims3()?;
+
+        let q_full = self.attention_wq.forward_autocast(x)?;
+        let k = self.attention_wk.forward_autocast(x)?;
+        let v = self.attention_wv.forward_autocast(x)?;
+
+        // If Q projects to 2*head_dim per head, split into query and output gate.
+        // Gate values are interleaved per head: reshape to (b, seq, n_head, 2*head_dim)
+        // then narrow dim 3 to split each head's [q | gate].
+        let (q, output_gate) = if self.has_output_gate {
+            let q_gate = q_full.reshape((b_sz, seq_len, self.n_head, self.head_dim * 2))?;
+            let q = q_gate.narrow(D::Minus1, 0, self.head_dim)?
+                .reshape((b_sz, seq_len, self.n_head * self.head_dim))?;
+            let gate = q_gate.narrow(D::Minus1, self.head_dim, self.head_dim)?
+                .reshape((b_sz, seq_len, self.n_head * self.head_dim))?;
+            (q, Some(gate))
+        } else {
+            (q_full, None)
+        };
+
+        let (q, k, v) = if seq_len != 1 {
+            let q = q
+                .reshape((b_sz, seq_len, self.n_head, self.head_dim))?
+                .transpose(1, 2)?;
+            let k = k
+                .reshape((b_sz, seq_len, self.n_kv_head, self.head_dim))?
+                .transpose(1, 2)?;
+            let v = v
+                .reshape((b_sz, seq_len, self.n_kv_head, self.head_dim))?
+                .transpose(1, 2)?;
+            (q, k, v)
+        } else {
+            let q = q.reshape((b_sz, self.n_head, seq_len, self.head_dim))?;
+            let k = k.reshape((b_sz, self.n_kv_head, seq_len, self.head_dim))?;
+            let v = v.reshape((b_sz, self.n_kv_head, seq_len, self.head_dim))?;
+            (q, k, v)
+        };
+
+        // Per-head RMSNorm (Qwen3.5 specific)
+        let (q, k) = if let (Some(ref q_norm), Some(ref k_norm)) = (&self.q_norm, &self.k_norm) {
+            let q_flat = q.flatten(0, 2)?;
+            let k_flat = k.flatten(0, 2)?;
+            let q_flat = q_norm.forward(&q_flat)?;
+            let k_flat = k_norm.forward(&k_flat)?;
+            let q = q_flat.reshape((b_sz, self.n_head, seq_len, self.head_dim))?;
+            let k = k_flat.reshape((b_sz, self.n_kv_head, seq_len, self.head_dim))?;
+            (q, k)
+        } else {
+            (q, k)
+        };
+
+        let (q, k) = self.rotary.forward(&q, &k, start_offsets)?;
+
+        let (q, k, v) = (
+            q.to_dtype(self.dtype)?,
+            k.to_dtype(self.dtype)?,
+            v.to_dtype(self.dtype)?,
+        );
+
+        let mut y = match &self.paged_attn {
+            Some(paged_attn) => {
+                let ((key_cache, value_cache), input_metadata) = metadata.unwrap();
+                paged_attn.forward(
+                    &q,
+                    &k,
+                    &v,
+                    mask,
+                    Some(key_cache),
+                    Some(value_cache),
+                    input_metadata,
+                    &self.sdpa_params,
+                    None,
+                )?
+            }
+            None => {
+                let (k, v) = kv_cache.append(&k, &v)?;
+                Sdpa.run_attention(&q, &k, &v, mask, None, &self.sdpa_params)?
+            }
+        };
+
+        y = if mask.is_some() {
+            y.transpose(1, 2)?.reshape((b_sz, seq_len, ()))?
+        } else {
+            y.reshape((b_sz, seq_len, ()))?
+        };
+
+        // Apply output gate: y = y * sigmoid(gate)
+        if let Some(ref gate) = output_gate {
+            y = (y * candle_nn::ops::sigmoid(gate)?)?;
+        }
+
+        let y = self.attention_wo.forward_autocast(&y.to_dtype(x.dtype())?)?;
+        Ok(y)
+    }
+}
+
+// ====================== Decoder layer (hybrid) ======================
+
+enum LayerImpl {
+    FullAttention(FullAttentionLayer),
+    LinearAttention(GatedDeltaNet),
+}
+
+struct DecoderLayer {
+    layer_impl: LayerImpl,
+    attn_norm: QRmsNorm,
+    ffn_norm: QRmsNorm,
+    ffn: FfnBlock,
+}
+
+// ====================== Per-layer cache ======================
+
+enum LocalLayerCache {
+    Attention(KvCache),
+    LinearAttention(GdnLayerCache),
+}
+
+struct LocalHybridCache {
+    caches: Vec<LocalLayerCache>,
+}
+
+impl LocalHybridCache {
+    fn seqlen(&self) -> usize {
+        for cache in &self.caches {
+            if let LocalLayerCache::Attention(kv) = cache {
+                return kv.current_seq_len();
+            }
+        }
+        0
+    }
+}
+
+impl PastKvLenCache for LocalHybridCache {
+    fn get_past_kv_len(&self) -> Result<usize> {
+        Ok(self.seqlen())
+    }
+}
+
+// ====================== Top-level model ======================
+
+pub struct ModelWeights {
+    tok_embeddings: Embedding,
+    layers: Vec<DecoderLayer>,
+    norm: QRmsNorm,
+    output: Arc<dyn QuantMethod>,
+    pub device: Device,
+    pub cache: EitherCache,
+    pub max_seq_len: usize,
+    mapper: Option<Box<dyn DeviceMapper + Send + Sync>>,
+    dtype: DType,
+    local_cache: std::sync::Mutex<LocalHybridCache>,
+}
+
+// ====================== GGUF metadata ======================
+
+struct PropsGGUF {
+    head_count: usize,
+    head_count_kv: usize,
+    block_count: usize,
+    embedding_length: usize,
+    rms_norm_eps: f32,
+    max_seq_len: usize,
+    rope_freq_base: f32,
+    head_dim: usize,
+    num_experts: Option<usize>,
+    num_experts_per_tok: Option<usize>,
+    // GDN-specific
+    linear_num_k_heads: usize,
+    linear_num_v_heads: usize,
+    linear_head_k_dim: usize,
+    linear_head_v_dim: usize,
+    linear_conv_kernel_size: usize,
+}
+
+fn verify_arch(
+    metadata: &HashMap<String, candle_core::quantized::gguf_file::Value>,
+) -> Result<String> {
+    use crate::utils::gguf_metadata::TryValueInto;
+    let actual_arch: String = metadata
+        .get("general.architecture")
+        .cloned()
+        .try_value_into()?;
+
+    if actual_arch != "qwen35moe" && actual_arch != "qwen35" {
+        candle_core::bail!("Expected `qwen35moe` or `qwen35` architecture, got `{actual_arch}`.");
+    }
+    Ok(actual_arch)
+}
+
+impl TryFrom<ContentMetadata<'_>> for PropsGGUF {
+    type Error = anyhow::Error;
+
+    fn try_from(c: ContentMetadata) -> std::result::Result<Self, Self::Error> {
+        let required = [
+            "attention.head_count",
+            "attention.head_count_kv",
+            "block_count",
+            "embedding_length",
+            "attention.layer_norm_rms_epsilon",
+        ];
+        c.has_required_keys(&required)?;
+
+        let embed_len = c.get_value::<u32>("embedding_length")? as usize;
+        let head_count = c.get_value::<u32>("attention.head_count")? as usize;
+        let head_count_kv = c.get_value::<u32>("attention.head_count_kv")? as usize;
+        let head_dim = c
+            .get_value::<u32>("attention.key_length")
+            .ok()
+            .map(|x| x as usize)
+            .unwrap_or(embed_len / head_count);
+
+        // GDN linear attention head configuration.
+        // ssm.state_size = per-head dim for both K and V in GDN (default 128)
+        let ssm_state_size = c
+            .get_value::<u32>("ssm.state_size")
+            .ok()
+            .map(|x| x as usize)
+            .unwrap_or(128);
+        // ssm.group_count = num_k_heads (default 16, same as attention head_count)
+        let linear_num_k_heads = c
+            .get_value::<u32>("ssm.group_count")
+            .ok()
+            .map(|x| x as usize)
+            .unwrap_or(head_count);
+        // num_v_heads = 2 * num_k_heads for Qwen3.5 (kv_group_size=2)
+        let linear_num_v_heads = c
+            .get_value::<u32>("attention.linear_head_count")
+            .ok()
+            .map(|x| x as usize)
+            .unwrap_or(linear_num_k_heads * 2);
+        let linear_head_k_dim = c
+            .get_value::<u32>("attention.linear_key_length")
+            .ok()
+            .map(|x| x as usize)
+            .unwrap_or(ssm_state_size);
+        let linear_head_v_dim = c
+            .get_value::<u32>("attention.linear_value_length")
+            .ok()
+            .map(|x| x as usize)
+            .unwrap_or(ssm_state_size);
+        let linear_conv_kernel_size = c
+            .get_value::<u32>("ssm.conv_kernel")
+            .ok()
+            .map(|x| x as usize)
+            .unwrap_or(4);
+
+        Ok(Self {
+            head_count,
+            head_count_kv,
+            block_count: c.get_value::<u32>("block_count")? as usize,
+            embedding_length: embed_len,
+            rms_norm_eps: c.get_value("attention.layer_norm_rms_epsilon")?,
+            max_seq_len: c
+                .get_value::<u64>("context_length")
+                .ok()
+                .unwrap_or(DEFAULT_MAX_SEQ_LEN as u64) as usize,
+            rope_freq_base: c.get_value("rope.freq_base").ok().unwrap_or(10_000_000_f32),
+            head_dim,
+            num_experts: c.get_value::<u32>("expert_count").ok().map(|x| x as usize),
+            num_experts_per_tok: c.get_value::<u32>("expert_used_count").ok().map(|x| x as usize),
+            linear_num_k_heads,
+            linear_num_v_heads,
+            linear_head_k_dim,
+            linear_head_v_dim,
+            linear_conv_kernel_size,
+        })
+    }
+}
+
+// ====================== GGUF loading ======================
+
+fn gguf_matmul(tensor: candle_core::quantized::QTensor) -> Result<Arc<dyn QuantMethod>> {
+    Ok(Arc::new(GgufMatMul::new(QuantMethodConfig::Gguf {
+        q_weight: Arc::new(tensor),
+        b: None,
+    })?))
+}
+
+impl ModelConfig::FromGGUF for ModelWeights {
+    fn from_gguf<R: std::io::Seek + std::io::Read>(
+        mut ct: Content<'_, R>,
+        device: &Device,
+        mapper: Box<dyn DeviceMapper + Send + Sync>,
+        attention_mechanism: AttentionImplementation,
+        dtype: DType,
+    ) -> Result<Self> {
+        let meta = ct.get_metadata();
+        let actual_arch = verify_arch(meta)?;
+
+        let metadata = ContentMetadata {
+            path_prefix: &actual_arch,
+            metadata: meta,
+        };
+        let props = PropsGGUF::try_from(metadata).or_else(|err| candle_core::bail!("{err}"))?;
+
+        let qtok_embeddings = ct.tensor("token_embd.weight", device)?;
+        let tok_embeddings = qtok_embeddings.dequantize(device)?;
+        let norm = QRmsNorm::new(ct.tensor("output_norm.weight", device)?, props.rms_norm_eps)?;
+        let output = if !ct.has_tensor("output.weight") {
+            ct.tensor("token_embd.weight", device)?
+        } else {
+            ct.tensor("output.weight", device)?
+        };
+
+        let mut ropes = HashMap::new();
+        for layer_idx in 0..props.block_count {
+            let device = mapper.device_for(layer_idx, false).unwrap_or(device);
+            ropes.insert(
+                device.location(),
+                Arc::new(RotaryEmbedding::new(
+                    props.rope_freq_base,
+                    props.head_dim,
+                    props.max_seq_len,
+                    device,
+                    true,
+                    dtype,
+                )?),
+            );
+        }
+
+        let key_dim = props.linear_num_k_heads * props.linear_head_k_dim;
+        let value_dim = props.linear_num_v_heads * props.linear_head_v_dim;
+        let conv_dim = key_dim * 2 + value_dim;
+
+        let mut layers = Vec::with_capacity(props.block_count);
+        let mut local_caches = Vec::with_capacity(props.block_count);
+
+        for layer_idx in NiceProgressBar::<_, 'b'>(
+            0..props.block_count,
+            "Loading repeating layers",
+            &new_multi_progress(),
+        ) {
+            let prefix = format!("blk.{layer_idx}");
+            let device = mapper.device_for(layer_idx, false).unwrap_or(device);
+            let rotary = ropes
+                .get(&device.location())
+                .expect("No RoPE for device location!")
+                .clone();
+
+            // --- Layer implementation (attention or GDN) ---
+            let layer_impl = if is_full_attention_layer(layer_idx) {
+                // Full attention with output gate
+                let attention_wq = ct.tensor(&format!("{prefix}.attn_q.weight"), device)?;
+                let attention_wk = ct.tensor(&format!("{prefix}.attn_k.weight"), device)?;
+                let attention_wv = ct.tensor(&format!("{prefix}.attn_v.weight"), device)?;
+                let attention_wo = ct.tensor(&format!("{prefix}.attn_output.weight"), device)?;
+
+                // Check if Q projects to 2*head_dim (output gate)
+                let q_out_features = attention_wq.shape().dims()[0];
+                let expected_q_dim = props.head_count * props.head_dim;
+                let has_output_gate = q_out_features == expected_q_dim * 2;
+
+                let q_norm = if ct.has_tensor(&format!("{prefix}.attn_q_norm.weight")) {
+                    Some(QRmsNorm::new(
+                        ct.tensor(&format!("{prefix}.attn_q_norm.weight"), device)?,
+                        props.rms_norm_eps,
+                    )?)
+                } else {
+                    None
+                };
+                let k_norm = if ct.has_tensor(&format!("{prefix}.attn_k_norm.weight")) {
+                    Some(QRmsNorm::new(
+                        ct.tensor(&format!("{prefix}.attn_k_norm.weight"), device)?,
+                        props.rms_norm_eps,
+                    )?)
+                } else {
+                    None
+                };
+
+                let paged_attn = match &attention_mechanism {
+                    AttentionImplementation::Eager => None,
+                    AttentionImplementation::PagedAttention => {
+                        Some(PagedAttention::new(props.head_dim, device, None)?)
+                    }
+                };
+
+                local_caches.push(LocalLayerCache::Attention(KvCache::new_normal(
+                    2,
+                    props.max_seq_len,
+                    64, // cache grow size
+                )));
+
+                LayerImpl::FullAttention(FullAttentionLayer {
+                    attention_wq: gguf_matmul(attention_wq)?,
+                    attention_wk: gguf_matmul(attention_wk)?,
+                    attention_wv: gguf_matmul(attention_wv)?,
+                    attention_wo: gguf_matmul(attention_wo)?,
+                    q_norm,
+                    k_norm,
+                    n_head: props.head_count,
+                    n_kv_head: props.head_count_kv,
+                    head_dim: props.head_dim,
+                    has_output_gate,
+                    rotary,
+                    paged_attn,
+                    sdpa_params: SdpaParams {
+                        n_kv_groups: props.head_count / props.head_count_kv,
+                        softcap: None,
+                        softmax_scale: 1.0 / (props.head_dim as f32).sqrt(),
+                        sliding_window: None,
+                        sinks: None,
+                    },
+                    dtype,
+                })
+            } else {
+                // GDN linear attention layer
+                let in_proj_qkv = ct.tensor(&format!("{prefix}.attn_qkv.weight"), device)?;
+                let in_proj_z = ct.tensor(&format!("{prefix}.attn_gate.weight"), device)?;
+                let ssm_alpha = ct.tensor(&format!("{prefix}.ssm_alpha.weight"), device)?;
+                let ssm_beta = ct.tensor(&format!("{prefix}.ssm_beta.weight"), device)?;
+                let conv1d_weight = ct.tensor(&format!("{prefix}.ssm_conv1d.weight"), device)?;
+                let ssm_a = ct.tensor(&format!("{prefix}.ssm_a"), device)?;
+                let dt_bias_t = ct.tensor(&format!("{prefix}.ssm_dt.bias"), device)?;
+                let ssm_norm = ct.tensor(&format!("{prefix}.ssm_norm.weight"), device)?;
+                let out_proj = ct.tensor(&format!("{prefix}.ssm_out.weight"), device)?;
+
+                // Convert ssm_a: GGUF stores -exp(A_log), recover A_log = log(-ssm_a)
+                let ssm_a_deq = ssm_a.dequantize(device)?;
+                let a_log = ssm_a_deq.neg()?.log()?.to_dtype(dtype)?;
+                let dt_bias = dt_bias_t.dequantize(device)?.to_dtype(dtype)?;
+                let conv_w = conv1d_weight.dequantize(device)?.to_dtype(dtype)?;
+                let norm_w = ssm_norm.dequantize(device)?.to_dtype(dtype)?;
+
+                // GGUF stores V-heads in tiled layout for both MoE and dense Qwen3.5.
+                let gdn = GatedDeltaNet {
+                    projection: GdnProjection::SplitQkvZa {
+                        in_proj_qkv: gguf_matmul(in_proj_qkv)?,
+                        in_proj_z: gguf_matmul(in_proj_z)?,
+                        in_proj_b: gguf_matmul(ssm_beta)?,
+                        in_proj_a: gguf_matmul(ssm_alpha)?,
+                    },
+                    conv1d_weight: conv_w,
+                    dt_bias,
+                    a_log,
+                    norm: RmsNormGated {
+                        weight: norm_w,
+                        eps: props.rms_norm_eps as f64,
+                    },
+                    out_proj: gguf_matmul(out_proj)?,
+                    num_k_heads: props.linear_num_k_heads,
+                    num_v_heads: props.linear_num_v_heads,
+                    head_k_dim: props.linear_head_k_dim,
+                    head_v_dim: props.linear_head_v_dim,
+                    conv_kernel_size: props.linear_conv_kernel_size,
+                    key_dim,
+                    value_dim,
+                    tiled_v_heads: true,
+                };
+
+                let cache = GdnLayerCache {
+                    conv_state: Tensor::zeros(
+                        (1, conv_dim, props.linear_conv_kernel_size),
+                        dtype,
+                        device,
+                    )?,
+                    recurrent_state: Tensor::zeros(
+                        (1, props.linear_num_v_heads, props.linear_head_k_dim, props.linear_head_v_dim),
+                        dtype,
+                        device,
+                    )?,
+                    seqlen_offset: 0,
+                };
+                local_caches.push(LocalLayerCache::LinearAttention(cache));
+
+                LayerImpl::LinearAttention(gdn)
+            };
+
+            // --- Norms ---
+            let attn_norm = QRmsNorm::new(
+                ct.tensor(&format!("{prefix}.attn_norm.weight"), device)?,
+                props.rms_norm_eps,
+            )?;
+            let ffn_norm_tensor_name = if ct.has_tensor(&format!("{prefix}.ffn_norm.weight")) {
+                format!("{prefix}.ffn_norm.weight")
+            } else {
+                format!("{prefix}.post_attention_norm.weight")
+            };
+            let ffn_norm = QRmsNorm::new(
+                ct.tensor(&ffn_norm_tensor_name, device)?,
+                props.rms_norm_eps,
+            )?;
+
+            // --- FFN: MoE or dense MLP ---
+            let ffn = if ct.has_tensor(&format!("{prefix}.ffn_gate_inp.weight")) {
+                // MoE variant (Qwen3.5 MoE models)
+                let gate = ct.tensor(&format!("{prefix}.ffn_gate_inp.weight"), device)?;
+                let gate_experts = ct.tensor(&format!("{prefix}.ffn_gate_exps.weight"), device)?;
+                let up_experts = ct.tensor(&format!("{prefix}.ffn_up_exps.weight"), device)?;
+                let down_experts = ct.tensor(&format!("{prefix}.ffn_down_exps.weight"), device)?;
+
+                let sparse_moe = FusedMoe {
+                    gate: QMatMul::from_qtensor(gate)?,
+                    gate_experts: QMatMul::from_qtensor(gate_experts)?,
+                    up_experts: QMatMul::from_qtensor(up_experts)?,
+                    down_experts: QMatMul::from_qtensor(down_experts)?,
+                    norm_topk_prob: true,
+                    num_experts_per_tok: props.num_experts_per_tok.unwrap_or(4),
+                };
+
+                // Shared expert
+                let shared_gate_proj = ct.tensor(&format!("{prefix}.ffn_gate_shexp.weight"), device)?;
+                let shared_up_proj = ct.tensor(&format!("{prefix}.ffn_up_shexp.weight"), device)?;
+                let shared_down_proj = ct.tensor(&format!("{prefix}.ffn_down_shexp.weight"), device)?;
+                let shared_gate_qt = ct.tensor(&format!("{prefix}.ffn_gate_inp_shexp.weight"), device)?;
+                let shared_gate_w = shared_gate_qt.dequantize(device)?
+                    .reshape((1, props.embedding_length))?;
+                let shared_gate = candle_nn::Linear::new(shared_gate_w, None);
+
+                FfnBlock::Moe(MoeBlock {
+                    sparse_moe,
+                    shared_expert: SharedExpert {
+                        gate_proj: gguf_matmul(shared_gate_proj)?,
+                        up_proj: gguf_matmul(shared_up_proj)?,
+                        down_proj: gguf_matmul(shared_down_proj)?,
+                        shared_gate,
+                    },
+                })
+            } else {
+                // Dense MLP variant (Qwen3.5 dense models like 9B)
+                let gate_proj = ct.tensor(&format!("{prefix}.ffn_gate.weight"), device)?;
+                let up_proj = ct.tensor(&format!("{prefix}.ffn_up.weight"), device)?;
+                let down_proj = ct.tensor(&format!("{prefix}.ffn_down.weight"), device)?;
+
+                FfnBlock::Dense(DenseMlp {
+                    gate_proj: gguf_matmul(gate_proj)?,
+                    up_proj: gguf_matmul(up_proj)?,
+                    down_proj: gguf_matmul(down_proj)?,
+                })
+            };
+
+            layers.push(DecoderLayer {
+                layer_impl,
+                attn_norm,
+                ffn_norm,
+                ffn,
+            });
+        }
+
+        let local_cache = LocalHybridCache {
+            caches: local_caches,
+        };
+
+        Ok(Self {
+            tok_embeddings: Embedding::new(tok_embeddings, props.embedding_length),
+            layers,
+            norm,
+            output: gguf_matmul(output)?,
+            device: device.clone(),
+            cache: EitherCache::Normal(NormalCache::new(props.block_count, props.max_seq_len)),
+            max_seq_len: props.max_seq_len,
+            mapper: Some(mapper),
+            dtype,
+            local_cache: std::sync::Mutex::new(local_cache),
+        })
+    }
+}
+
+// ====================== Cache management ======================
+
+impl ModelWeights {
+    /// Clear the local hybrid cache (GDN recurrent state + attention KV).
+    /// Called by the pipeline between requests to free GPU memory.
+    pub fn clear_local_cache(&self) {
+        let mut local_cache = self.local_cache.lock().unwrap();
+        // Free attention KV caches FIRST (these are large, grow with seq_len)
+        for cache in &mut local_cache.caches {
+            if let LocalLayerCache::Attention(kv_cache) = cache {
+                kv_cache.reset();
+            }
+        }
+        // Then reset GDN caches (small fixed-size, zeros_like allocates before freeing)
+        for cache in &mut local_cache.caches {
+            if let LocalLayerCache::LinearAttention(gdn_cache) = cache {
+                let _ = gdn_cache.reset();
+            }
+        }
+    }
+}
+
+// ====================== Forward pass ======================
+
+impl ModelWeights {
+    pub fn forward(
+        &self,
+        x: &Tensor,
+        start_offsets: &[usize],
+        context_lens: Vec<(usize, usize)>,
+        metadata: Option<(Vec<(Tensor, Tensor)>, &PagedAttentionInputMetadata)>,
+    ) -> Result<Tensor> {
+        let mut layer_in = self.tok_embeddings.forward(x)?.to_dtype(self.dtype)?;
+        let mut local_cache = self.local_cache.lock().unwrap();
+
+        // Reset ALL caches on new sequence (both GDN recurrent state and attention KV).
+        // Free attention KV first (large), then GDN (small but zeros_like allocates).
+        if start_offsets[0] == 0 {
+            for cache in &mut local_cache.caches {
+                if let LocalLayerCache::Attention(kv_cache) = cache {
+                    kv_cache.reset();
+                }
+            }
+            for cache in &mut local_cache.caches {
+                if let LocalLayerCache::LinearAttention(gdn_cache) = cache {
+                    gdn_cache.reset()?;
+                }
+            }
+        }
+
+        // Build causal mask for full attention layers
+        let mask = CausalMasker.make_causal_mask_matrix(
+            x,
+            metadata
+                .as_ref()
+                .map(|(_, _)| &start_offsets as &dyn PastKvLenCache)
+                .unwrap_or(&*local_cache as &dyn PastKvLenCache),
+            self.dtype,
+            self.layers[0]
+                .layer_impl
+                .n_head_for_mask()
+                .unwrap_or(1),
+        )?;
+        let mask = mask.filter(|_| {
+            metadata
+                .as_ref()
+                .map(|(_, meta)| meta.is_first_prompt_chunk)
+                .unwrap_or(true)
+        });
+        let mask = if let Some(ref mapper) = self.mapper {
+            DeviceMappedMask::new(mask, &**mapper)?
+        } else {
+            DeviceMappedMask::from_single(mask)
+        };
+
+        for (i, layer) in self.layers.iter().enumerate() {
+            if let Some(ref mapper) = self.mapper {
+                layer_in = mapper.map(layer_in, i)?;
+            }
+            let residual = &layer_in;
+            let x = layer.attn_norm.forward(&layer_in)?;
+
+            let attn_out = match &layer.layer_impl {
+                LayerImpl::FullAttention(attn) => {
+                    if let LocalLayerCache::Attention(ref mut kv_cache) = local_cache.caches[i] {
+                        attn.forward(
+                            &x,
+                            mask.as_ref().map(|m| m.get(x.device())),
+                            start_offsets,
+                            kv_cache,
+                            metadata
+                                .as_ref()
+                                .map(|(kv_cache, metadata)| (kv_cache[i].clone(), *metadata)),
+                        ).map_err(|e| candle_core::Error::Msg(format!("layer {i} full_attn: {e}")))?
+                    } else {
+                        candle_core::bail!("Expected KV cache for full attention layer {i}");
+                    }
+                }
+                LayerImpl::LinearAttention(gdn) => {
+                    if let LocalLayerCache::LinearAttention(ref mut gdn_cache) = local_cache.caches[i]
+                    {
+                        gdn.forward(&x, gdn_cache)
+                            .map_err(|e| candle_core::Error::Msg(format!("layer {i} gdn: {e}")))?
+                    } else {
+                        candle_core::bail!("Expected GDN cache for linear attention layer {i}");
+                    }
+                }
+            };
+
+            let x = (attn_out + residual)
+                .map_err(|e| candle_core::Error::Msg(format!("layer {i} attn_residual: {e}")))?;
+            let residual = &x;
+            let x = layer.ffn_norm.forward(&x)?;
+            let x = layer.ffn.forward(&x)
+                .map_err(|e| candle_core::Error::Msg(format!("layer {i} ffn: {e}")))?;
+            layer_in = (x + residual)
+                .map_err(|e| candle_core::Error::Msg(format!("layer {i} moe_residual: {e}")))?;
+        }
+
+        let x = self.norm.forward(&layer_in)?;
+        let x = extract_logits(&x, context_lens)?;
+        let result = self.output.forward_autocast(&x.contiguous()?)?;
+        Ok(result)
+    }
+}
+
+impl LayerImpl {
+    fn n_head_for_mask(&self) -> Option<usize> {
+        match self {
+            LayerImpl::FullAttention(attn) => Some(attn.n_head),
+            LayerImpl::LinearAttention(_) => None,
+        }
+    }
+}

--- a/mistralrs-core/src/pipeline/gguf.rs
+++ b/mistralrs-core/src/pipeline/gguf.rs
@@ -584,7 +584,7 @@ impl Loader for GGUFLoader {
             }
         }
 
-        let eos = calculate_eos_tokens(&chat_template, gen_conf, &tokenizer);
+        let eos = calculate_eos_tokens(&chat_template, gen_conf.as_ref(), &tokenizer);
         Ok(Arc::new(Mutex::new(GGUFPipeline {
             model,
             tokenizer: tokenizer.into(),

--- a/mistralrs-core/src/pipeline/gguf.rs
+++ b/mistralrs-core/src/pipeline/gguf.rs
@@ -43,6 +43,7 @@ use crate::{
     models::quantized_qwen::ModelWeights as QQwen,
     models::quantized_qwen3::ModelWeights as QQwen3,
     models::quantized_qwen3_moe::ModelWeights as QQwen3MoE,
+    models::quantized_qwen3_next::ModelWeights as QQwen3Next,
     models::quantized_starcoder2::ModelWeights as QStarcoder2,
     utils::tokens::get_token,
     xlora_models::{XLoraQLlama, XLoraQPhi3},
@@ -72,6 +73,7 @@ enum Model {
     Qwen(QQwen),
     Qwen3(QQwen3),
     Qwen3MoE(QQwen3MoE),
+    Qwen3Next(QQwen3Next),
 }
 
 pub struct GGUFPipeline {
@@ -82,7 +84,6 @@ pub struct GGUFPipeline {
     model_id: String,
     non_granular_state: Option<NonGranularState>,
     metadata: Arc<GeneralMetadata>,
-    generation_defaults: Option<crate::ModelGenerationDefaults>,
     mapper: Box<dyn DeviceMapper + Send + Sync>,
 }
 
@@ -482,7 +483,9 @@ impl Loader for GGUFLoader {
                 }
                 GGUFArchitecture::Qwen2 => Model::Qwen(QQwen::try_from(model_config)?),
                 GGUFArchitecture::Qwen3 => Model::Qwen3(QQwen3::try_from(model_config)?),
+                GGUFArchitecture::Qwen35 => Model::Qwen3Next(QQwen3Next::try_from(model_config)?),
                 GGUFArchitecture::Qwen3MoE => Model::Qwen3MoE(QQwen3MoE::try_from(model_config)?),
+                GGUFArchitecture::Qwen35Moe => Model::Qwen3Next(QQwen3Next::try_from(model_config)?),
                 a => bail!("Unsupported architecture `{a:?}` for GGUF"),
             },
             ModelKind::GgufAdapter { adapter, .. } => match arch {
@@ -549,6 +552,7 @@ impl Loader for GGUFLoader {
             Model::Qwen(ref p) => p.max_seq_len,
             Model::Qwen3(ref p) => p.max_seq_len,
             Model::Qwen3MoE(ref p) => p.max_seq_len,
+            Model::Qwen3Next(ref p) => p.max_seq_len,
         };
         let llg_factory = build_llg_factory(tokenizer.clone())?;
         let num_hidden_layers = match model {
@@ -561,6 +565,7 @@ impl Loader for GGUFLoader {
             Model::Qwen(ref model) => model.cache.normal().0.len(),
             Model::Qwen3(ref model) => model.cache.normal().0.len(),
             Model::Qwen3MoE(ref model) => model.cache.normal().0.len(),
+            Model::Qwen3Next(ref model) => model.cache.normal().0.len(),
         };
 
         if chat_template.bos_token.is_none() {
@@ -579,10 +584,7 @@ impl Loader for GGUFLoader {
             }
         }
 
-        let generation_defaults = gen_conf
-            .as_ref()
-            .and_then(GenerationConfig::generation_defaults);
-        let eos = calculate_eos_tokens(&chat_template, gen_conf.as_ref(), &tokenizer);
+        let eos = calculate_eos_tokens(&chat_template, gen_conf, &tokenizer);
         Ok(Arc::new(Mutex::new(GGUFPipeline {
             model,
             tokenizer: tokenizer.into(),
@@ -617,7 +619,6 @@ impl Loader for GGUFLoader {
                     output: vec![SupportedModality::Text],
                 },
             }),
-            generation_defaults,
             mapper: pipeline_mapper,
         })))
     }
@@ -653,6 +654,12 @@ impl IsqPipelineMixin for GGUFPipeline {
 
 impl CacheManagerMixin for GGUFPipeline {
     fn clone_in_cache(&self, seqs: &mut [&mut Sequence]) {
+        // Qwen3Next: free local_cache before clone_in allocates pipeline cache
+        // tensors. Prefix caching uses clone_in rather than set_none_cache, and
+        // local_cache holds the real KV data that the pipeline cache can't see.
+        if let Model::Qwen3Next(ref model) = self.model {
+            model.clear_local_cache();
+        }
         if matches!(self.cache(), EitherCache::Full(_)) {
             FullCacheManager.clone_in_cache(self, seqs, false)
         } else {
@@ -683,6 +690,12 @@ impl CacheManagerMixin for GGUFPipeline {
                 load_preallocated_cache,
             );
         }
+        // Qwen3Next uses a local hybrid cache (GDN + attention KV) that is
+        // separate from the pipeline-level EitherCache. Clear it here so GPU
+        // memory is freed between requests.
+        if let Model::Qwen3Next(ref model) = self.model {
+            model.clear_local_cache();
+        }
         if reset_non_granular {
             self.reset_non_granular_state()
         }
@@ -698,6 +711,7 @@ impl CacheManagerMixin for GGUFPipeline {
             Model::Qwen(ref model) => &model.cache,
             Model::Qwen3(ref model) => &model.cache,
             Model::Qwen3MoE(ref model) => &model.cache,
+            Model::Qwen3Next(ref model) => &model.cache,
         }
     }
 }
@@ -714,6 +728,7 @@ impl MetadataMixin for GGUFPipeline {
             Model::Qwen(ref model) => model.device.clone(),
             Model::Qwen3(ref model) => model.device.clone(),
             Model::Qwen3MoE(ref model) => model.device.clone(),
+            Model::Qwen3Next(ref model) => model.device.clone(),
         }
     }
     fn tokenizer(&self) -> Option<Arc<Tokenizer>> {
@@ -730,9 +745,6 @@ impl MetadataMixin for GGUFPipeline {
     }
     fn get_metadata(&self) -> Arc<GeneralMetadata> {
         self.metadata.clone()
-    }
-    fn generation_defaults(&self) -> Option<crate::ModelGenerationDefaults> {
-        self.generation_defaults.clone()
     }
     fn device_mapper(&self) -> Option<&dyn DeviceMapper> {
         Some(&*self.mapper)
@@ -812,6 +824,9 @@ impl Pipeline for GGUFPipeline {
                 model.forward(&input_ids, &seqlen_offsets, context_lens, paged_attn_meta)?
             }
             Model::Qwen3MoE(ref model) => {
+                model.forward(&input_ids, &seqlen_offsets, context_lens, paged_attn_meta)?
+            }
+            Model::Qwen3Next(ref model) => {
                 model.forward(&input_ids, &seqlen_offsets, context_lens, paged_attn_meta)?
             }
         };

--- a/mistralrs-core/src/utils/model_config.rs
+++ b/mistralrs-core/src/utils/model_config.rs
@@ -301,6 +301,7 @@ use crate::{
     models::quantized_qwen::ModelWeights as QQwen,
     models::quantized_qwen3::ModelWeights as QQwen3,
     models::quantized_qwen3_moe::ModelWeights as QQwen3MoE,
+    models::quantized_qwen3_next::ModelWeights as QQwen3Next,
     models::quantized_starcoder2::ModelWeights as QStarcoder2,
     xlora_models::{XLoraQLlama, XLoraQPhi3},
 };
@@ -325,7 +326,7 @@ impl TryFrom<ModelParams<'_, ParamsGGML>> for XLoraQLlama {
 }
 
 akin! {
-    let &models_gguf = [QLlama, QPhi, QPhi3, QStarcoder2, QQwen, QQwen3, QQwen3MoE];
+    let &models_gguf = [QLlama, QPhi, QPhi3, QStarcoder2, QQwen, QQwen3, QQwen3MoE, QQwen3Next];
 
     impl<R: std::io::Seek + std::io::Read> TryFrom<ModelParams<'_, ParamsGGUF<'_, R>>> for *models_gguf {
         type Error = candle_core::Error;


### PR DESCRIPTION
## Summary

This PR adds full GGUF support for the Qwen3.5 architecture (internally `qwen3-next`), including hybrid GDN (GatedDeltaNet) + attention layers and MoE variants.

Qwen3.5 is not a standard transformer: it combines recurrent GDN layers, attention blocks, and mixture-of-experts routing. Supporting it in GGUF required implementing both the architecture and its tensor layout/dtype semantics.

This enables inference of quantized Qwen3.5 models (e.g. Qwen3.5-35B-Instruct GGUF) on both Metal and CUDA backends.

## Key changes

### Model support
- New `quantized_qwen3_next.rs` implementing:
  - Hybrid GDN + attention execution
  - MoE (including shared expert variant)
  - Dense (non-MoE) variant

### GGUF compatibility fixes
- Correct conv1d weight layout transformation (kernel, dim → dim, 1, kernel)
- RoPE computation uses model dtype instead of forced F32
- QRmsNorm casts weights to input dtype (BF16 compatibility)
- V-head expansion matches GGUF tensor layout
- SharedExpert gate properly dequantized and reshaped

### Runtime state
- Hybrid cache:
  - GDN recurrent state (fixed size)
  - Attention KV cache (sequence-dependent)
- Proper reset between requests

## Testing

- Verified on:
  - Qwen3.5-35B-Instruct GGUF (MoE)
  - Qwen3.5 dense GGUF variant
- Tested on Metal and CUDA backends
- Validated multi-turn conversation correctness