### PR TITLE
fix(quant): avoid F8E4M3 compute dtype in FP8 dequantization

### DIFF
--- a/.typos.toml
+++ b/.typos.toml
@@ -5,6 +5,7 @@ extend-exclude = [
     "examples/server/phi3_duckduckgo_mistral.rs.ipynb",
     "mistralrs-web-chat/static/",
     "mistralrs-cli/static/",
+    "mistralrs-quant/kernels/mmq_gguf/",
     "CLAUDE.md",
 ]
 ignore-hidden = false
@@ -12,6 +13,7 @@ ignore-hidden = false
 [default]
 extend-ignore-re = [
     "cudaDevAttrMaxSharedMemoryPerBlockOptin",
+    "CU_DEVICE_ATTRIBUTE_MAX_SHARED_MEMORY_PER_BLOCK_OPTIN",
     '"tese"',
     "setp\\.ne\\.b32",
     # metal_kernels

--- a/.typos.toml
+++ b/.typos.toml
@@ -5,7 +5,6 @@ extend-exclude = [
     "examples/server/phi3_duckduckgo_mistral.rs.ipynb",
     "mistralrs-web-chat/static/",
     "mistralrs-cli/static/",
-    "mistralrs-quant/kernels/mmq_gguf/",
     "CLAUDE.md",
 ]
 ignore-hidden = false
@@ -13,7 +12,6 @@ ignore-hidden = false
 [default]
 extend-ignore-re = [
     "cudaDevAttrMaxSharedMemoryPerBlockOptin",
-    "CU_DEVICE_ATTRIBUTE_MAX_SHARED_MEMORY_PER_BLOCK_OPTIN",
     '"tese"',
     "setp\\.ne\\.b32",
     # metal_kernels

--- a/mistralrs-cli/src/commands/bench.rs
+++ b/mistralrs-cli/src/commands/bench.rs
@@ -99,7 +99,7 @@ pub async fn run_bench(
     if warmup > 0 {
         info!("Running {} warmup iteration(s)...", warmup);
         for _ in 0..warmup {
-            let _ = run_single_bench(&mistralrs, 32, 16).await?;
+            run_single_bench(&mistralrs, 32, 16).await?;
         }
         info!("Warmup complete.");
 

--- a/mistralrs-cli/src/commands/bench.rs
+++ b/mistralrs-cli/src/commands/bench.rs
@@ -99,7 +99,7 @@ pub async fn run_bench(
     if warmup > 0 {
         info!("Running {} warmup iteration(s)...", warmup);
         for _ in 0..warmup {
-            run_single_bench(&mistralrs, 32, 16).await?;
+            let _ = run_single_bench(&mistralrs, 32, 16).await?;
         }
         info!("Warmup complete.");
 

--- a/mistralrs-core/src/engine/tool_dispatch.rs
+++ b/mistralrs-core/src/engine/tool_dispatch.rs
@@ -102,10 +102,8 @@ pub(super) async fn execute_search(
     );
 
     // Sort by token length (shortest first).
-    let mut combined: Vec<(SearchResult, usize)> = results
-        .into_iter()
-        .zip(result_token_lens.into_iter())
-        .collect();
+    let mut combined: Vec<(SearchResult, usize)> =
+        results.into_iter().zip(result_token_lens).collect();
     combined.sort_by_key(|(_, len)| *len);
     let (results, result_token_lens): (Vec<SearchResult>, Vec<usize>) =
         combined.into_iter().unzip();

--- a/mistralrs-core/src/engine/tool_dispatch.rs
+++ b/mistralrs-core/src/engine/tool_dispatch.rs
@@ -102,8 +102,10 @@ pub(super) async fn execute_search(
     );
 
     // Sort by token length (shortest first).
-    let mut combined: Vec<(SearchResult, usize)> =
-        results.into_iter().zip(result_token_lens).collect();
+    let mut combined: Vec<(SearchResult, usize)> = results
+        .into_iter()
+        .zip(result_token_lens.into_iter())
+        .collect();
     combined.sort_by_key(|(_, len)| *len);
     let (results, result_token_lens): (Vec<SearchResult>, Vec<usize>) =
         combined.into_iter().unzip();

--- a/mistralrs-core/src/moe/experts.rs
+++ b/mistralrs-core/src/moe/experts.rs
@@ -95,6 +95,7 @@ struct SlowExpertsWeights {
 pub struct MoEExperts {
     backend: MoEExpertsBackendImpl,
     act: Activation,
+    #[allow(dead_code)]
     num_experts: usize,
     num_experts_per_tok: usize,
     all_reduce: SumAllReduce,

--- a/mistralrs-core/src/moe/experts.rs
+++ b/mistralrs-core/src/moe/experts.rs
@@ -95,7 +95,6 @@ struct SlowExpertsWeights {
 pub struct MoEExperts {
     backend: MoEExpertsBackendImpl,
     act: Activation,
-    #[allow(dead_code)]
     num_experts: usize,
     num_experts_per_tok: usize,
     all_reduce: SumAllReduce,

--- a/mistralrs-core/src/scheduler/default_scheduler.rs
+++ b/mistralrs-core/src/scheduler/default_scheduler.rs
@@ -131,8 +131,8 @@ impl<Backer: FcfsBacker> BucketingManager<Backer> for FixedBucketingManager {
         let running = if seq_buckets.len() <= 1 {
             // Full steam ahead or have everything
             seq_buckets
-                .into_iter()
-                .flat_map(|(_, x)| x)
+                .into_values()
+                .flatten()
                 .map(|s| s.reset_urgency())
                 .collect::<Vec<_>>()
         } else {

--- a/mistralrs-core/src/scheduler/default_scheduler.rs
+++ b/mistralrs-core/src/scheduler/default_scheduler.rs
@@ -131,8 +131,8 @@ impl<Backer: FcfsBacker> BucketingManager<Backer> for FixedBucketingManager {
         let running = if seq_buckets.len() <= 1 {
             // Full steam ahead or have everything
             seq_buckets
-                .into_values()
-                .flatten()
+                .into_iter()
+                .flat_map(|(_, x)| x)
                 .map(|s| s.reset_urgency())
                 .collect::<Vec<_>>()
         } else {

--- a/mistralrs-core/src/search/rag.rs
+++ b/mistralrs-core/src/search/rag.rs
@@ -139,7 +139,7 @@ impl SearchPipeline {
                 .to_dtype(DType::F32)?
                 .to_device(&Device::Cpu)?
                 .to_vec2::<f32>()?;
-            for ((idx, _), embedding) in chunk_entries.iter().zip(vecs.into_iter()) {
+            for ((idx, _), embedding) in chunk_entries.iter().zip(vecs) {
                 outputs[*idx] = embedding;
             }
         }
@@ -339,7 +339,7 @@ pub fn rank_document_chunks(
 
     let mut scored: Vec<ScoredChunk> = top_indices
         .iter()
-        .zip(top_embeddings.into_iter())
+        .zip(top_embeddings)
         .map(|(&i, embedding)| {
             let (result_index, ref chunk) = bindings[i];
             let score = cosine_similarity(&query_embedding, &embedding);

--- a/mistralrs-core/src/search/rag.rs
+++ b/mistralrs-core/src/search/rag.rs
@@ -139,7 +139,7 @@ impl SearchPipeline {
                 .to_dtype(DType::F32)?
                 .to_device(&Device::Cpu)?
                 .to_vec2::<f32>()?;
-            for ((idx, _), embedding) in chunk_entries.iter().zip(vecs) {
+            for ((idx, _), embedding) in chunk_entries.iter().zip(vecs.into_iter()) {
                 outputs[*idx] = embedding;
             }
         }
@@ -339,7 +339,7 @@ pub fn rank_document_chunks(
 
     let mut scored: Vec<ScoredChunk> = top_indices
         .iter()
-        .zip(top_embeddings)
+        .zip(top_embeddings.into_iter())
         .map(|(&i, embedding)| {
             let (result_index, ref chunk) = bindings[i];
             let score = cosine_similarity(&query_embedding, &embedding);

--- a/mistralrs-core/src/vision_models/gemma4/audio_processing.rs
+++ b/mistralrs-core/src/vision_models/gemma4/audio_processing.rs
@@ -117,7 +117,7 @@ impl AudioProcessor {
         let mut mel_data = Vec::<f32>::with_capacity(batch_size * max_frames * self.feature_size);
         let mut mask_data = Vec::<f32>::with_capacity(batch_size * max_frames);
 
-        for (mel, valid_mask) in mel_batches.into_iter().zip(valid_masks.into_iter()) {
+        for (mel, valid_mask) in mel_batches.into_iter().zip(valid_masks) {
             for (frame, &is_valid) in mel.iter().zip(valid_mask.iter()) {
                 if is_valid {
                     mel_data.extend_from_slice(frame);

--- a/mistralrs-core/src/vision_models/gemma4/audio_processing.rs
+++ b/mistralrs-core/src/vision_models/gemma4/audio_processing.rs
@@ -117,7 +117,7 @@ impl AudioProcessor {
         let mut mel_data = Vec::<f32>::with_capacity(batch_size * max_frames * self.feature_size);
         let mut mask_data = Vec::<f32>::with_capacity(batch_size * max_frames);
 
-        for (mel, valid_mask) in mel_batches.into_iter().zip(valid_masks) {
+        for (mel, valid_mask) in mel_batches.into_iter().zip(valid_masks.into_iter()) {
             for (frame, &is_valid) in mel.iter().zip(valid_mask.iter()) {
                 if is_valid {
                     mel_data.extend_from_slice(frame);

--- a/mistralrs-core/src/vision_models/idefics3/inputs_processor.rs
+++ b/mistralrs-core/src/vision_models/idefics3/inputs_processor.rs
@@ -171,8 +171,7 @@ impl InputsProcessor for Idefics3ImageProcessor {
                         .expect("Detokenization failed!");
 
                     let mut image_prompt_strings = Vec::new();
-                    for (n_rows, n_cols) in rows.unwrap().into_iter().zip(cols.unwrap().into_iter())
-                    {
+                    for (n_rows, n_cols) in rows.unwrap().into_iter().zip(cols.unwrap()) {
                         let image_prompt_string =
                             get_image_prompt_string(n_rows, n_cols, self.image_seq_len);
                         image_prompt_strings.push(image_prompt_string);
@@ -569,7 +568,7 @@ impl ImagePreProcessor for Idefics3ImageProcessor {
 
                 let (split_image_array, rows, cols) =
                     split_image(image, max_image_size["longest_edge"] as usize)?;
-                new_images.extend(split_image_array.into_iter());
+                new_images.extend(split_image_array);
                 image_rows.push(rows);
                 image_cols.push(cols);
             }

--- a/mistralrs-core/src/vision_models/idefics3/inputs_processor.rs
+++ b/mistralrs-core/src/vision_models/idefics3/inputs_processor.rs
@@ -171,7 +171,8 @@ impl InputsProcessor for Idefics3ImageProcessor {
                         .expect("Detokenization failed!");
 
                     let mut image_prompt_strings = Vec::new();
-                    for (n_rows, n_cols) in rows.unwrap().into_iter().zip(cols.unwrap()) {
+                    for (n_rows, n_cols) in rows.unwrap().into_iter().zip(cols.unwrap().into_iter())
+                    {
                         let image_prompt_string =
                             get_image_prompt_string(n_rows, n_cols, self.image_seq_len);
                         image_prompt_strings.push(image_prompt_string);
@@ -568,7 +569,7 @@ impl ImagePreProcessor for Idefics3ImageProcessor {
 
                 let (split_image_array, rows, cols) =
                     split_image(image, max_image_size["longest_edge"] as usize)?;
-                new_images.extend(split_image_array);
+                new_images.extend(split_image_array.into_iter());
                 image_rows.push(rows);
                 image_cols.push(cols);
             }

--- a/mistralrs-core/src/vision_models/llava/llava_inputs_processor.rs
+++ b/mistralrs-core/src/vision_models/llava/llava_inputs_processor.rs
@@ -214,11 +214,10 @@ impl InputsProcessor for LLaVAInputProcessor {
             )
             .expect("Decoding failed");
 
-        for (detokenized, (seq, num_img_tokens)) in detokenized.into_iter().zip(
-            input_seqs
-                .iter_mut()
-                .zip(num_img_tokens.unwrap().into_iter()),
-        ) {
+        for (detokenized, (seq, num_img_tokens)) in detokenized
+            .into_iter()
+            .zip(input_seqs.iter_mut().zip(num_img_tokens.unwrap()))
+        {
             let splits = self
                 .image_tag_splitter
                 .split(&detokenized)

--- a/mistralrs-core/src/vision_models/llava/llava_inputs_processor.rs
+++ b/mistralrs-core/src/vision_models/llava/llava_inputs_processor.rs
@@ -214,10 +214,11 @@ impl InputsProcessor for LLaVAInputProcessor {
             )
             .expect("Decoding failed");
 
-        for (detokenized, (seq, num_img_tokens)) in detokenized
-            .into_iter()
-            .zip(input_seqs.iter_mut().zip(num_img_tokens.unwrap()))
-        {
+        for (detokenized, (seq, num_img_tokens)) in detokenized.into_iter().zip(
+            input_seqs
+                .iter_mut()
+                .zip(num_img_tokens.unwrap().into_iter()),
+        ) {
             let splits = self
                 .image_tag_splitter
                 .split(&detokenized)

--- a/mistralrs-core/src/vision_models/llava/llava_next_inputs_processor.rs
+++ b/mistralrs-core/src/vision_models/llava/llava_next_inputs_processor.rs
@@ -257,11 +257,10 @@ impl InputsProcessor for LLaVANextInputProcessor {
             )
             .expect("Decode failed");
 
-        for (detokenized, (seq, num_img_tokens)) in detokenized.into_iter().zip(
-            input_seqs
-                .iter_mut()
-                .zip(num_img_tokens.unwrap().into_iter()),
-        ) {
+        for (detokenized, (seq, num_img_tokens)) in detokenized
+            .into_iter()
+            .zip(input_seqs.iter_mut().zip(num_img_tokens.unwrap()))
+        {
             let splits = self
                 .image_tag_splitter
                 .split(&detokenized)

--- a/mistralrs-core/src/vision_models/llava/llava_next_inputs_processor.rs
+++ b/mistralrs-core/src/vision_models/llava/llava_next_inputs_processor.rs
@@ -257,10 +257,11 @@ impl InputsProcessor for LLaVANextInputProcessor {
             )
             .expect("Decode failed");
 
-        for (detokenized, (seq, num_img_tokens)) in detokenized
-            .into_iter()
-            .zip(input_seqs.iter_mut().zip(num_img_tokens.unwrap()))
-        {
+        for (detokenized, (seq, num_img_tokens)) in detokenized.into_iter().zip(
+            input_seqs
+                .iter_mut()
+                .zip(num_img_tokens.unwrap().into_iter()),
+        ) {
             let splits = self
                 .image_tag_splitter
                 .split(&detokenized)

--- a/mistralrs-pyo3/src/util.rs
+++ b/mistralrs-pyo3/src/util.rs
@@ -379,11 +379,7 @@ fn decode_gif_frames(bytes: &[u8]) -> anyhow::Result<VideoInput> {
         .iter()
         .map(|f| {
             let (num, den) = f.delay().numer_denom_ms();
-            if den == 0 {
-                100
-            } else {
-                num * 1000 / den
-            }
+            (num * 1000).checked_div(den).unwrap_or(100)
         })
         .sum();
     let fps = if total_delay_ms > 0 {

--- a/mistralrs-pyo3/src/util.rs
+++ b/mistralrs-pyo3/src/util.rs
@@ -379,7 +379,11 @@ fn decode_gif_frames(bytes: &[u8]) -> anyhow::Result<VideoInput> {
         .iter()
         .map(|f| {
             let (num, den) = f.delay().numer_denom_ms();
-            (num * 1000).checked_div(den).unwrap_or(100)
+            if den == 0 {
+                100
+            } else {
+                num * 1000 / den
+            }
         })
         .sum();
     let fps = if total_delay_ms > 0 {

--- a/mistralrs-quant/src/blockwise_fp8/mod.rs
+++ b/mistralrs-quant/src/blockwise_fp8/mod.rs
@@ -449,7 +449,9 @@ pub fn blockwise_fp8_linear_b(
     }
 
     // Handle the case where the layer is dummy (no tensors)
-    if !(vb.contains_tensor("weight") && (vb.contains_tensor("weight_scale_inv") || vb.contains_tensor("weight_scale"))) {
+    if !(vb.contains_tensor("weight")
+        && (vb.contains_tensor("weight_scale_inv") || vb.contains_tensor("weight_scale")))
+    {
         let layer = <DummyLayer as QuantMethod>::new(QuantMethodConfig::Dummy)?;
         return Ok(Arc::new(layer) as Arc<dyn QuantMethod>);
     }
@@ -477,7 +479,7 @@ pub fn blockwise_fp8_linear_b(
         None
     };
 
-    let dequant_dtype = bias.as_ref().map(|b| b.dtype()).unwrap_or(DType::BF16);
+    let dequant_dtype = crate::fp8_dequant_dtype(vb.dtype(), bias.as_ref());
 
     Ok(Arc::new(BlockwiseFP8Linear {
         weight,

--- a/mistralrs-quant/src/blockwise_fp8/mod.rs
+++ b/mistralrs-quant/src/blockwise_fp8/mod.rs
@@ -477,11 +477,13 @@ pub fn blockwise_fp8_linear_b(
         None
     };
 
+    let dequant_dtype = bias.as_ref().map(|b| b.dtype()).unwrap_or(DType::BF16);
+
     Ok(Arc::new(BlockwiseFP8Linear {
         weight,
         weight_block_size: weight_block_size.clone(),
         weight_scale_inv,
         bias,
-        dequant_dtype: vb.dtype(),
+        dequant_dtype,
     }))
 }

--- a/mistralrs-quant/src/blockwise_fp8/mod.rs
+++ b/mistralrs-quant/src/blockwise_fp8/mod.rs
@@ -441,12 +441,15 @@ pub fn blockwise_fp8_linear_b(
     };
 
     // Handle the case where we actually have an unquantized layer
-    if vb.contains_tensor("weight") && !vb.contains_tensor("weight_scale_inv") {
+    if vb.contains_tensor("weight")
+        && !vb.contains_tensor("weight_scale_inv")
+        && !vb.contains_tensor("weight_scale")
+    {
         return crate::linear_b(in_dim, out_dim, bias, &None, vb);
     }
 
     // Handle the case where the layer is dummy (no tensors)
-    if !(vb.contains_tensor("weight") && vb.contains_tensor("weight_scale_inv")) {
+    if !(vb.contains_tensor("weight") && (vb.contains_tensor("weight_scale_inv") || vb.contains_tensor("weight_scale"))) {
         let layer = <DummyLayer as QuantMethod>::new(QuantMethodConfig::Dummy)?;
         return Ok(Arc::new(layer) as Arc<dyn QuantMethod>);
     }
@@ -459,15 +462,15 @@ pub fn blockwise_fp8_linear_b(
         candle_core::bail!("Expected weight_block_size to have length 2, got {weight_block_size:?}")
     }
     let weight = vb.get_with_hints_dtype((out_dim, in_dim), "weight", hints, DType::F8E4M3)?;
-    let weight_scale_inv = vb.get_with_hints_dtype(
-        (
-            out_dim.div_ceil(weight_block_size[0]),
-            in_dim.div_ceil(weight_block_size[1]),
-        ),
-        "weight_scale_inv",
-        hints,
-        DType::F32,
-    )?;
+    let expected_scale_shape = (
+        out_dim.div_ceil(weight_block_size[0]),
+        in_dim.div_ceil(weight_block_size[1]),
+    );
+    let weight_scale_inv = if vb.contains_tensor("weight_scale_inv") {
+        vb.get_with_hints_dtype(expected_scale_shape, "weight_scale_inv", hints, DType::F32)?
+    } else {
+        vb.get_with_hints_dtype(expected_scale_shape, "weight_scale", hints, DType::F32)?
+    };
     let bias = if bias {
         Some(vb.get((out_dim,), "bias")?)
     } else {

--- a/mistralrs-quant/src/distributed/layers.rs
+++ b/mistralrs-quant/src/distributed/layers.rs
@@ -1431,9 +1431,7 @@ impl PackedExperts {
             let mut gs = Vec::new();
             let mut us = Vec::new();
             let mut ds = Vec::new();
-            for ((mut gate_proj, mut up_proj), mut down_proj) in
-                gc.into_iter().zip(uc.into_iter()).zip(dc.into_iter())
-            {
+            for ((mut gate_proj, mut up_proj), mut down_proj) in gc.into_iter().zip(uc).zip(dc) {
                 gate_proj = gate_proj.squeeze(0)?;
                 up_proj = up_proj.squeeze(0)?;
                 down_proj = down_proj.squeeze(0)?;
@@ -2036,9 +2034,7 @@ pub fn compute_n_kv_groups(
     } else {
         1
     };
-    if kv_replicate != 0 {
-        (num_attention_heads / total_num_kv_heads) / kv_replicate
-    } else {
-        num_attention_heads / total_num_kv_heads
-    }
+    (num_attention_heads / total_num_kv_heads)
+        .checked_div(kv_replicate)
+        .unwrap_or(num_attention_heads / total_num_kv_heads)
 }

--- a/mistralrs-quant/src/distributed/layers.rs
+++ b/mistralrs-quant/src/distributed/layers.rs
@@ -18,6 +18,24 @@ use crate::{
 
 use super::{Comm, SumAllReduce};
 
+/// Resolve the FP8 scale tensor name for a given projection prefix.
+///
+/// HuggingFace FP8 models use either `weight_scale_inv` or `weight_scale`
+/// (both are semantically equivalent inverse scales). This helper checks
+/// which one exists and returns the correct name, or errors if neither is found.
+fn fp8_scale_name(vb: &ShardedVarBuilder, base: &str) -> candle_core::Result<String> {
+    let inv = format!("{base}.weight_scale_inv");
+    let fwd = format!("{base}.weight_scale");
+
+    if vb.contains_tensor(&inv) {
+        Ok(inv)
+    } else if vb.contains_tensor(&fwd) {
+        Ok(fwd)
+    } else {
+        candle_core::bail!("Missing FP8 scale tensor: expected `{inv}` or `{fwd}`")
+    }
+}
+
 fn shard(dim: usize, rank: usize, world_size: usize) -> Shard {
     Shard::Simple {
         dim,
@@ -1100,7 +1118,8 @@ impl PackedExperts {
 
                     if is_stacked_format {
                         // Stacked format: load FP8 tensors and split
-                        let has_fp8_scales = vb.contains_tensor("gate_up_proj.weight_scale_inv");
+                        let has_fp8_scales = vb.contains_tensor("gate_up_proj.weight_scale_inv")
+                            || vb.contains_tensor("gate_up_proj.weight_scale");
 
                         if has_fp8_scales {
                             // Load gate_up_proj FP8 tensor and scale
@@ -1110,13 +1129,14 @@ impl PackedExperts {
                                 Default::default(),
                                 candle_core::DType::F8E4M3,
                             )?;
+                            let gate_up_scale_name = fp8_scale_name(&vb, "gate_up_proj")?;
                             let gate_up_scale = vb.get_with_hints_dtype(
                                 (
                                     num_local_experts,
                                     hidden_size.div_ceil(weight_block_size[0]),
                                     (intermediate_size * 2).div_ceil(weight_block_size[1]),
                                 ),
-                                "gate_up_proj.weight_scale_inv",
+                                &gate_up_scale_name,
                                 Default::default(),
                                 candle_core::DType::F32,
                             )?;
@@ -1128,13 +1148,14 @@ impl PackedExperts {
                                 Default::default(),
                                 candle_core::DType::F8E4M3,
                             )?;
+                            let down_scale_name = fp8_scale_name(&vb, "down_proj")?;
                             let down_scale = vb.get_with_hints_dtype(
                                 (
                                     num_local_experts,
                                     intermediate_size.div_ceil(weight_block_size[0]),
                                     hidden_size.div_ceil(weight_block_size[1]),
                                 ),
-                                "down_proj.weight_scale_inv",
+                                &down_scale_name,
                                 Default::default(),
                                 candle_core::DType::F32,
                             )?;
@@ -1212,7 +1233,7 @@ impl PackedExperts {
                             (gs, us, ds)
                         } else {
                             candle_core::bail!(
-                                "PackedExperts with FP8 requires weight_scale_inv tensors"
+                                "PackedExperts with FP8 requires weight_scale_inv or weight_scale tensors"
                             );
                         }
                     } else {
@@ -1231,12 +1252,13 @@ impl PackedExperts {
                                 Default::default(),
                                 candle_core::DType::F8E4M3,
                             )?;
+                            let gate_scale_name = fp8_scale_name(&expert_vb, "gate_proj")?;
                             let gate_scale = expert_vb.get_with_hints_dtype(
                                 (
                                     intermediate_size.div_ceil(weight_block_size[0]),
                                     hidden_size.div_ceil(weight_block_size[1]),
                                 ),
-                                "gate_proj.weight_scale_inv",
+                                &gate_scale_name,
                                 Default::default(),
                                 candle_core::DType::F32,
                             )?;
@@ -1247,12 +1269,13 @@ impl PackedExperts {
                                 Default::default(),
                                 candle_core::DType::F8E4M3,
                             )?;
+                            let up_scale_name = fp8_scale_name(&expert_vb, "up_proj")?;
                             let up_scale = expert_vb.get_with_hints_dtype(
                                 (
                                     intermediate_size.div_ceil(weight_block_size[0]),
                                     hidden_size.div_ceil(weight_block_size[1]),
                                 ),
-                                "up_proj.weight_scale_inv",
+                                &up_scale_name,
                                 Default::default(),
                                 candle_core::DType::F32,
                             )?;
@@ -1263,12 +1286,13 @@ impl PackedExperts {
                                 Default::default(),
                                 candle_core::DType::F8E4M3,
                             )?;
+                            let down_scale_name = fp8_scale_name(&expert_vb, "down_proj")?;
                             let down_scale = expert_vb.get_with_hints_dtype(
                                 (
                                     hidden_size.div_ceil(weight_block_size[0]),
                                     intermediate_size.div_ceil(weight_block_size[1]),
                                 ),
-                                "down_proj.weight_scale_inv",
+                                &down_scale_name,
                                 Default::default(),
                                 candle_core::DType::F32,
                             )?;
@@ -1538,7 +1562,8 @@ impl FusedExperts {
         {
             // Stacked format with FP8 quantization
             // Keep weights as FP8 using BlockwiseFP8 to leverage native FP8 GEMM in gather_forward
-            let has_fp8_scales = experts_vb.contains_tensor("gate_up_proj.weight_scale_inv");
+            let has_fp8_scales = experts_vb.contains_tensor("gate_up_proj.weight_scale_inv")
+                || experts_vb.contains_tensor("gate_up_proj.weight_scale");
 
             if has_fp8_scales {
                 let weight_block_size = match quantization_config {
@@ -1565,13 +1590,14 @@ impl FusedExperts {
                     Default::default(),
                     candle_core::DType::F8E4M3,
                 )?;
+                let gate_up_scale_name = fp8_scale_name(&experts_vb, "gate_up_proj")?;
                 let gate_up_scale = experts_vb.get_with_hints_dtype(
                     (
                         num_experts,
                         hidden_size.div_ceil(weight_block_size[0]),
                         (moe_intermediate_size * 2).div_ceil(weight_block_size[1]),
                     ),
-                    "gate_up_proj.weight_scale_inv",
+                    &gate_up_scale_name,
                     Default::default(),
                     candle_core::DType::F32,
                 )?;
@@ -1584,13 +1610,14 @@ impl FusedExperts {
                     Default::default(),
                     candle_core::DType::F8E4M3,
                 )?;
+                let down_scale_name = fp8_scale_name(&experts_vb, "down_proj")?;
                 let down_scale = experts_vb.get_with_hints_dtype(
                     (
                         num_experts,
                         moe_intermediate_size.div_ceil(weight_block_size[0]),
                         hidden_size.div_ceil(weight_block_size[1]),
                     ),
-                    "down_proj.weight_scale_inv",
+                    &down_scale_name,
                     Default::default(),
                     candle_core::DType::F32,
                 )?;
@@ -1624,12 +1651,17 @@ impl FusedExperts {
                 let down_scale = down_scale.transpose(1, 2)?.contiguous()?;
 
                 // Create BlockwiseFP8Linear for each projection
-                let fused_gate_proj =
-                    blockwise_fp8_moe(gate_fp8, gate_scale, weight_block_size.clone(), vb.dtype())?;
+                let dequant_dtype = crate::fp8_dequant_dtype(vb.dtype(), None);
+                let fused_gate_proj = blockwise_fp8_moe(
+                    gate_fp8,
+                    gate_scale,
+                    weight_block_size.clone(),
+                    dequant_dtype,
+                )?;
                 let fused_up_proj =
-                    blockwise_fp8_moe(up_fp8, up_scale, weight_block_size.clone(), vb.dtype())?;
+                    blockwise_fp8_moe(up_fp8, up_scale, weight_block_size.clone(), dequant_dtype)?;
                 let fused_down_proj =
-                    blockwise_fp8_moe(down_fp8, down_scale, weight_block_size, vb.dtype())?;
+                    blockwise_fp8_moe(down_fp8, down_scale, weight_block_size, dequant_dtype)?;
 
                 (fused_gate_proj, fused_up_proj, fused_down_proj)
             } else {
@@ -1866,12 +1898,13 @@ impl FusedExperts {
                     Default::default(),
                     candle_core::DType::F8E4M3,
                 )?;
+                let gate_scale_name = fp8_scale_name(&expert_vb, "gate_proj")?;
                 let gate_scale = expert_vb.get_with_hints_dtype(
                     (
                         moe_intermediate_size.div_ceil(weight_block_size[0]),
                         hidden_size.div_ceil(weight_block_size[1]),
                     ),
-                    "gate_proj.weight_scale_inv",
+                    &gate_scale_name,
                     Default::default(),
                     candle_core::DType::F32,
                 )?;
@@ -1882,12 +1915,13 @@ impl FusedExperts {
                     Default::default(),
                     candle_core::DType::F8E4M3,
                 )?;
+                let up_scale_name = fp8_scale_name(&expert_vb, "up_proj")?;
                 let up_scale = expert_vb.get_with_hints_dtype(
                     (
                         moe_intermediate_size.div_ceil(weight_block_size[0]),
                         hidden_size.div_ceil(weight_block_size[1]),
                     ),
-                    "up_proj.weight_scale_inv",
+                    &up_scale_name,
                     Default::default(),
                     candle_core::DType::F32,
                 )?;
@@ -1898,12 +1932,13 @@ impl FusedExperts {
                     Default::default(),
                     candle_core::DType::F8E4M3,
                 )?;
+                let down_scale_name = fp8_scale_name(&expert_vb, "down_proj")?;
                 let down_scale = expert_vb.get_with_hints_dtype(
                     (
                         hidden_size.div_ceil(weight_block_size[0]),
                         moe_intermediate_size.div_ceil(weight_block_size[1]),
                     ),
-                    "down_proj.weight_scale_inv",
+                    &down_scale_name,
                     Default::default(),
                     candle_core::DType::F32,
                 )?;
@@ -1925,12 +1960,17 @@ impl FusedExperts {
             let down_scale = Tensor::stack(&down_scale_vec, 0)?;
 
             // Create BlockwiseFP8Linear for each projection
-            let fused_gate_proj =
-                blockwise_fp8_moe(gate_fp8, gate_scale, weight_block_size.clone(), vb.dtype())?;
+            let dequant_dtype = crate::fp8_dequant_dtype(vb.dtype(), None);
+            let fused_gate_proj = blockwise_fp8_moe(
+                gate_fp8,
+                gate_scale,
+                weight_block_size.clone(),
+                dequant_dtype,
+            )?;
             let fused_up_proj =
-                blockwise_fp8_moe(up_fp8, up_scale, weight_block_size.clone(), vb.dtype())?;
+                blockwise_fp8_moe(up_fp8, up_scale, weight_block_size.clone(), dequant_dtype)?;
             let fused_down_proj =
-                blockwise_fp8_moe(down_fp8, down_scale, weight_block_size, vb.dtype())?;
+                blockwise_fp8_moe(down_fp8, down_scale, weight_block_size, dequant_dtype)?;
 
             (fused_gate_proj, fused_up_proj, fused_down_proj)
         } else if !experts_vb.pp("0").contains_tensor("gate_proj.weight") {

--- a/mistralrs-quant/src/distributed/layers.rs
+++ b/mistralrs-quant/src/distributed/layers.rs
@@ -1455,9 +1455,7 @@ impl PackedExperts {
             let mut gs = Vec::new();
             let mut us = Vec::new();
             let mut ds = Vec::new();
-            for ((mut gate_proj, mut up_proj), mut down_proj) in
-                gc.into_iter().zip(uc.into_iter()).zip(dc.into_iter())
-            {
+            for ((mut gate_proj, mut up_proj), mut down_proj) in gc.into_iter().zip(uc).zip(dc) {
                 gate_proj = gate_proj.squeeze(0)?;
                 up_proj = up_proj.squeeze(0)?;
                 down_proj = down_proj.squeeze(0)?;
@@ -2076,9 +2074,7 @@ pub fn compute_n_kv_groups(
     } else {
         1
     };
-    if kv_replicate != 0 {
-        (num_attention_heads / total_num_kv_heads) / kv_replicate
-    } else {
-        num_attention_heads / total_num_kv_heads
-    }
+    (num_attention_heads / total_num_kv_heads)
+        .checked_div(kv_replicate)
+        .unwrap_or(num_attention_heads / total_num_kv_heads)
 }

--- a/mistralrs-quant/src/distributed/layers.rs
+++ b/mistralrs-quant/src/distributed/layers.rs
@@ -1431,7 +1431,9 @@ impl PackedExperts {
             let mut gs = Vec::new();
             let mut us = Vec::new();
             let mut ds = Vec::new();
-            for ((mut gate_proj, mut up_proj), mut down_proj) in gc.into_iter().zip(uc).zip(dc) {
+            for ((mut gate_proj, mut up_proj), mut down_proj) in
+                gc.into_iter().zip(uc.into_iter()).zip(dc.into_iter())
+            {
                 gate_proj = gate_proj.squeeze(0)?;
                 up_proj = up_proj.squeeze(0)?;
                 down_proj = down_proj.squeeze(0)?;
@@ -2034,7 +2036,9 @@ pub fn compute_n_kv_groups(
     } else {
         1
     };
-    (num_attention_heads / total_num_kv_heads)
-        .checked_div(kv_replicate)
-        .unwrap_or(num_attention_heads / total_num_kv_heads)
+    if kv_replicate != 0 {
+        (num_attention_heads / total_num_kv_heads) / kv_replicate
+    } else {
+        num_attention_heads / total_num_kv_heads
+    }
 }

--- a/mistralrs-quant/src/distributed/layers.rs
+++ b/mistralrs-quant/src/distributed/layers.rs
@@ -1181,7 +1181,7 @@ impl PackedExperts {
                                         weight: gate_expert,
                                         weight_scale_inv: gate_scale_expert.transpose(0, 1)?,
                                         bias: None,
-                                        dequant_dtype: vb.dtype(),
+                                        dequant_dtype: candle_core::DType::BF16,
                                         weight_block_size: weight_block_size.clone(),
                                     })?,
                                 );
@@ -1190,7 +1190,7 @@ impl PackedExperts {
                                         weight: up_expert,
                                         weight_scale_inv: up_scale_expert.transpose(0, 1)?,
                                         bias: None,
-                                        dequant_dtype: vb.dtype(),
+                                        dequant_dtype: candle_core::DType::BF16,
                                         weight_block_size: weight_block_size.clone(),
                                     })?,
                                 );
@@ -1199,7 +1199,7 @@ impl PackedExperts {
                                         weight: down_expert,
                                         weight_scale_inv: down_scale_expert.transpose(0, 1)?,
                                         bias: None,
-                                        dequant_dtype: vb.dtype(),
+                                        dequant_dtype: candle_core::DType::BF16,
                                         weight_block_size: weight_block_size.clone(),
                                     })?,
                                 );
@@ -1282,7 +1282,7 @@ impl PackedExperts {
                                     weight: gate_fp8,
                                     weight_scale_inv: gate_scale,
                                     bias: None,
-                                    dequant_dtype: vb.dtype(),
+                                    dequant_dtype: candle_core::DType::BF16,
                                     weight_block_size: weight_block_size.clone(),
                                 })?,
                             );
@@ -1291,7 +1291,7 @@ impl PackedExperts {
                                     weight: up_fp8,
                                     weight_scale_inv: up_scale,
                                     bias: None,
-                                    dequant_dtype: vb.dtype(),
+                                    dequant_dtype: candle_core::DType::BF16,
                                     weight_block_size: weight_block_size.clone(),
                                 },
                             )?);
@@ -1300,7 +1300,7 @@ impl PackedExperts {
                                     weight: down_fp8,
                                     weight_scale_inv: down_scale,
                                     bias: None,
-                                    dequant_dtype: vb.dtype(),
+                                    dequant_dtype: candle_core::DType::BF16,
                                     weight_block_size: weight_block_size.clone(),
                                 })?,
                             );

--- a/mistralrs-quant/src/lib.rs
+++ b/mistralrs-quant/src/lib.rs
@@ -93,6 +93,29 @@ pub use utils::{log, BitWiseOp, CumSumOp, LeftshiftOp, NonZeroOp, SortOp, UQFF_Q
 pub use vector_fp8::{fp8_vector_dequantize, fp8_vector_quantize};
 
 use candle_nn::{Conv1d, Conv2d, Linear, Module};
+
+/// Determine the correct output dtype for FP8 dequantization.
+///
+/// The critical invariant is: **never dequantize FP8 back into `F8E4M3`**.
+/// When `vb.dtype()` returns `F8E4M3` (the storage type for FP8 weights),
+/// using it as the dequant target would silently truncate the expanded
+/// parameters back to 8-bit, causing garbled output or hard engine crashes
+/// (`unexpected dtype, expected: BF16, got: F8E4M3`).
+///
+/// Resolution order:
+/// 1. If a bias tensor is present, use its dtype (it's already in compute precision).
+/// 2. If `vb_dtype` is `F8E4M3`, return `BF16` as a safe default.
+/// 3. Otherwise, pass through `vb_dtype` unchanged (e.g. `BF16`, `F16`, `F32`).
+pub fn fp8_dequant_dtype(vb_dtype: DType, bias: Option<&Tensor>) -> DType {
+    if let Some(bias) = bias {
+        return bias.dtype();
+    }
+    match vb_dtype {
+        DType::F8E4M3 => DType::BF16,
+        DType::BF16 | DType::F16 | DType::F32 => vb_dtype,
+        _ => DType::BF16,
+    }
+}
 use serde::{Deserialize, Deserializer, Serialize};
 
 /// Limits outstanding async ISQ jobs to prevent unbounded memory growth.

--- a/mistralrs-quant/src/lib.rs
+++ b/mistralrs-quant/src/lib.rs
@@ -116,6 +116,24 @@ pub fn fp8_dequant_dtype(vb_dtype: DType, bias: Option<&Tensor>) -> DType {
         _ => DType::BF16,
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn fp8_dequant_dtype_never_uses_fp8_storage_dtype() -> Result<()> {
+        let bias = Tensor::zeros((1,), DType::F32, &Device::Cpu)?;
+
+        assert_eq!(fp8_dequant_dtype(DType::F8E4M3, None), DType::BF16);
+        assert_eq!(fp8_dequant_dtype(DType::F8E4M3, Some(&bias)), DType::F32);
+        assert_eq!(fp8_dequant_dtype(DType::F16, None), DType::F16);
+        assert_eq!(fp8_dequant_dtype(DType::F32, None), DType::F32);
+        assert_eq!(fp8_dequant_dtype(DType::U8, None), DType::BF16);
+
+        Ok(())
+    }
+}
 use serde::{Deserialize, Deserializer, Serialize};
 
 /// Limits outstanding async ISQ jobs to prevent unbounded memory growth.

--- a/mistralrs-quant/src/pertensor_fp8/mod.rs
+++ b/mistralrs-quant/src/pertensor_fp8/mod.rs
@@ -346,12 +346,16 @@ pub fn pertensor_fp8_linear_b(
     let activation_scale = if vb.contains_tensor("activation_scale") {
         Some(vb.get_with_hints_dtype((), "activation_scale", Default::default(), DType::F32)?)
     } else if vb.contains_tensor("input_scale") {
-        Some(if let Ok(s) = vb.get_with_hints_dtype((), "input_scale", Default::default(), DType::F32) {
-            s
-        } else {
-            vb.get_with_hints_dtype((1,), "input_scale", Default::default(), DType::F32)?
-                .squeeze(0)?
-        })
+        Some(
+            if let Ok(s) =
+                vb.get_with_hints_dtype((), "input_scale", Default::default(), DType::F32)
+            {
+                s
+            } else {
+                vb.get_with_hints_dtype((1,), "input_scale", Default::default(), DType::F32)?
+                    .squeeze(0)?
+            },
+        )
     } else {
         None
     };

--- a/mistralrs-quant/src/pertensor_fp8/mod.rs
+++ b/mistralrs-quant/src/pertensor_fp8/mod.rs
@@ -307,7 +307,10 @@ pub fn pertensor_fp8_linear_b(
     vb: ShardedVarBuilder,
 ) -> Result<Arc<dyn QuantMethod>> {
     // Handle the case where we actually have unquantized weights
-    if vb.contains_tensor("weight") && !vb.contains_tensor("weight_scale_inv") {
+    if vb.contains_tensor("weight")
+        && !vb.contains_tensor("weight_scale_inv")
+        && !vb.contains_tensor("weight_scale")
+    {
         return crate::linear_b(in_dim, out_dim, bias, &None, vb);
     }
 
@@ -326,12 +329,29 @@ pub fn pertensor_fp8_linear_b(
     )?;
 
     // Load per-tensor weight scale (scalar)
-    let weight_scale_inv =
-        vb.get_with_hints_dtype((), "weight_scale_inv", Default::default(), DType::F32)?;
+    let weight_scale_inv = if vb.contains_tensor("weight_scale_inv") {
+        vb.get_with_hints_dtype((), "weight_scale_inv", Default::default(), DType::F32)?
+    } else {
+        // Fallback to HF standard `weight_scale`.
+        // We attempt to load it as a scalar `()` or a 1D tensor `(1,)` and squeeze it.
+        if let Ok(s) = vb.get_with_hints_dtype((), "weight_scale", Default::default(), DType::F32) {
+            s
+        } else {
+            vb.get_with_hints_dtype((1,), "weight_scale", Default::default(), DType::F32)?
+                .squeeze(0)?
+        }
+    };
 
     // Load activation scale if present (optional - some models may not have it)
     let activation_scale = if vb.contains_tensor("activation_scale") {
         Some(vb.get_with_hints_dtype((), "activation_scale", Default::default(), DType::F32)?)
+    } else if vb.contains_tensor("input_scale") {
+        Some(if let Ok(s) = vb.get_with_hints_dtype((), "input_scale", Default::default(), DType::F32) {
+            s
+        } else {
+            vb.get_with_hints_dtype((1,), "input_scale", Default::default(), DType::F32)?
+                .squeeze(0)?
+        })
     } else {
         None
     };

--- a/mistralrs-quant/src/unquantized/mod.rs
+++ b/mistralrs-quant/src/unquantized/mod.rs
@@ -68,6 +68,16 @@ impl QuantMethod for UnquantLinear {
             _ => self.w.clone(),
         };
 
+        let w = if w.dtype() != a.dtype() {
+            if matches!(w.dtype(), candle_core::DType::F8E4M3) {
+                crate::scalar_fp8::ops::fp8_to_dtype(&w, a.dtype())?
+            } else {
+                w.to_dtype(a.dtype())?
+            }
+        } else {
+            w
+        };
+
         if let Some(stats) = &self.stats {
             stats.process(a)?;
         }

--- a/mistralrs-quant/src/unquantized/mod.rs
+++ b/mistralrs-quant/src/unquantized/mod.rs
@@ -70,7 +70,7 @@ impl QuantMethod for UnquantLinear {
 
         let w = if w.dtype() != a.dtype() {
             if matches!(w.dtype(), candle_core::DType::F8E4M3) {
-                crate::scalar_fp8::ops::fp8_to_dtype(&w, a.dtype())?
+                candle_core::bail!("FP8 weights found without a corresponding scale tensor. Please ensure the model has an FP8 quantization config, or if it is unquantized, that it is not in FP8 format.")
             } else {
                 w.to_dtype(a.dtype())?
             }

--- a/mistralrs-quant/src/vector_fp8/mod.rs
+++ b/mistralrs-quant/src/vector_fp8/mod.rs
@@ -272,7 +272,9 @@ pub fn vector_fp8_linear_b(
     }
 
     // Handle the case where the layer is dummy (no tensors)
-    if !(vb.contains_tensor("weight") && (vb.contains_tensor("weight_scale_inv") || vb.contains_tensor("weight_scale"))) {
+    if !(vb.contains_tensor("weight")
+        && (vb.contains_tensor("weight_scale_inv") || vb.contains_tensor("weight_scale")))
+    {
         let layer = <DummyLayer as QuantMethod>::new(QuantMethodConfig::Dummy)?;
         return Ok(Arc::new(layer) as Arc<dyn QuantMethod>);
     }
@@ -296,10 +298,12 @@ pub fn vector_fp8_linear_b(
         None
     };
 
+    let dequant_dtype = crate::fp8_dequant_dtype(vb.dtype(), bias.as_ref());
+
     Ok(Arc::new(VectorFP8Linear {
         weight,
         weight_scale_inv,
         bias,
-        dequant_dtype: vb.dtype(),
+        dequant_dtype,
     }))
 }

--- a/mistralrs-quant/src/vector_fp8/mod.rs
+++ b/mistralrs-quant/src/vector_fp8/mod.rs
@@ -263,13 +263,16 @@ pub fn vector_fp8_linear_b(
         );
     }
 
-    // Handle the case where we actually have an unquantized
-    if vb.contains_tensor("weight") && !vb.contains_tensor("weight_scale_inv") {
+    // Handle the case where we actually have an unquantized layer
+    if vb.contains_tensor("weight")
+        && !vb.contains_tensor("weight_scale_inv")
+        && !vb.contains_tensor("weight_scale")
+    {
         return crate::linear_b(in_dim, out_dim, bias, &None, vb);
     }
 
     // Handle the case where the layer is dummy (no tensors)
-    if !(vb.contains_tensor("weight") && vb.contains_tensor("weight_scale_inv")) {
+    if !(vb.contains_tensor("weight") && (vb.contains_tensor("weight_scale_inv") || vb.contains_tensor("weight_scale"))) {
         let layer = <DummyLayer as QuantMethod>::new(QuantMethodConfig::Dummy)?;
         return Ok(Arc::new(layer) as Arc<dyn QuantMethod>);
     }
@@ -281,8 +284,11 @@ pub fn vector_fp8_linear_b(
     let total_elements = out_dim * in_dim;
     let num_vectors = total_elements.div_ceil(VECTOR_SIZE);
 
-    let weight_scale_inv =
-        vb.get_with_hints_dtype(num_vectors, "weight_scale_inv", hints, DType::F32)?;
+    let weight_scale_inv = if vb.contains_tensor("weight_scale_inv") {
+        vb.get_with_hints_dtype(num_vectors, "weight_scale_inv", hints, DType::F32)?
+    } else {
+        vb.get_with_hints_dtype(num_vectors, "weight_scale", hints, DType::F32)?
+    };
 
     let bias = if bias {
         Some(vb.get((out_dim,), "bias")?)

--- a/mistralrs-server-core/src/openapi_doc.rs
+++ b/mistralrs-server-core/src/openapi_doc.rs
@@ -6,7 +6,7 @@ use crate::{
     chat_completion::__path_chatcompletions,
     completions::__path_completions,
     embeddings::__path_embeddings,
-    handlers::{ReIsqRequest, __path_health, __path_models, __path_re_isq},
+    handlers::{__path_health, __path_models, __path_re_isq, ReIsqRequest},
     image_generation::__path_image_generation,
     openai::{
         AudioResponseFormat, ChatCompletionRequest, CompletionRequest, EmbeddingData,

--- a/mistralrs-server-core/src/openapi_doc.rs
+++ b/mistralrs-server-core/src/openapi_doc.rs
@@ -6,7 +6,7 @@ use crate::{
     chat_completion::__path_chatcompletions,
     completions::__path_completions,
     embeddings::__path_embeddings,
-    handlers::{__path_health, __path_models, __path_re_isq, ReIsqRequest},
+    handlers::{ReIsqRequest, __path_health, __path_models, __path_re_isq},
     image_generation::__path_image_generation,
     openai::{
         AudioResponseFormat, ChatCompletionRequest, CompletionRequest, EmbeddingData,

--- a/mistralrs-server-core/src/video.rs
+++ b/mistralrs-server-core/src/video.rs
@@ -119,11 +119,7 @@ fn decode_gif_frames(bytes: &[u8], num_frames: usize) -> Result<VideoInput> {
         .iter()
         .map(|f| {
             let (num, den) = f.delay().numer_denom_ms();
-            if den == 0 {
-                100
-            } else {
-                num * 1000 / den
-            }
+            (num * 1000).checked_div(den).unwrap_or(100)
         })
         .sum();
     let fps = if total_delay_ms > 0 {

--- a/mistralrs-server-core/src/video.rs
+++ b/mistralrs-server-core/src/video.rs
@@ -119,7 +119,11 @@ fn decode_gif_frames(bytes: &[u8], num_frames: usize) -> Result<VideoInput> {
         .iter()
         .map(|f| {
             let (num, den) = f.delay().numer_denom_ms();
-            (num * 1000).checked_div(den).unwrap_or(100)
+            if den == 0 {
+                100
+            } else {
+                num * 1000 / den
+            }
         })
         .sum();
     let fps = if total_delay_ms > 0 {


### PR DESCRIPTION
## Fix: FP8 Unquant Linear Mismatch Crash & Dequantization Truncation

This PR fixes two fatal FP8 runtime bugs:

1. **UnquantLinear fallback crash**: if an FP8 `weight` tensor reaches the unquantized path without a corresponding FP8 scale tensor, the old path attempted an unsupported cast and failed with `unexpected dtype, expected: BF16, got: F8E4M3`. The patched path now rejects this malformed state with an explicit error instead of continuing into the dtype mismatch.

2. **Dequantization truncation**: `BlockwiseFP8Linear`, `VectorFP8Linear`, and distributed MoE expert paths used `vb.dtype()` as the dequant target. For FP8 models, `vb.dtype()` can be `F8E4M3` (the storage type), so expanded parameters could be coerced back to 8-bit floats. The patch centralizes FP8 dequant dtype selection and keeps dequantized tensors in a compute dtype.

### Changes

#### Centralized helper (`lib.rs`)
- `fp8_dequant_dtype(vb_dtype, bias)`: determines the output dtype for FP8 dequantization. The invariant is: never dequantize FP8 back into `F8E4M3`.
- Added durable unit coverage for the invariant on branch head `698933761`.

#### Scale name resolution (`distributed/layers.rs`)
- `fp8_scale_name(vb, base)`: resolves `weight_scale_inv` vs `weight_scale` dynamically and errors if neither exists.
- Applied to distributed MoE paths: `PackedExperts` and `FusedExperts`, stacked and per-expert forms, covering `gate_proj`, `up_proj`, `down_proj`, and `gate_up_proj` scale lookups.

#### Dequant dtype fixes
- `blockwise_fp8/mod.rs`: uses `fp8_dequant_dtype` instead of raw `vb.dtype()`.
- `vector_fp8/mod.rs`: uses `fp8_dequant_dtype` instead of raw `vb.dtype()`.
- `distributed/layers.rs`: `blockwise_fp8_moe()` calls use a compute dtype rather than FP8 storage dtype.

#### Missing-scale fallback (`unquantized/mod.rs`)
- `UnquantLinear` now explicitly errors on FP8 weights without scale tensors. This is intentionally a clean rejection, not an attempted dequantization path, because the scale tensor needed to recover the values is absent.

### Empirical Execution Baseline (GCP `g2-standard-32` L4 GPU)

Validated on a representative dynamic FP8 model (`CalamitousFelicitousness/Qwen2.5-1.5B-Instruct-fp8-dynamic`).

#### Before (Master Branch)
```bash
echo "What is 2+2? Only answer with the number 4." | ./target/release/mistralrs run text -m CalamitousFelicitousness/Qwen2.5-1.5B-Instruct-fp8-dynamic -a qwen2 --max-seq-len 4096
```
```text
2026-04-27T21:37:48.499309Z ERROR mistralrs_core::engine: step - Model failed with error: unexpected dtype, expected: BF16, got: F8E4M3
2026-04-27T21:37:48.509262Z ERROR mistralrs_core::engine: step - Model failed with error: unexpected dtype, expected: BF16, got: F8E4M3
2026-04-27T21:37:48.522146Z ERROR mistralrs_core::engine: step - Model failed with error: unexpected dtype, expected: BF16, got: F8E4M3
```

#### After (Patched Branch)
```bash
echo "What is 2+2? Only answer with the number 4." | ./target/release/mistralrs run text -m CalamitousFelicitousness/Qwen2.5-1.5B-Instruct-fp8-dynamic -a qwen2 --max-seq-len 1024 --paged-attn off
```
```text
4

Stats:
Time to first token: 0.88s
Prompt: 44 tokens, 50.11 T/s
Decode: 2 tokens, 95.24 T/s
Prefix cache: 0 hits / 1 turns
Sampling: temp=0.7, top_k=20, top_p=0.8, min_p=off, rep_pen=1.1
```

### Additional logic-vet validation (`698933761`)

```bash
cargo test -p mistralrs-quant fp8_dequant_dtype_never_uses_fp8_storage_dtype --lib
cargo fmt --all -- --check
git diff --check
cargo clippy --workspace --tests --examples -- -D warnings
```

All passed locally.

> Runtime validation used `Qwen2.5-1.5B-Instruct-fp8-dynamic` as a representative dynamic FP8/Qwen path. The exact original 27B repro (`Qwen/Qwen3.5-27B-FP8`) still has not been run and likely requires an A100/H100-class GPU with sufficient VRAM.
