### PR TITLE
Fix: Resolve NaN Logit Memory Leak During Sequential Benchmarks (Issue #2095)

### DIFF
--- a/mistralrs-cli/src/commands/bench.rs
+++ b/mistralrs-cli/src/commands/bench.rs
@@ -102,6 +102,10 @@ pub async fn run_bench(
         }
         info!("Warmup complete.");
 
+        // Clear any residual KV cache from warmup
+        let sender = mistralrs.get_sender(None).unwrap();
+        let _ = sender.send(mistralrs_core::Request::TerminateAllSeqsNextStep).await;
+
         // Reset logger counters so benchmark stats are clean
         if let Ok(logger) = mistralrs.get_logger(None) {
             logger.reset();
@@ -142,6 +146,10 @@ pub async fn run_bench(
             let ms_per_tok = 1000.0 / tok_per_sec;
             decode_results.push((tok_per_sec, ms_per_tok));
         }
+
+        // Extremely aggressive cache sweep. Flush the sequences out of the engine.
+        let sender = mistralrs.get_sender(None).unwrap();
+        let _ = sender.send(mistralrs_core::Request::TerminateAllSeqsNextStep).await;
     }
 
     // Calculate statistics

--- a/mistralrs-cli/src/commands/bench.rs
+++ b/mistralrs-cli/src/commands/bench.rs
@@ -8,7 +8,7 @@ use mistralrs_core::{
 };
 use mistralrs_server_core::mistralrs_for_server_builder::MistralRsForServerBuilder;
 use std::sync::Arc;
-use std::time::Instant;
+use std::time::{Duration, Instant};
 use tokio::sync::mpsc::channel;
 use tracing::info;
 
@@ -102,9 +102,12 @@ pub async fn run_bench(
         }
         info!("Warmup complete.");
 
-        // Clear any residual KV cache from warmup
+        // Flush any residual KV state left over from warmup, then yield to the
+        // engine's scheduler loop so the termination is processed before we start
+        // timing. Without the sleep the next request can race ahead in the channel.
         let sender = mistralrs.get_sender(None).unwrap();
         let _ = sender.send(mistralrs_core::Request::TerminateAllSeqsNextStep).await;
+        tokio::time::sleep(Duration::from_millis(50)).await;
 
         // Reset logger counters so benchmark stats are clean
         if let Ok(logger) = mistralrs.get_logger(None) {
@@ -147,9 +150,12 @@ pub async fn run_bench(
             decode_results.push((tok_per_sec, ms_per_tok));
         }
 
-        // Extremely aggressive cache sweep. Flush the sequences out of the engine.
+        // Flush state between iterations. Yield after sending so the engine
+        // scheduler has a chance to process the termination before the next
+        // iteration's request enters the channel.
         let sender = mistralrs.get_sender(None).unwrap();
         let _ = sender.send(mistralrs_core::Request::TerminateAllSeqsNextStep).await;
+        tokio::time::sleep(Duration::from_millis(50)).await;
     }
 
     // Calculate statistics

--- a/mistralrs-cli/src/commands/bench.rs
+++ b/mistralrs-cli/src/commands/bench.rs
@@ -102,9 +102,10 @@ pub async fn run_bench(
         }
         info!("Warmup complete.");
 
-        // Flush any residual KV state left over from warmup, then yield to the
-        // engine's scheduler loop so the termination is processed before we start
-        // timing. Without the sleep the next request can race ahead in the channel.
+        // Flush KV state from warmup. TerminateAllSeqsNextStep sets a global
+        // AtomicBool; the engine reads and acts on it at the top of its next
+        // scheduler iteration. The sleep yields to allow that iteration to
+        // complete before the next benchmark request enters the channel.
         let sender = mistralrs.get_sender(None).unwrap();
         let _ = sender.send(mistralrs_core::Request::TerminateAllSeqsNextStep).await;
         tokio::time::sleep(Duration::from_millis(50)).await;
@@ -150,9 +151,9 @@ pub async fn run_bench(
             decode_results.push((tok_per_sec, ms_per_tok));
         }
 
-        // Flush state between iterations. Yield after sending so the engine
-        // scheduler has a chance to process the termination before the next
-        // iteration's request enters the channel.
+        // Flush KV state between iterations. Same mechanism as the post-warmup
+        // flush above: set the flag then sleep so the engine gets one full loop
+        // iteration to process the termination before the next run begins.
         let sender = mistralrs.get_sender(None).unwrap();
         let _ = sender.send(mistralrs_core::Request::TerminateAllSeqsNextStep).await;
         tokio::time::sleep(Duration::from_millis(50)).await;


### PR DESCRIPTION
Fixes #2095.

## Problem

Between consecutive `mistralrs bench` iterations, the previous benchmark's sequences were evicted asynchronously. The next iteration could enter the engine pipeline before the flush completed, carrying over stale KV state from the prior run. This produced NaN logits in the sampler and panics on long `--gen-len` runs.

## Root cause

`TerminateAllSeqsNextStep` sets a global `AtomicBool` (`TERMINATE_ALL_NEXT_STEP`). The engine reads this flag at the **top** of each scheduler loop iteration. Without a delay, the next benchmark request could enter the channel before the engine had a single iteration to act on the flag.

## Fix

After sending `TerminateAllSeqsNextStep`, wait 50 ms to give the engine at least one full scheduler loop iteration to read the flag and flush sequences before the next request enters the channel. This applies after warmup and between all benchmark iterations.

## Files changed

- `mistralrs-cli/src/commands/bench.rs`