### PR TITLE
fix(quant): fail missing dummy layers outside uqff

### DIFF
--- a/mistralrs-core/src/pipeline/isq.rs
+++ b/mistralrs-core/src/pipeline/isq.rs
@@ -1248,9 +1248,15 @@ pub trait IsqModel {
         {
             let (check_tensors, _) = self.get_layers();
             for (i, (tensor, layer_num)) in check_tensors.iter().enumerate() {
-                if tensor.name() == "dummy" {
+                if let Some(info) = tensor.dummy_info() {
+                    let artifact_note = if artifact_isqs.contains_key(&i) {
+                        "the matching UQFF artifact did not deserialize into a real layer"
+                    } else {
+                        "the UQFF artifact set did not contain an entry for this layer index"
+                    };
                     candle_core::bail!(
-                        "DummyLayer not replaced at index {i}, layer {layer_num:?} after load_from_artifacts"
+                        "UQFF placeholder was not replaced at artifact index {i}, model layer {layer_num:?}: {artifact_note}. {}",
+                        info.message("UQFF artifact loading")
                     );
                 }
             }

--- a/mistralrs-core/src/utils/varbuilder_utils.rs
+++ b/mistralrs-core/src/utils/varbuilder_utils.rs
@@ -179,10 +179,11 @@ pub(crate) fn from_mmaped_safetensors(
 
     // TODO(EricLBuehler): separation of concerns.
     // This is to have WNA16 for GPTQ which is required. No bf16 for GPTQ
-    Ok(ShardedSafeTensors::wrap(
+    Ok(ShardedSafeTensors::wrap_with_dummy_regexes(
         backend,
         dtype.unwrap_or(DType::F16),
         base_device.clone(),
+        make_dummy_regexes,
     ))
 }
 

--- a/mistralrs-quant/src/blockwise_fp8/mod.rs
+++ b/mistralrs-quant/src/blockwise_fp8/mod.rs
@@ -13,9 +13,9 @@ pub(crate) use ops::{fp8_blockwise_matmul, fp8_indexed_moe_gemm};
 mod ffi;
 
 use crate::{
-    generate_isq, generate_isq_imatrix,
+    generate_isq, generate_isq_imatrix, has_missing_required_tensors,
     hqq::{ISQ_HQQ_DEFAULT_OPT_STEPS, ISQ_HQQ_GROUP_SIZE},
-    AfqBits, AfqGroupSize, AfqLayer, DummyLayer, FP8Linear, GgufMatMul, HqqAxis, HqqBits,
+    make_dummy_or_error, AfqBits, AfqGroupSize, AfqLayer, FP8Linear, GgufMatMul, HqqAxis, HqqBits,
     HqqConfig, HqqLayer, IsqType, QuantMethod, QuantMethodConfig, QuantizeOntoGuard,
     QuantizedConfig, QuantizedSerde, Shard, ShardedVarBuilder, UnquantLinear,
 };
@@ -445,10 +445,8 @@ pub fn blockwise_fp8_linear_b(
         return crate::linear_b(in_dim, out_dim, bias, &None, vb);
     }
 
-    // Handle the case where the layer is dummy (no tensors)
-    if !(vb.contains_tensor("weight") && vb.contains_tensor("weight_scale_inv")) {
-        let layer = <DummyLayer as QuantMethod>::new(QuantMethodConfig::Dummy)?;
-        return Ok(Arc::new(layer) as Arc<dyn QuantMethod>);
+    if has_missing_required_tensors(&vb, &["weight", "weight_scale_inv"]) {
+        return make_dummy_or_error("blockwise_fp8_linear", &vb, &["weight", "weight_scale_inv"]);
     }
 
     // Blockwise FP8 requires weight_block_size to be set

--- a/mistralrs-quant/src/distributed/layers.rs
+++ b/mistralrs-quant/src/distributed/layers.rs
@@ -8,11 +8,12 @@ use crate::{
     distributed,
     gptq::gptq_linear,
     lora::merge_lora_weights,
+    make_dummy_or_error,
     pertensor_fp8::pertensor_fp8_linear_b,
     should_apply_immediate_isq,
     utils::isq::apply_immediate_isq,
-    AfqLayer, BnbLinear, DistributedKind, DummyLayer, F8Q8Linear, FP8Linear, GgufMatMul, HqqLayer,
-    MXFP4Layer, QuantMethod, QuantMethodConfig, QuantizeOntoGuard, QuantizedConfig, QuantizedSerde,
+    AfqLayer, BnbLinear, DistributedKind, F8Q8Linear, FP8Linear, GgufMatMul, HqqLayer, MXFP4Layer,
+    QuantMethod, QuantMethodConfig, QuantizeOntoGuard, QuantizedConfig, QuantizedSerde,
     QuantizedSerdeType, Shard, ShardedVarBuilder, UnquantLinear,
 };
 
@@ -108,10 +109,8 @@ impl RowParallelLayer {
                 }
             }
         } else {
-            // Handle the case where the layer is dummy (no tensors)
             if !vb.contains_tensor("weight") {
-                let layer = <DummyLayer as QuantMethod>::new(QuantMethodConfig::Dummy)?;
-                Arc::new(layer) as Arc<dyn QuantMethod>
+                make_dummy_or_error("row_parallel_linear", &vb, &["weight"])?
             } else {
                 let weight = vb.get_with_hints((out_dim, in_dim), "weight", shard)?;
                 let weight = merge_lora_weights(&vb, weight, in_dim, out_dim, shard)?;
@@ -164,10 +163,8 @@ impl RowParallelLayer {
             candle_core::bail!("Cannot load a matformer layer with a pre-quantized model.");
         }
 
-        // Handle the case where the layer is dummy (no tensors)
         let weight = if !vb.contains_tensor("weight") {
-            let layer = <DummyLayer as QuantMethod>::new(QuantMethodConfig::Dummy)?;
-            Arc::new(layer) as Arc<dyn QuantMethod>
+            make_dummy_or_error("row_parallel_matformer_linear", &vb, &["weight"])?
         } else {
             let weight = vb
                 .get_with_hints(
@@ -410,10 +407,8 @@ impl ColumnParallelLayer {
                 }
             }
         } else {
-            // Handle the case where the layer is dummy (no tensors)
             if !vb.contains_tensor("weight") {
-                let layer = <DummyLayer as QuantMethod>::new(QuantMethodConfig::Dummy)?;
-                Arc::new(layer) as Arc<dyn QuantMethod>
+                make_dummy_or_error("column_parallel_linear", &vb, &["weight"])?
             } else {
                 let weight = vb.get_with_hints((out_dim, in_dim), "weight", shard)?;
                 let weight = merge_lora_weights(&vb, weight, in_dim, out_dim, shard)?;
@@ -478,10 +473,8 @@ impl ColumnParallelLayer {
             candle_core::bail!("Cannot load a matformer layer with a pre-quantized model.");
         }
 
-        // Handle the case where the layer is dummy (no tensors)
         let weight = if !vb.contains_tensor("weight") {
-            let layer = <DummyLayer as QuantMethod>::new(QuantMethodConfig::Dummy)?;
-            Arc::new(layer) as Arc<dyn QuantMethod>
+            make_dummy_or_error("column_parallel_matformer_linear", &vb, &["weight"])?
         } else {
             let weight = vb
                 .get_with_hints(
@@ -771,10 +764,8 @@ impl ReplicatedLayer {
                 }
             }
         } else {
-            // Handle the case where the layer is dummy (no tensors)
             if !vb.contains_tensor("weight") {
-                let layer = <DummyLayer as QuantMethod>::new(QuantMethodConfig::Dummy)?;
-                Arc::new(layer) as Arc<dyn QuantMethod>
+                make_dummy_or_error("replicated_linear", &vb, &["weight"])?
             } else {
                 let weight = vb.get_with_hints((out_dim, in_dim), "weight", Default::default())?;
                 let weight = merge_lora_weights(&vb, weight, in_dim, out_dim, Default::default())?;
@@ -854,10 +845,8 @@ impl ReplicatedLayer {
                 }
             }
         } else {
-            // Handle the case where the layer is dummy (no tensors)
             if !vb.contains_tensor("weight") {
-                let layer = <DummyLayer as QuantMethod>::new(QuantMethodConfig::Dummy)?;
-                Arc::new(layer) as Arc<dyn QuantMethod>
+                make_dummy_or_error("replicated_matformer_linear", &vb, &["weight"])?
             } else {
                 let mut weight =
                     vb.get_with_hints((out_dim, in_dim), "weight", Default::default())?;
@@ -1354,9 +1343,21 @@ impl PackedExperts {
             let mut us: Vec<Arc<dyn QuantMethod>> = Vec::new();
             let mut ds: Vec<Arc<dyn QuantMethod>> = Vec::new();
             for _ in 0..num_local_experts {
-                gs.push(Arc::new(DummyLayer::new(QuantMethodConfig::Dummy)?));
-                us.push(Arc::new(DummyLayer::new(QuantMethodConfig::Dummy)?));
-                ds.push(Arc::new(DummyLayer::new(QuantMethodConfig::Dummy)?));
+                gs.push(make_dummy_or_error(
+                    "packed_experts_gate_proj",
+                    &vb,
+                    &["gate_up_proj"],
+                )?);
+                us.push(make_dummy_or_error(
+                    "packed_experts_up_proj",
+                    &vb,
+                    &["gate_up_proj"],
+                )?);
+                ds.push(make_dummy_or_error(
+                    "packed_experts_down_proj",
+                    &vb,
+                    &["gate_up_proj"],
+                )?);
             }
             (gs, us, ds)
         } else {
@@ -1934,12 +1935,13 @@ impl FusedExperts {
         } else if !experts_vb.pp("0").contains_tensor("gate_proj.weight") {
             // Handle the case where the layer is dummy (no tensors) during UQFF loading.
             // Deserialize will handle it.
-            let fused_gate_proj: Arc<dyn QuantMethod> =
-                Arc::new(DummyLayer::new(QuantMethodConfig::Dummy)?);
-            let fused_up_proj: Arc<dyn QuantMethod> =
-                Arc::new(DummyLayer::new(QuantMethodConfig::Dummy)?);
-            let fused_down_proj: Arc<dyn QuantMethod> =
-                Arc::new(DummyLayer::new(QuantMethodConfig::Dummy)?);
+            let expert_vb = experts_vb.pp("0");
+            let fused_gate_proj =
+                make_dummy_or_error("fused_experts_gate_proj", &expert_vb, &["gate_proj.weight"])?;
+            let fused_up_proj =
+                make_dummy_or_error("fused_experts_up_proj", &expert_vb, &["gate_proj.weight"])?;
+            let fused_down_proj =
+                make_dummy_or_error("fused_experts_down_proj", &expert_vb, &["gate_proj.weight"])?;
             (fused_gate_proj, fused_up_proj, fused_down_proj)
         } else {
             // Per-expert format: load each expert individually and stack

--- a/mistralrs-quant/src/dummy/mod.rs
+++ b/mistralrs-quant/src/dummy/mod.rs
@@ -2,24 +2,67 @@ use candle_core::Result;
 
 use crate::{QuantMethod, QuantizeOntoGuard, QuantizedSerde};
 
-#[derive(Debug, Copy, Clone)]
-pub struct DummyLayer;
+#[derive(Debug, Clone)]
+pub struct DummyLayerInfo {
+    pub context: String,
+    pub prefix: String,
+    pub missing_tensors: Vec<String>,
+}
+
+impl DummyLayerInfo {
+    pub fn unknown() -> Self {
+        Self {
+            context: "unknown".to_string(),
+            prefix: "<unknown>".to_string(),
+            missing_tensors: Vec::new(),
+        }
+    }
+
+    pub fn message(&self, action: &str) -> String {
+        let missing = if self.missing_tensors.is_empty() {
+            "<unknown>".to_string()
+        } else {
+            self.missing_tensors.join(", ")
+        };
+        format!(
+            "DummyLayer reached {action} for {} at prefix `{}`. Missing tensor path(s): {missing}. Dummy layers are only valid as temporary UQFF placeholders and must be replaced before inference.",
+            self.context, self.prefix
+        )
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct DummyLayer {
+    info: DummyLayerInfo,
+}
+
+impl DummyLayer {
+    pub fn placeholder(info: DummyLayerInfo) -> Self {
+        Self { info }
+    }
+
+    pub fn info(&self) -> &DummyLayerInfo {
+        &self.info
+    }
+}
 
 impl QuantMethod for DummyLayer {
     fn new(_method: crate::QuantMethodConfig) -> candle_core::Result<Self>
     where
         Self: Sized,
     {
-        Ok(Self)
+        Ok(Self {
+            info: DummyLayerInfo::unknown(),
+        })
     }
     fn dequantize_w(&self) -> Result<candle_core::Tensor> {
-        candle_core::bail!("DummyLayer cannot be dequantized!")
+        candle_core::bail!("{}", self.info.message("dequantization"))
     }
     fn add_delta_w(
         &self,
         _delta: &candle_core::Tensor,
     ) -> candle_core::Result<std::sync::Arc<dyn QuantMethod>> {
-        candle_core::bail!("DummyLayer should not ever be present in forward pass!")
+        candle_core::bail!("{}", self.info.message("LoRA delta application"))
     }
     fn apply_isq(
         self: std::sync::Arc<Self>,
@@ -36,10 +79,14 @@ impl QuantMethod for DummyLayer {
         (candle_core::DType::F32, candle_core::Device::Cpu)
     }
     fn forward_raw(&self, _a: &candle_core::Tensor) -> candle_core::Result<candle_core::Tensor> {
-        candle_core::bail!("DummyLayer should not ever be present in forward pass!")
+        candle_core::bail!("{}", self.info.message("forward pass"))
     }
     fn quantized_act_type(&self) -> Option<candle_core::DType> {
         None
+    }
+
+    fn dummy_info(&self) -> Option<&crate::DummyLayerInfo> {
+        Some(&self.info)
     }
 }
 

--- a/mistralrs-quant/src/gptq/gptq_cpu.rs
+++ b/mistralrs-quant/src/gptq/gptq_cpu.rs
@@ -1,6 +1,6 @@
 use crate::{
-    DummyLayer, IsqType, QuantMethod, QuantMethodConfig, QuantizeOntoGuard, QuantizedConfig,
-    QuantizedSerde, ShardedVarBuilder,
+    has_missing_required_tensors, make_dummy_or_error, IsqType, QuantMethod, QuantMethodConfig,
+    QuantizeOntoGuard, QuantizedConfig, QuantizedSerde, ShardedVarBuilder,
 };
 use candle_core::{DType, Device, Result, Tensor};
 use std::sync::{atomic::AtomicUsize, Arc};
@@ -98,14 +98,12 @@ pub fn gptq_linear(
         return crate::linear_b(in_dim, out_dim, false, &None, vb);
     }
 
-    // Handle the case where the layer is dummy (no tensors)
-    if !vb.contains_tensor("qweight")
-        || !vb.contains_tensor("qzeros")
-        || !vb.contains_tensor("scales")
-        || !is_awq && !vb.contains_tensor("g_idx")
-    {
-        let layer = <DummyLayer as QuantMethod>::new(QuantMethodConfig::Dummy)?;
-        return Ok(Arc::new(layer) as Arc<dyn QuantMethod>);
+    let mut required = vec!["qweight", "qzeros", "scales"];
+    if !is_awq {
+        required.push("g_idx");
+    }
+    if has_missing_required_tensors(&vb, &required) {
+        return make_dummy_or_error("gptq_awq_linear", &vb, &required);
     }
 
     let qw_shape = if !is_awq {

--- a/mistralrs-quant/src/gptq/gptq_cuda.rs
+++ b/mistralrs-quant/src/gptq/gptq_cuda.rs
@@ -23,9 +23,10 @@ use half::f16;
 
 use crate::{
     gptq::marlin_backend::{marlin_matmul, marlin_weight_repack},
+    has_missing_required_tensors, make_dummy_or_error,
     utils::get_cuda_device,
-    DummyLayer, IsqType, QuantMethod, QuantMethodConfig, QuantizeOntoGuard, QuantizedConfig,
-    QuantizedSerde, ShardedVarBuilder,
+    IsqType, QuantMethod, QuantMethodConfig, QuantizeOntoGuard, QuantizedConfig, QuantizedSerde,
+    ShardedVarBuilder,
 };
 
 use super::{
@@ -449,14 +450,12 @@ pub fn gptq_linear(
     };
 
     let is_awq = *is_awq;
-    // Handle the case where the layer is dummy (no tensors)
-    if !vb.contains_tensor("qweight")
-        || !vb.contains_tensor("qzeros")
-        || !vb.contains_tensor("scales")
-        || !is_awq && !vb.contains_tensor("g_idx")
-    {
-        let layer = <DummyLayer as QuantMethod>::new(QuantMethodConfig::Dummy)?;
-        return Ok(Arc::new(layer) as Arc<dyn QuantMethod>);
+    let mut required = vec!["qweight", "qzeros", "scales"];
+    if !is_awq {
+        required.push("g_idx");
+    }
+    if has_missing_required_tensors(&vb, &required) {
+        return make_dummy_or_error("gptq_awq_linear", &vb, &required);
     }
 
     let marlin_compatible = *bits == 4 || *bits == 8;

--- a/mistralrs-quant/src/lib.rs
+++ b/mistralrs-quant/src/lib.rs
@@ -57,7 +57,7 @@ pub use distributed::{
     socket::{Client, Server},
     BarrierLike, Comm, Id, RingConfig, SumAllReduce,
 };
-pub use dummy::DummyLayer;
+pub use dummy::{DummyLayer, DummyLayerInfo};
 pub use f8q8::F8Q8Linear;
 pub use fp8::FP8Linear;
 #[cfg(feature = "cuda")]
@@ -1052,12 +1052,68 @@ pub trait QuantMethod: Send + Sync + Debug + QuantizedSerde {
     fn is_distributed(&self) -> Option<DistributedKind> {
         None
     }
+
+    fn dummy_info(&self) -> Option<&DummyLayerInfo> {
+        None
+    }
 }
 
 impl Module for dyn QuantMethod {
     fn forward(&self, xs: &Tensor) -> Result<Tensor> {
         QuantMethod::forward(self, xs)
     }
+}
+
+fn tensor_prefix(vb: &ShardedVarBuilder) -> String {
+    let prefix = vb.prefix();
+    if prefix.is_empty() {
+        "<root>".to_string()
+    } else {
+        prefix
+    }
+}
+
+fn missing_required_tensors(vb: &ShardedVarBuilder, required: &[&str]) -> Vec<String> {
+    required
+        .iter()
+        .copied()
+        .filter(|name| !vb.contains_tensor(name))
+        .map(|name| safetensors::full_tensor_name(vb, name))
+        .collect()
+}
+
+pub(crate) fn has_missing_required_tensors(vb: &ShardedVarBuilder, required: &[&str]) -> bool {
+    required.iter().any(|name| !vb.contains_tensor(name))
+}
+
+pub(crate) fn make_dummy_or_error(
+    context: &str,
+    vb: &ShardedVarBuilder,
+    required: &[&str],
+) -> Result<Arc<dyn QuantMethod>> {
+    let missing = missing_required_tensors(vb, required);
+    if missing.is_empty() {
+        candle_core::bail!(
+            "Internal error: requested DummyLayer for {context} without missing tensors"
+        );
+    }
+
+    let has_uqff_placeholder = required
+        .iter()
+        .any(|name| safetensors::is_uqff_dummy_tensor(vb, name));
+    if !has_uqff_placeholder {
+        candle_core::bail!(
+            "Missing required tensor(s) for {context} at prefix `{}`: {}. Dummy layers are only allowed for tensors intentionally omitted while loading UQFF artifacts.",
+            tensor_prefix(vb),
+            missing.join(", ")
+        );
+    }
+
+    Ok(Arc::new(DummyLayer::placeholder(DummyLayerInfo {
+        context: context.to_string(),
+        prefix: tensor_prefix(vb),
+        missing_tensors: missing,
+    })))
 }
 
 pub fn linear_no_bias(
@@ -1108,10 +1164,8 @@ pub fn linear_no_bias(
             }
         }
     } else {
-        // Handle the case where the layer is dummy (no tensors)
         if !vb.contains_tensor("weight") {
-            let layer = <DummyLayer as QuantMethod>::new(QuantMethodConfig::Dummy)?;
-            Arc::new(layer) as Arc<dyn QuantMethod>
+            make_dummy_or_error("linear_no_bias", &vb, &["weight"])?
         } else {
             let weight = vb.get_with_hints((out_dim, in_dim), "weight", Default::default())?;
             let weight = merge_lora_weights(&vb, weight, in_dim, out_dim, Default::default())?;
@@ -1173,10 +1227,8 @@ pub fn linear(
             }
         }
     } else {
-        // Handle the case where the layer is dummy (no tensors)
-        if !(vb.contains_tensor("weight") && vb.contains_tensor("bias")) {
-            let layer = <DummyLayer as QuantMethod>::new(QuantMethodConfig::Dummy)?;
-            Arc::new(layer) as Arc<dyn QuantMethod>
+        if has_missing_required_tensors(&vb, &["weight", "bias"]) {
+            make_dummy_or_error("linear", &vb, &["weight", "bias"])?
         } else {
             let weight = vb.get_with_hints((out_dim, in_dim), "weight", Default::default())?;
             let weight = merge_lora_weights(&vb, weight, in_dim, out_dim, Default::default())?;
@@ -1202,5 +1254,66 @@ pub fn linear_b(
         linear(in_dim, out_dim, config, vb)
     } else {
         linear_no_bias(in_dim, out_dim, config, vb)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashMap;
+
+    use super::*;
+
+    fn empty_vb(make_dummy_regexes: Option<Vec<&str>>) -> ShardedVarBuilder {
+        let backend: HashMap<String, Tensor> = HashMap::new();
+        let make_dummy_regexes = make_dummy_regexes.map(|regexes| {
+            Arc::new(
+                regexes
+                    .into_iter()
+                    .map(Regex::new)
+                    .collect::<std::result::Result<Vec<_>, _>>()
+                    .unwrap(),
+            )
+        });
+        ShardedSafeTensors::wrap_with_dummy_regexes(
+            Box::new(backend),
+            DType::F32,
+            Device::Cpu,
+            make_dummy_regexes,
+        )
+    }
+
+    #[test]
+    fn missing_linear_weight_outside_uqff_errors() {
+        let err = linear_no_bias(2, 3, &None, empty_vb(None).pp("foo")).unwrap_err();
+        let msg = err.to_string();
+
+        assert!(msg.contains("Missing required tensor(s)"));
+        assert!(msg.contains("foo.weight"));
+        assert!(msg.contains("UQFF"));
+    }
+
+    #[test]
+    fn missing_uqff_placeholder_creates_contextual_dummy() -> Result<()> {
+        let layer = linear_no_bias(
+            2,
+            3,
+            &None,
+            empty_vb(Some(vec![r"^foo\.weight$"])).pp("foo"),
+        )?;
+
+        let info = layer.dummy_info().unwrap();
+        assert_eq!(layer.name(), "dummy");
+        assert_eq!(info.context, "linear_no_bias");
+        assert_eq!(info.prefix, "foo");
+        assert_eq!(info.missing_tensors, vec!["foo.weight"]);
+
+        let input = Tensor::zeros((1, 2), DType::F32, &Device::Cpu)?;
+        let err = layer.forward_raw(&input).unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("forward pass"));
+        assert!(msg.contains("foo.weight"));
+        assert!(msg.contains("temporary UQFF placeholders"));
+
+        Ok(())
     }
 }

--- a/mistralrs-quant/src/lora/static_lora.rs
+++ b/mistralrs-quant/src/lora/static_lora.rs
@@ -4,7 +4,9 @@ use candle_core::{DType, Result};
 use candle_nn::Linear;
 use regex::Regex;
 
-use crate::{DummyLayer, QuantMethod, QuantMethodConfig, ShardedVarBuilder, UnquantLinear};
+use crate::{
+    make_dummy_or_error, QuantMethod, QuantMethodConfig, ShardedVarBuilder, UnquantLinear,
+};
 
 use super::StaticLoraConfig;
 
@@ -21,10 +23,8 @@ pub fn linear_no_bias_static_lora(
     vb: ShardedVarBuilder,
 ) -> Result<Arc<dyn QuantMethod>> {
     let layer = {
-        // Handle the case where the layer is dummy (no tensors)
         if !vb.contains_tensor("base_layer.weight") {
-            let layer = <DummyLayer as QuantMethod>::new(QuantMethodConfig::Dummy)?;
-            Arc::new(layer) as Arc<dyn QuantMethod>
+            make_dummy_or_error("static_lora_linear_no_bias", &vb, &["base_layer.weight"])?
         } else {
             let mut weight =
                 vb.get_with_hints((out_dim, in_dim), "base_layer.weight", Default::default())?;

--- a/mistralrs-quant/src/pertensor_fp8/mod.rs
+++ b/mistralrs-quant/src/pertensor_fp8/mod.rs
@@ -9,12 +9,13 @@ use candle_nn::Linear;
 mod ops;
 
 use crate::{
-    generate_isq, generate_isq_imatrix,
+    generate_isq, generate_isq_imatrix, has_missing_required_tensors,
     hqq::{ISQ_HQQ_DEFAULT_OPT_STEPS, ISQ_HQQ_GROUP_SIZE},
+    make_dummy_or_error,
     utils::{serialize_tensor, UQFF_VERSION},
-    AfqBits, AfqGroupSize, AfqLayer, DummyLayer, FP8Linear, GgufMatMul, HqqAxis, HqqBits,
-    HqqConfig, HqqLayer, IsqType, QuantMethod, QuantMethodConfig, QuantizeOntoGuard,
-    QuantizedConfig, QuantizedSerde, QuantizedSerdeType, Shard, ShardedVarBuilder, UnquantLinear,
+    AfqBits, AfqGroupSize, AfqLayer, FP8Linear, GgufMatMul, HqqAxis, HqqBits, HqqConfig, HqqLayer,
+    IsqType, QuantMethod, QuantMethodConfig, QuantizeOntoGuard, QuantizedConfig, QuantizedSerde,
+    QuantizedSerdeType, Shard, ShardedVarBuilder, UnquantLinear,
 };
 
 /// Per-tensor FP8 Linear layer with static activation scaling.
@@ -311,10 +312,8 @@ pub fn pertensor_fp8_linear_b(
         return crate::linear_b(in_dim, out_dim, bias, &None, vb);
     }
 
-    // Handle the case where the layer is dummy (no tensors)
-    if !vb.contains_tensor("weight") {
-        let layer = <DummyLayer as QuantMethod>::new(QuantMethodConfig::Dummy)?;
-        return Ok(Arc::new(layer) as Arc<dyn QuantMethod>);
+    if has_missing_required_tensors(&vb, &["weight", "weight_scale_inv"]) {
+        return make_dummy_or_error("pertensor_fp8_linear", &vb, &["weight", "weight_scale_inv"]);
     }
 
     // Load FP8 weight tensor

--- a/mistralrs-quant/src/safetensors.rs
+++ b/mistralrs-quant/src/safetensors.rs
@@ -8,6 +8,19 @@ use std::collections::HashMap;
 use std::path::Path;
 use std::sync::Arc;
 
+const UQFF_DUMMY_TENSOR_MARKER: &str = "__mistralrs_uqff_dummy_tensor__";
+
+fn marked_uqff_dummy_tensor(name: &str) -> Option<&str> {
+    name.strip_prefix(UQFF_DUMMY_TENSOR_MARKER)
+        .and_then(|path| path.strip_prefix('.'))
+}
+
+fn matches_dummy_regex(make_dummy_regexes: &Option<Arc<Vec<Regex>>>, path: &str) -> bool {
+    make_dummy_regexes
+        .as_ref()
+        .is_some_and(|regexes| regexes.iter().any(|regex| regex.is_match(path)))
+}
+
 fn convert_slice<T: WithDType>(data: &[u8], shape: &[usize], device: &Device) -> Result<Tensor> {
     let size_in_bytes = T::DTYPE.size_in_bytes();
     let elem_count = data.len() / size_in_bytes;
@@ -349,10 +362,28 @@ pub enum ShardedSafeTensors {
         make_dummy_regexes: Option<Arc<Vec<Regex>>>,
         predicate: Arc<dyn Fn(String) -> bool + Send + Sync + 'static>,
     },
-    SimpleBackend(Box<dyn SimpleBackend + 'static>),
+    SimpleBackend {
+        b: Box<dyn SimpleBackend + 'static>,
+        make_dummy_regexes: Option<Arc<Vec<Regex>>>,
+    },
 }
 
 pub type ShardedVarBuilder = VarBuilderArgs<'static, ShardedSafeTensors>;
+
+pub fn full_tensor_name(vb: &ShardedVarBuilder, name: &str) -> String {
+    let prefix = vb.prefix();
+    if prefix.is_empty() {
+        name.to_string()
+    } else {
+        format!("{prefix}.{name}")
+    }
+}
+
+pub fn is_uqff_dummy_tensor(vb: &ShardedVarBuilder, name: &str) -> bool {
+    let path = full_tensor_name(vb, name);
+    vb.root()
+        .contains_tensor(&format!("{UQFF_DUMMY_TENSOR_MARKER}.{path}"))
+}
 
 impl ShardedSafeTensors {
     /// Initializes a `VarBuilder` that retrieves tensors stored in a collection of safetensors
@@ -387,7 +418,23 @@ impl ShardedSafeTensors {
         dtype: DType,
         dev: Device,
     ) -> ShardedVarBuilder {
-        VarBuilderArgs::new_with_args(Self::SimpleBackend(backend), dtype, &dev)
+        Self::wrap_with_dummy_regexes(backend, dtype, dev, None)
+    }
+
+    pub fn wrap_with_dummy_regexes(
+        backend: Box<dyn SimpleBackend + 'static>,
+        dtype: DType,
+        dev: Device,
+        make_dummy_regexes: Option<Arc<Vec<Regex>>>,
+    ) -> ShardedVarBuilder {
+        VarBuilderArgs::new_with_args(
+            Self::SimpleBackend {
+                b: backend,
+                make_dummy_regexes,
+            },
+            dtype,
+            &dev,
+        )
     }
 }
 
@@ -519,7 +566,7 @@ impl Backend for ShardedSafeTensors {
                         dev,
                     );
                 }
-                Self::SimpleBackend(b) => {
+                Self::SimpleBackend { b, .. } => {
                     return SimpleBackend::get(
                         b.as_ref(),
                         target_shape,
@@ -607,7 +654,7 @@ impl Backend for ShardedSafeTensors {
                         let raw: Vec<u8> = iterator.into_iter().flatten().cloned().collect();
                         Tensor::from_raw_buffer(&raw, view_dtype, &shape, dev)?.to_dtype(dtype)?
                     }
-                    Self::SimpleBackend(b) => {
+                    Self::SimpleBackend { b, .. } => {
                         let tensor = b.get(target_shape, path, Default::default(), dtype, dev)?;
                         h.apply_to(&tensor)?
                     }
@@ -674,7 +721,7 @@ impl Backend for ShardedSafeTensors {
                         let raw: Vec<u8> = iterator.into_iter().flatten().cloned().collect();
                         Tensor::from_raw_buffer(&raw, view_dtype, &shape, dev)?.to_dtype(dtype)?
                     }
-                    Self::SimpleBackend(b) => {
+                    Self::SimpleBackend { b, .. } => {
                         let tensor = b.get(target_shape, path, Default::default(), dtype, dev)?;
                         h.apply_to(&tensor)?
                     }
@@ -707,7 +754,7 @@ impl Backend for ShardedSafeTensors {
                 }
                 <MmapedSafetensors as SimpleBackend>::get_unchecked(b, name, dtype, dev)
             }
-            Self::SimpleBackend(b) => b.as_ref().get_unchecked(name, dtype, dev),
+            Self::SimpleBackend { b, .. } => b.as_ref().get_unchecked(name, dtype, dev),
         }
     }
 
@@ -718,6 +765,9 @@ impl Backend for ShardedSafeTensors {
                 make_dummy_regexes,
                 predicate,
             } => {
+                if let Some(path) = marked_uqff_dummy_tensor(name) {
+                    return matches_dummy_regex(make_dummy_regexes, path);
+                }
                 if let Some(make_dummy_regexes) = make_dummy_regexes {
                     if make_dummy_regexes.iter().any(|x| x.is_match(name)) {
                         return false;
@@ -729,7 +779,15 @@ impl Backend for ShardedSafeTensors {
                 }
                 b.get(name).is_ok()
             }
-            Self::SimpleBackend(b) => b.as_ref().contains_tensor(name),
+            Self::SimpleBackend {
+                b,
+                make_dummy_regexes,
+            } => {
+                if let Some(path) = marked_uqff_dummy_tensor(name) {
+                    return matches_dummy_regex(make_dummy_regexes, path);
+                }
+                b.as_ref().contains_tensor(name)
+            }
         }
     }
 }

--- a/mistralrs-quant/src/vector_fp8/mod.rs
+++ b/mistralrs-quant/src/vector_fp8/mod.rs
@@ -10,9 +10,9 @@ pub use ops::{fp8_vector_dequantize, fp8_vector_quantize};
 pub(crate) mod ffi;
 
 use crate::{
-    generate_isq, generate_isq_imatrix,
+    generate_isq, generate_isq_imatrix, has_missing_required_tensors,
     hqq::{ISQ_HQQ_DEFAULT_OPT_STEPS, ISQ_HQQ_GROUP_SIZE},
-    AfqBits, AfqGroupSize, AfqLayer, DummyLayer, FP8Linear, GgufMatMul, HqqAxis, HqqBits,
+    make_dummy_or_error, AfqBits, AfqGroupSize, AfqLayer, FP8Linear, GgufMatMul, HqqAxis, HqqBits,
     HqqConfig, HqqLayer, IsqType, QuantMethod, QuantMethodConfig, QuantizeOntoGuard,
     QuantizedSerde, Shard, ShardedVarBuilder, UnquantLinear,
 };
@@ -268,10 +268,8 @@ pub fn vector_fp8_linear_b(
         return crate::linear_b(in_dim, out_dim, bias, &None, vb);
     }
 
-    // Handle the case where the layer is dummy (no tensors)
-    if !(vb.contains_tensor("weight") && vb.contains_tensor("weight_scale_inv")) {
-        let layer = <DummyLayer as QuantMethod>::new(QuantMethodConfig::Dummy)?;
-        return Ok(Arc::new(layer) as Arc<dyn QuantMethod>);
+    if has_missing_required_tensors(&vb, &["weight", "weight_scale_inv"]) {
+        return make_dummy_or_error("vector_fp8_linear", &vb, &["weight", "weight_scale_inv"]);
     }
 
     let weight = vb.get_with_hints_dtype((out_dim, in_dim), "weight", hints, DType::F8E4M3)?;


### PR DESCRIPTION
Fixes #2102.

This changes dummy-layer handling so missing layer tensors fail during model construction unless the layer is explicitly being created as a UQFF placeholder. UQFF placeholders now also retain context about which tensor path was missing, making unreplaced placeholders and runtime failures much easier to diagnose.