### PR TITLE
fix(bench): require a successful KV flush probe barrier

### DIFF
--- a/.typos.toml
+++ b/.typos.toml
@@ -5,6 +5,7 @@ extend-exclude = [
     "examples/server/phi3_duckduckgo_mistral.rs.ipynb",
     "mistralrs-web-chat/static/",
     "mistralrs-cli/static/",
+    "mistralrs-quant/kernels/mmq_gguf/",
     "CLAUDE.md",
 ]
 ignore-hidden = false
@@ -12,6 +13,7 @@ ignore-hidden = false
 [default]
 extend-ignore-re = [
     "cudaDevAttrMaxSharedMemoryPerBlockOptin",
+    "CU_DEVICE_ATTRIBUTE_MAX_SHARED_MEMORY_PER_BLOCK_OPTIN",
     '"tese"',
     "setp\\.ne\\.b32",
     # metal_kernels

--- a/.typos.toml
+++ b/.typos.toml
@@ -5,7 +5,6 @@ extend-exclude = [
     "examples/server/phi3_duckduckgo_mistral.rs.ipynb",
     "mistralrs-web-chat/static/",
     "mistralrs-cli/static/",
-    "mistralrs-quant/kernels/mmq_gguf/",
     "CLAUDE.md",
 ]
 ignore-hidden = false
@@ -13,7 +12,6 @@ ignore-hidden = false
 [default]
 extend-ignore-re = [
     "cudaDevAttrMaxSharedMemoryPerBlockOptin",
-    "CU_DEVICE_ATTRIBUTE_MAX_SHARED_MEMORY_PER_BLOCK_OPTIN",
     '"tese"',
     "setp\\.ne\\.b32",
     # metal_kernels

--- a/mistralrs-cli/src/commands/bench.rs
+++ b/mistralrs-cli/src/commands/bench.rs
@@ -99,7 +99,7 @@ pub async fn run_bench(
     if warmup > 0 {
         info!("Running {} warmup iteration(s)...", warmup);
         for _ in 0..warmup {
-            let _ = run_single_bench(&mistralrs, 32, 16).await?;
+            run_single_bench(&mistralrs, 32, 16).await?;
         }
         info!("Warmup complete.");
 

--- a/mistralrs-cli/src/commands/bench.rs
+++ b/mistralrs-cli/src/commands/bench.rs
@@ -10,7 +10,7 @@ use mistralrs_server_core::mistralrs_for_server_builder::MistralRsForServerBuild
 use std::sync::Arc;
 use std::time::Instant;
 use tokio::sync::mpsc::channel;
-use tracing::info;
+use tracing::{info, warn};
 
 use crate::args::{GlobalOptions, ModelType, RuntimeOptions};
 
@@ -103,6 +103,9 @@ pub async fn run_bench(
         }
         info!("Warmup complete.");
 
+        // Flush KV state from warmup so benchmark stats start clean
+        flush_kv_state(&mistralrs).await?;
+
         // Reset logger counters so benchmark stats are clean
         if let Ok(logger) = mistralrs.get_logger(None) {
             logger.reset();
@@ -137,6 +140,13 @@ pub async fn run_bench(
             let tok_per_sec = gen_len as f32 / elapsed.as_secs_f32();
             let ms_per_tok = 1000.0 / tok_per_sec;
             decode_results.push((tok_per_sec, ms_per_tok));
+        }
+
+        // Flush KV state between iterations so each measurement starts from a
+        // clean cache. This prevents stale KV entries from previous iterations
+        // from corrupting subsequent logit computations.
+        if i + 1 < iterations {
+            flush_kv_state(&mistralrs).await?;
         }
     }
 
@@ -241,6 +251,65 @@ async fn run_single_bench(
         Some(_) => anyhow::bail!("Unexpected response type"),
         None => anyhow::bail!("No response received"),
     }
+}
+
+/// Flush KV cache state by sending a `TerminateAllSeqsNextStep` flag and then
+/// issuing a minimal probe request whose completion confirms the engine has
+/// processed the termination. This is a synchronous barrier — no sleep needed.
+async fn flush_kv_state(mistralrs: &Arc<mistralrs_core::MistralRs>) -> Result<()> {
+    let sender = mistralrs.get_sender(None)?;
+
+    // Set the global termination flag for the next scheduler iteration.
+    let _ = sender.send(Request::TerminateAllSeqsNextStep).await;
+
+    // Send a 1-token probe request and await its response. When the engine
+    // replies, it has completed at least one full loop iteration, which
+    // includes processing the termination flag and clearing sequences.
+    let (tx, mut rx) = channel(1);
+    let probe = Request::Normal(Box::new(NormalRequest {
+        id: mistralrs.next_request_id(),
+        messages: RequestMessage::CompletionTokens(vec![1]),
+        sampling_params: SamplingParams {
+            max_len: Some(1),
+            temperature: Some(0.0),
+            top_k: None,
+            top_p: None,
+            min_p: None,
+            top_n_logprobs: 0,
+            frequency_penalty: None,
+            presence_penalty: None,
+            repetition_penalty: None,
+            stop_toks: None,
+            logits_bias: None,
+            n_choices: 1,
+            dry_params: None,
+        },
+        response: tx,
+        return_logprobs: false,
+        is_streaming: false,
+        constraint: Constraint::None,
+        suffix: None,
+        tools: None,
+        tool_choice: None,
+        logits_processors: None,
+        return_raw_logits: false,
+        web_search_options: None,
+        max_tool_rounds: None,
+        tool_dispatch_url: None,
+        model_id: None,
+        truncate_sequence: false,
+    }));
+    sender.send(probe).await?;
+
+    // Wait for the probe response — this confirms the flush completed.
+    match rx.recv().await {
+        Some(Response::CompletionDone(_) | Response::Done(_)) => {}
+        Some(Response::InternalError(e)) => warn!("KV flush probe error (non-fatal): {e:?}"),
+        Some(Response::ModelError(e, _)) => warn!("KV flush probe error (non-fatal): {e}"),
+        _ => {}
+    }
+
+    Ok(())
 }
 
 /// Print benchmark results in a nice table

--- a/mistralrs-cli/src/commands/bench.rs
+++ b/mistralrs-cli/src/commands/bench.rs
@@ -10,7 +10,7 @@ use mistralrs_server_core::mistralrs_for_server_builder::MistralRsForServerBuild
 use std::sync::Arc;
 use std::time::Instant;
 use tokio::sync::mpsc::channel;
-use tracing::{info, warn};
+use tracing::info;
 
 use crate::args::{GlobalOptions, ModelType, RuntimeOptions};
 
@@ -260,7 +260,7 @@ async fn flush_kv_state(mistralrs: &Arc<mistralrs_core::MistralRs>) -> Result<()
     let sender = mistralrs.get_sender(None)?;
 
     // Set the global termination flag for the next scheduler iteration.
-    let _ = sender.send(Request::TerminateAllSeqsNextStep).await;
+    sender.send(Request::TerminateAllSeqsNextStep).await?;
 
     // Send a 1-token probe request and await its response. When the engine
     // replies, it has completed at least one full loop iteration, which
@@ -301,15 +301,28 @@ async fn flush_kv_state(mistralrs: &Arc<mistralrs_core::MistralRs>) -> Result<()
     }));
     sender.send(probe).await?;
 
