### PR TITLE
fix(core): bind CUDA context and trim memory pool during model unload

### DIFF
--- a/.typos.toml
+++ b/.typos.toml
@@ -5,6 +5,7 @@ extend-exclude = [
     "examples/server/phi3_duckduckgo_mistral.rs.ipynb",
     "mistralrs-web-chat/static/",
     "mistralrs-cli/static/",
+    "mistralrs-quant/kernels/mmq_gguf/",
     "CLAUDE.md",
 ]
 ignore-hidden = false
@@ -12,6 +13,7 @@ ignore-hidden = false
 [default]
 extend-ignore-re = [
     "cudaDevAttrMaxSharedMemoryPerBlockOptin",
+    "CU_DEVICE_ATTRIBUTE_MAX_SHARED_MEMORY_PER_BLOCK_OPTIN",
     '"tese"',
     "setp\\.ne\\.b32",
     # metal_kernels

--- a/.typos.toml
+++ b/.typos.toml
@@ -5,7 +5,6 @@ extend-exclude = [
     "examples/server/phi3_duckduckgo_mistral.rs.ipynb",
     "mistralrs-web-chat/static/",
     "mistralrs-cli/static/",
-    "mistralrs-quant/kernels/mmq_gguf/",
     "CLAUDE.md",
 ]
 ignore-hidden = false
@@ -13,7 +12,6 @@ ignore-hidden = false
 [default]
 extend-ignore-re = [
     "cudaDevAttrMaxSharedMemoryPerBlockOptin",
-    "CU_DEVICE_ATTRIBUTE_MAX_SHARED_MEMORY_PER_BLOCK_OPTIN",
     '"tese"',
     "setp\\.ne\\.b32",
     # metal_kernels

--- a/mistralrs-cli/src/commands/bench.rs
+++ b/mistralrs-cli/src/commands/bench.rs
@@ -99,7 +99,7 @@ pub async fn run_bench(
     if warmup > 0 {
         info!("Running {} warmup iteration(s)...", warmup);
         for _ in 0..warmup {
-            let _ = run_single_bench(&mistralrs, 32, 16).await?;
+            run_single_bench(&mistralrs, 32, 16).await?;
         }
         info!("Warmup complete.");
 

--- a/mistralrs-cli/src/commands/bench.rs
+++ b/mistralrs-cli/src/commands/bench.rs
@@ -99,7 +99,7 @@ pub async fn run_bench(
     if warmup > 0 {
         info!("Running {} warmup iteration(s)...", warmup);
         for _ in 0..warmup {
-            run_single_bench(&mistralrs, 32, 16).await?;
+            let _ = run_single_bench(&mistralrs, 32, 16).await?;
         }
         info!("Warmup complete.");
 

--- a/mistralrs-core/src/engine/tool_dispatch.rs
+++ b/mistralrs-core/src/engine/tool_dispatch.rs
@@ -102,10 +102,8 @@ pub(super) async fn execute_search(
     );
 
     // Sort by token length (shortest first).
-    let mut combined: Vec<(SearchResult, usize)> = results
-        .into_iter()
-        .zip(result_token_lens.into_iter())
-        .collect();
+    let mut combined: Vec<(SearchResult, usize)> =
+        results.into_iter().zip(result_token_lens).collect();
     combined.sort_by_key(|(_, len)| *len);
     let (results, result_token_lens): (Vec<SearchResult>, Vec<usize>) =
         combined.into_iter().unzip();

--- a/mistralrs-core/src/engine/tool_dispatch.rs
+++ b/mistralrs-core/src/engine/tool_dispatch.rs
@@ -102,8 +102,10 @@ pub(super) async fn execute_search(
     );
 
     // Sort by token length (shortest first).
-    let mut combined: Vec<(SearchResult, usize)> =
-        results.into_iter().zip(result_token_lens).collect();
+    let mut combined: Vec<(SearchResult, usize)> = results
+        .into_iter()
+        .zip(result_token_lens.into_iter())
+        .collect();
     combined.sort_by_key(|(_, len)| *len);
     let (results, result_token_lens): (Vec<SearchResult>, Vec<usize>) =
         combined.into_iter().unzip();

--- a/mistralrs-core/src/lib.rs
+++ b/mistralrs-core/src/lib.rs
@@ -1498,6 +1498,48 @@ impl MistralRs {
         // Send terminate signal to the engine
         let _ = engine_instance.sender.try_send(Request::Terminate);
 
+        let device = engine_instance.config.device.clone();
+
+        // Wait for the engine thread to finish processing and drop its state.
+        let _ = engine_instance.engine_handler.join();
+
+        // Bind the CUDA context to this thread before dropping tensors.
+        // cuMemFreeAsync requires the CUDA context to be bound to the calling
+        // thread; without this, deallocation silently fails into the pool void.
+        #[cfg(feature = "cuda")]
+        let _ctx_guard = {
+            if let candle_core::Device::Cuda(dev) = &device {
+                dev.cuda_stream().context().bind_to_thread().ok()
+            } else {
+                None
+            }
+        };
+
+        // Explicitly drop the reboot state (which holds model tensors) while
+        // the CUDA context is bound, then synchronize to ensure all
+        // deallocation is complete.
+        drop(engine_instance.reboot_state);
+        let _ = device.synchronize();
+
+        // Trim the CUDA memory pool to release cached allocations back to the OS.
+        #[cfg(feature = "cuda")]
+        if let candle_core::Device::Cuda(dev) = &device {
+            unsafe {
+                use candle_core::cuda::cudarc::driver::sys;
+                if let Ok(_ctx) = dev.cuda_stream().context().bind_to_thread() {
+                    let mut dev_id = 0;
+                    if sys::cuCtxGetDevice(&mut dev_id) == sys::CUresult::CUDA_SUCCESS {
+                        let mut pool: sys::CUmemoryPool = std::ptr::null_mut();
+                        if sys::cuDeviceGetDefaultMemPool(&mut pool, dev_id)
+                            == sys::CUresult::CUDA_SUCCESS
+                        {
+                            sys::cuMemPoolTrimTo(pool, 0);
+                        }
+                    }
+                }
+            }
+        }
+
         drop(engines);
 
         // Store the unloaded state

--- a/mistralrs-core/src/moe/experts.rs
+++ b/mistralrs-core/src/moe/experts.rs
@@ -95,6 +95,7 @@ struct SlowExpertsWeights {
 pub struct MoEExperts {
     backend: MoEExpertsBackendImpl,
     act: Activation,
+    #[allow(dead_code)]
     num_experts: usize,
     num_experts_per_tok: usize,
     all_reduce: SumAllReduce,

--- a/mistralrs-core/src/moe/experts.rs
+++ b/mistralrs-core/src/moe/experts.rs
@@ -95,7 +95,6 @@ struct SlowExpertsWeights {
 pub struct MoEExperts {
     backend: MoEExpertsBackendImpl,
     act: Activation,
-    #[allow(dead_code)]
     num_experts: usize,
     num_experts_per_tok: usize,
     all_reduce: SumAllReduce,

--- a/mistralrs-core/src/scheduler/default_scheduler.rs
+++ b/mistralrs-core/src/scheduler/default_scheduler.rs
@@ -131,8 +131,8 @@ impl<Backer: FcfsBacker> BucketingManager<Backer> for FixedBucketingManager {
         let running = if seq_buckets.len() <= 1 {
             // Full steam ahead or have everything
             seq_buckets
-                .into_iter()
-                .flat_map(|(_, x)| x)
+                .into_values()
+                .flatten()
                 .map(|s| s.reset_urgency())
                 .collect::<Vec<_>>()
         } else {

--- a/mistralrs-core/src/scheduler/default_scheduler.rs
+++ b/mistralrs-core/src/scheduler/default_scheduler.rs
@@ -131,8 +131,8 @@ impl<Backer: FcfsBacker> BucketingManager<Backer> for FixedBucketingManager {
         let running = if seq_buckets.len() <= 1 {
             // Full steam ahead or have everything
             seq_buckets
-                .into_values()
-                .flatten()
+                .into_iter()
+                .flat_map(|(_, x)| x)
                 .map(|s| s.reset_urgency())
                 .collect::<Vec<_>>()
         } else {

--- a/mistralrs-core/src/search/rag.rs
+++ b/mistralrs-core/src/search/rag.rs
@@ -139,7 +139,7 @@ impl SearchPipeline {
                 .to_dtype(DType::F32)?
                 .to_device(&Device::Cpu)?
                 .to_vec2::<f32>()?;
-            for ((idx, _), embedding) in chunk_entries.iter().zip(vecs.into_iter()) {
+            for ((idx, _), embedding) in chunk_entries.iter().zip(vecs) {
                 outputs[*idx] = embedding;
             }
         }
@@ -339,7 +339,7 @@ pub fn rank_document_chunks(
 
     let mut scored: Vec<ScoredChunk> = top_indices
         .iter()
-        .zip(top_embeddings.into_iter())
+        .zip(top_embeddings)
         .map(|(&i, embedding)| {
             let (result_index, ref chunk) = bindings[i];
             let score = cosine_similarity(&query_embedding, &embedding);

--- a/mistralrs-core/src/search/rag.rs
+++ b/mistralrs-core/src/search/rag.rs
@@ -139,7 +139,7 @@ impl SearchPipeline {
                 .to_dtype(DType::F32)?
                 .to_device(&Device::Cpu)?
                 .to_vec2::<f32>()?;
-            for ((idx, _), embedding) in chunk_entries.iter().zip(vecs) {
+            for ((idx, _), embedding) in chunk_entries.iter().zip(vecs.into_iter()) {
                 outputs[*idx] = embedding;
             }
         }
@@ -339,7 +339,7 @@ pub fn rank_document_chunks(
 
     let mut scored: Vec<ScoredChunk> = top_indices
         .iter()
-        .zip(top_embeddings)
+        .zip(top_embeddings.into_iter())
         .map(|(&i, embedding)| {
             let (result_index, ref chunk) = bindings[i];
             let score = cosine_similarity(&query_embedding, &embedding);

--- a/mistralrs-core/src/vision_models/gemma4/audio_processing.rs
+++ b/mistralrs-core/src/vision_models/gemma4/audio_processing.rs
@@ -117,7 +117,7 @@ impl AudioProcessor {
         let mut mel_data = Vec::<f32>::with_capacity(batch_size * max_frames * self.feature_size);
         let mut mask_data = Vec::<f32>::with_capacity(batch_size * max_frames);
 
-        for (mel, valid_mask) in mel_batches.into_iter().zip(valid_masks.into_iter()) {
+        for (mel, valid_mask) in mel_batches.into_iter().zip(valid_masks) {
             for (frame, &is_valid) in mel.iter().zip(valid_mask.iter()) {
                 if is_valid {
                     mel_data.extend_from_slice(frame);

--- a/mistralrs-core/src/vision_models/gemma4/audio_processing.rs
+++ b/mistralrs-core/src/vision_models/gemma4/audio_processing.rs
@@ -117,7 +117,7 @@ impl AudioProcessor {
         let mut mel_data = Vec::<f32>::with_capacity(batch_size * max_frames * self.feature_size);
         let mut mask_data = Vec::<f32>::with_capacity(batch_size * max_frames);
 
-        for (mel, valid_mask) in mel_batches.into_iter().zip(valid_masks) {
+        for (mel, valid_mask) in mel_batches.into_iter().zip(valid_masks.into_iter()) {
             for (frame, &is_valid) in mel.iter().zip(valid_mask.iter()) {
                 if is_valid {
                     mel_data.extend_from_slice(frame);

--- a/mistralrs-core/src/vision_models/idefics3/inputs_processor.rs
+++ b/mistralrs-core/src/vision_models/idefics3/inputs_processor.rs
@@ -171,8 +171,7 @@ impl InputsProcessor for Idefics3ImageProcessor {
                         .expect("Detokenization failed!");
 
                     let mut image_prompt_strings = Vec::new();
-                    for (n_rows, n_cols) in rows.unwrap().into_iter().zip(cols.unwrap().into_iter())
-                    {
+                    for (n_rows, n_cols) in rows.unwrap().into_iter().zip(cols.unwrap()) {
                         let image_prompt_string =
                             get_image_prompt_string(n_rows, n_cols, self.image_seq_len);
                         image_prompt_strings.push(image_prompt_string);
@@ -569,7 +568,7 @@ impl ImagePreProcessor for Idefics3ImageProcessor {
 
                 let (split_image_array, rows, cols) =
                     split_image(image, max_image_size["longest_edge"] as usize)?;
-                new_images.extend(split_image_array.into_iter());
+                new_images.extend(split_image_array);
                 image_rows.push(rows);
                 image_cols.push(cols);
             }

--- a/mistralrs-core/src/vision_models/idefics3/inputs_processor.rs
+++ b/mistralrs-core/src/vision_models/idefics3/inputs_processor.rs
@@ -171,7 +171,8 @@ impl InputsProcessor for Idefics3ImageProcessor {
                         .expect("Detokenization failed!");
 
                     let mut image_prompt_strings = Vec::new();
-                    for (n_rows, n_cols) in rows.unwrap().into_iter().zip(cols.unwrap()) {
+                    for (n_rows, n_cols) in rows.unwrap().into_iter().zip(cols.unwrap().into_iter())
+                    {
                         let image_prompt_string =
                             get_image_prompt_string(n_rows, n_cols, self.image_seq_len);
                         image_prompt_strings.push(image_prompt_string);
@@ -568,7 +569,7 @@ impl ImagePreProcessor for Idefics3ImageProcessor {
 
                 let (split_image_array, rows, cols) =
                     split_image(image, max_image_size["longest_edge"] as usize)?;
-                new_images.extend(split_image_array);
+                new_images.extend(split_image_array.into_iter());
                 image_rows.push(rows);
                 image_cols.push(cols);
             }

--- a/mistralrs-core/src/vision_models/llava/llava_inputs_processor.rs
+++ b/mistralrs-core/src/vision_models/llava/llava_inputs_processor.rs
@@ -214,11 +214,10 @@ impl InputsProcessor for LLaVAInputProcessor {
             )
             .expect("Decoding failed");
 
-        for (detokenized, (seq, num_img_tokens)) in detokenized.into_iter().zip(
-            input_seqs
-                .iter_mut()
-                .zip(num_img_tokens.unwrap().into_iter()),
-        ) {
+        for (detokenized, (seq, num_img_tokens)) in detokenized
+            .into_iter()
+            .zip(input_seqs.iter_mut().zip(num_img_tokens.unwrap()))
+        {
             let splits = self
                 .image_tag_splitter
                 .split(&detokenized)

--- a/mistralrs-core/src/vision_models/llava/llava_inputs_processor.rs
+++ b/mistralrs-core/src/vision_models/llava/llava_inputs_processor.rs
@@ -214,10 +214,11 @@ impl InputsProcessor for LLaVAInputProcessor {
             )
             .expect("Decoding failed");
 
-        for (detokenized, (seq, num_img_tokens)) in detokenized
-            .into_iter()
-            .zip(input_seqs.iter_mut().zip(num_img_tokens.unwrap()))
-        {
+        for (detokenized, (seq, num_img_tokens)) in detokenized.into_iter().zip(
+            input_seqs
+                .iter_mut()
+                .zip(num_img_tokens.unwrap().into_iter()),
+        ) {
             let splits = self
                 .image_tag_splitter
                 .split(&detokenized)

--- a/mistralrs-core/src/vision_models/llava/llava_next_inputs_processor.rs
+++ b/mistralrs-core/src/vision_models/llava/llava_next_inputs_processor.rs
@@ -257,11 +257,10 @@ impl InputsProcessor for LLaVANextInputProcessor {
             )
             .expect("Decode failed");
 
-        for (detokenized, (seq, num_img_tokens)) in detokenized.into_iter().zip(
-            input_seqs
-                .iter_mut()
-                .zip(num_img_tokens.unwrap().into_iter()),
-        ) {
+        for (detokenized, (seq, num_img_tokens)) in detokenized
+            .into_iter()
+            .zip(input_seqs.iter_mut().zip(num_img_tokens.unwrap()))
+        {
             let splits = self
                 .image_tag_splitter
                 .split(&detokenized)

--- a/mistralrs-core/src/vision_models/llava/llava_next_inputs_processor.rs
+++ b/mistralrs-core/src/vision_models/llava/llava_next_inputs_processor.rs
@@ -257,10 +257,11 @@ impl InputsProcessor for LLaVANextInputProcessor {
             )
             .expect("Decode failed");
 
-        for (detokenized, (seq, num_img_tokens)) in detokenized
-            .into_iter()
-            .zip(input_seqs.iter_mut().zip(num_img_tokens.unwrap()))
-        {
+        for (detokenized, (seq, num_img_tokens)) in detokenized.into_iter().zip(
+            input_seqs
+                .iter_mut()
+                .zip(num_img_tokens.unwrap().into_iter()),
+        ) {
             let splits = self
                 .image_tag_splitter
                 .split(&detokenized)

--- a/mistralrs-pyo3/src/util.rs
+++ b/mistralrs-pyo3/src/util.rs
@@ -379,11 +379,7 @@ fn decode_gif_frames(bytes: &[u8]) -> anyhow::Result<VideoInput> {
         .iter()
         .map(|f| {
             let (num, den) = f.delay().numer_denom_ms();
-            if den == 0 {
-                100
-            } else {
-                num * 1000 / den
-            }
+            (num * 1000).checked_div(den).unwrap_or(100)
         })
         .sum();
     let fps = if total_delay_ms > 0 {

--- a/mistralrs-pyo3/src/util.rs
+++ b/mistralrs-pyo3/src/util.rs
@@ -379,7 +379,11 @@ fn decode_gif_frames(bytes: &[u8]) -> anyhow::Result<VideoInput> {
         .iter()
         .map(|f| {
             let (num, den) = f.delay().numer_denom_ms();
-            (num * 1000).checked_div(den).unwrap_or(100)
+            if den == 0 {
+                100
+            } else {
+                num * 1000 / den
+            }
         })
         .sum();
     let fps = if total_delay_ms > 0 {

--- a/mistralrs-quant/src/distributed/layers.rs
+++ b/mistralrs-quant/src/distributed/layers.rs
@@ -1431,9 +1431,7 @@ impl PackedExperts {
             let mut gs = Vec::new();
             let mut us = Vec::new();
             let mut ds = Vec::new();
-            for ((mut gate_proj, mut up_proj), mut down_proj) in
-                gc.into_iter().zip(uc.into_iter()).zip(dc.into_iter())
-            {
+            for ((mut gate_proj, mut up_proj), mut down_proj) in gc.into_iter().zip(uc).zip(dc) {
                 gate_proj = gate_proj.squeeze(0)?;
                 up_proj = up_proj.squeeze(0)?;
                 down_proj = down_proj.squeeze(0)?;
@@ -2036,9 +2034,7 @@ pub fn compute_n_kv_groups(
     } else {
         1
     };
-    if kv_replicate != 0 {
-        (num_attention_heads / total_num_kv_heads) / kv_replicate
-    } else {
-        num_attention_heads / total_num_kv_heads
-    }
+    (num_attention_heads / total_num_kv_heads)
+        .checked_div(kv_replicate)
+        .unwrap_or(num_attention_heads / total_num_kv_heads)
 }

--- a/mistralrs-quant/src/distributed/layers.rs
+++ b/mistralrs-quant/src/distributed/layers.rs
@@ -1431,7 +1431,9 @@ impl PackedExperts {
             let mut gs = Vec::new();
             let mut us = Vec::new();
             let mut ds = Vec::new();
-            for ((mut gate_proj, mut up_proj), mut down_proj) in gc.into_iter().zip(uc).zip(dc) {
+            for ((mut gate_proj, mut up_proj), mut down_proj) in
+                gc.into_iter().zip(uc.into_iter()).zip(dc.into_iter())
+            {
                 gate_proj = gate_proj.squeeze(0)?;
                 up_proj = up_proj.squeeze(0)?;
                 down_proj = down_proj.squeeze(0)?;
@@ -2034,7 +2036,9 @@ pub fn compute_n_kv_groups(
     } else {
         1
     };
-    (num_attention_heads / total_num_kv_heads)
-        .checked_div(kv_replicate)
-        .unwrap_or(num_attention_heads / total_num_kv_heads)
+    if kv_replicate != 0 {
+        (num_attention_heads / total_num_kv_heads) / kv_replicate
+    } else {
+        num_attention_heads / total_num_kv_heads
+    }
 }

--- a/mistralrs-server-core/src/openapi_doc.rs
+++ b/mistralrs-server-core/src/openapi_doc.rs
@@ -6,7 +6,7 @@ use crate::{
     chat_completion::__path_chatcompletions,
     completions::__path_completions,
     embeddings::__path_embeddings,
-    handlers::{ReIsqRequest, __path_health, __path_models, __path_re_isq},
+    handlers::{__path_health, __path_models, __path_re_isq, ReIsqRequest},
     image_generation::__path_image_generation,
     openai::{
         AudioResponseFormat, ChatCompletionRequest, CompletionRequest, EmbeddingData,

--- a/mistralrs-server-core/src/openapi_doc.rs
+++ b/mistralrs-server-core/src/openapi_doc.rs
@@ -6,7 +6,7 @@ use crate::{
     chat_completion::__path_chatcompletions,
     completions::__path_completions,
     embeddings::__path_embeddings,
-    handlers::{__path_health, __path_models, __path_re_isq, ReIsqRequest},
+    handlers::{ReIsqRequest, __path_health, __path_models, __path_re_isq},
     image_generation::__path_image_generation,
     openai::{
         AudioResponseFormat, ChatCompletionRequest, CompletionRequest, EmbeddingData,

--- a/mistralrs-server-core/src/video.rs
+++ b/mistralrs-server-core/src/video.rs
@@ -119,11 +119,7 @@ fn decode_gif_frames(bytes: &[u8], num_frames: usize) -> Result<VideoInput> {
         .iter()
         .map(|f| {
             let (num, den) = f.delay().numer_denom_ms();
-            if den == 0 {
-                100
-            } else {
-                num * 1000 / den
-            }
+            (num * 1000).checked_div(den).unwrap_or(100)
         })
         .sum();
     let fps = if total_delay_ms > 0 {

--- a/mistralrs-server-core/src/video.rs
+++ b/mistralrs-server-core/src/video.rs
@@ -119,7 +119,11 @@ fn decode_gif_frames(bytes: &[u8], num_frames: usize) -> Result<VideoInput> {
         .iter()
         .map(|f| {
             let (num, den) = f.delay().numer_denom_ms();
-            (num * 1000).checked_div(den).unwrap_or(100)
+            if den == 0 {
+                100
+            } else {
+                num * 1000 / den
+            }
         })
         .sum();
     let fps = if total_delay_ms > 0 {


### PR DESCRIPTION
> [!WARNING]
> Agent 4 A100 validation update (2026-05-13 UTC): classification `TARGETED`, feasibility `FEASIBLE_NOW`. Base `2d4ba4f16f61e5e18be085d0dd137bc95cba038a` reproduced the CUDA unload defect: VRAM stayed `36458MiB / 40960MiB` after unload and 5s delay, and reload failed with `CUDA_ERROR_INVALID_CONTEXT` followed by `EnginePoisoned`. Current PR head `0216528c46a860a80553cc84fe2e0ae30a401a69` fixed the VRAM release (`36458MiB -> 554MiB`) and concrete model reload/chat passed, but `model:"default"` after reload still returned `EnginePoisoned`. A local fixed head `bb8d671ea5001715698ce99d7660e45ae2339c23` restores default routing after reloading the first/only model; both concrete-model and `default` chats passed while VRAM cleanup stayed at `554MiB`. Required follow-up before merge: set `default_engine_id` when reloading the first/only model. Multi-model unload/reload remains not fully proven; a config-loaded multi-model unload control returned `no_loader_config`.

---

## Fix: CUDA VRAM leak on model unload

Binds the CUDA context and trims the memory pool during model unload to release VRAM.

### Before/After result: unload VRAM

| Point in same patched-branch run | Raw `nvidia-smi` memory |
| --- | --- |
| Before unload, after model load + chat request | `20304MiB / 23034MiB` |
| 5 seconds after `/v1/models/unload` | `272MiB / 23034MiB` |

### Runtime Validation (GCP g2-standard-8, L4 GPU)

**Branch head tested**: `fe1de591525f84b8082c01ed3730a444c25f0db7`  
**Hardware**: GCP `g2-standard-8`, 1x NVIDIA L4, driver `580.126.09`  
**Model**: `Qwen/Qwen2.5-0.5B-Instruct-GGUF`, file `qwen2.5-0.5b-instruct-q4_k_m.gguf`

**Build:**
```bash
cargo build --release --features cuda -p mistralrs-server
```
Result: build completed successfully on the L4 VM.

**Server:**
```bash
./target/release/mistralrs-server --port 18084 gguf \
  -m Qwen/Qwen2.5-0.5B-Instruct-GGUF \
  -f qwen2.5-0.5b-instruct-q4_k_m.gguf
```

**Model list before unload:**
```json
{"object":"list","data":[{"id":"default","object":"model","created":1777338086,"owned_by":"local"},{"id":"Qwen/Qwen2.5-0.5B-Instruct-GGUF","object":"model","created":1777338086,"owned_by":"local","status":"loaded"}]}
```

**Chat smoke request:**
```bash
curl -sS -X POST http://127.0.0.1:18084/v1/chat/completions \
  -H "Content-Type: application/json" \
  -d '{"model":"default","messages":[{"role":"user","content":"Hello"}],"max_tokens":8}'
```
Result: request completed successfully with model `Qwen/Qwen2.5-0.5B-Instruct-GGUF`.

**Raw `nvidia-smi` after load/chat, before unload:**
```text
Tue Apr 28 01:01:27 2026
|   0  NVIDIA L4 ... |   20304MiB /  23034MiB |
|    0   N/A  N/A           19207      C   ...rget/release/mistralrs-server      20296MiB |
```

**Unload request:**
```bash
curl -sS -X POST http://127.0.0.1:18084/v1/models/unload \
  -H "Content-Type: application/json" \
  -d '{"model_id":"Qwen/Qwen2.5-0.5B-Instruct-GGUF"}'
```
Response:
```json
{"model_id":"Qwen/Qwen2.5-0.5B-Instruct-GGUF","status":"unloaded"}
```

**Raw `nvidia-smi` 5 seconds after unload:**
```text
Tue Apr 28 01:01:32 2026
|   0  NVIDIA L4 ... |     272MiB /  23034MiB |
|    0   N/A  N/A           19207      C   ...rget/release/mistralrs-server        264MiB |
```

**Model list after unload:**
```json
{"object":"list","data":[{"id":"default","object":"model","created":1777338086,"owned_by":"local"},{"id":"Qwen/Qwen2.5-0.5B-Instruct-GGUF","object":"model","created":1777338086,"owned_by":"local","status":"unloaded"}]}
```

Server log scan for `error|panic|failed`: no matches. Server log included `Model Qwen/Qwen2.5-0.5B-Instruct-GGUF unloaded successfully`.

Note: the correct current unload endpoint is `/v1/models/unload` with the concrete model id from `/v1/models`; `model_id: "default"` returns `not_found`.

### A100 validation (2026-05-01)

Additional validation on GCP Spot `a2-highgpu-1g` in `[redacted-region]` with 1x NVIDIA A100-SXM4-40GB, driver `580.126.20`, branch head `0216528c46a860a80553cc84fe2e0ae30a401a69`.

```bash
cargo build --release --features cuda -p mistralrs-server
./target/release/mistralrs-server --port 18084 gguf \
  -m Qwen/Qwen2.5-0.5B-Instruct-GGUF \
  -f qwen2.5-0.5b-instruct-q4_k_m.gguf
```

Result: build passed; model loaded and completed a chat smoke request. Raw A100 memory before unload was `36458MiB / 40960MiB`. Five seconds after `POST /v1/models/unload` for `Qwen/Qwen2.5-0.5B-Instruct-GGUF`, raw A100 memory was `554MiB / 40960MiB`, with the server process holding about `542MiB`. `/v1/models` reported the model `status":"unloaded"`; server log scan for `error|panic|failed` had no matches.