### PR TITLE
Fix Gemma softcap F16 overflow NaN and scheduler hang (#2058)

### DIFF
--- a/mistralrs-core/src/attention/backends/naive.rs
+++ b/mistralrs-core/src/attention/backends/naive.rs
@@ -36,9 +36,16 @@ pub(crate) fn naive_sdpa(
             MatMul.matmul_affine_mul(q_chunk, &k.t()?, sdpa_params.softmax_scale.into())?;
 
         if let Some(softcap) = sdpa_params.softcap {
+            let att_dtype = att.dtype();
+            if att_dtype == candle_core::DType::BF16 || att_dtype == candle_core::DType::F16 {
+                att = att.to_dtype(candle_core::DType::F32)?;
+            }
             att = (att / softcap as f64)?;
             att = att.tanh()?;
             att = (att * softcap as f64)?;
+            if att.dtype() != att_dtype {
+                att = att.to_dtype(att_dtype)?;
+            }
         }
 
         if let Some(mask) = mask_chunk {

--- a/mistralrs-core/src/sequence.rs
+++ b/mistralrs-core/src/sequence.rs
@@ -757,6 +757,7 @@ impl Sequence {
             *self.state.read().unwrap(),
             SequenceState::FinishedAborted
                 | SequenceState::FinishedIgnored
+                | SequenceState::Error
                 | SequenceState::Done(_)
         )
     }


### PR DESCRIPTION
Fixes #2058.

## Two independent fixes

### 1. Softcap NaN in F16/BF16 (naive attention backend)

Gemma models use an attention softcap (logit / softcap → tanh → logit * softcap). The naive SDPA backend was performing the tanh in the input dtype (F16 or BF16). For F16, values outside approximately ±65504 become ±Inf before tanh, and tanh(Inf) = NaN when computed in reduced precision, producing silent NaN logits.

**Fix:** Promote attention scores to F32 before computing the softcap tanh, then cast back to the original dtype.

**Scope note:** This fix applies to the CPU/naive fallback path in `attention/backends/naive.rs`. The primary CUDA (FlashAttention) and Metal SDPA backends have their own softcap handling and are not changed here.

### 2. `SequenceState::Error` missing from `is_finished_paged_attn`

When a sequence enters `SequenceState::Error`, it was not recognized as "finished" by the paged attention scheduler. This caused KV blocks to remain allocated and the scheduler to stall waiting for capacity that would never be returned.

**Fix:** Add `SequenceState::Error` to the match arms in `is_finished_paged_attn()`.

## Files changed

- `mistralrs-core/src/attention/backends/naive.rs`
- `mistralrs-core/src/sequence.rs`