### PR TITLE
fix(core): restrict interprocess dependency to desktop targets

### DIFF
--- a/mistralrs-core/Cargo.toml
+++ b/mistralrs-core/Cargo.toml
@@ -83,7 +83,7 @@ toktrie.workspace = true
 candle-flash-attn-v3 = { workspace = true, optional = true }
 safetensors.workspace = true
 serde-big-array.workspace = true
-interprocess.workspace = true
+
 urlencoding.workspace = true
 scraper.workspace = true
 html2text.workspace = true
@@ -106,6 +106,9 @@ rust-mcp-schema.workspace = true
 mistralrs-mcp = { workspace = true, features = ["utoipa"] }
 statrs.workspace = true
 openai-harmony = "0.0.8"
+
+[target.'cfg(any(target_os = "macos", target_os = "linux", target_os = "windows"))'.dependencies]
+interprocess.workspace = true
 
 [target.'cfg(any(target_os = "macos", target_os = "ios", target_os = "tvos"))'.dependencies]
 objc = { workspace = true, optional = true }

--- a/mistralrs-core/src/distributed.rs
+++ b/mistralrs-core/src/distributed.rs
@@ -1,8 +1,11 @@
 use anyhow::Context;
 use candle_core::{DType, Device};
 use core::ffi::c_char;
+#[cfg(any(target_os = "macos", target_os = "linux", target_os = "windows"))]
 use interprocess::local_socket::traits::{Listener, Stream};
+#[cfg(any(target_os = "macos", target_os = "linux", target_os = "windows"))]
 use interprocess::local_socket::{GenericNamespaced, Name, ToNsName};
+#[cfg(any(target_os = "macos", target_os = "linux", target_os = "windows"))]
 use interprocess::local_socket::{ListenerOptions, Stream as LocalStream};
 pub use mistralrs_quant::distributed::{use_nccl, use_ring};
 use mistralrs_quant::{RingConfig, ShardedVarBuilder};
@@ -35,6 +38,7 @@ pub fn is_daemon() -> bool {
     }
 }
 
+#[cfg(any(target_os = "macos", target_os = "linux", target_os = "windows"))]
 pub fn nccl_daemon_replicator(request_sender: Sender<Request>) {
     use std::io::BufRead;
     use std::io::BufReader;
@@ -141,6 +145,11 @@ pub fn nccl_daemon_replicator(request_sender: Sender<Request>) {
     });
 }
 
+#[cfg(not(any(target_os = "macos", target_os = "linux", target_os = "windows")))]
+pub fn nccl_daemon_replicator(_request_sender: Sender<Request>) {
+    // No-op: multi-GPU IPC doesn't exist on mobile/embedded targets.
+}
+
 pub fn ring_daemon_replicator(request_sender: Sender<Request>) {
     use std::io::BufRead;
     use std::io::BufReader;
@@ -215,11 +224,13 @@ pub(crate) enum WorkerTransferData {
     },
 }
 
+#[cfg(any(target_os = "macos", target_os = "linux", target_os = "windows"))]
 pub(crate) fn ipc_name() -> anyhow::Result<Name<'static>> {
     let printname = "mistralrs_daemon.sock";
     Ok(printname.to_ns_name::<GenericNamespaced>()?)
 }
 
+#[cfg(any(target_os = "macos", target_os = "linux", target_os = "windows"))]
 #[allow(clippy::too_many_arguments)]
 pub(crate) fn prepare_distributed_mapper<T: DeviceMappedModelLoader + IsqModelLoader + ?Sized>(
     dtype: DType,
@@ -411,4 +422,21 @@ pub(crate) fn prepare_distributed_mapper<T: DeviceMappedModelLoader + IsqModelLo
     };
 
     Ok((mapper, sharded_vb))
+}
+
+#[cfg(not(any(target_os = "macos", target_os = "linux", target_os = "windows")))]
+#[allow(clippy::too_many_arguments)]
+pub(crate) fn prepare_distributed_mapper<T: DeviceMappedModelLoader + IsqModelLoader + ?Sized>(
+    _dtype: DType,
+    _device: &Device,
+    _available_devices: &[Device],
+    _silent: bool,
+    _config: &str,
+    _loading_isq: bool,
+    _from_uqff: bool,
+    _organization: IsqOrganization,
+    _model: &T,
+    _paths: &dyn ModelPaths,
+) -> anyhow::Result<(Box<dyn DeviceMapper + Send + Sync>, ShardedVarBuilder)> {
+    anyhow::bail!("distributed inference requires desktop (macOS/Linux/Windows)")
 }

--- a/mistralrs-core/src/engine/mod.rs
+++ b/mistralrs-core/src/engine/mod.rs
@@ -13,6 +13,7 @@ use crate::{
     sequence::{SeqStepType, StopReason},
     tools, CompletionResponse, SchedulerConfig, DEBUG,
 };
+#[cfg(any(target_os = "macos", target_os = "linux", target_os = "windows"))]
 use interprocess::local_socket::{traits::Listener, ListenerOptions};
 use llguidance::ParserFactory;
 pub use logger::IntervalLogger;
@@ -845,6 +846,8 @@ impl Engine {
     }
 
     fn replicate_request_to_daemons(&self, request: &Request) {
+        // NCCL: local IPC via interprocess (desktop only)
+        #[cfg(any(target_os = "macos", target_os = "linux", target_os = "windows"))]
         if !distributed::is_daemon() && mistralrs_quant::distributed::use_nccl() {
             let name = distributed::ipc_name().unwrap();
             let num_workers =
@@ -857,7 +860,11 @@ impl Engine {
                 let req = format!("{}\n", serde_json::to_string(&request).unwrap());
                 writer.write_all(req.as_bytes()).unwrap();
             }
-        } else if !distributed::is_daemon() && cfg!(feature = "ring") {
+            return;
+        }
+
+        // Ring: plain TCP, works everywhere
+        if !distributed::is_daemon() && cfg!(feature = "ring") {
             let num_workers =
                 mistralrs_quant::distributed::get_global_tp_size_from_devices().unwrap() - 1;
             let master_port = RingConfig::load().master_port;


### PR DESCRIPTION
I stumbled upon this when building for tvOS.

# Changes
Move interprocess dependency and related code to only build on macOS, Linux, and Windows. Provide no-op stubs for unsupported platforms to avoid build errors on mobile/embedded targets.