-    // Wait for the probe response — this confirms the flush completed.
-    match rx.recv().await {
-        Some(Response::CompletionDone(_) | Response::Done(_)) => {}
-        Some(Response::InternalError(e)) => warn!("KV flush probe error (non-fatal): {e:?}"),
-        Some(Response::ModelError(e, _)) => warn!("KV flush probe error (non-fatal): {e}"),
-        _ => {}
-    }
+    // Wait for the probe response. A failed probe is not a completed barrier.
+    validate_flush_probe_response(rx.recv().await)?;
 
     Ok(())
+}
+
+fn validate_flush_probe_response(response: Option<Response>) -> Result<()> {
+    match response {
+        Some(Response::CompletionDone(_) | Response::Done(_)) => Ok(()),
+        Some(Response::InternalError(e)) => {
+            anyhow::bail!("KV flush probe internal error: {e:?}")
+        }
+        Some(Response::ModelError(e, _)) => anyhow::bail!("KV flush probe model error: {e}"),
+        Some(Response::CompletionModelError(e, _)) => {
+            anyhow::bail!("KV flush probe completion model error: {e}")
+        }
+        Some(Response::ValidationError(e)) => {
+            anyhow::bail!("KV flush probe validation error: {e:?}")
+        }
+        Some(_) => anyhow::bail!("Unexpected KV flush probe response type"),
+        None => anyhow::bail!("No KV flush probe response received"),
+    }
 }
 
 /// Print benchmark results in a nice table
