### PR TITLE
fix(cuda): support AFQ BF16 on sm_75 (#2092)

### DIFF
--- a/mistralrs-quant/kernels/afq/afq.cu
+++ b/mistralrs-quant/kernels/afq/afq.cu
@@ -147,12 +147,9 @@ __device__ void compute_scale_bias_warp(const T *w, int group_start, int cols,
         val = w[col];
       } else if constexpr (std::is_same_v<T, __half>) {
         val = __half2float(w[col]);
-      }
-#if __CUDA_ARCH__ >= 800
-      else if constexpr (std::is_same_v<T, __nv_bfloat16>) {
+      } else if constexpr (std::is_same_v<T, __nv_bfloat16>) {
         val = __bfloat162float(w[col]);
       }
-#endif
       local_min = fminf(local_min, val);
       local_max = fmaxf(local_max, val);
     }
@@ -212,13 +209,10 @@ afq_quantize_kernel(const T *__restrict__ w, uint32_t *__restrict__ w_q,
     } else if constexpr (std::is_same_v<T, __half>) {
       scales[row * groups_per_row + group_idx] = __float2half(final_scale);
       biases[row * groups_per_row + group_idx] = __float2half(bias);
-    }
-#if __CUDA_ARCH__ >= 800
-    else if constexpr (std::is_same_v<T, __nv_bfloat16>) {
+    } else if constexpr (std::is_same_v<T, __nv_bfloat16>) {
       scales[row * groups_per_row + group_idx] = __float2bfloat16(final_scale);
       biases[row * groups_per_row + group_idx] = __float2bfloat16(bias);
     }
-#endif
   }
 
   // Quantize and pack values
@@ -234,12 +228,9 @@ afq_quantize_kernel(const T *__restrict__ w, uint32_t *__restrict__ w_q,
       val = row_w[col];
     } else if constexpr (std::is_same_v<T, __half>) {
       val = __half2float(row_w[col]);
-    }
-#if __CUDA_ARCH__ >= 800
-    else if constexpr (std::is_same_v<T, __nv_bfloat16>) {
+    } else if constexpr (std::is_same_v<T, __nv_bfloat16>) {
       val = __bfloat162float(row_w[col]);
     }
-#endif
 
     // Quantize
     float q_float = roundf((val - bias) * inv_scale);

--- a/mistralrs-quant/kernels/afq/afq_gemm.cu
+++ b/mistralrs-quant/kernels/afq/afq_gemm.cu
@@ -78,13 +78,10 @@ afq_qmv_kernel(const T *__restrict__ x, const uint32_t *__restrict__ w_q,
     } else if constexpr (std::is_same_v<T, __half>) {
       scale = __half2float(scales_row[group_idx]);
       bias = __half2float(biases_row[group_idx]);
-    }
-#if __CUDA_ARCH__ >= 800
-    else if constexpr (std::is_same_v<T, __nv_bfloat16>) {
+    } else if constexpr (std::is_same_v<T, __nv_bfloat16>) {
       scale = __bfloat162float(scales_row[group_idx]);
       bias = __bfloat162float(biases_row[group_idx]);
     }
-#endif
 
     // Dequantize: w = q * scale + bias
     float w = (float)q * scale + bias;
@@ -95,12 +92,9 @@ afq_qmv_kernel(const T *__restrict__ x, const uint32_t *__restrict__ w_q,
       x_val = x_row[k];
     } else if constexpr (std::is_same_v<T, __half>) {
       x_val = __half2float(x_row[k]);
-    }
-#if __CUDA_ARCH__ >= 800
-    else if constexpr (std::is_same_v<T, __nv_bfloat16>) {
+    } else if constexpr (std::is_same_v<T, __nv_bfloat16>) {
       x_val = __bfloat162float(x_row[k]);
     }
-#endif
 
     acc = fmaf(x_val, w, acc);
   }
@@ -114,12 +108,9 @@ afq_qmv_kernel(const T *__restrict__ x, const uint32_t *__restrict__ w_q,
       y[m * N + n] = acc;
     } else if constexpr (std::is_same_v<T, __half>) {
       y[m * N + n] = __float2half(acc);
-    }
-#if __CUDA_ARCH__ >= 800
-    else if constexpr (std::is_same_v<T, __nv_bfloat16>) {
+    } else if constexpr (std::is_same_v<T, __nv_bfloat16>) {
       y[m * N + n] = __float2bfloat16(acc);
     }
