### PR TITLE
fix(scheduler): treat Error state sequences as finished in PagedAttention

### DIFF
--- a/mistralrs-core/src/sequence.rs
+++ b/mistralrs-core/src/sequence.rs
@@ -757,6 +757,7 @@ impl Sequence {
             *self.state.read().unwrap(),
             SequenceState::FinishedAborted
                 | SequenceState::FinishedIgnored
+                | SequenceState::Error
                 | SequenceState::Done(_)
         )
     }
@@ -1653,6 +1654,51 @@ mod tests {
             false,
             vec![],
         )
+    }
+
+    #[test]
+    fn error_state_is_finished_for_paged_attention_cleanup() {
+        let seq = make_test_sequence();
+        seq.set_state(SequenceState::Error);
+
+        assert!(
+            seq.is_finished_paged_attn(),
+            "SequenceState::Error must be terminal for PagedAttention cleanup"
+        );
+    }
+
+    #[test]
+    fn paged_attention_finished_state_predicate_preserves_existing_states() {
+        for state in [
+            SequenceState::Done(StopReason::Length(0)),
+            SequenceState::FinishedAborted,
+            SequenceState::FinishedIgnored,
+            SequenceState::Error,
+        ] {
+            let seq = make_test_sequence();
+            seq.set_state(state);
+
+            assert!(
+                seq.is_finished_paged_attn(),
+                "{state:?} should be terminal for PagedAttention cleanup"
+            );
+        }
+
+        for state in [
+            SequenceState::RunningPrompt,
+            SequenceState::RunningCompletion,
+            SequenceState::RunningPrefillPrompt,
+            SequenceState::Waiting,
+            SequenceState::Swapped,
+        ] {
+            let seq = make_test_sequence();
+            seq.set_state(state);
+
+            assert!(
+                !seq.is_finished_paged_attn(),
+                "{state:?} should not be terminal for PagedAttention cleanup"
+            );
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Problem

Sequences that enter `SequenceState::Error` were not matched by `is_finished_paged_attn()`. In PagedAttention, that means an errored sequence can remain in scheduler state instead of being treated as terminal for cleanup.

`SequenceState::Error` is set on real inference error paths, including `handle_seq_error_stateaware_ok!` and `handle_pipeline_forward_error!`. Scheduler cleanup calls `free_finished_sequence_groups()`, which depends on `is_finished_paged_attn()`.

## Fix

Add `SequenceState::Error` to the terminal states returned by `is_finished_paged_attn()`, alongside `FinishedAborted`, `FinishedIgnored`, and `Done`.

## Files changed

- `mistralrs-core/src/sequence.rs`

## Validation

Current branch head after Agent 5 follow-up: `593b6f298989769801cabaee4102c4069be3ce7a`.

A100 hardware/software used by Agent 5:

- GCP `a2-highgpu-1g`, 1x `NVIDIA A100-SXM4-40GB`, 40960 MiB
- Driver `580.126.09`; `nvidia-smi` CUDA `13.0`; CUDA toolkit `12.9.41`
- Rust `1.95.0`; Cargo `1.95.0`

Before/after targeted check:

```bash
cargo test -q -p mistralrs-core error_state_is_finished_for_paged_attention_cleanup --lib
```

- base `2d4ba4f16f61e5e18be085d0dd137bc95cba038a` plus injected regression: failed; `SequenceState::Error must be terminal for PagedAttention cleanup`.
- previous PR head `0715e0a2ddb90099d353547dc9840f03897f23f2` plus the same regression: passed.

Committed tests on current head:

```bash
cargo test -q -p mistralrs-core error_state_is_finished_for_paged_attention --lib
cargo test -q -p mistralrs-core paged_attention_finished_state_predicate_preserves_existing_states --lib
```

A100 result: both passed.

The committed coverage verifies that `Error` is terminal for PagedAttention cleanup and that existing `Done` / `FinishedAborted` / `FinishedIgnored` behavior remains terminal while normal running states remain nonterminal.

## Merge / Issue-Linking Note

The branch commit with stale auto-close wording has been rewritten. Final squash/merge wording should use `Refs #2058` or `Related to #2058`, without a closing keyword before `#2058`, so #2058 is not closed automatically. Safe wording: “Fixes the scheduler-state half: `SequenceState::Error` is terminal for PagedAttention cleanup; does not prove the full Windows RTX 3080 hang is fixed.”

## Relationship to #2058 / #2076

Classification: `TARGETED`.

This is the scheduler-state half of #2076. It is related to #2058, but it is not a full runtime reproduction of #2058. Agent 5 did not recover a live A100 inference repro where a sequence enters `SequenceState::Error`, blocks KV cleanup, and then prevents new scheduling. The original #2058 report used Windows 11, RTX 3080 12GB, CUDA 12.9 / driver 591.86, and `google/gemma-4-E2B-it`.

Safe merge claim: this PR makes `SequenceState::Error` terminal for PagedAttention cleanup. It should not claim to fully resolve the #2058 report without a runtime before/after on the original hang conditions.