### PR TITLE
ci: fix Clippy, Rustfmt, and Typos failures for Rust 1.95 stable

### DIFF
--- a/.typos.toml
+++ b/.typos.toml
@@ -5,6 +5,7 @@ extend-exclude = [
     "examples/server/phi3_duckduckgo_mistral.rs.ipynb",
     "mistralrs-web-chat/static/",
     "mistralrs-cli/static/",
+    "mistralrs-quant/kernels/mmq_gguf/",
     "CLAUDE.md",
 ]
 ignore-hidden = false
@@ -12,6 +13,7 @@ ignore-hidden = false
 [default]
 extend-ignore-re = [
     "cudaDevAttrMaxSharedMemoryPerBlockOptin",
+    "CU_DEVICE_ATTRIBUTE_MAX_SHARED_MEMORY_PER_BLOCK_OPTIN",
     '"tese"',
     "setp\\.ne\\.b32",
     # metal_kernels

--- a/mistralrs-cli/src/commands/bench.rs
+++ b/mistralrs-cli/src/commands/bench.rs
@@ -99,7 +99,7 @@ pub async fn run_bench(
     if warmup > 0 {
         info!("Running {} warmup iteration(s)...", warmup);
         for _ in 0..warmup {
-            let _ = run_single_bench(&mistralrs, 32, 16).await?;
+            run_single_bench(&mistralrs, 32, 16).await?;
         }
         info!("Warmup complete.");
 

--- a/mistralrs-core/src/engine/tool_dispatch.rs
+++ b/mistralrs-core/src/engine/tool_dispatch.rs
@@ -102,10 +102,8 @@ pub(super) async fn execute_search(
     );
 
     // Sort by token length (shortest first).
-    let mut combined: Vec<(SearchResult, usize)> = results
-        .into_iter()
-        .zip(result_token_lens.into_iter())
-        .collect();
+    let mut combined: Vec<(SearchResult, usize)> =
+        results.into_iter().zip(result_token_lens).collect();
     combined.sort_by_key(|(_, len)| *len);
     let (results, result_token_lens): (Vec<SearchResult>, Vec<usize>) =
         combined.into_iter().unzip();

--- a/mistralrs-core/src/moe/experts.rs
+++ b/mistralrs-core/src/moe/experts.rs
@@ -95,6 +95,7 @@ struct SlowExpertsWeights {
 pub struct MoEExperts {
     backend: MoEExpertsBackendImpl,
     act: Activation,
+    #[allow(dead_code)]
     num_experts: usize,
     num_experts_per_tok: usize,
     all_reduce: SumAllReduce,

--- a/mistralrs-core/src/scheduler/default_scheduler.rs
+++ b/mistralrs-core/src/scheduler/default_scheduler.rs
@@ -131,8 +131,8 @@ impl<Backer: FcfsBacker> BucketingManager<Backer> for FixedBucketingManager {
         let running = if seq_buckets.len() <= 1 {
             // Full steam ahead or have everything
             seq_buckets
-                .into_iter()
-                .flat_map(|(_, x)| x)
+                .into_values()
+                .flatten()
                 .map(|s| s.reset_urgency())
                 .collect::<Vec<_>>()
         } else {

--- a/mistralrs-core/src/search/rag.rs
+++ b/mistralrs-core/src/search/rag.rs
@@ -139,7 +139,7 @@ impl SearchPipeline {
                 .to_dtype(DType::F32)?
                 .to_device(&Device::Cpu)?
                 .to_vec2::<f32>()?;
-            for ((idx, _), embedding) in chunk_entries.iter().zip(vecs.into_iter()) {
+            for ((idx, _), embedding) in chunk_entries.iter().zip(vecs) {
                 outputs[*idx] = embedding;
             }
         }
@@ -339,7 +339,7 @@ pub fn rank_document_chunks(
 
     let mut scored: Vec<ScoredChunk> = top_indices
         .iter()
-        .zip(top_embeddings.into_iter())
+        .zip(top_embeddings)
         .map(|(&i, embedding)| {
             let (result_index, ref chunk) = bindings[i];
             let score = cosine_similarity(&query_embedding, &embedding);

--- a/mistralrs-core/src/vision_models/gemma4/audio_processing.rs
+++ b/mistralrs-core/src/vision_models/gemma4/audio_processing.rs
@@ -117,7 +117,7 @@ impl AudioProcessor {
         let mut mel_data = Vec::<f32>::with_capacity(batch_size * max_frames * self.feature_size);
         let mut mask_data = Vec::<f32>::with_capacity(batch_size * max_frames);
 
-        for (mel, valid_mask) in mel_batches.into_iter().zip(valid_masks.into_iter()) {
+        for (mel, valid_mask) in mel_batches.into_iter().zip(valid_masks) {
             for (frame, &is_valid) in mel.iter().zip(valid_mask.iter()) {
                 if is_valid {
                     mel_data.extend_from_slice(frame);

--- a/mistralrs-core/src/vision_models/idefics3/inputs_processor.rs
+++ b/mistralrs-core/src/vision_models/idefics3/inputs_processor.rs
@@ -171,8 +171,7 @@ impl InputsProcessor for Idefics3ImageProcessor {
                         .expect("Detokenization failed!");
 
                     let mut image_prompt_strings = Vec::new();
-                    for (n_rows, n_cols) in rows.unwrap().into_iter().zip(cols.unwrap().into_iter())
-                    {
+                    for (n_rows, n_cols) in rows.unwrap().into_iter().zip(cols.unwrap()) {
                         let image_prompt_string =
                             get_image_prompt_string(n_rows, n_cols, self.image_seq_len);
                         image_prompt_strings.push(image_prompt_string);
@@ -569,7 +568,7 @@ impl ImagePreProcessor for Idefics3ImageProcessor {
 
                 let (split_image_array, rows, cols) =
                     split_image(image, max_image_size["longest_edge"] as usize)?;
-                new_images.extend(split_image_array.into_iter());
+                new_images.extend(split_image_array);
                 image_rows.push(rows);
                 image_cols.push(cols);
             }

--- a/mistralrs-core/src/vision_models/llava/llava_inputs_processor.rs
+++ b/mistralrs-core/src/vision_models/llava/llava_inputs_processor.rs
@@ -214,11 +214,10 @@ impl InputsProcessor for LLaVAInputProcessor {
             )
             .expect("Decoding failed");
 
-        for (detokenized, (seq, num_img_tokens)) in detokenized.into_iter().zip(
-            input_seqs
-                .iter_mut()
-                .zip(num_img_tokens.unwrap().into_iter()),
-        ) {
+        for (detokenized, (seq, num_img_tokens)) in detokenized
+            .into_iter()
+            .zip(input_seqs.iter_mut().zip(num_img_tokens.unwrap()))
+        {
             let splits = self
                 .image_tag_splitter
                 .split(&detokenized)

--- a/mistralrs-core/src/vision_models/llava/llava_next_inputs_processor.rs
+++ b/mistralrs-core/src/vision_models/llava/llava_next_inputs_processor.rs
@@ -257,11 +257,10 @@ impl InputsProcessor for LLaVANextInputProcessor {
             )
             .expect("Decode failed");
 
-        for (detokenized, (seq, num_img_tokens)) in detokenized.into_iter().zip(
-            input_seqs
-                .iter_mut()
-                .zip(num_img_tokens.unwrap().into_iter()),
-        ) {
+        for (detokenized, (seq, num_img_tokens)) in detokenized
+            .into_iter()
+            .zip(input_seqs.iter_mut().zip(num_img_tokens.unwrap()))
+        {
             let splits = self
                 .image_tag_splitter
                 .split(&detokenized)

--- a/mistralrs-pyo3/src/util.rs
+++ b/mistralrs-pyo3/src/util.rs
@@ -379,11 +379,7 @@ fn decode_gif_frames(bytes: &[u8]) -> anyhow::Result<VideoInput> {
         .iter()
         .map(|f| {
             let (num, den) = f.delay().numer_denom_ms();
-            if den == 0 {
-                100
-            } else {
-                num * 1000 / den
-            }
+            (num * 1000).checked_div(den).unwrap_or(100)
         })
         .sum();
     let fps = if total_delay_ms > 0 {

--- a/mistralrs-quant/src/distributed/layers.rs
+++ b/mistralrs-quant/src/distributed/layers.rs
@@ -1431,9 +1431,7 @@ impl PackedExperts {
             let mut gs = Vec::new();
             let mut us = Vec::new();
             let mut ds = Vec::new();
-            for ((mut gate_proj, mut up_proj), mut down_proj) in
-                gc.into_iter().zip(uc.into_iter()).zip(dc.into_iter())
-            {
+            for ((mut gate_proj, mut up_proj), mut down_proj) in gc.into_iter().zip(uc).zip(dc) {
                 gate_proj = gate_proj.squeeze(0)?;
                 up_proj = up_proj.squeeze(0)?;
                 down_proj = down_proj.squeeze(0)?;
@@ -2036,9 +2034,7 @@ pub fn compute_n_kv_groups(
     } else {
         1
     };
-    if kv_replicate != 0 {
-        (num_attention_heads / total_num_kv_heads) / kv_replicate
-    } else {
-        num_attention_heads / total_num_kv_heads
-    }
+    (num_attention_heads / total_num_kv_heads)
+        .checked_div(kv_replicate)
+        .unwrap_or(num_attention_heads / total_num_kv_heads)
 }

--- a/mistralrs-server-core/src/openapi_doc.rs
+++ b/mistralrs-server-core/src/openapi_doc.rs
@@ -6,7 +6,7 @@ use crate::{
     chat_completion::__path_chatcompletions,
     completions::__path_completions,
     embeddings::__path_embeddings,
-    handlers::{ReIsqRequest, __path_health, __path_models, __path_re_isq},
+    handlers::{__path_health, __path_models, __path_re_isq, ReIsqRequest},
     image_generation::__path_image_generation,
     openai::{
         AudioResponseFormat, ChatCompletionRequest, CompletionRequest, EmbeddingData,

--- a/mistralrs-server-core/src/video.rs
+++ b/mistralrs-server-core/src/video.rs
@@ -119,11 +119,7 @@ fn decode_gif_frames(bytes: &[u8], num_frames: usize) -> Result<VideoInput> {
         .iter()
         .map(|f| {
             let (num, den) = f.delay().numer_denom_ms();
-            if den == 0 {
-                100
-            } else {
-                num * 1000 / den
-            }
+            (num * 1000).checked_div(den).unwrap_or(100)
         })
         .sum();
     let fps = if total_delay_ms > 0 {


### PR DESCRIPTION
## Summary

Fixes CI failures introduced by #2109 (fast CUDA MMQ GGUF kernels) merged on 2026-04-15, combined with new lints in Rust 1.95 stable.

CI has been red on master since #2109 was merged. Every PR targeting master inherits these failures because CI merges the PR branch into current master.

## Changes

### Typos

- Exclude vendored `mistralrs-quant/kernels/mmq_gguf/` directory
- Add `CU_DEVICE_ATTRIBUTE_MAX_SHARED_MEMORY_PER_BLOCK_OPTIN` to ignore list

### Rustfmt (1.95)

- Fix import ordering in `openapi_doc.rs`
- Reformat lines affected by other lint fixes

### Clippy (1.95)

- `useless_conversion`: remove redundant `.into_iter()` in `zip`/`extend` calls across `tool_dispatch`, `rag`, `llava`, `idefics3`, `gemma4`, `distributed/layers`
- `iter_kv_map`: use `.into_values().flatten()` in `default_scheduler`
- `manual_checked_ops`: use `.checked_div()` in `distributed/layers`, `video.rs`, `pyo3/util.rs`
- `let_unit_value`: remove unit let binding in `bench.rs`
- `dead_code`: allow unused `num_experts` field in `MoEExperts` (set but not yet read)

## Validation Result

**Validation, 2026-05-14:** `ACTUAL`, `FEASIBLE_NOW`.

Environment:

- GPU validation environment
- Rust `1.95.0 (59807616e 2026-04-14)`
- Typos `1.46.1`

Base commit tested: `2d4ba4f16f61e5e18be085d0dd137bc95cba038a`

```bash
cargo fmt --all -- --check
typos --config .typos.toml
cargo clippy --workspace --tests --examples -- -D warnings
```

Base result: all three failed. Rustfmt failed import ordering in `mistralrs-server-core/src/openapi_doc.rs`; typos failed on CUDA MMQ GGUF kernel terms; clippy failed two `useless_conversion` lints and one `manual_checked_ops` lint in `mistralrs-quant/src/distributed/layers.rs`.

PR head tested: `0a11bf2d931d76f7440c9ac24bc874fc69ba0134`

Same commands all passed cleanly:

```bash
cargo fmt --all -- --check
typos --config .typos.toml
cargo clippy --workspace --tests --examples -- -D warnings
```

This is ACTUAL before/after validation for the Rust 1.95 CI/lint failures. GPU behavior is not material for this PR; the A100 machine was only the requested validation host.