-#endif
   }
 }
 
@@ -160,13 +151,10 @@ afq_qmv_3bit_kernel(const T *__restrict__ x, const uint8_t *__restrict__ w_q,
     } else if constexpr (std::is_same_v<T, __half>) {
       scale = __half2float(scales_row[group_idx]);
       bias = __half2float(biases_row[group_idx]);
-    }
-#if __CUDA_ARCH__ >= 800
-    else if constexpr (std::is_same_v<T, __nv_bfloat16>) {
+    } else if constexpr (std::is_same_v<T, __nv_bfloat16>) {
       scale = __bfloat162float(scales_row[group_idx]);
       bias = __bfloat162float(biases_row[group_idx]);
     }
-#endif
 
     float w = (float)q * scale + bias;
 
@@ -175,12 +163,9 @@ afq_qmv_3bit_kernel(const T *__restrict__ x, const uint8_t *__restrict__ w_q,
       x_val = x_row[k];
     } else if constexpr (std::is_same_v<T, __half>) {
       x_val = __half2float(x_row[k]);
-    }
-#if __CUDA_ARCH__ >= 800
-    else if constexpr (std::is_same_v<T, __nv_bfloat16>) {
+    } else if constexpr (std::is_same_v<T, __nv_bfloat16>) {
       x_val = __bfloat162float(x_row[k]);
     }
-#endif
 
     acc = fmaf(x_val, w, acc);
   }
@@ -192,12 +177,9 @@ afq_qmv_3bit_kernel(const T *__restrict__ x, const uint8_t *__restrict__ w_q,
       y[m * N + n] = acc;
     } else if constexpr (std::is_same_v<T, __half>) {
       y[m * N + n] = __float2half(acc);
-    }
-#if __CUDA_ARCH__ >= 800
-    else if constexpr (std::is_same_v<T, __nv_bfloat16>) {
+    } else if constexpr (std::is_same_v<T, __nv_bfloat16>) {
       y[m * N + n] = __float2bfloat16(acc);
     }
-#endif
   }
 }
 
@@ -238,13 +220,10 @@ afq_qmv_6bit_kernel(const T *__restrict__ x, const uint8_t *__restrict__ w_q,
     } else if constexpr (std::is_same_v<T, __half>) {
       scale = __half2float(scales_row[group_idx]);
       bias = __half2float(biases_row[group_idx]);
-    }
-#if __CUDA_ARCH__ >= 800
-    else if constexpr (std::is_same_v<T, __nv_bfloat16>) {
+    } else if constexpr (std::is_same_v<T, __nv_bfloat16>) {
       scale = __bfloat162float(scales_row[group_idx]);
       bias = __bfloat162float(biases_row[group_idx]);
     }
-#endif
 
     float w = (float)q * scale + bias;
 
@@ -253,12 +232,9 @@ afq_qmv_6bit_kernel(const T *__restrict__ x, const uint8_t *__restrict__ w_q,
       x_val = x_row[k];
     } else if constexpr (std::is_same_v<T, __half>) {
       x_val = __half2float(x_row[k]);
-    }
-#if __CUDA_ARCH__ >= 800
-    else if constexpr (std::is_same_v<T, __nv_bfloat16>) {
+    } else if constexpr (std::is_same_v<T, __nv_bfloat16>) {
       x_val = __bfloat162float(x_row[k]);
     }
-#endif
 
     acc = fmaf(x_val, w, acc);
   }
@@ -270,12 +246,9 @@ afq_qmv_6bit_kernel(const T *__restrict__ x, const uint8_t *__restrict__ w_q,
       y[m * N + n] = acc;
     } else if constexpr (std::is_same_v<T, __half>) {
       y[m * N + n] = __float2half(acc);
-    }
-#if __CUDA_ARCH__ >= 800
-    else if constexpr (std::is_same_v<T, __nv_bfloat16>) {
+    } else if constexpr (std::is_same_v<T, __nv_bfloat16>) {
       y[m * N + n] = __float2bfloat16(acc);
     }
-#endif
   }
 }
 
@@ -319,12 +292,9 @@ afq_qmm_kernel(const T *__restrict__ x, const uint32_t *__restrict__ w_q,
         x_tile[ty][tx] = x[m_idx * K + k_idx];
       } else if constexpr (std::is_same_v<T, __half>) {
         x_tile[ty][tx] = __half2float(x[m_idx * K + k_idx]);
-      }
-#if __CUDA_ARCH__ >= 800
-      else if constexpr (std::is_same_v<T, __nv_bfloat16>) {
+      } else if constexpr (std::is_same_v<T, __nv_bfloat16>) {
         x_tile[ty][tx] = __bfloat162float(x[m_idx * K + k_idx]);
       }
