### PR TITLE
refactor(core): memory usage to handle discrete/unified systems better

### DIFF
--- a/mistralrs-core/src/attention/backends/naive.rs
+++ b/mistralrs-core/src/attention/backends/naive.rs
@@ -14,7 +14,7 @@ pub(crate) fn maybe_synchronize(device: &Device) -> Result<()> {
     const FOUR_GIB: usize = 4 * 1024 * 1024 * 1024;
     #[cfg(not(target_pointer_width = "64"))]
     const FOUR_GIB: usize = usize::MAX;
-    if MemoryUsage.get_memory_available(device)? < FOUR_GIB {
+    if MemoryUsage.query(device)?.available() < FOUR_GIB {
         device.synchronize()?;
     }
     Ok(())

--- a/mistralrs-core/src/device_map.rs
+++ b/mistralrs-core/src/device_map.rs
@@ -248,7 +248,8 @@ impl DeviceMapSetting {
                                 i - 1,
                                 current_dev.device_pretty_repr(),
                                 MemoryUsage
-                                    .get_total_memory(current_dev)?
+                                    .query(current_dev)?
+                                    .total()
                                     .div_ceil(1024 * 1024 * 1024),
                             ));
                             start_index = i; // start a new range
@@ -262,7 +263,8 @@ impl DeviceMapSetting {
                         combined.len() - 1,
                         current_dev.device_pretty_repr(),
                         MemoryUsage
-                            .get_total_memory(current_dev)?
+                            .query(current_dev)?
+                            .total()
                             .div_ceil(1024 * 1024 * 1024),
                     ));
                 }

