### PR TITLE
Bump candle to use new Metal input/output encoder tracking

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -624,8 +624,7 @@ checksum = "ade8366b8bd5ba243f0a58f036cc0ca8a2f069cff1a2351ef1cac6b083e16fc0"
 [[package]]
 name = "candle-core"
 version = "0.10.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6bd9895436c1ba5dc1037a19935d084b838db066ff4e15ef7dded020b7c12a4a"
+source = "git+https://github.com/huggingface/candle.git?rev=d3510d5#d3510d5e2658e807bdfb057a20068a422c4d8014"
 dependencies = [
  "accelerate-src",
  "byteorder",
@@ -657,8 +656,7 @@ dependencies = [
 [[package]]
 name = "candle-flash-attn"
 version = "0.10.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12512cf8e706744642e9a8579305a6ed1e44a0c636ce20c416cd5c519de19b7d"
+source = "git+https://github.com/huggingface/candle.git?rev=d3510d5#d3510d5e2658e807bdfb057a20068a422c4d8014"
 dependencies = [
  "anyhow",
  "candle-core",
@@ -669,8 +667,7 @@ dependencies = [
 [[package]]
 name = "candle-flash-attn-v3"
 version = "0.10.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8da1101859e200bd6cbd8fe58e9ff45882257a136697fa2fe086684577f5926"
+source = "git+https://github.com/huggingface/candle.git?rev=d3510d5#d3510d5e2658e807bdfb057a20068a422c4d8014"
 dependencies = [
  "anyhow",
  "candle-core",
@@ -683,8 +680,7 @@ dependencies = [
 [[package]]
 name = "candle-kernels"
 version = "0.10.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "742e2ac226b777134436e9e692f44e77c278b8a7abb1554dc10e44dc911b349f"
+source = "git+https://github.com/huggingface/candle.git?rev=d3510d5#d3510d5e2658e807bdfb057a20068a422c4d8014"
 dependencies = [
  "cudaforge",
 ]
@@ -692,9 +688,9 @@ dependencies = [
 [[package]]
 name = "candle-metal-kernels"
 version = "0.10.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b6b5a4cae6b4e1ab0efcee4dc05272d11b374a3d1ba121b3a961e36be54ab60"
+source = "git+https://github.com/huggingface/candle.git?rev=d3510d5#d3510d5e2658e807bdfb057a20068a422c4d8014"
 dependencies = [
+ "block2",
  "half",
  "objc2",
  "objc2-foundation",
@@ -707,8 +703,7 @@ dependencies = [
 [[package]]
 name = "candle-nn"
 version = "0.10.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9317a09d6530b758990ed7f625ac69ff43653bc9ee28b0464644ad1169ada87"
+source = "git+https://github.com/huggingface/candle.git?rev=d3510d5#d3510d5e2658e807bdfb057a20068a422c4d8014"
 dependencies = [
  "accelerate-src",
  "candle-core",
@@ -727,8 +722,7 @@ dependencies = [
 [[package]]
 name = "candle-ug"
 version = "0.10.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca0fc3167cbc99c8ec1be618cb620aa21dca95038f118c3579a79370e3dc5f77"
+source = "git+https://github.com/huggingface/candle.git?rev=d3510d5#d3510d5e2658e807bdfb057a20068a422c4d8014"
 dependencies = [
  "ug",
  "ug-cuda",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,16 +30,16 @@ license = "MIT"
 rust-version = "1.88"
 
 [workspace.dependencies]
-candle-core = { version = "0.10.2" }
-candle-nn = { version = "0.10.2" }
-candle-flash-attn-v3 = { version = "0.10.2" }
-candle-flash-attn = { version = "0.10.2" }
-candle-metal-kernels = { version = "0.10.2" }
-# candle-core = { git = "https://github.com/huggingface/candle.git", version = "0.10.2", rev = "1f67d14" }
-# candle-nn = { git = "https://github.com/huggingface/candle.git", version = "0.10.2", rev = "1f67d14" }
-# candle-flash-attn-v3 = { git = "https://github.com/huggingface/candle.git", version = "0.10.2", rev = "1f67d14" }
-# candle-flash-attn = { git = "https://github.com/huggingface/candle.git", version = "0.10.2", rev = "1f67d14" }
-# candle-metal-kernels = { git = "https://github.com/huggingface/candle.git", version = "0.10.2", rev = "1f67d14" }
+# candle-core = { version = "0.10.2" }
+# candle-nn = { version = "0.10.2" }
+# candle-flash-attn-v3 = { version = "0.10.2" }
+# candle-flash-attn = { version = "0.10.2" }
+# candle-metal-kernels = { version = "0.10.2" }
+candle-core = { git = "https://github.com/huggingface/candle.git", version = "0.10.2", rev = "d3510d5" }
+candle-nn = { git = "https://github.com/huggingface/candle.git", version = "0.10.2", rev = "d3510d5" }
+candle-flash-attn-v3 = { git = "https://github.com/huggingface/candle.git", version = "0.10.2", rev = "d3510d5" }
+candle-flash-attn = { git = "https://github.com/huggingface/candle.git", version = "0.10.2", rev = "d3510d5" }
+candle-metal-kernels = { git = "https://github.com/huggingface/candle.git", version = "0.10.2", rev = "d3510d5" }
 # candle-core = { path = "../candle/candle-core" }
 # candle-nn = { path = "../candle/candle-nn" }
 # candle-flash-attn-v3 = { path = "../candle/candle-flash-attn-v3" }

--- a/mistralrs-core/src/metal/gdn.rs
+++ b/mistralrs-core/src/metal/gdn.rs
@@ -151,13 +151,13 @@ pub fn gated_delta_rule_recurrence_metal(
     let encoder: &ComputeCommandEncoder = encoder.as_ref();
     encoder.set_compute_pipeline_state(&pipeline);
 
-    encoder.set_buffer(0, Some(&q_buf), q_off);
-    encoder.set_buffer(1, Some(&k_buf), k_off);
-    encoder.set_buffer(2, Some(&v_buf), v_off);
-    encoder.set_buffer(3, Some(&g_buf), g_off);
-    encoder.set_buffer(4, Some(&beta_buf), beta_off);
-    encoder.set_buffer(5, Some(&state_buf), state_off);
-    encoder.set_buffer(6, Some(&out_buf), out_off);
+    encoder.set_input_buffer(0, Some(&q_buf), q_off);
+    encoder.set_input_buffer(1, Some(&k_buf), k_off);
+    encoder.set_input_buffer(2, Some(&v_buf), v_off);
+    encoder.set_input_buffer(3, Some(&g_buf), g_off);
+    encoder.set_input_buffer(4, Some(&beta_buf), beta_off);
+    encoder.set_output_buffer(5, Some(&state_buf), state_off);
+    encoder.set_output_buffer(6, Some(&out_buf), out_off);
 
     let seq_len_i32 = seq_len as i32;
     let v_dim_i32 = v_dim as i32;
@@ -265,13 +265,13 @@ pub fn chunked_gated_delta_rule_recurrence_metal(
     let encoder: &ComputeCommandEncoder = encoder.as_ref();
     encoder.set_compute_pipeline_state(&pipeline);
 
-    encoder.set_buffer(0, Some(&q_buf), q_off);
-    encoder.set_buffer(1, Some(&k_buf), k_off);
-    encoder.set_buffer(2, Some(&v_buf), v_off);
-    encoder.set_buffer(3, Some(&g_buf), g_off);
-    encoder.set_buffer(4, Some(&beta_buf), beta_off);
-    encoder.set_buffer(5, Some(&state_buf), state_off);
-    encoder.set_buffer(6, Some(&out_buf), out_off);
+    encoder.set_input_buffer(0, Some(&q_buf), q_off);
+    encoder.set_input_buffer(1, Some(&k_buf), k_off);
+    encoder.set_input_buffer(2, Some(&v_buf), v_off);
+    encoder.set_input_buffer(3, Some(&g_buf), g_off);
+    encoder.set_input_buffer(4, Some(&beta_buf), beta_off);
+    encoder.set_output_buffer(5, Some(&state_buf), state_off);
+    encoder.set_output_buffer(6, Some(&out_buf), out_off);
 
     let seq_len_i32 = seq_len as i32;
     let v_dim_i32 = v_dim as i32;
@@ -361,10 +361,10 @@ pub fn causal_conv1d_metal(
         let encoder: &ComputeCommandEncoder = encoder.as_ref();
         encoder.set_compute_pipeline_state(&pipeline);
 
-        encoder.set_buffer(0, Some(&x_buf), x_off);
-        encoder.set_buffer(1, Some(&w_buf), w_off);
-        encoder.set_buffer(2, Some(&cs_buf), cs_off);
-        encoder.set_buffer(3, Some(&out_buf), out_off);
+        encoder.set_input_buffer(0, Some(&x_buf), x_off);
+        encoder.set_input_buffer(1, Some(&w_buf), w_off);
+        encoder.set_output_buffer(2, Some(&cs_buf), cs_off);
+        encoder.set_output_buffer(3, Some(&out_buf), out_off);
 
         let bs = batch_size as i32;
         let cd = conv_dim as i32;
@@ -406,9 +406,9 @@ pub fn causal_conv1d_metal(
             let encoder: &ComputeCommandEncoder = encoder.as_ref();
             encoder.set_compute_pipeline_state(&conv_pipeline);
 
-            encoder.set_buffer(0, Some(&x_buf), x_off);
-            encoder.set_buffer(1, Some(&w_buf), w_off);
-            encoder.set_buffer(2, Some(&out_buf), out_off);
+            encoder.set_input_buffer(0, Some(&x_buf), x_off);
+            encoder.set_input_buffer(1, Some(&w_buf), w_off);
+            encoder.set_output_buffer(2, Some(&out_buf), out_off);
 
             let bs = batch_size as i32;
             let cd = conv_dim as i32;
@@ -444,8 +444,8 @@ pub fn causal_conv1d_metal(
             let encoder: &ComputeCommandEncoder = encoder.as_ref();
             encoder.set_compute_pipeline_state(&save_pipeline);
 
-            encoder.set_buffer(0, Some(&x_buf), x_off);
-            encoder.set_buffer(1, Some(&cs_buf), cs_off);
+            encoder.set_input_buffer(0, Some(&x_buf), x_off);
+            encoder.set_output_buffer(1, Some(&cs_buf), cs_off);
 
             let bs = batch_size as i32;
             let cd = conv_dim as i32;
@@ -539,12 +539,12 @@ pub fn fused_gdn_gating_metal(
     let encoder: &ComputeCommandEncoder = encoder.as_ref();
     encoder.set_compute_pipeline_state(&pipeline);
 
-    encoder.set_buffer(0, Some(&b_buf), b_off);
-    encoder.set_buffer(1, Some(&a_buf), a_off);
-    encoder.set_buffer(2, Some(&alog_buf), alog_off);
-    encoder.set_buffer(3, Some(&dtb_buf), dtb_off);
-    encoder.set_buffer(4, Some(&beta_buf), beta_off);
-    encoder.set_buffer(5, Some(&g_buf), g_off);
+    encoder.set_input_buffer(0, Some(&b_buf), b_off);
+    encoder.set_input_buffer(1, Some(&a_buf), a_off);
+    encoder.set_input_buffer(2, Some(&alog_buf), alog_off);
+    encoder.set_input_buffer(3, Some(&dtb_buf), dtb_off);
+    encoder.set_output_buffer(4, Some(&beta_buf), beta_off);
+    encoder.set_output_buffer(5, Some(&g_buf), g_off);
 
     let total = total_elements as i32;
     let heads = num_heads as i32;

--- a/mistralrs-core/src/metal/ssm.rs
+++ b/mistralrs-core/src/metal/ssm.rs
@@ -173,15 +173,15 @@ pub fn selective_scan_metal(
     let encoder: &ComputeCommandEncoder = encoder.as_ref();
     encoder.set_compute_pipeline_state(&pipeline);
 
-    encoder.set_buffer(0, Some(&x_buf), x_off);
-    encoder.set_buffer(1, Some(&dt_buf), dt_off);
-    encoder.set_buffer(2, Some(&a_buf), a_off);
-    encoder.set_buffer(3, Some(&b_buf), b_off);
-    encoder.set_buffer(4, Some(&c_buf), c_off);
-    encoder.set_buffer(5, Some(&d_buf), d_off);
-    encoder.set_buffer(6, Some(&dtb_buf), dtb_off);
-    encoder.set_buffer(7, Some(&st_buf), st_off);
-    encoder.set_buffer(8, Some(&y_buf), y_off);
+    encoder.set_input_buffer(0, Some(&x_buf), x_off);
+    encoder.set_input_buffer(1, Some(&dt_buf), dt_off);
+    encoder.set_input_buffer(2, Some(&a_buf), a_off);
+    encoder.set_input_buffer(3, Some(&b_buf), b_off);
+    encoder.set_input_buffer(4, Some(&c_buf), c_off);
+    encoder.set_input_buffer(5, Some(&d_buf), d_off);
+    encoder.set_input_buffer(6, Some(&dtb_buf), dtb_off);
+    encoder.set_output_buffer(7, Some(&st_buf), st_off);
+    encoder.set_output_buffer(8, Some(&y_buf), y_off);
 
     let n_heads_i32 = n_heads as i32;
     let head_dim_i32 = head_dim as i32;

--- a/mistralrs-paged-attn/src/metal/backend/cache.rs
+++ b/mistralrs-paged-attn/src/metal/backend/cache.rs
@@ -146,7 +146,7 @@ pub unsafe fn swap_blocks(
                 let dst_offset = dst_block_number * block_size_in_bytes
                     + dst_layout.start_offset() * dst_storage.dtype().size_in_bytes();
 
-                let blit = src_dev.blit_command_encoder()?;
+                let mut blit = src_dev.blit_command_encoder()?;
                 blit.set_label("swap-blocks-gpu-gpu");
                 let length = src_layout.shape().elem_count() * src_storage.dtype().size_in_bytes();
                 blit.copy_from_buffer(
@@ -156,7 +156,6 @@ pub unsafe fn swap_blocks(
                     dst_offset,
                     length,
                 );
-                blit.end_encoding();
             }
         }
         (Device::Cpu, Device::Metal(dev)) => {
@@ -190,7 +189,7 @@ pub unsafe fn swap_blocks(
                         &src_slice[src_offset..src_offset + block_size_in_bytes],
                     )?;
 
-                    let blit = dev.blit_command_encoder()?;
+                    let mut blit = dev.blit_command_encoder()?;
                     blit.set_label("swap-blocks-cpu-gpu");
                     let length = src_layout.shape().elem_count() * SRCT::DTYPE.size_in_bytes();
                     blit.copy_from_buffer(
@@ -200,7 +199,6 @@ pub unsafe fn swap_blocks(
                         dst_offset,
                         length,
                     );
-                    blit.end_encoding();
                 }
                 Ok(())
             }

--- a/mistralrs-paged-attn/src/metal/kernels/mod.rs
+++ b/mistralrs-paged-attn/src/metal/kernels/mod.rs
@@ -10,8 +10,6 @@ use std::{collections::HashMap, ffi::c_void};
 pub mod utils;
 use utils::{EncoderProvider, RawBytesEncoder};
 
-use crate::set_params;
-
 // Backward-compatible aliases to ease migration from the `metal` crate API.
 type ComputeCommandEncoderRef = ComputeCommandEncoder;
 type ComputePipelineState = ComputePipeline;
@@ -370,16 +368,12 @@ pub fn call_copy_blocks(
         numel_per_block_key, numel_per_block_value,
         "key and value blocks must be the same size"
     );
-    set_params!(
-        encoder,
-        (
-            (key_cache, key_cache_offset),
-            (value_cache, value_cache_offset),
-            (block_mapping, block_mapping_offset),
-            numel_per_block_key,
-            numel_per_block_value
-        )
-    );
+    // key_cache and value_cache are read+written by copy_blocks; mark as outputs.
+    encoder.set_output_buffer(0, Some(key_cache), key_cache_offset);
+    encoder.set_output_buffer(1, Some(value_cache), value_cache_offset);
+    encoder.set_input_buffer(2, Some(block_mapping), block_mapping_offset);
+    encoder.set_bytes(3, &numel_per_block_key);
+    encoder.set_bytes(4, &numel_per_block_value);
 
     let thread_groups_count = MTLSize {
         width: num_pairs as usize,
@@ -456,14 +450,14 @@ pub fn call_reshape_and_cache(
     let encoder: &ComputeCommandEncoderRef = encoder.as_ref();
     encoder.set_compute_pipeline_state(&pipeline);
 
-    encoder.set_buffer(0, Some(key), key_offset);
-    encoder.set_buffer(1, Some(value), value_offset);
-    encoder.set_buffer(2, Some(key_cache), key_cache_offset);
-    encoder.set_buffer(3, Some(value_cache), value_cache_offset);
-    encoder.set_buffer(4, Some(slot_mapping), slot_mapping_offset);
+    encoder.set_input_buffer(0, Some(key), key_offset);
+    encoder.set_input_buffer(1, Some(value), value_offset);
+    encoder.set_output_buffer(2, Some(key_cache), key_cache_offset);
+    encoder.set_output_buffer(3, Some(value_cache), value_cache_offset);
+    encoder.set_input_buffer(4, Some(slot_mapping), slot_mapping_offset);
     if let Some((k_scale, v_scale)) = k_v_scale {
-        encoder.set_buffer(5, Some(&k_scale), 0_usize);
-        encoder.set_buffer(6, Some(&v_scale), 0_usize);
+        encoder.set_input_buffer(5, Some(&k_scale), 0_usize);
+        encoder.set_input_buffer(6, Some(&v_scale), 0_usize);
     }
     encoder.set_bytes_raw(
         7,
@@ -575,13 +569,13 @@ pub fn call_paged_attention_v1(
     let shared_mem_size = logits_size.max(outputs_size);
     encoder.set_threadgroup_memory_length(0, shared_mem_size as usize);
 
-    encoder.set_buffer(2, Some(output), 0_usize);
-    encoder.set_buffer(3, Some(q), q_offset);
-    encoder.set_buffer(4, Some(k_cache), k_cache_offset);
-    encoder.set_buffer(5, Some(v_cache), v_cache_offset);
+    encoder.set_output_buffer(2, Some(output), 0_usize);
+    encoder.set_input_buffer(3, Some(q), q_offset);
+    encoder.set_input_buffer(4, Some(k_cache), k_cache_offset);
+    encoder.set_input_buffer(5, Some(v_cache), v_cache_offset);
     if let Some((k_scale, v_scale)) = &k_v_scale {
-        encoder.set_buffer(6, Some(k_scale), 0_usize);
-        encoder.set_buffer(7, Some(v_scale), 0_usize);
+        encoder.set_input_buffer(6, Some(k_scale), 0_usize);
+        encoder.set_input_buffer(7, Some(v_scale), 0_usize);
     }
     encoder.set_bytes_raw(
         8,
@@ -598,15 +592,15 @@ pub fn call_paged_attention_v1(
         core::mem::size_of_val(&softcapping),
         &softcapping as *const _ as *const c_void,
     );
-    encoder.set_buffer(11, Some(block_tables), block_tables_offset);
-    encoder.set_buffer(12, Some(context_lens), context_lens_offset);
+    encoder.set_input_buffer(11, Some(block_tables), block_tables_offset);
+    encoder.set_input_buffer(12, Some(context_lens), context_lens_offset);
     encoder.set_bytes_raw(
         13,
         core::mem::size_of_val(&max_num_blocks_per_seq),
         &max_num_blocks_per_seq as *const _ as *const c_void,
     );
     if let Some((alibi, alibi_offset)) = alibi_storage_and_offset {
-        encoder.set_buffer(14, Some(alibi.buffer()), alibi_offset);
+        encoder.set_input_buffer(14, Some(alibi.buffer()), alibi_offset);
     }
     encoder.set_bytes_raw(
         15,
@@ -624,7 +618,7 @@ pub fn call_paged_attention_v1(
         &kv_head_stride as *const _ as *const c_void,
     );
     if let Some((sinks_buf, sinks_offset)) = sinks {
-        encoder.set_buffer(18, Some(sinks_buf), sinks_offset);
+        encoder.set_input_buffer(18, Some(sinks_buf), sinks_offset);
     }
 
     let thread_groups_count = MTLSize {
@@ -716,15 +710,15 @@ pub fn call_paged_attention_v2(
         let shared_mem_size = logits_size.max(outputs_size);
         encoder.set_threadgroup_memory_length(0, shared_mem_size as usize);
 
-        encoder.set_buffer(0, Some(exp_sums), 0_usize);
-        encoder.set_buffer(1, Some(max_logits), 0_usize);
-        encoder.set_buffer(2, Some(tmp_out), 0_usize);
-        encoder.set_buffer(3, Some(q), q_offset);
-        encoder.set_buffer(4, Some(k_cache), k_cache_offset);
-        encoder.set_buffer(5, Some(v_cache), v_cache_offset);
+        encoder.set_output_buffer(0, Some(exp_sums), 0_usize);
+        encoder.set_output_buffer(1, Some(max_logits), 0_usize);
+        encoder.set_output_buffer(2, Some(tmp_out), 0_usize);
+        encoder.set_input_buffer(3, Some(q), q_offset);
+        encoder.set_input_buffer(4, Some(k_cache), k_cache_offset);
+        encoder.set_input_buffer(5, Some(v_cache), v_cache_offset);
         if let Some((k_scale, v_scale)) = &k_v_scale {
-            encoder.set_buffer(6, Some(k_scale), 0_usize);
-            encoder.set_buffer(7, Some(v_scale), 0_usize);
+            encoder.set_input_buffer(6, Some(k_scale), 0_usize);
+            encoder.set_input_buffer(7, Some(v_scale), 0_usize);
         }
         encoder.set_bytes_raw(
             8,
@@ -741,15 +735,15 @@ pub fn call_paged_attention_v2(
             core::mem::size_of_val(&softcapping),
             &softcapping as *const _ as *const c_void,
         );
-        encoder.set_buffer(11, Some(block_tables), block_tables_offset);
-        encoder.set_buffer(12, Some(context_lens), context_lens_offset);
+        encoder.set_input_buffer(11, Some(block_tables), block_tables_offset);
+        encoder.set_input_buffer(12, Some(context_lens), context_lens_offset);
         encoder.set_bytes_raw(
             13,
             core::mem::size_of_val(&max_num_blocks_per_seq),
             &max_num_blocks_per_seq as *const _ as *const c_void,
         );
         if let Some((alibi, alibi_offset)) = alibi_storage_and_offset {
-            encoder.set_buffer(14, Some(alibi.buffer()), alibi_offset);
+            encoder.set_input_buffer(14, Some(alibi.buffer()), alibi_offset);
         }
         encoder.set_bytes_raw(
             15,
@@ -767,7 +761,7 @@ pub fn call_paged_attention_v2(
             &kv_head_stride as *const _ as *const c_void,
         );
         if let Some((sinks_buf, sinks_offset)) = sinks {
-            encoder.set_buffer(18, Some(sinks_buf), sinks_offset);
+            encoder.set_input_buffer(18, Some(sinks_buf), sinks_offset);
         }
 
         let thread_groups_count = MTLSize {
@@ -817,18 +811,18 @@ pub fn call_paged_attention_v2(
         let reduce_shared_mem_size = 2 * max_num_partitions * std::mem::size_of::<f32>() as i32;
         encoder.set_threadgroup_memory_length(0, reduce_shared_mem_size as usize);
 
-        encoder.set_buffer(0, Some(output), 0_usize);
-        encoder.set_buffer(1, Some(exp_sums), 0_usize);
-        encoder.set_buffer(2, Some(max_logits), 0_usize);
-        encoder.set_buffer(3, Some(tmp_out), 0_usize);
-        encoder.set_buffer(4, Some(context_lens), context_lens_offset);
+        encoder.set_output_buffer(0, Some(output), 0_usize);
+        encoder.set_input_buffer(1, Some(exp_sums), 0_usize);
+        encoder.set_input_buffer(2, Some(max_logits), 0_usize);
+        encoder.set_input_buffer(3, Some(tmp_out), 0_usize);
+        encoder.set_input_buffer(4, Some(context_lens), context_lens_offset);
         encoder.set_bytes_raw(
             5,
             core::mem::size_of_val(&max_num_partitions),
             &max_num_partitions as *const _ as *const c_void,
         );
         if let Some((sinks_buf, sinks_offset)) = sinks {
-            encoder.set_buffer(6, Some(sinks_buf), sinks_offset);
+            encoder.set_input_buffer(6, Some(sinks_buf), sinks_offset);
         }
 
         let thread_groups_count = MTLSize {
@@ -890,16 +884,16 @@ pub fn call_gather_kv_cache(
     let encoder: &ComputeCommandEncoderRef = encoder.as_ref();
     encoder.set_compute_pipeline_state(&pipeline);
 
-    encoder.set_buffer(0, Some(key_cache), key_cache_offset);
-    encoder.set_buffer(1, Some(value_cache), value_cache_offset);
-    encoder.set_buffer(2, Some(k_out), k_out_offset);
-    encoder.set_buffer(3, Some(v_out), v_out_offset);
+    encoder.set_input_buffer(0, Some(key_cache), key_cache_offset);
+    encoder.set_input_buffer(1, Some(value_cache), value_cache_offset);
+    encoder.set_output_buffer(2, Some(k_out), k_out_offset);
+    encoder.set_output_buffer(3, Some(v_out), v_out_offset);
     if let Some((k_scale, v_scale)) = k_v_scale {
-        encoder.set_buffer(4, Some(k_scale), 0_usize);
-        encoder.set_buffer(5, Some(v_scale), 0_usize);
+        encoder.set_input_buffer(4, Some(k_scale), 0_usize);
+        encoder.set_input_buffer(5, Some(v_scale), 0_usize);
     }
-    encoder.set_buffer(6, Some(block_table), block_table_offset);
-    encoder.set_buffer(7, Some(cu_seq_lens), cu_seq_lens_offset);
+    encoder.set_input_buffer(6, Some(block_table), block_table_offset);
+    encoder.set_input_buffer(7, Some(cu_seq_lens), cu_seq_lens_offset);
     encoder.set_bytes_raw(
         8,
         core::mem::size_of_val(&num_tokens),
@@ -981,10 +975,10 @@ pub fn call_kv_scale_update(
     let encoder: &ComputeCommandEncoderRef = encoder.as_ref();
     encoder.set_compute_pipeline_state(&pipeline);
 
-    encoder.set_buffer(0, Some(k), k_offset);
-    encoder.set_buffer(1, Some(v), v_offset);
-    encoder.set_buffer(2, Some(k_scale), 0);
-    encoder.set_buffer(3, Some(v_scale), 0);
+    encoder.set_input_buffer(0, Some(k), k_offset);
+    encoder.set_input_buffer(1, Some(v), v_offset);
+    encoder.set_output_buffer(2, Some(k_scale), 0);
+    encoder.set_output_buffer(3, Some(v_scale), 0);
     encoder.set_bytes_raw(
         4,
         core::mem::size_of_val(&num_elements),

--- a/mistralrs-paged-attn/src/metal/kernels/utils.rs
+++ b/mistralrs-paged-attn/src/metal/kernels/utils.rs
@@ -1,4 +1,4 @@
-use candle_metal_kernels::metal::{Buffer, CommandBuffer, ComputeCommandEncoder};
+use candle_metal_kernels::metal::{CommandBuffer, CommandsGuard, ComputeCommandEncoder};
 use std::ffi::c_void;
 
 pub trait RawBytesEncoder {
@@ -9,85 +9,6 @@ impl RawBytesEncoder for ComputeCommandEncoder {
     fn set_bytes_raw(&self, index: usize, length: usize, bytes: *const c_void) {
         self.set_bytes_directly(index, length, bytes);
     }
-}
-
-pub fn set_param<P: EncoderParam>(encoder: &ComputeCommandEncoder, position: usize, data: P) {
-    <P as EncoderParam>::set_param(encoder, position, data)
-}
-
-/// Helper functions to create the various objects on the compute command encoder
-/// on a single line.
-/// Prevents getting wrong some arguments number and mixing length and size in bytes.
-pub trait EncoderParam {
-    fn set_param(encoder: &ComputeCommandEncoder, position: usize, data: Self);
-}
-macro_rules! primitive {
-    ($type:ty) => {
-        impl EncoderParam for $type {
-            fn set_param(encoder: &ComputeCommandEncoder, position: usize, data: Self) {
-                encoder.set_bytes(position, &data);
-            }
-        }
-    };
-}
-primitive!(bool);
-primitive!(usize);
-primitive!(i32);
-primitive!(i64);
-primitive!(u32);
-primitive!(u64);
-primitive!(f32);
-
-pub struct BufferOffset<'a> {
-    pub buffer: &'a Buffer,
-    pub offset_in_bytes: usize,
-}
-
-impl<T> EncoderParam for &[T] {
-    fn set_param(encoder: &ComputeCommandEncoder, position: usize, data: Self) {
-        encoder.set_bytes_directly(position, core::mem::size_of_val(data), data.as_ptr().cast());
-    }
-}
-
-impl EncoderParam for &Buffer {
-    fn set_param(encoder: &ComputeCommandEncoder, position: usize, data: Self) {
-        encoder.set_buffer(position, Some(data), 0);
-    }
-}
-
-impl EncoderParam for (&Buffer, usize) {
-    fn set_param(encoder: &ComputeCommandEncoder, position: usize, data: Self) {
-        encoder.set_buffer(position, Some(data.0), data.1);
-    }
-}
-
-impl EncoderParam for &BufferOffset<'_> {
-    fn set_param(encoder: &ComputeCommandEncoder, position: usize, data: Self) {
-        encoder.set_buffer(position, Some(data.buffer), data.offset_in_bytes);
-    }
-}
-
-impl EncoderParam for &mut Buffer {
-    fn set_param(encoder: &ComputeCommandEncoder, position: usize, data: Self) {
-        encoder.set_buffer(position, Some(data), 0);
-    }
-}
-
-impl EncoderParam for (&mut Buffer, usize) {
-    fn set_param(encoder: &ComputeCommandEncoder, position: usize, data: Self) {
-        encoder.set_buffer(position, Some(data.0), data.1);
-    }
-}
-
-#[macro_export]
-macro_rules! set_params {
-    ($encoder:ident, ($($param:expr),+)) => (
-        let mut _index = 0;
-        $(
-            $crate::metal::kernels::utils::set_param($encoder, _index, $param);
-            _index += 1;
-        )*
-    );
 }
 
 pub trait EncoderProvider {
@@ -122,7 +43,7 @@ impl EncoderProvider for &CommandBuffer {
     where
         Self: 'a;
     fn encoder(&self) -> Self::Encoder<'_> {
-        self.compute_command_encoder()
+        self.compute_command_encoder_no_fence()
     }
 }
 
@@ -136,5 +57,15 @@ impl EncoderProvider for &ComputeCommandEncoder {
             inner: self,
             end_encoding_on_drop: false,
         }
+    }
+}
+
+impl EncoderProvider for &CommandsGuard<'_> {
+    type Encoder<'a>
+        = &'a CommandsGuard<'a>
+    where
+        Self: 'a;
+    fn encoder(&self) -> Self::Encoder<'_> {
+        self
     }
 }

--- a/mistralrs-quant/src/metal_kernels/mod.rs
+++ b/mistralrs-quant/src/metal_kernels/mod.rs
@@ -15,7 +15,7 @@ use std::{collections::HashMap, sync::OnceLock};
 pub mod utils;
 use utils::{
     get_2d_grid_dims, get_2d_grid_dims_divisor, get_block_dims, linear_split, EncoderParam,
-    EncoderProvider, RawBytesEncoder,
+    EncoderProvider, Output, RawBytesEncoder,
 };
 
 use crate::set_params;
@@ -370,7 +370,7 @@ pub fn call_dequant_8bit(
 
     let length = h * w;
 
-    set_params!(encoder, (weight, scale, zero, output, h, w));
+    set_params!(encoder, (weight, scale, zero, Output::new(output), h, w));
 
     let (thread_group_count, thread_group_size) = linear_split(&pipeline, length as usize);
     encoder.dispatch_thread_groups(thread_group_count, thread_group_size);
@@ -409,7 +409,7 @@ pub fn call_dequant_4bit(
 
     let length = h * w;
 
-    set_params!(encoder, (weight, scale, zero, output, h, w));
+    set_params!(encoder, (weight, scale, zero, Output::new(output), h, w));
 
     let (thread_group_count, thread_group_size) = linear_split(&pipeline, length as usize);
     encoder.dispatch_thread_groups(thread_group_count, thread_group_size);
@@ -448,7 +448,7 @@ pub fn call_dequant_2bit(
 
     let length = h * w;
 
-    set_params!(encoder, (weight, scale, zero, output, h, w));
+    set_params!(encoder, (weight, scale, zero, Output::new(output), h, w));
 
     let (thread_group_count, thread_group_size) = linear_split(&pipeline, length as usize);
     encoder.dispatch_thread_groups(thread_group_count, thread_group_size);
@@ -487,7 +487,7 @@ pub fn call_dequant_1bit(
 
     let length = h * w;
 
-    set_params!(encoder, (weight, scale, zero, output, h, w));
+    set_params!(encoder, (weight, scale, zero, Output::new(output), h, w));
 
     let (thread_group_count, thread_group_size) = linear_split(&pipeline, length as usize);
     encoder.dispatch_thread_groups(thread_group_count, thread_group_size);
@@ -526,7 +526,7 @@ pub fn call_dequant_3bit(
 
     let length = h * w;
 
-    set_params!(encoder, (weight, scale, zero, output, h, w));
+    set_params!(encoder, (weight, scale, zero, Output::new(output), h, w));
 
     let (thread_group_count, thread_group_size) = linear_split(&pipeline, length as usize);
     encoder.dispatch_thread_groups(thread_group_count, thread_group_size);
@@ -562,7 +562,7 @@ pub fn call_bitwise_not(
     let encoder: &ComputeCommandEncoderRef = encoder.as_ref();
     encoder.set_compute_pipeline_state(&pipeline);
 
-    set_params!(encoder, ((a, a_offset), output));
+    set_params!(encoder, ((a, a_offset), Output::new(output)));
 
     let (thread_group_count, thread_group_size) = linear_split(&pipeline, length);
     encoder.dispatch_thread_groups(thread_group_count, thread_group_size);
@@ -600,7 +600,7 @@ pub fn call_bitwise_or(
     let encoder: &ComputeCommandEncoderRef = encoder.as_ref();
     encoder.set_compute_pipeline_state(&pipeline);
 
-    set_params!(encoder, ((a, a_offset), (b, b_offset), output));
+    set_params!(encoder, ((a, a_offset), (b, b_offset), Output::new(output)));
 
     let (thread_group_count, thread_group_size) = linear_split(&pipeline, length);
     encoder.dispatch_thread_groups(thread_group_count, thread_group_size);
@@ -638,7 +638,7 @@ pub fn call_bitwise_and(
     let encoder: &ComputeCommandEncoderRef = encoder.as_ref();
     encoder.set_compute_pipeline_state(&pipeline);
 
-    set_params!(encoder, ((a, a_offset), (b, b_offset), output));
+    set_params!(encoder, ((a, a_offset), (b, b_offset), Output::new(output)));
 
     let (thread_group_count, thread_group_size) = linear_split(&pipeline, length);
     encoder.dispatch_thread_groups(thread_group_count, thread_group_size);
@@ -676,7 +676,7 @@ pub fn call_bitwise_xor(
     let encoder: &ComputeCommandEncoderRef = encoder.as_ref();
     encoder.set_compute_pipeline_state(&pipeline);
 
-    set_params!(encoder, ((a, a_offset), (b, b_offset), output));
+    set_params!(encoder, ((a, a_offset), (b, b_offset), Output::new(output)));
 
     let (thread_group_count, thread_group_size) = linear_split(&pipeline, length);
     encoder.dispatch_thread_groups(thread_group_count, thread_group_size);
@@ -713,7 +713,7 @@ pub fn call_bitwise_leftshift(
     let encoder: &ComputeCommandEncoderRef = encoder.as_ref();
     encoder.set_compute_pipeline_state(&pipeline);
 
-    set_params!(encoder, ((a, a_offset), output, k));
+    set_params!(encoder, ((a, a_offset), Output::new(output), k));
 
     let (thread_group_count, thread_group_size) = linear_split(&pipeline, length);
     encoder.dispatch_thread_groups(thread_group_count, thread_group_size);
@@ -752,7 +752,7 @@ pub fn call_dequant_bnb_nf4(
 
     set_params!(
         encoder,
-        (code, input, absmax, output, blocksize as i32, n as i32)
+        (code, input, absmax, Output::new(output), blocksize as i32, n as i32)
     );
 
     let (thread_group_count, thread_group_size) = linear_split(&pipeline, n.div_ceil(blocksize));
@@ -792,7 +792,7 @@ pub fn call_dequant_bnb_fp4(
 
     set_params!(
         encoder,
-        (code, input, absmax, output, blocksize as i32, n as i32)
+        (code, input, absmax, Output::new(output), blocksize as i32, n as i32)
     );
 
     let (thread_group_count, thread_group_size) = linear_split(&pipeline, n.div_ceil(blocksize));
@@ -832,7 +832,7 @@ pub fn call_dequant_bnb_int8(
 
     set_params!(
         encoder,
-        (code, input, absmax, output, blocksize as i32, n as i32)
+        (code, input, absmax, Output::new(output), blocksize as i32, n as i32)
     );
 
     let (thread_group_count, thread_group_size) = linear_split(&pipeline, n.div_ceil(blocksize));
@@ -926,9 +926,17 @@ pub fn call_affine_quantize(
     };
 
     if dequantize {
-        set_params!(encoder, ((input, input_offset), scales, biases, output));
+        set_params!(encoder, ((input, input_offset), scales, biases, Output::new(output)));
     } else {
-        set_params!(encoder, ((input, input_offset), output, scales, biases));
+        set_params!(
+            encoder,
+            (
+                (input, input_offset),
+                Output::new(output),
+                Output::new(scales),
+                Output::new(biases)
+            )
+        );
     }
 
     encoder.dispatch_threads(grid_dims, group_dims);
@@ -1132,11 +1140,11 @@ pub fn call_afq_qmm(
     let encoder: &ComputeCommandEncoderRef = encoder.as_ref();
     encoder.set_compute_pipeline_state(&pipeline);
 
-    encoder.set_buffer(0, Some(w), 0);
-    encoder.set_buffer(1, Some(scales), 0);
-    encoder.set_buffer(2, Some(biases), 0);
-    encoder.set_buffer(3, Some(x), x_offset);
-    encoder.set_buffer(4, Some(out), 0);
+    encoder.set_input_buffer(0, Some(w), 0);
+    encoder.set_input_buffer(1, Some(scales), 0);
+    encoder.set_input_buffer(2, Some(biases), 0);
+    encoder.set_input_buffer(3, Some(x), x_offset);
+    encoder.set_output_buffer(4, Some(out), 0);
     <i32 as EncoderParam>::set_param(encoder, 5, d as i32);
     <i32 as EncoderParam>::set_param(encoder, 6, o as i32);
 
@@ -1195,8 +1203,8 @@ pub fn call_afq_qmm(
             offset + 9,
             &batch_shape.iter().map(|x| *x as i32).collect::<Vec<_>>(),
         );
-        encoder.set_buffer(offset + 10, Some(lhs_indices), 0);
-        encoder.set_buffer(offset + 11, Some(rhs_indices), 0);
+        encoder.set_input_buffer(offset + 10, Some(lhs_indices), 0);
+        encoder.set_input_buffer(offset + 11, Some(rhs_indices), 0);
         <&[i64] as EncoderParam>::set_param(
             encoder,
             offset + 12,
@@ -1253,7 +1261,7 @@ pub fn call_mxfp4_matmul(
             w,
             scales,
             bias,
-            out,
+            Output::new(out),
             m as i32,
             n as i32,
             k as i32,
@@ -1318,7 +1326,7 @@ pub fn call_mxfp4_vecmat(
             w,
             scales,
             bias,
-            out,
+            Output::new(out),
             m as i32,
             n as i32,
             k as i32,
@@ -1390,7 +1398,7 @@ pub fn call_mxfp4_moe_gemm(
                 scales,
                 biases,
                 indices,
-                out,
+                Output::new(out),
                 num_tokens as i32,
                 topk as i32,
                 num_experts as i32,
@@ -1408,7 +1416,7 @@ pub fn call_mxfp4_moe_gemm(
                 scales,
                 biases,
                 indices,
-                out,
+                Output::new(out),
                 num_tokens as i32,
                 topk as i32,
                 num_experts as i32,
@@ -1496,7 +1504,7 @@ pub fn call_dequant_blockwise_fp8(
         }
     }
 
-    set_params!(encoder, (weight, scales, output, &dequant_params));
+    set_params!(encoder, (weight, scales, Output::new(output), &dequant_params));
 
     let tg = MTLSize {
         width: 32,
@@ -1593,8 +1601,8 @@ pub fn call_scan(
     encoder.set_compute_pipeline_state(&pipeline);
 
     if contiguous {
-        encoder.set_buffer(0, Some(xs), xs_offset);
-        encoder.set_buffer(1, Some(output), 0);
+        encoder.set_input_buffer(0, Some(xs), xs_offset);
+        encoder.set_output_buffer(1, Some(output), 0);
 
         let size = shape[axis];
         encoder.set_bytes_raw(
@@ -1635,8 +1643,8 @@ pub fn call_scan(
         let bn = 32;
         let stride_blocks = stride.div_ceil(bn);
 
-        encoder.set_buffer(0, Some(xs), xs_offset);
-        encoder.set_buffer(1, Some(output), 0);
+        encoder.set_input_buffer(0, Some(xs), xs_offset);
+        encoder.set_output_buffer(1, Some(output), 0);
 
         encoder.set_bytes_raw(
             2,
@@ -1992,8 +2000,8 @@ fn call_copy_gpu_inplace(
     // === Buffers (slots 0/1) =================================================
     let byte_offset_src = src_offset * ty.size_in_bytes();
     let byte_offset_dst = dst_offset * ty.size_in_bytes();
-    encoder.set_buffer(0, Some(src), byte_offset_src);
-    encoder.set_buffer(1, Some(dst), byte_offset_dst);
+    encoder.set_input_buffer(0, Some(src), byte_offset_src);
+    encoder.set_output_buffer(1, Some(dst), byte_offset_dst);
 
     // === Specialisation for each CopyType ===================================
     match copy_type {
@@ -2161,8 +2169,8 @@ fn call_single_block_sort<'a>(
     encoder.set_compute_pipeline_state(&pipeline);
 
     // Buffers
-    encoder.set_buffer(0, Some(src), src_offset);
-    encoder.set_buffer(1, Some(dst), 0);
+    encoder.set_input_buffer(0, Some(src), src_offset);
+    encoder.set_output_buffer(1, Some(dst), 0);
 
     // Scalar params
     <i32 as EncoderParam>::set_param(encoder, 2, size_sorted_axis as i32);
@@ -2296,9 +2304,9 @@ fn call_multi_block_sort<'a>(
         let encoder: &ComputeCommandEncoderRef = encoder.as_ref();
         encoder.set_compute_pipeline_state(&pipeline);
 
-        encoder.set_buffer(0, Some(src), src_offset);
-        encoder.set_buffer(1, Some(&*dev_vals_0), 0);
-        encoder.set_buffer(2, Some(&*dev_idxs_0), 0);
+        encoder.set_input_buffer(0, Some(src), src_offset);
+        encoder.set_output_buffer(1, Some(&*dev_vals_0), 0);
+        encoder.set_output_buffer(2, Some(&*dev_idxs_0), 0);
         <i32 as EncoderParam>::set_param(encoder, 3, size_sorted_axis as i32);
         <i32 as EncoderParam>::set_param(encoder, 4, stride_sorted_axis as i32);
         <i32 as EncoderParam>::set_param(encoder, 5, nc_dim as i32);
@@ -2376,9 +2384,9 @@ fn call_multi_block_sort<'a>(
             let encoder: &ComputeCommandEncoderRef = encoder.as_ref();
             encoder.set_compute_pipeline_state(&pipeline);
 
-            encoder.set_buffer(0, Some(&*block_partitions), 0);
-            encoder.set_buffer(1, Some(&*dev_vals_in), 0);
-            encoder.set_buffer(2, Some(&*dev_idxs_in), 0);
+            encoder.set_output_buffer(0, Some(&*block_partitions), 0);
+            encoder.set_input_buffer(1, Some(&*dev_vals_in), 0);
+            encoder.set_input_buffer(2, Some(&*dev_idxs_in), 0);
             <i32 as EncoderParam>::set_param(encoder, 3, size_sorted_axis as i32);
             <i32 as EncoderParam>::set_param(encoder, 4, merge_tiles as i32);
             <i32 as EncoderParam>::set_param(encoder, 5, n_blocks as i32);
@@ -2411,11 +2419,11 @@ fn call_multi_block_sort<'a>(
             let encoder: &ComputeCommandEncoderRef = encoder.as_ref();
             encoder.set_compute_pipeline_state(&pipeline);
 
-            encoder.set_buffer(0, Some(&*block_partitions), 0);
-            encoder.set_buffer(1, Some(&*dev_vals_in), 0);
-            encoder.set_buffer(2, Some(&*dev_idxs_in), 0);
-            encoder.set_buffer(3, Some(&*dev_vals_out), 0);
-            encoder.set_buffer(4, Some(&*dev_idxs_out), 0);
+            encoder.set_input_buffer(0, Some(&*block_partitions), 0);
+            encoder.set_input_buffer(1, Some(&*dev_vals_in), 0);
+            encoder.set_input_buffer(2, Some(&*dev_idxs_in), 0);
+            encoder.set_output_buffer(3, Some(&*dev_vals_out), 0);
+            encoder.set_output_buffer(4, Some(&*dev_idxs_out), 0);
             <i32 as EncoderParam>::set_param(encoder, 5, size_sorted_axis as i32);
             <i32 as EncoderParam>::set_param(encoder, 6, merge_tiles as i32);
             <i32 as EncoderParam>::set_param(encoder, 7, n_blocks as i32);
@@ -2528,7 +2536,7 @@ pub fn call_hqq_pack_8bit(
     let pipeline = kernels.load_pipeline(device, "pack_8bit")?;
     encoder.set_compute_pipeline_state(&pipeline);
 
-    set_params!(encoder, (input, output, num_elements));
+    set_params!(encoder, (input, Output::new(output), num_elements));
 
     let grid_size = MTLSize {
         width: num_elements.div_ceil(256),
@@ -2559,7 +2567,7 @@ pub fn call_hqq_pack_4bit(
     let pipeline = kernels.load_pipeline(device, "pack_4bit")?;
     encoder.set_compute_pipeline_state(&pipeline);
 
-    set_params!(encoder, (input, output, height, width));
+    set_params!(encoder, (input, Output::new(output), height, width));
 
     let step = height / 2;
     let grid_size = MTLSize {
@@ -2592,7 +2600,7 @@ pub fn call_hqq_pack_2bit(
     let pipeline = kernels.load_pipeline(device, "pack_2bit")?;
     encoder.set_compute_pipeline_state(&pipeline);
 
-    set_params!(encoder, (input, output, height, width));
+    set_params!(encoder, (input, Output::new(output), height, width));
 
     let step = height / 4;
     let grid_size = MTLSize {
@@ -2625,7 +2633,7 @@ pub fn call_hqq_pack_3bit(
     let pipeline = kernels.load_pipeline(device, "pack_3bit")?;
     encoder.set_compute_pipeline_state(&pipeline);
 
-    set_params!(encoder, (input, output, height, width));
+    set_params!(encoder, (input, Output::new(output), height, width));
 
     let step = height / 10;
     let grid_size = MTLSize {
@@ -2658,7 +2666,7 @@ pub fn call_hqq_pack_1bit(
     let pipeline = kernels.load_pipeline(device, "pack_1bit")?;
     encoder.set_compute_pipeline_state(&pipeline);
 
-    set_params!(encoder, (input, output, height, width));
+    set_params!(encoder, (input, Output::new(output), height, width));
 
     let step = height / 8;
     let grid_size = MTLSize {
@@ -2712,7 +2720,7 @@ pub fn call_fused_glu(
         (
             (a, a_offset),
             (b, b_offset),
-            output,
+            Output::new(output),
             n_elements as u32,
             activation
         )
@@ -2781,7 +2789,7 @@ pub fn call_softmax_with_sinks(
         (
             (logits, logits_offset),
             (sinks, sinks_offset),
-            output,
+            Output::new(output),
             num_heads,
             q_len,
             k_len
@@ -2862,7 +2870,7 @@ pub fn call_sdpa_vector_with_sinks(
             (k_buffer, k_offset),
             (v_buffer, v_offset),
             (sinks_buffer, sinks_offset),
-            output,
+            Output::new(output),
             gqa_factor,
             n,
             k_stride,
@@ -2933,9 +2941,9 @@ pub fn call_sdpa_vector_with_sinks_2pass(
                 (q_buffer, q_offset),
                 (k_buffer, k_offset),
                 (v_buffer, v_offset),
-                intermediate,
-                sums,
-                maxs,
+                Output::new(intermediate),
+                Output::new(sums),
+                Output::new(maxs),
                 gqa_factor,
                 n,
                 k_stride,
@@ -2973,7 +2981,7 @@ pub fn call_sdpa_vector_with_sinks_2pass(
                 sums,
                 maxs,
                 (sinks_buffer, sinks_offset),
-                output
+                Output::new(output)
             )
         );
 
@@ -3058,7 +3066,7 @@ pub fn call_flash_attn_sinks_prefill(
             (k_buffer, k_offset),
             (v_buffer, v_offset),
             (sinks_buffer, sinks_offset),
-            output,
+            Output::new(output),
             scale,
             q_len_i32,
             k_len_i32,
@@ -3147,7 +3155,7 @@ pub fn call_flash_attn_sinks_varlen_prefill(
             (k_buffer, k_offset),
             (v_buffer, v_offset),
             (sinks_buffer, sinks_offset),
-            output,
+            Output::new(output),
             (cu_seqlens_q_buffer, cu_seqlens_q_offset),
             (cu_seqlens_k_buffer, cu_seqlens_k_offset),
             scale,
@@ -3204,7 +3212,7 @@ pub fn call_fp8_to_dtype(
     let encoder: &ComputeCommandEncoderRef = encoder.as_ref();
     encoder.set_compute_pipeline_state(&pipeline);
 
-    set_params!(encoder, (input, output, num_elements as u32));
+    set_params!(encoder, (input, Output::new(output), num_elements as u32));
 
     let (thread_group_count, thread_group_size) = linear_split(&pipeline, num_elements);
     encoder.dispatch_thread_groups(thread_group_count, thread_group_size);
@@ -3239,7 +3247,7 @@ pub fn call_dtype_to_fp8(
     let encoder: &ComputeCommandEncoderRef = encoder.as_ref();
     encoder.set_compute_pipeline_state(&pipeline);
 
-    set_params!(encoder, (input, output, num_elements as u32));
+    set_params!(encoder, (input, Output::new(output), num_elements as u32));
 
     let (thread_group_count, thread_group_size) = linear_split(&pipeline, num_elements);
     encoder.dispatch_thread_groups(thread_group_count, thread_group_size);
@@ -3276,7 +3284,7 @@ pub fn call_fp8_pertensor_dequant(
     let encoder: &ComputeCommandEncoderRef = encoder.as_ref();
     encoder.set_compute_pipeline_state(&pipeline);
 
-    set_params!(encoder, (weight, scale_inv, output, num_elements as u32));
+    set_params!(encoder, (weight, scale_inv, Output::new(output), num_elements as u32));
 
     let (thread_group_count, thread_group_size) = linear_split(&pipeline, num_elements);
     encoder.dispatch_thread_groups(thread_group_count, thread_group_size);
@@ -3313,7 +3321,7 @@ pub fn call_fp8_vector_dequant(
     let encoder: &ComputeCommandEncoderRef = encoder.as_ref();
     encoder.set_compute_pipeline_state(&pipeline);
 
-    set_params!(encoder, (weight, scale, output, num_elements as u32));
+    set_params!(encoder, (weight, scale, Output::new(output), num_elements as u32));
 
     let (thread_group_count, thread_group_size) = linear_split(&pipeline, num_elements);
     encoder.dispatch_thread_groups(thread_group_count, thread_group_size);

--- a/mistralrs-quant/src/metal_kernels/mod.rs
+++ b/mistralrs-quant/src/metal_kernels/mod.rs
@@ -752,7 +752,14 @@ pub fn call_dequant_bnb_nf4(
 
     set_params!(
         encoder,
-        (code, input, absmax, Output::new(output), blocksize as i32, n as i32)
+        (
+            code,
+            input,
+            absmax,
+            Output::new(output),
+            blocksize as i32,
+            n as i32
+        )
     );
 
     let (thread_group_count, thread_group_size) = linear_split(&pipeline, n.div_ceil(blocksize));
@@ -792,7 +799,14 @@ pub fn call_dequant_bnb_fp4(
 
     set_params!(
         encoder,
-        (code, input, absmax, Output::new(output), blocksize as i32, n as i32)
+        (
+            code,
+            input,
+            absmax,
+            Output::new(output),
+            blocksize as i32,
+            n as i32
+        )
     );
 
     let (thread_group_count, thread_group_size) = linear_split(&pipeline, n.div_ceil(blocksize));
@@ -832,7 +846,14 @@ pub fn call_dequant_bnb_int8(
 
     set_params!(
         encoder,
-        (code, input, absmax, Output::new(output), blocksize as i32, n as i32)
+        (
+            code,
+            input,
+            absmax,
+            Output::new(output),
+            blocksize as i32,
+            n as i32
+        )
     );
 
     let (thread_group_count, thread_group_size) = linear_split(&pipeline, n.div_ceil(blocksize));
@@ -926,7 +947,10 @@ pub fn call_affine_quantize(
     };
 
     if dequantize {
-        set_params!(encoder, ((input, input_offset), scales, biases, Output::new(output)));
+        set_params!(
+            encoder,
+            ((input, input_offset), scales, biases, Output::new(output))
+        );
     } else {
         set_params!(
             encoder,
@@ -1504,7 +1528,10 @@ pub fn call_dequant_blockwise_fp8(
         }
     }
 
-    set_params!(encoder, (weight, scales, Output::new(output), &dequant_params));
+    set_params!(
+        encoder,
+        (weight, scales, Output::new(output), &dequant_params)
+    );
 
     let tg = MTLSize {
         width: 32,
@@ -3284,7 +3311,10 @@ pub fn call_fp8_pertensor_dequant(
     let encoder: &ComputeCommandEncoderRef = encoder.as_ref();
     encoder.set_compute_pipeline_state(&pipeline);
 
-    set_params!(encoder, (weight, scale_inv, Output::new(output), num_elements as u32));
+    set_params!(
+        encoder,
+        (weight, scale_inv, Output::new(output), num_elements as u32)
+    );
 
     let (thread_group_count, thread_group_size) = linear_split(&pipeline, num_elements);
     encoder.dispatch_thread_groups(thread_group_count, thread_group_size);
@@ -3321,7 +3351,10 @@ pub fn call_fp8_vector_dequant(
     let encoder: &ComputeCommandEncoderRef = encoder.as_ref();
     encoder.set_compute_pipeline_state(&pipeline);
 
-    set_params!(encoder, (weight, scale, Output::new(output), num_elements as u32));
+    set_params!(
+        encoder,
+        (weight, scale, Output::new(output), num_elements as u32)
+    );
 
     let (thread_group_count, thread_group_size) = linear_split(&pipeline, num_elements);
     encoder.dispatch_thread_groups(thread_group_count, thread_group_size);

--- a/mistralrs-quant/src/metal_kernels/utils.rs
+++ b/mistralrs-quant/src/metal_kernels/utils.rs
@@ -3,7 +3,9 @@
 // Licensed under the Apache License 2.0
 // Copyright © 2023 Apple Inc.
 
-use candle_metal_kernels::metal::{Buffer, CommandBuffer, ComputeCommandEncoder, ComputePipeline};
+use candle_metal_kernels::metal::{
+    Buffer, CommandBuffer, CommandsGuard, ComputeCommandEncoder, ComputePipeline,
+};
 use objc2_metal::MTLSize;
 use std::ffi::c_void;
 
@@ -215,31 +217,54 @@ impl<T> EncoderParam for &[T] {
 
 impl EncoderParam for &Buffer {
     fn set_param(encoder: &ComputeCommandEncoder, position: usize, data: Self) {
-        encoder.set_buffer(position, Some(data), 0);
+        encoder.set_input_buffer(position, Some(data), 0);
     }
 }
 
 impl EncoderParam for (&Buffer, usize) {
     fn set_param(encoder: &ComputeCommandEncoder, position: usize, data: Self) {
-        encoder.set_buffer(position, Some(data.0), data.1);
+        encoder.set_input_buffer(position, Some(data.0), data.1);
     }
 }
 
 impl EncoderParam for &BufferOffset<'_> {
     fn set_param(encoder: &ComputeCommandEncoder, position: usize, data: Self) {
-        encoder.set_buffer(position, Some(data.buffer), data.offset_in_bytes);
+        encoder.set_input_buffer(position, Some(data.buffer), data.offset_in_bytes);
     }
 }
 
 impl EncoderParam for &mut Buffer {
     fn set_param(encoder: &ComputeCommandEncoder, position: usize, data: Self) {
-        encoder.set_buffer(position, Some(data), 0);
+        encoder.set_output_buffer(position, Some(data), 0);
     }
 }
 
 impl EncoderParam for (&mut Buffer, usize) {
     fn set_param(encoder: &ComputeCommandEncoder, position: usize, data: Self) {
-        encoder.set_buffer(position, Some(data.0), data.1);
+        encoder.set_output_buffer(position, Some(data.0), data.1);
+    }
+}
+
+/// Wrapper for `set_params!` callers to mark a buffer slot as a kernel output
+/// (writes), so hazard tracking and inter-encoder fence ordering see the write.
+/// Use this whenever a kernel's `device T*` (non-const) argument is passed
+/// through `set_params!`.
+#[derive(Copy, Clone)]
+pub struct Output<'a> {
+    buffer: &'a Buffer,
+    offset: usize,
+}
+
+impl<'a> Output<'a> {
+    #[inline]
+    pub fn new(buffer: &'a Buffer) -> Self {
+        Self { buffer, offset: 0 }
+    }
+}
+
+impl<'a> EncoderParam for Output<'a> {
+    fn set_param(encoder: &ComputeCommandEncoder, position: usize, data: Self) {
+        encoder.set_output_buffer(position, Some(data.buffer), data.offset);
     }
 }
 
@@ -286,7 +311,7 @@ impl EncoderProvider for &CommandBuffer {
     where
         Self: 'a;
     fn encoder(&self) -> Self::Encoder<'_> {
-        self.compute_command_encoder()
+        self.compute_command_encoder_no_fence()
     }
 }
 
@@ -300,5 +325,15 @@ impl EncoderProvider for &ComputeCommandEncoder {
             inner: self,
             end_encoding_on_drop: false,
         }
+    }
+}
+
+impl EncoderProvider for &CommandsGuard<'_> {
+    type Encoder<'a>
+        = &'a CommandsGuard<'a>
+    where
+        Self: 'a;
+    fn encoder(&self) -> Self::Encoder<'_> {
+        self
     }
 }

--- a/mistralrs-server-core/src/openapi_doc.rs
+++ b/mistralrs-server-core/src/openapi_doc.rs
@@ -6,7 +6,7 @@ use crate::{
     chat_completion::__path_chatcompletions,
     completions::__path_completions,
     embeddings::__path_embeddings,
-    handlers::{ReIsqRequest, __path_health, __path_models, __path_re_isq},
+    handlers::{__path_health, __path_models, __path_re_isq, ReIsqRequest},
     image_generation::__path_image_generation,
     openai::{
         AudioResponseFormat, ChatCompletionRequest, CompletionRequest, EmbeddingData,

--- a/mistralrs-server-core/src/openapi_doc.rs
+++ b/mistralrs-server-core/src/openapi_doc.rs
@@ -6,7 +6,7 @@ use crate::{
     chat_completion::__path_chatcompletions,
     completions::__path_completions,
     embeddings::__path_embeddings,
-    handlers::{__path_health, __path_models, __path_re_isq, ReIsqRequest},
+    handlers::{ReIsqRequest, __path_health, __path_models, __path_re_isq},
     image_generation::__path_image_generation,
     openai::{
         AudioResponseFormat, ChatCompletionRequest, CompletionRequest, EmbeddingData,


### PR DESCRIPTION
Big performance gains for unquantized models on Metal at ~2x from: https://github.com/huggingface/candle/pull/3532

Quantized (e.g. AFQ) seem to have ~+10% which is a very nice boost.