### PR TITLE
fix(core): avoid constant recompilation

### DIFF
--- a/mistralrs-core/build.rs
+++ b/mistralrs-core/build.rs
@@ -89,13 +89,17 @@ fn set_git_revision() {
         .unwrap_or_else(|| "unknown".to_string());
 
     println!("cargo:rustc-env=MISTRALRS_GIT_REVISION={commit}");
-    println!("cargo:rerun-if-changed=.git/HEAD");
-    if let Ok(head) = std::fs::read_to_string(".git/HEAD") {
-        if let Some(ref_path) = head.strip_prefix("ref:") {
-            let ref_path = ref_path.trim();
-            if !ref_path.is_empty() {
-                println!("cargo:rerun-if-changed=.git/{}", ref_path);
+    if let Ok(true) = std::fs::exists("../.git") {
+        println!("cargo:rerun-if-changed=../.git/HEAD");
+        if let Ok(head) = std::fs::read_to_string("../.git/HEAD") {
+            if let Some(ref_path) = head.strip_prefix("ref:") {
+                let ref_path = ref_path.trim();
+                if !ref_path.is_empty() {
+                    println!("cargo:rerun-if-changed=../.git/{}", ref_path);
+                }
             }
         }
+    } else {
+        println!("cargo:rerun-if-changed=build.rs");
     }
 }


### PR DESCRIPTION
Currently, `mistralrs-core` recompiles on every run because `build.rs` looks for `.git/HEAD` in the subproject directory instead of the workspace root. Since the file isn't found, Cargo invalidates the build fingerprint every time.

**Changes:**
- Updated git path to `../.git` to match the workspace structure.
- Added existence check to prevent issues when `.git` is missing.

Fixes the infinite recompilation cycle.