@@ -351,4 +364,33 @@ fn print_results(model_id: &str, iterations: usize, results: &[BenchResult]) {
 
     println!("{table}");
     println!();
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn flush_probe_rejects_missing_response() {
+        let err = validate_flush_probe_response(None)
+            .expect_err("missing probe response must fail the flush barrier");
+
+        assert!(
+            err.to_string().contains("No KV flush probe response"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn flush_probe_rejects_internal_error_response() {
+        let err = validate_flush_probe_response(Some(Response::InternalError(
+            anyhow::anyhow!("probe failed").into(),
+        )))
+        .expect_err("probe internal error must fail the flush barrier");
+
+        assert!(
+            err.to_string().contains("KV flush probe internal error"),
+            "unexpected error: {err}"
+        );
+    }
 }

--- a/mistralrs-cli/src/commands/bench.rs
+++ b/mistralrs-cli/src/commands/bench.rs
@@ -370,10 +370,71 @@ fn print_results(model_id: &str, iterations: usize, results: &[BenchResult]) {
 mod tests {
     use super::*;
 
+    fn test_usage() -> mistralrs_core::Usage {
+        mistralrs_core::Usage {
+            completion_tokens: 0,
+            prompt_tokens: 0,
+            total_tokens: 0,
+            avg_tok_per_sec: 0.0,
+            avg_prompt_tok_per_sec: 0.0,
+            avg_compl_tok_per_sec: 0.0,
+            total_time_sec: 0.0,
+            total_prompt_time_sec: 0.0,
+            total_completion_time_sec: 0.0,
+        }
+    }
+
+    fn test_completion_response() -> mistralrs_core::CompletionResponse {
+        mistralrs_core::CompletionResponse {
+            id: "probe".to_string(),
+            choices: Vec::new(),
+            created: 0,
+            model: "test".to_string(),
+            system_fingerprint: "local".to_string(),
+            object: "text_completion".to_string(),
+            usage: test_usage(),
+        }
+    }
+
+    fn test_chat_response() -> mistralrs_core::ChatCompletionResponse {
+        mistralrs_core::ChatCompletionResponse {
+            id: "probe".to_string(),
+            choices: Vec::new(),
+            created: 0,
+            model: "test".to_string(),
+            system_fingerprint: "local".to_string(),
+            object: "chat.completion".to_string(),
+            usage: test_usage(),
+        }
+    }
+
+    #[test]
+    fn flush_probe_accepts_completion_done_response() {
+        validate_flush_probe_response(Some(Response::CompletionDone(test_completion_response())))
+            .expect("completion completion must satisfy the flush barrier");
+    }
+
+    #[test]
+    fn flush_probe_accepts_chat_done_response() {
+        validate_flush_probe_response(Some(Response::Done(test_chat_response())))
+            .expect("chat completion must satisfy the flush barrier");
+    }
+
     #[test]
     fn flush_probe_rejects_missing_response() {
         let err = validate_flush_probe_response(None)
             .expect_err("missing probe response must fail the flush barrier");
+
+        assert!(
+            err.to_string().contains("No KV flush probe response"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn flush_probe_rejects_closed_response_channel() {
+        let err = validate_flush_probe_response(None)
+            .expect_err("closed probe response channel must fail the flush barrier");
 
         assert!(
             err.to_string().contains("No KV flush probe response"),
@@ -390,6 +451,64 @@ mod tests {
 
         assert!(
             err.to_string().contains("KV flush probe internal error"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn flush_probe_rejects_model_error_response() {
+        let err = validate_flush_probe_response(Some(Response::ModelError(
+            "probe model failed".to_string(),
+            test_chat_response(),
+        )))
+        .expect_err("probe model error must fail the flush barrier");
+
+        assert!(
+            err.to_string().contains("KV flush probe model error"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn flush_probe_rejects_completion_model_error_response() {
+        let err = validate_flush_probe_response(Some(Response::CompletionModelError(
+            "probe completion failed".to_string(),
+            test_completion_response(),
+        )))
+        .expect_err("probe completion model error must fail the flush barrier");
+
+        assert!(
+            err.to_string()
+                .contains("KV flush probe completion model error"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn flush_probe_rejects_validation_error_response() {
+        let err = validate_flush_probe_response(Some(Response::ValidationError(
+            anyhow::anyhow!("probe validation failed").into(),
+        )))
+        .expect_err("probe validation error must fail the flush barrier");
+
+        assert!(
+            err.to_string().contains("KV flush probe validation error"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn flush_probe_rejects_unexpected_response_type() {
+        let err = validate_flush_probe_response(Some(Response::Embeddings {
+            embeddings: Vec::new(),
+            prompt_tokens: 0,
+            total_tokens: 0,
+        }))
+        .expect_err("only completion responses may satisfy the flush barrier");
+
+        assert!(
+            err.to_string()
+                .contains("Unexpected KV flush probe response type"),
             "unexpected error: {err}"
         );
     }

--- a/mistralrs-cli/src/commands/bench.rs
+++ b/mistralrs-cli/src/commands/bench.rs
@@ -10,7 +10,7 @@ use mistralrs_server_core::mistralrs_for_server_builder::MistralRsForServerBuild
 use std::sync::Arc;
 use std::time::Instant;
 use tokio::sync::mpsc::channel;
-use tracing::{info, warn};
+use tracing::info;
 
 use crate::args::{GlobalOptions, ModelType, RuntimeOptions};
 
@@ -99,12 +99,9 @@ pub async fn run_bench(
     if warmup > 0 {
         info!("Running {} warmup iteration(s)...", warmup);
         for _ in 0..warmup {
-            run_single_bench(&mistralrs, 32, 16).await?;
+            let _ = run_single_bench(&mistralrs, 32, 16).await?;
         }
         info!("Warmup complete.");
-
-        // Flush KV state from warmup so benchmark stats start clean
-        flush_kv_state(&mistralrs).await?;
 
         // Reset logger counters so benchmark stats are clean
         if let Ok(logger) = mistralrs.get_logger(None) {
@@ -140,13 +137,6 @@ pub async fn run_bench(
             let tok_per_sec = gen_len as f32 / elapsed.as_secs_f32();
             let ms_per_tok = 1000.0 / tok_per_sec;
             decode_results.push((tok_per_sec, ms_per_tok));
-        }
-
-        // Flush KV state between iterations so each measurement starts from a
-        // clean cache. This prevents stale KV entries from previous iterations
-        // from corrupting subsequent logit computations.
-        if i + 1 < iterations {
-            flush_kv_state(&mistralrs).await?;
         }
     }
 
@@ -251,65 +241,6 @@ async fn run_single_bench(
         Some(_) => anyhow::bail!("Unexpected response type"),
         None => anyhow::bail!("No response received"),
     }
-}
-
-/// Flush KV cache state by sending a `TerminateAllSeqsNextStep` flag and then
-/// issuing a minimal probe request whose completion confirms the engine has
-/// processed the termination. This is a synchronous barrier — no sleep needed.
-async fn flush_kv_state(mistralrs: &Arc<mistralrs_core::MistralRs>) -> Result<()> {
-    let sender = mistralrs.get_sender(None)?;
-
-    // Set the global termination flag for the next scheduler iteration.
-    let _ = sender.send(Request::TerminateAllSeqsNextStep).await;
-
-    // Send a 1-token probe request and await its response. When the engine
-    // replies, it has completed at least one full loop iteration, which
-    // includes processing the termination flag and clearing sequences.
-    let (tx, mut rx) = channel(1);
-    let probe = Request::Normal(Box::new(NormalRequest {
-        id: mistralrs.next_request_id(),
-        messages: RequestMessage::CompletionTokens(vec![1]),
-        sampling_params: SamplingParams {
-            max_len: Some(1),
-            temperature: Some(0.0),
-            top_k: None,
-            top_p: None,
-            min_p: None,
-            top_n_logprobs: 0,
-            frequency_penalty: None,
-            presence_penalty: None,
-            repetition_penalty: None,
-            stop_toks: None,
-            logits_bias: None,
-            n_choices: 1,
-            dry_params: None,
-        },
-        response: tx,
-        return_logprobs: false,
-        is_streaming: false,
-        constraint: Constraint::None,
-        suffix: None,
-        tools: None,
-        tool_choice: None,
-        logits_processors: None,
-        return_raw_logits: false,
-        web_search_options: None,
-        max_tool_rounds: None,
-        tool_dispatch_url: None,
-        model_id: None,
-        truncate_sequence: false,
-    }));
-    sender.send(probe).await?;
-
-    // Wait for the probe response — this confirms the flush completed.
-    match rx.recv().await {
-        Some(Response::CompletionDone(_) | Response::Done(_)) => {}
-        Some(Response::InternalError(e)) => warn!("KV flush probe error (non-fatal): {e:?}"),
-        Some(Response::ModelError(e, _)) => warn!("KV flush probe error (non-fatal): {e}"),
-        _ => {}
-    }
-
-    Ok(())
 }
 
 /// Print benchmark results in a nice table

--- a/mistralrs-core/src/engine/tool_dispatch.rs
+++ b/mistralrs-core/src/engine/tool_dispatch.rs
@@ -102,10 +102,8 @@ pub(super) async fn execute_search(
     );
 
     // Sort by token length (shortest first).
-    let mut combined: Vec<(SearchResult, usize)> = results
-        .into_iter()
-        .zip(result_token_lens.into_iter())
-        .collect();
+    let mut combined: Vec<(SearchResult, usize)> =
+        results.into_iter().zip(result_token_lens).collect();
     combined.sort_by_key(|(_, len)| *len);
     let (results, result_token_lens): (Vec<SearchResult>, Vec<usize>) =
         combined.into_iter().unzip();

--- a/mistralrs-core/src/engine/tool_dispatch.rs
+++ b/mistralrs-core/src/engine/tool_dispatch.rs
@@ -102,8 +102,10 @@ pub(super) async fn execute_search(
     );
 
     // Sort by token length (shortest first).
-    let mut combined: Vec<(SearchResult, usize)> =
-        results.into_iter().zip(result_token_lens).collect();
+    let mut combined: Vec<(SearchResult, usize)> = results
+        .into_iter()
+        .zip(result_token_lens.into_iter())
+        .collect();
     combined.sort_by_key(|(_, len)| *len);
     let (results, result_token_lens): (Vec<SearchResult>, Vec<usize>) =
         combined.into_iter().unzip();

--- a/mistralrs-core/src/moe/experts.rs
+++ b/mistralrs-core/src/moe/experts.rs
@@ -95,6 +95,7 @@ struct SlowExpertsWeights {
 pub struct MoEExperts {
     backend: MoEExpertsBackendImpl,
     act: Activation,
+    #[allow(dead_code)]
     num_experts: usize,
     num_experts_per_tok: usize,
     all_reduce: SumAllReduce,

--- a/mistralrs-core/src/moe/experts.rs
+++ b/mistralrs-core/src/moe/experts.rs
@@ -95,7 +95,6 @@ struct SlowExpertsWeights {
 pub struct MoEExperts {
     backend: MoEExpertsBackendImpl,
     act: Activation,
-    #[allow(dead_code)]
     num_experts: usize,
     num_experts_per_tok: usize,
     all_reduce: SumAllReduce,

--- a/mistralrs-core/src/scheduler/default_scheduler.rs
+++ b/mistralrs-core/src/scheduler/default_scheduler.rs
@@ -131,8 +131,8 @@ impl<Backer: FcfsBacker> BucketingManager<Backer> for FixedBucketingManager {
         let running = if seq_buckets.len() <= 1 {
             // Full steam ahead or have everything
             seq_buckets
-                .into_iter()
-                .flat_map(|(_, x)| x)
+                .into_values()
+                .flatten()
                 .map(|s| s.reset_urgency())
                 .collect::<Vec<_>>()
         } else {

--- a/mistralrs-core/src/search/rag.rs
+++ b/mistralrs-core/src/search/rag.rs
@@ -139,7 +139,7 @@ impl SearchPipeline {
                 .to_dtype(DType::F32)?
                 .to_device(&Device::Cpu)?
                 .to_vec2::<f32>()?;
-            for ((idx, _), embedding) in chunk_entries.iter().zip(vecs.into_iter()) {
+            for ((idx, _), embedding) in chunk_entries.iter().zip(vecs) {
                 outputs[*idx] = embedding;
             }
         }
@@ -339,7 +339,7 @@ pub fn rank_document_chunks(
 
     let mut scored: Vec<ScoredChunk> = top_indices
         .iter()
-        .zip(top_embeddings.into_iter())
+        .zip(top_embeddings)
         .map(|(&i, embedding)| {
             let (result_index, ref chunk) = bindings[i];
             let score = cosine_similarity(&query_embedding, &embedding);

--- a/mistralrs-core/src/search/rag.rs
+++ b/mistralrs-core/src/search/rag.rs
@@ -139,7 +139,7 @@ impl SearchPipeline {
                 .to_dtype(DType::F32)?
                 .to_device(&Device::Cpu)?
                 .to_vec2::<f32>()?;
-            for ((idx, _), embedding) in chunk_entries.iter().zip(vecs) {
+            for ((idx, _), embedding) in chunk_entries.iter().zip(vecs.into_iter()) {
                 outputs[*idx] = embedding;
             }
         }
@@ -339,7 +339,7 @@ pub fn rank_document_chunks(
 
     let mut scored: Vec<ScoredChunk> = top_indices
         .iter()
-        .zip(top_embeddings)
+        .zip(top_embeddings.into_iter())
         .map(|(&i, embedding)| {
             let (result_index, ref chunk) = bindings[i];
             let score = cosine_similarity(&query_embedding, &embedding);

--- a/mistralrs-core/src/vision_models/gemma4/audio_processing.rs
+++ b/mistralrs-core/src/vision_models/gemma4/audio_processing.rs
@@ -117,7 +117,7 @@ impl AudioProcessor {
         let mut mel_data = Vec::<f32>::with_capacity(batch_size * max_frames * self.feature_size);
         let mut mask_data = Vec::<f32>::with_capacity(batch_size * max_frames);
 
-        for (mel, valid_mask) in mel_batches.into_iter().zip(valid_masks.into_iter()) {
+        for (mel, valid_mask) in mel_batches.into_iter().zip(valid_masks) {
             for (frame, &is_valid) in mel.iter().zip(valid_mask.iter()) {
                 if is_valid {
                     mel_data.extend_from_slice(frame);

--- a/mistralrs-core/src/vision_models/gemma4/audio_processing.rs
+++ b/mistralrs-core/src/vision_models/gemma4/audio_processing.rs
@@ -117,7 +117,7 @@ impl AudioProcessor {
         let mut mel_data = Vec::<f32>::with_capacity(batch_size * max_frames * self.feature_size);
         let mut mask_data = Vec::<f32>::with_capacity(batch_size * max_frames);
 
-        for (mel, valid_mask) in mel_batches.into_iter().zip(valid_masks) {
+        for (mel, valid_mask) in mel_batches.into_iter().zip(valid_masks.into_iter()) {
             for (frame, &is_valid) in mel.iter().zip(valid_mask.iter()) {
                 if is_valid {
                     mel_data.extend_from_slice(frame);

--- a/mistralrs-core/src/vision_models/idefics3/inputs_processor.rs
+++ b/mistralrs-core/src/vision_models/idefics3/inputs_processor.rs
@@ -171,8 +171,7 @@ impl InputsProcessor for Idefics3ImageProcessor {
                         .expect("Detokenization failed!");
 
                     let mut image_prompt_strings = Vec::new();
-                    for (n_rows, n_cols) in rows.unwrap().into_iter().zip(cols.unwrap().into_iter())
-                    {
+                    for (n_rows, n_cols) in rows.unwrap().into_iter().zip(cols.unwrap()) {
                         let image_prompt_string =
                             get_image_prompt_string(n_rows, n_cols, self.image_seq_len);
                         image_prompt_strings.push(image_prompt_string);
@@ -569,7 +568,7 @@ impl ImagePreProcessor for Idefics3ImageProcessor {
 
                 let (split_image_array, rows, cols) =
                     split_image(image, max_image_size["longest_edge"] as usize)?;
-                new_images.extend(split_image_array.into_iter());
+                new_images.extend(split_image_array);
                 image_rows.push(rows);
                 image_cols.push(cols);
             }

--- a/mistralrs-core/src/vision_models/idefics3/inputs_processor.rs
+++ b/mistralrs-core/src/vision_models/idefics3/inputs_processor.rs
@@ -171,7 +171,8 @@ impl InputsProcessor for Idefics3ImageProcessor {
                         .expect("Detokenization failed!");
 
                     let mut image_prompt_strings = Vec::new();
-                    for (n_rows, n_cols) in rows.unwrap().into_iter().zip(cols.unwrap()) {
+                    for (n_rows, n_cols) in rows.unwrap().into_iter().zip(cols.unwrap().into_iter())
+                    {
                         let image_prompt_string =
                             get_image_prompt_string(n_rows, n_cols, self.image_seq_len);
                         image_prompt_strings.push(image_prompt_string);
@@ -568,7 +569,7 @@ impl ImagePreProcessor for Idefics3ImageProcessor {
 
                 let (split_image_array, rows, cols) =
                     split_image(image, max_image_size["longest_edge"] as usize)?;
-                new_images.extend(split_image_array);
+                new_images.extend(split_image_array.into_iter());
                 image_rows.push(rows);
                 image_cols.push(cols);
             }

--- a/mistralrs-core/src/vision_models/llava/llava_inputs_processor.rs
+++ b/mistralrs-core/src/vision_models/llava/llava_inputs_processor.rs
@@ -214,11 +214,10 @@ impl InputsProcessor for LLaVAInputProcessor {
             )
             .expect("Decoding failed");
 
-        for (detokenized, (seq, num_img_tokens)) in detokenized.into_iter().zip(
-            input_seqs
-                .iter_mut()
-                .zip(num_img_tokens.unwrap().into_iter()),
-        ) {
+        for (detokenized, (seq, num_img_tokens)) in detokenized
+            .into_iter()
+            .zip(input_seqs.iter_mut().zip(num_img_tokens.unwrap()))
+        {
             let splits = self
                 .image_tag_splitter
                 .split(&detokenized)

--- a/mistralrs-core/src/vision_models/llava/llava_inputs_processor.rs
+++ b/mistralrs-core/src/vision_models/llava/llava_inputs_processor.rs
@@ -214,10 +214,11 @@ impl InputsProcessor for LLaVAInputProcessor {
             )
             .expect("Decoding failed");
 
-        for (detokenized, (seq, num_img_tokens)) in detokenized
-            .into_iter()
-            .zip(input_seqs.iter_mut().zip(num_img_tokens.unwrap()))
-        {
+        for (detokenized, (seq, num_img_tokens)) in detokenized.into_iter().zip(
+            input_seqs
+                .iter_mut()
+                .zip(num_img_tokens.unwrap().into_iter()),
+        ) {
             let splits = self
                 .image_tag_splitter
                 .split(&detokenized)

--- a/mistralrs-core/src/vision_models/llava/llava_next_inputs_processor.rs
+++ b/mistralrs-core/src/vision_models/llava/llava_next_inputs_processor.rs
@@ -257,11 +257,10 @@ impl InputsProcessor for LLaVANextInputProcessor {
             )
             .expect("Decode failed");
 
-        for (detokenized, (seq, num_img_tokens)) in detokenized.into_iter().zip(
-            input_seqs
-                .iter_mut()
-                .zip(num_img_tokens.unwrap().into_iter()),
-        ) {
+        for (detokenized, (seq, num_img_tokens)) in detokenized
+            .into_iter()
+            .zip(input_seqs.iter_mut().zip(num_img_tokens.unwrap()))
+        {
             let splits = self
                 .image_tag_splitter
                 .split(&detokenized)

--- a/mistralrs-core/src/vision_models/llava/llava_next_inputs_processor.rs
+++ b/mistralrs-core/src/vision_models/llava/llava_next_inputs_processor.rs
@@ -257,10 +257,11 @@ impl InputsProcessor for LLaVANextInputProcessor {
             )
             .expect("Decode failed");
 
-        for (detokenized, (seq, num_img_tokens)) in detokenized
-            .into_iter()
-            .zip(input_seqs.iter_mut().zip(num_img_tokens.unwrap()))
-        {
+        for (detokenized, (seq, num_img_tokens)) in detokenized.into_iter().zip(
+            input_seqs
+                .iter_mut()
+                .zip(num_img_tokens.unwrap().into_iter()),
+        ) {
             let splits = self
                 .image_tag_splitter
                 .split(&detokenized)

--- a/mistralrs-pyo3/src/util.rs
+++ b/mistralrs-pyo3/src/util.rs
@@ -379,11 +379,7 @@ fn decode_gif_frames(bytes: &[u8]) -> anyhow::Result<VideoInput> {
         .iter()
         .map(|f| {
             let (num, den) = f.delay().numer_denom_ms();
-            if den == 0 {
-                100
-            } else {
-                num * 1000 / den
-            }
+            (num * 1000).checked_div(den).unwrap_or(100)
         })
         .sum();
     let fps = if total_delay_ms > 0 {

--- a/mistralrs-pyo3/src/util.rs
+++ b/mistralrs-pyo3/src/util.rs
@@ -379,7 +379,11 @@ fn decode_gif_frames(bytes: &[u8]) -> anyhow::Result<VideoInput> {
         .iter()
         .map(|f| {
             let (num, den) = f.delay().numer_denom_ms();
-            (num * 1000).checked_div(den).unwrap_or(100)
+            if den == 0 {
+                100
+            } else {
+                num * 1000 / den
+            }
         })
         .sum();
     let fps = if total_delay_ms > 0 {

--- a/mistralrs-quant/src/distributed/layers.rs
+++ b/mistralrs-quant/src/distributed/layers.rs
@@ -1431,9 +1431,7 @@ impl PackedExperts {
             let mut gs = Vec::new();
             let mut us = Vec::new();
             let mut ds = Vec::new();
-            for ((mut gate_proj, mut up_proj), mut down_proj) in
-                gc.into_iter().zip(uc.into_iter()).zip(dc.into_iter())
-            {
+            for ((mut gate_proj, mut up_proj), mut down_proj) in gc.into_iter().zip(uc).zip(dc) {
                 gate_proj = gate_proj.squeeze(0)?;
                 up_proj = up_proj.squeeze(0)?;
                 down_proj = down_proj.squeeze(0)?;
@@ -2036,9 +2034,7 @@ pub fn compute_n_kv_groups(
     } else {
         1
     };
-    if kv_replicate != 0 {
-        (num_attention_heads / total_num_kv_heads) / kv_replicate
-    } else {
-        num_attention_heads / total_num_kv_heads
-    }
+    (num_attention_heads / total_num_kv_heads)
+        .checked_div(kv_replicate)
+        .unwrap_or(num_attention_heads / total_num_kv_heads)
 }

--- a/mistralrs-quant/src/distributed/layers.rs
+++ b/mistralrs-quant/src/distributed/layers.rs
@@ -1431,7 +1431,9 @@ impl PackedExperts {
             let mut gs = Vec::new();
             let mut us = Vec::new();
             let mut ds = Vec::new();
-            for ((mut gate_proj, mut up_proj), mut down_proj) in gc.into_iter().zip(uc).zip(dc) {
+            for ((mut gate_proj, mut up_proj), mut down_proj) in
+                gc.into_iter().zip(uc.into_iter()).zip(dc.into_iter())
+            {
                 gate_proj = gate_proj.squeeze(0)?;
                 up_proj = up_proj.squeeze(0)?;
                 down_proj = down_proj.squeeze(0)?;
@@ -2034,7 +2036,9 @@ pub fn compute_n_kv_groups(
     } else {
         1
     };
-    (num_attention_heads / total_num_kv_heads)
-        .checked_div(kv_replicate)
-        .unwrap_or(num_attention_heads / total_num_kv_heads)
+    if kv_replicate != 0 {
+        (num_attention_heads / total_num_kv_heads) / kv_replicate
+    } else {
+        num_attention_heads / total_num_kv_heads
+    }
 }

--- a/mistralrs-server-core/src/openapi_doc.rs
+++ b/mistralrs-server-core/src/openapi_doc.rs
@@ -6,7 +6,7 @@ use crate::{
     chat_completion::__path_chatcompletions,
     completions::__path_completions,
     embeddings::__path_embeddings,
-    handlers::{ReIsqRequest, __path_health, __path_models, __path_re_isq},
+    handlers::{__path_health, __path_models, __path_re_isq, ReIsqRequest},
     image_generation::__path_image_generation,
     openai::{
         AudioResponseFormat, ChatCompletionRequest, CompletionRequest, EmbeddingData,

--- a/mistralrs-server-core/src/openapi_doc.rs
+++ b/mistralrs-server-core/src/openapi_doc.rs
@@ -6,7 +6,7 @@ use crate::{
     chat_completion::__path_chatcompletions,
     completions::__path_completions,
     embeddings::__path_embeddings,
-    handlers::{__path_health, __path_models, __path_re_isq, ReIsqRequest},
+    handlers::{ReIsqRequest, __path_health, __path_models, __path_re_isq},
     image_generation::__path_image_generation,
     openai::{
         AudioResponseFormat, ChatCompletionRequest, CompletionRequest, EmbeddingData,

--- a/mistralrs-server-core/src/video.rs
+++ b/mistralrs-server-core/src/video.rs
@@ -119,11 +119,7 @@ fn decode_gif_frames(bytes: &[u8], num_frames: usize) -> Result<VideoInput> {
         .iter()
         .map(|f| {
             let (num, den) = f.delay().numer_denom_ms();
-            if den == 0 {
-                100
-            } else {
-                num * 1000 / den
-            }
+            (num * 1000).checked_div(den).unwrap_or(100)
         })
         .sum();
     let fps = if total_delay_ms > 0 {

--- a/mistralrs-server-core/src/video.rs
+++ b/mistralrs-server-core/src/video.rs
@@ -119,7 +119,11 @@ fn decode_gif_frames(bytes: &[u8], num_frames: usize) -> Result<VideoInput> {
         .iter()
         .map(|f| {
             let (num, den) = f.delay().numer_denom_ms();
-            (num * 1000).checked_div(den).unwrap_or(100)
+            if den == 0 {
+                100
+            } else {
+                num * 1000 / den
+            }
         })
         .sum();
     let fps = if total_delay_ms > 0 {


### PR DESCRIPTION
## Concrete issue fixed

Benchmark iteration cleanup should not continue unless the engine has acknowledged a KV-cache flush barrier. A sleep-based delay is only a timing guess, and a failed probe is not a completed barrier.

## Fix

Replace the sleep with a synchronous probe barrier:

1. Send `TerminateAllSeqsNextStep` to request sequence termination.
2. Send a minimal probe request and await its response.
3. Treat only `CompletionDone` / `Done` as a completed flush barrier.
4. Return an error if the termination send fails, the probe send fails, the probe response channel closes, or the probe returns any error/unexpected response.

## Tests

Current branch head after Agent 5 follow-up: `843298d071f8efb566e7ec130840e6862b5dd8f6`.

```bash
cargo test -q -p mistralrs-cli flush_probe --bin mistralrs
```

A100 result: passed, `9 passed; 0 failed`.

The focused tests now cover:

- successful `CompletionDone` probe;
- successful `Done` probe;
- missing probe response;
- closed probe response channel;
- fatal `InternalError`;
- fatal `ModelError`;
- fatal `CompletionModelError`;
- fatal validation error;
- unexpected response type.

## A100 validation, Agent 5, 2026-05-13

Hardware/software:

- GCP `a2-highgpu-1g`, 1x `NVIDIA A100-SXM4-40GB`, 40960 MiB
- Driver `580.126.09`; `nvidia-smi` CUDA `13.0`; CUDA toolkit `12.9.41`
- Rust `1.95.0`; Cargo `1.95.0`

Previous PR head `587102d122836b80cd6cdb7bf3c1bb6842b9e947` passed the original focused `flush_probe` tests with `2 passed`. Current head `843298d071f8efb566e7ec130840e6862b5dd8f6` passes the expanded `flush_probe` suite with `9 passed`.

## Merge / Issue-Linking Note

The branch commit with stale auto-close wording has been rewritten. Final squash/merge wording should use `Refs #2095` or `Related to #2095`, without a closing keyword before `#2095`, so #2095 is not closed automatically. Safe wording: “Fixes a benchmark flush-barrier invariant discovered while investigating the stale-KV/NaN report; does not claim a reproduced stale-KV/NaN runtime fix.”

## Relationship to stale-KV / NaN benchmark report

Classification: `TARGETED`.

Agent 5 did not reproduce the original stale-KV/NaN benchmark. The original report requires an RTX 5080 with compute capability 12.0, WSL2 Ubuntu 24.04, CUDA 13.2, and a local `google/gemma-4-E4B-it` q8_0 UQFF file. Those original conditions and artifact were not available on the A100 host.

Safe merge claim: this PR fixes and tests benchmark flush-barrier correctness. It should not be described as a reproduced stale-KV/NaN runtime fix without the original benchmark failing on base and passing on this branch.