-#endif
     } else {
       x_tile[ty][tx] = 0.0f;
     }
@@ -345,13 +315,10 @@ afq_qmm_kernel(const T *__restrict__ x, const uint32_t *__restrict__ w_q,
       } else if constexpr (std::is_same_v<T, __half>) {
         scale = __half2float(scales[n_idx * groups_per_row + group_idx]);
         bias = __half2float(biases[n_idx * groups_per_row + group_idx]);
-      }
-#if __CUDA_ARCH__ >= 800
-      else if constexpr (std::is_same_v<T, __nv_bfloat16>) {
+      } else if constexpr (std::is_same_v<T, __nv_bfloat16>) {
         scale = __bfloat162float(scales[n_idx * groups_per_row + group_idx]);
         bias = __bfloat162float(biases[n_idx * groups_per_row + group_idx]);
       }
-#endif
 
       w_tile[ty][tx] = (float)q * scale + bias;
     } else {
@@ -377,12 +344,9 @@ afq_qmm_kernel(const T *__restrict__ x, const uint32_t *__restrict__ w_q,
       y[m_out * N + n_out] = acc;
     } else if constexpr (std::is_same_v<T, __half>) {
       y[m_out * N + n_out] = __float2half(acc);
-    }
-#if __CUDA_ARCH__ >= 800
-    else if constexpr (std::is_same_v<T, __nv_bfloat16>) {
+    } else if constexpr (std::is_same_v<T, __nv_bfloat16>) {
       y[m_out * N + n_out] = __float2bfloat16(acc);
     }
-#endif
   }
 }
 

--- a/mistralrs-quant/kernels/afq/afq_utils.cuh
+++ b/mistralrs-quant/kernels/afq/afq_utils.cuh
@@ -94,14 +94,18 @@ __device__ __forceinline__ __half dequant_value<__half>(uint32_t q, __half scale
   return __hfma(__uint2half_rn(q), scale, bias);
 }
 
-#if __CUDA_ARCH__ >= 800
 template <>
 __device__ __forceinline__ __nv_bfloat16
 dequant_value<__nv_bfloat16>(uint32_t q, __nv_bfloat16 scale,
-                              __nv_bfloat16 bias) {
+                             __nv_bfloat16 bias) {
+#if __CUDA_ARCH__ >= 800
   return __hfma(__uint2bfloat16_rn(q), scale, bias);
-}
+#else
+  float out =
+      fmaf((float)q, __bfloat162float(scale), __bfloat162float(bias));
+  return __float2bfloat16(out);
 #endif
+}
 
 // ============================================================================
 // Quantization helpers (round((w - bias) / scale))
@@ -201,8 +205,6 @@ __device__ __forceinline__ uint32_t quant_value<__half, 8>(__half w,
   return min(max((int)q, 0), 255);
 }
 
-#if __CUDA_ARCH__ >= 800
-// BFloat16 versions
 template <>
 __device__ __forceinline__ uint32_t
 quant_value<__nv_bfloat16, 2>(__nv_bfloat16 w, __nv_bfloat16 scale,
@@ -257,13 +259,11 @@ quant_value<__nv_bfloat16, 8>(__nv_bfloat16 w, __nv_bfloat16 scale,
   float q = roundf((wf - bf) / sf);
   return min(max((int)q, 0), 255);
 }
-#endif
 
 // ============================================================================
 // Warp-level primitives
 // ============================================================================
 
-// Warp reduce sum
 __device__ __forceinline__ float warp_reduce_sum(float val) {
 #pragma unroll
   for (int offset = AFQ_WARP_SIZE / 2; offset > 0; offset /= 2) {


### PR DESCRIPTION
Fixes [#2092](https://github.com/EricLBuehler/mistral.rs/issues/2092)

This fixes AFQ BF16 CUDA support on sm_75 by keeping the native BF16 dequant path for sm_80+ and using a float fallback below that. It also ungates BF16 branches that already use float conversions and are not architecture-specific.

Tested:
- CUDA build with `CUDA_COMPUTE_CAP=75`
- CUDA build with `CUDA_COMPUTE_CAP=80`
- Runtime AFQ test on sm_75