### PR TITLE
Add tensor parallelism support for GDN layers + fix UQFF artifact count

### DIFF
--- a/mistralrs-core/src/models/gdn.rs
+++ b/mistralrs-core/src/models/gdn.rs
@@ -319,6 +319,60 @@ impl GatedDeltaNet {
         let mut dt_bias = vb_la.get(num_v_heads, "dt_bias")?;
         let mut a_log = vb_la.get(num_v_heads, "A_log")?;
 
+        // TP sharding: shard GDN weights by key-head groups so each rank
+        // operates on a subset of heads. The grouped weight layout has
+        // contiguous groups, so a simple narrow by group count works.
+        let world_size = comm.world_size();
+        let rank = comm.rank();
+        let mut num_k_heads = num_k_heads;
+        let mut num_v_heads = num_v_heads;
+        let mut key_dim = key_dim;
+        let mut value_dim = value_dim;
+
+        if world_size > 1 {
+            assert!(
+                num_k_heads % world_size == 0,
+                "GDN linear_num_key_heads ({num_k_heads}) must be divisible by world_size ({world_size})"
+            );
+            let local_k_heads = num_k_heads / world_size;
+            let local_v_heads = local_k_heads * v_per_group;
+            let local_key_dim = local_k_heads * head_k_dim;
+            let local_value_dim = local_v_heads * head_v_dim;
+
+            // Shard qkvz projection (grouped layout: contiguous per key-head group)
+            let group_size_qkvz = 2 * head_k_dim + 2 * v_per_group * head_v_dim;
+            qkvz_w = qkvz_w.narrow(
+                0,
+                rank * local_k_heads * group_size_qkvz,
+                local_k_heads * group_size_qkvz,
+            )?;
+
+            // Shard ba projection (grouped layout: contiguous per key-head group)
+            let group_size_ba = 2 * v_per_group;
+            ba_w = ba_w.narrow(
+                0,
+                rank * local_k_heads * group_size_ba,
+                local_k_heads * group_size_ba,
+            )?;
+
+            // Shard conv1d weight: layout is [q_channels, k_channels, v_channels]
+            // Each section is contiguous by head, so narrow each part separately.
+            let q_conv = conv1d_weight.narrow(0, rank * local_key_dim, local_key_dim)?;
+            let k_conv = conv1d_weight.narrow(0, key_dim + rank * local_key_dim, local_key_dim)?;
+            let v_conv =
+                conv1d_weight.narrow(0, key_dim * 2 + rank * local_value_dim, local_value_dim)?;
+            conv1d_weight = Tensor::cat(&[q_conv, k_conv, v_conv], 0)?;
+
+            // Shard per-head parameters
+            dt_bias = dt_bias.narrow(0, rank * local_v_heads, local_v_heads)?;
+            a_log = a_log.narrow(0, rank * local_v_heads, local_v_heads)?;
+
+            num_k_heads = local_k_heads;
+            num_v_heads = local_v_heads;
+            key_dim = local_key_dim;
+            value_dim = local_value_dim;
+        }
+
         if let Some(ref target_dev) = isq_target_device {
             qkvz_w = qkvz_w.to_device(target_dev)?;
             ba_w = ba_w.to_device(target_dev)?;

--- a/mistralrs-core/src/models/qwen3_next.rs
+++ b/mistralrs-core/src/models/qwen3_next.rs
@@ -847,14 +847,21 @@ impl Model {
             })
             .collect();
 
+        let tp_world_size = mapper.get_comm_for(0)?.world_size();
+        let local_num_v_heads = cfg.linear_num_value_heads / tp_world_size;
+        let local_num_k_heads = cfg.linear_num_key_heads / tp_world_size;
+        let local_key_dim = local_num_k_heads * cfg.linear_key_head_dim;
+        let local_value_dim = local_num_v_heads * cfg.linear_value_head_dim;
+        let local_conv_dim = local_key_dim * 2 + local_value_dim;
+
         let hybrid_cache_config = HybridCacheConfig {
             layer_types: pipeline_layer_types,
             max_seq_len: cfg.max_position_embeddings,
             recurrent: RecurrentLayerConfig {
-                conv_dim: cfg.linear_conv_dim(),
+                conv_dim: local_conv_dim,
                 conv_width: cfg.linear_conv_kernel_dim,
                 state_dims: vec![
-                    cfg.linear_num_value_heads,
+                    local_num_v_heads,
                     cfg.linear_key_head_dim,
                     cfg.linear_value_head_dim,
                 ],

--- a/mistralrs-core/src/pipeline/isq.rs
+++ b/mistralrs-core/src/pipeline/isq.rs
@@ -1036,9 +1036,12 @@ pub trait IsqModel {
             })
             .collect::<HashMap<_, _>>();
 
-        if artifact_isqs.len() != total_tensors {
+        // The serialized artifact count may be less than total_tensors
+        // because serialization filters by isq_serde_supported(). Only
+        // check that we don't have MORE artifacts than layers.
+        if artifact_isqs.len() > total_tensors {
             candle_core::bail!(
-                "Number of artifacts ({}) does not match the number of ISQ layers ({total_tensors})",
+                "Number of artifacts ({}) exceeds the number of ISQ layers ({total_tensors})",
                 artifact_isqs.len(),
             );
         }

--- a/mistralrs-core/src/vision_models/qwen3_5/text.rs
+++ b/mistralrs-core/src/vision_models/qwen3_5/text.rs
@@ -600,14 +600,23 @@ impl Qwen3_5TextModel {
             })
             .collect();
 
+        // Adjust recurrent cache dimensions for TP: each rank only stores
+        // its local subset of heads.
+        let tp_world_size = mapper.get_comm_for(0)?.world_size();
+        let local_num_v_heads = cfg.linear_num_value_heads / tp_world_size;
+        let local_num_k_heads = cfg.linear_num_key_heads / tp_world_size;
+        let local_key_dim = local_num_k_heads * cfg.linear_key_head_dim;
+        let local_value_dim = local_num_v_heads * cfg.linear_value_head_dim;
+        let local_conv_dim = local_key_dim * 2 + local_value_dim;
+
         let hybrid_cache_config = HybridCacheConfig {
             layer_types: pipeline_layer_types,
             max_seq_len: cfg.max_position_embeddings,
             recurrent: RecurrentLayerConfig {
-                conv_dim: cfg.linear_conv_dim(),
+                conv_dim: local_conv_dim,
                 conv_width: cfg.linear_conv_kernel_dim,
                 state_dims: vec![
-                    cfg.linear_num_value_heads,
+                    local_num_v_heads,
                     cfg.linear_key_head_dim,
                     cfg.linear_value_head_dim,
                 ],

--- a/mistralrs-core/src/vision_models/qwen3_5_moe/text.rs
+++ b/mistralrs-core/src/vision_models/qwen3_5_moe/text.rs
@@ -724,14 +724,21 @@ impl Qwen3_5MoeTextModel {
             })
             .collect();
 
+        let tp_world_size = mapper.get_comm_for(0)?.world_size();
+        let local_num_v_heads = cfg.linear_num_value_heads / tp_world_size;
+        let local_num_k_heads = cfg.linear_num_key_heads / tp_world_size;
+        let local_key_dim = local_num_k_heads * cfg.linear_key_head_dim;
+        let local_value_dim = local_num_v_heads * cfg.linear_value_head_dim;
+        let local_conv_dim = local_key_dim * 2 + local_value_dim;
+
         let hybrid_cache_config = HybridCacheConfig {
             layer_types: pipeline_layer_types,
             max_seq_len: cfg.max_position_embeddings,
             recurrent: RecurrentLayerConfig {
-                conv_dim: cfg.linear_conv_dim(),
+                conv_dim: local_conv_dim,
                 conv_width: cfg.linear_conv_kernel_dim,
                 state_dims: vec![
-                    cfg.linear_num_value_heads,
+                    local_num_v_heads,
                     cfg.linear_key_head_dim,
                     cfg.linear_value_head_dim,
                 ],


### PR DESCRIPTION
Fixes #2052

Two issues found while running Qwen3.5-27B with NCCL TP on 2x RTX 3090:

**1. GDN layers not TP-aware**

In `models/gdn.rs`, `in_proj_qkvz` and `in_proj_ba` were plain `Linear` while `out_proj` was `RowParallelLayer`. The forward pass ran at full width then hit the sharded out_proj, causing `mismatch on matmul dim [5120, 3072] [1, 1, 6144]`.

Fix: shard GDN weights by key-head groups during `load()` when `world_size > 1`. Also adjusted the hybrid cache pool dimensions in `qwen3_5/text.rs`, `qwen3_5_moe/text.rs`, and `qwen3_next.rs` to use local (per-rank) head counts.

**2. UQFF artifact count mismatch**

Serialization filters tensors by `isq_serde_supported()` (isq.rs:718) but deserialization checked against the unfiltered count, causing `Number of artifacts (304) does not match the number of ISQ layers (305)`. The loading code already handles missing artifacts gracefully via `if let Some(artifact)`, so relaxed the check to only reject cases where there are more artifacts than layers.

Tested with Qwen3.5-27B on 2x RTX 3090 with ISQ Q5K + NCCL TP=2 — inference works correctly. (UQFF + TP has a separate VRAM issue tracked in #2053.)