--- a/mistralrs-core/src/diagnostics.rs
+++ b/mistralrs-core/src/diagnostics.rs
@@ -143,11 +143,9 @@ fn collect_devices(sys: &System) -> Vec<DeviceInfo> {
     {
         let mut ord = 0;
         while let Ok(dev) = Device::new_cuda(ord) {
-            let total = MemoryUsage.get_total_memory(&dev).ok().map(|v| v as u64);
-            let avail = MemoryUsage
-                .get_memory_available(&dev)
-                .ok()
-                .map(|v| v as u64);
+            let mem = MemoryUsage.query(&dev).ok();
+            let total = mem.map(|m| m.total() as u64);
+            let avail = mem.map(|m| m.available() as u64);
 
             // Get compute capability
             let compute_cap = get_cuda_compute_capability(ord);
@@ -180,11 +178,9 @@ fn collect_devices(sys: &System) -> Vec<DeviceInfo> {
         let total = candle_metal_kernels::metal::Device::all().len();
         for ord in 0..total {
             if let Ok(dev) = Device::new_metal(ord) {
-                let total = MemoryUsage.get_total_memory(&dev).ok().map(|v| v as u64);
-                let avail = MemoryUsage
-                    .get_memory_available(&dev)
-                    .ok()
-                    .map(|v| v as u64);
+                let mem = MemoryUsage.query(&dev).ok();
+                let total = mem.map(|m| m.total() as u64);
+                let avail = mem.map(|m| m.available() as u64);
                 devices.push(DeviceInfo {
                     kind: "metal".to_string(),
                     ordinal: Some(ord),

--- a/mistralrs-core/src/paged_attention/mod.rs
+++ b/mistralrs-core/src/paged_attention/mod.rs
@@ -132,22 +132,13 @@ pub fn calculate_cache_config(
         let mem_gpu = match mem_gpu {
             MemoryGpuConfig::MbAmount(v) => v,
             MemoryGpuConfig::Utilization(f) => {
-                let total = MemoryUsage.get_total_memory(device)? as f32 / SIZE_IN_MB as f32;
+                let mem = MemoryUsage.query(device)?;
+                let total = mem.total() as f32 / SIZE_IN_MB as f32;
                 if model_weight_size_in_bytes.is_some() {
                     // Pre-loading: compute budget from total memory and known model size.
                     (total * f - model_weight_per_device_mb as f32).max(0.0) as usize
                 } else {
-                    let free = MemoryUsage.get_memory_available(device)? as f32 / SIZE_IN_MB as f32;
-                    #[allow(unused_mut)]
-                    let mut used = total - free;
-                    // On Metal, get_total_memory (wired limit) and get_memory_available
-                    // (recommendedMaxWorkingSetSize - allocated) have different bases,
-                    // so `total - free` is incorrect. Use the device's tracked
-                    // allocation size directly.
-                    #[cfg(feature = "metal")]
-                    if let Device::Metal(dev) = device {
-                        used = dev.current_allocated_size() as f32 / SIZE_IN_MB as f32;
-                    }
+                    let used = (mem.total() - mem.available()) as f32 / SIZE_IN_MB as f32;
                     (total * f - used).max(0.0) as usize
                 }
             }

--- a/mistralrs-core/src/pipeline/loaders/auto_device_map.rs
+++ b/mistralrs-core/src/pipeline/loaders/auto_device_map.rs
@@ -231,7 +231,7 @@ pub fn get_device_layers(
                 MemoryGpuConfig::MbAmount(user_mb) => {
                     // Clamp user's KV budget to available memory.
                     let primary_dev = &devices[0];
-                    let avail_bytes = MemoryUsage.get_memory_available(primary_dev)?;
+                    let avail_bytes = MemoryUsage.query(primary_dev)?.available();
                     let cap = device_cap(avail_bytes, primary_dev);
                     let act_overhead = non_mapped_max.max(mapped_max);
                     let budget_mb = cap.saturating_sub(act_overhead) / (1024 * 1024);
@@ -243,7 +243,7 @@ pub fn get_device_layers(
                     // Cap the KV budget so model + activations + KV fits within
                     // the device capacity derived from *available* memory.
                     let primary_dev = &devices[0];
-                    let avail_bytes = MemoryUsage.get_memory_available(primary_dev)?;
+                    let avail_bytes = MemoryUsage.query(primary_dev)?.available();
                     let cap = device_cap(avail_bytes, primary_dev);
                     let act_overhead = non_mapped_max.max(mapped_max);
                     let budget_mb = ((cap as f64 * f as f64) as usize)
@@ -299,13 +299,13 @@ pub fn get_device_layers(
 
     let mut avail = Vec::new();
     for dev in devices {
-        let a = MemoryUsage.get_memory_available(dev)?;
+        let a = MemoryUsage.query(dev)?.available();
         avail.push((a, dev.clone()));
     }
     // On unified memory systems (iGPUs), GPU and CPU share the same physical RAM.
     // Don't add CPU as a fallback device since it would double-count memory.
     if !has_unified_memory {
-        let a = MemoryUsage.get_memory_available(&Device::Cpu)?;
+        let a = MemoryUsage.query(&Device::Cpu)?.available();
         avail.push((a, Device::Cpu));
     }
 

--- a/mistralrs-core/src/tuning.rs
+++ b/mistralrs-core/src/tuning.rs
@@ -385,7 +385,7 @@ fn total_vram(devices: &[Device]) -> u64 {
     devices
         .iter()
         .filter(|d| !matches!(d, Device::Cpu))
-        .filter_map(|d| MemoryUsage.get_total_memory(d).ok())
+        .filter_map(|d| MemoryUsage.query(d).ok().map(|m| m.total()))
         .sum::<usize>() as u64
 }
 
@@ -396,7 +396,7 @@ fn available_vram(devices: &[Device]) -> u64 {
     devices
         .iter()
         .filter(|d| !matches!(d, Device::Cpu))
-        .filter_map(|d| MemoryUsage.get_memory_available(d).ok())
+        .filter_map(|d| MemoryUsage.query(d).ok().map(|m| m.available()))
         .sum::<usize>() as u64
 }
 

--- a/mistralrs-core/src/utils/memory_usage.rs
+++ b/mistralrs-core/src/utils/memory_usage.rs
@@ -1,10 +1,104 @@
 use candle_core::{Device, Result};
 use sysinfo::System;
+#[cfg(feature = "metal")]
+use tracing::warn;
+
+#[cfg(feature = "metal")]
+const SIZE_IN_MB: usize = 1024 * 1024;
+
+#[derive(Debug, Clone, Copy)]
+pub enum DeviceMemory {
+    Discrete { total: usize, free: usize },
+    Unified { budget: usize, allocated: usize },
+}
+
+impl DeviceMemory {
+    pub fn total(&self) -> usize {
+        match *self {
+            Self::Discrete { total, .. } => total,
+            Self::Unified { budget, .. } => budget,
+        }
+    }
+
+    pub fn available(&self) -> usize {
+        match *self {
+            Self::Discrete { free, .. } => free,
+            Self::Unified { budget, allocated } => budget.saturating_sub(allocated),
+        }
+    }
+
+    pub fn is_unified(&self) -> bool {
+        matches!(self, Self::Unified { .. })
+    }
+}
 
 pub struct MemoryUsage;
 
-/// Returns the memory fraction to use for integrated CUDA GPUs.
-/// Defaults to 0.75, configurable via MISTRALRS_IGPU_MEMORY_FRACTION.
+impl MemoryUsage {
+    #[allow(clippy::cast_possible_truncation, clippy::cast_precision_loss)]
+    pub fn query(&self, device: &Device) -> Result<DeviceMemory> {
+        match device {
+            Device::Cpu => {
+                let sys = System::new_all();
+                Ok(DeviceMemory::Discrete {
+                    total: usize::try_from(sys.total_memory())?,
+                    free: usize::try_from(sys.available_memory())?,
+                })
+            }
+            #[cfg(feature = "cuda")]
+            Device::Cuda(dev) => {
+                if super::normal::is_integrated_gpu(device) {
+                    let sys = System::new_all();
+                    let total_bytes = usize::try_from(sys.total_memory())?;
+                    let avail_bytes = usize::try_from(sys.available_memory())?;
+                    let fraction = igpu_memory_fraction();
+                    let budget = (total_bytes as f64 * fraction) as usize;
+                    let free = (avail_bytes as f64 * fraction) as usize;
+                    Ok(DeviceMemory::Unified {
+                        budget,
+                        allocated: budget.saturating_sub(free),
+                    })
+                } else {
+                    use candle_core::cuda::cudarc::driver::result;
+                    use candle_core::cuda_backend::WrapErr;
+
+                    dev.cuda_stream().context().bind_to_thread().w()?;
+                    let (free, total) = result::mem_get_info().w()?;
+                    Ok(DeviceMemory::Discrete { total, free })
+                }
+            }
+            #[cfg(not(feature = "cuda"))]
+            Device::Cuda(_) => {
+                candle_core::bail!("Cannot query memory for CUDA device")
+            }
+            #[cfg(feature = "metal")]
+            Device::Metal(dev) => {
+                let sysctl_floor = metal_sysctl_floor_bytes()?;
+                let device_max = dev.device().recommended_max_working_set_size();
+                let budget = sysctl_floor.max(device_max);
+                let allocated = dev.current_allocated_size();
+
+                // recommendedMaxWorkingSetSize is dynamic and can underreport on small/pressured Apple Silicon.
+                // See: https://github.com/EricLBuehler/mistral.rs/issues/2127
+                if device_max != 0 && device_max < sysctl_floor / 2 {
+                    warn!(
+                        "Metal recommendedMaxWorkingSetSize ({} MB) is much smaller than the system-RAM floor ({} MB); currentAllocatedSize = {} MB. Using the floor.",
+                        device_max / SIZE_IN_MB,
+                        sysctl_floor / SIZE_IN_MB,
+                        allocated / SIZE_IN_MB,
+                    );
+                }
+
+                Ok(DeviceMemory::Unified { budget, allocated })
+            }
+            #[cfg(not(feature = "metal"))]
+            Device::Metal(_) => {
+                candle_core::bail!("Cannot query memory for Metal device")
+            }
+        }
+    }
+}
+
 #[cfg(feature = "cuda")]
 fn igpu_memory_fraction() -> f64 {
     std::env::var("MISTRALRS_IGPU_MEMORY_FRACTION")
@@ -20,134 +114,32 @@ fn igpu_memory_fraction() -> f64 {
         .unwrap_or(0.75)
 }
 
-impl MemoryUsage {
-    /// Amount of available memory in bytes.
-    #[allow(clippy::cast_possible_truncation, clippy::cast_precision_loss)]
-    pub fn get_memory_available(&self, device: &Device) -> Result<usize> {
-        match device {
-            Device::Cpu => {
-                let mut sys = System::new_all();
-                sys.refresh_cpu_all();
-                Ok(usize::try_from(sys.available_memory())?)
-            }
-            #[cfg(feature = "cuda")]
-            Device::Cuda(dev) => {
-                if super::normal::is_integrated_gpu(device) {
-                    // For integrated GPUs with unified memory, use system memory
-                    // scaled by a configurable fraction (default 75%)
-                    let mut sys = System::new_all();
-                    sys.refresh_cpu_all();
-                    let avail = usize::try_from(sys.available_memory())?;
-                    let fraction = igpu_memory_fraction();
-                    Ok((avail as f64 * fraction) as usize)
-                } else {
-                    use candle_core::cuda::cudarc::driver::result;
-                    use candle_core::cuda_backend::WrapErr;
+#[cfg(feature = "metal")]
+fn metal_sysctl_floor_bytes() -> Result<usize> {
+    let sys = System::new_all();
+    let system_ram_mb = usize::try_from(sys.total_memory())? / SIZE_IN_MB;
 
-                    dev.cuda_stream().context().bind_to_thread().w()?;
-                    let (free, _total) = result::mem_get_info().w()?;
-                    Ok(free)
-                }
-            }
-            #[cfg(not(feature = "cuda"))]
-            Device::Cuda(_) => {
-                candle_core::bail!("Cannot get memory available for CUDA device")
-            }
-            #[cfg(feature = "metal")]
-            Device::Metal(dev) => {
-                let max = dev.device().recommended_max_working_set_size();
-                let alloc = dev.current_allocated_size();
-                let avail = max.saturating_sub(alloc);
+    let sysctl_mb = std::process::Command::new("sysctl")
+        .arg("-n")
+        .arg("iogpu.wired_limit_mb")
+        .output()
+        .ok()
+        .and_then(|o| String::from_utf8(o.stdout).ok())
+        .and_then(|s| s.trim().parse::<usize>().ok());
 
-                #[allow(clippy::cast_possible_truncation)]
-                Ok(avail)
-            }
-            #[cfg(not(feature = "metal"))]
-            Device::Metal(_) => {
-                candle_core::bail!("Cannot get memory available for Metal device")
-            }
+    let default_cap_mb = match system_ram_mb {
+        x if x <= 36 * 1024 => (system_ram_mb * 2) / 3,
+        x if x > 36 * 1024 => (system_ram_mb * 3) / 4,
+        x => {
+            return Err(candle_core::Error::Msg(format!(
+                "Invalid system ram mb value {x}."
+            )))
         }
-    }
+    };
 
-    /// Amount of total memory in bytes.
-    #[allow(clippy::cast_possible_truncation, clippy::cast_precision_loss)]
-    pub fn get_total_memory(&self, device: &Device) -> Result<usize> {
-        match device {
-            Device::Cpu => {
-                let mut sys = System::new_all();
-                sys.refresh_cpu_all();
-                Ok(usize::try_from(sys.total_memory())?)
-            }
-            #[cfg(feature = "cuda")]
-            Device::Cuda(dev) => {
-                if super::normal::is_integrated_gpu(device) {
-                    // For integrated GPUs with unified memory, use system total memory
-                    // scaled by a configurable fraction (default 75%)
-                    let mut sys = System::new_all();
-                    sys.refresh_cpu_all();
-                    let total = usize::try_from(sys.total_memory())?;
-                    let fraction = igpu_memory_fraction();
-                    Ok((total as f64 * fraction) as usize)
-                } else {
-                    use candle_core::cuda::cudarc::driver::result;
-                    use candle_core::cuda_backend::WrapErr;
-
-                    dev.cuda_stream().context().bind_to_thread().w()?;
-                    let (_free, total) = result::mem_get_info().w()?;
-                    Ok(total)
-                }
-            }
-            #[cfg(not(feature = "cuda"))]
-            Device::Cuda(_) => {
-                candle_core::bail!("Cannot get total memory for CUDA device")
-            }
-            #[cfg(feature = "metal")]
-            #[allow(clippy::cast_possible_truncation)]
-            Device::Metal(dev) => {
-                const SIZE_IN_MB: usize = 1024 * 1024;
-
-                // Get system RAM in MB
-                let system_ram_mb = {
-                    let mut sys = System::new_all();
-                    sys.refresh_cpu_all();
-                    usize::try_from(sys.total_memory())? / SIZE_IN_MB
-                };
-
-                // Check for Metal GPU wired limit
-                let metal_cap_mb = std::process::Command::new("sysctl")
-                    .arg("-n")
-                    .arg("iogpu.wired_limit_mb")
-                    .output()
-                    .ok()
-                    .and_then(|o| String::from_utf8(o.stdout).ok())
-                    .and_then(|s| s.trim().parse::<usize>().ok());
-
-                // Apply default cap based on system RAM if not set or 0
-                let default_cap = match system_ram_mb {
-                    x if x <= 36 * 1024 => (system_ram_mb * 2) / 3,
-                    x if x > 36 * 1024 => (system_ram_mb * 3) / 4,
-                    x => {
-                        return Err(candle_core::Error::Msg(format!(
-                            "Invalid system ram mb value {x}."
-                        )))
-                    }
-                };
-
-                let metal_cap_mb = match metal_cap_mb {
-                    Some(0) => default_cap,
-                    Some(x) => x,
-                    None => default_cap,
-                };
-
-                let device_max = dev.recommended_max_working_set_size();
-                let metal_cap_bytes = metal_cap_mb * SIZE_IN_MB;
-
-                Ok(device_max.min(metal_cap_bytes))
-            }
-            #[cfg(not(feature = "metal"))]
-            Device::Metal(_) => {
-                candle_core::bail!("Cannot get memory available for Metal device")
-            }
-        }
-    }
+    let floor_mb = match sysctl_mb {
+        Some(0) | None => default_cap_mb,
+        Some(x) => x,
+    };
+    Ok(floor_mb * SIZE_IN_MB)
 }

--- a/mistralrs-core/src/utils/memory_usage.rs
+++ b/mistralrs-core/src/utils/memory_usage.rs
@@ -79,8 +79,9 @@ impl MemoryUsage {
                 let allocated = dev.current_allocated_size();
 
                 // recommendedMaxWorkingSetSize is dynamic and can underreport on small/pressured Apple Silicon.
+                // Dividing by 2 here is a heuristic to indicate that we are now below an expected value.
                 // See: https://github.com/EricLBuehler/mistral.rs/issues/2127
-                if device_max != 0 && device_max < sysctl_floor / 2 {
+                if device_max < sysctl_floor / 2 {
                     warn!(
                         "Metal recommendedMaxWorkingSetSize ({} MB) is much smaller than the system-RAM floor ({} MB); currentAllocatedSize = {} MB. Using the floor.",
                         device_max / SIZE_IN_MB,


### PR DESCRIPTION
Fixes #2127 as a side effect as a previous underflow in `recommendedMaxWorkingSetSize - currentAllocatedSize`. The unified budget is now computed as `max(sysctl_floor, recommendedMaxWorkingSetSize)`.