### PR TITLE
refactor(quant): centralize UQFF ISQ mapping

### DIFF
--- a/mistralrs-quant/src/gguf/mod.rs
+++ b/mistralrs-quant/src/gguf/mod.rs
@@ -387,28 +387,8 @@ impl QuantizedSerde for GgufMatMul {
         let data_len = buffer.read_u32::<LittleEndian>()? as usize;
 
         let has_bias = buffer.read_u8()? != 0;
-
-        // TODO: keep this in sync with get_isq_type_from_uqff!
         let dtype = buffer.read_u32::<LittleEndian>()?;
-        let dtype = match dtype {
-            0 => GgmlDType::F32,
-            1 => GgmlDType::F16,
-            2 => GgmlDType::Q4_0,
-            3 => GgmlDType::Q4_1,
-            6 => GgmlDType::Q5_0,
-            7 => GgmlDType::Q5_1,
-            8 => GgmlDType::Q8_0,
-            9 => GgmlDType::Q8_1,
-            10 => GgmlDType::Q2K,
-            11 => GgmlDType::Q3K,
-            12 => GgmlDType::Q4K,
-            13 => GgmlDType::Q5K,
-            14 => GgmlDType::Q6K,
-            15 => GgmlDType::Q8K,
-            // https://github.com/ggerganov/ggml/blob/29d87fc6676e7ed0cdfdec0804b06001d9c2bb44/include/ggml.h#L389
-            30 => GgmlDType::BF16,
-            _ => candle_core::bail!("unknown dtype for quantized weight tensor {dtype}"),
-        };
+        let dtype = crate::get_isq_type_from_uqff!(gguf, dtype);
 
         let n_dims = buffer.read_u32::<LittleEndian>()? as usize;
 
@@ -457,28 +437,8 @@ impl QuantizedSerde for GgufMatMul {
         let data_len = buffer.read_u32::<LittleEndian>()? as usize;
 
         let has_bias = buffer.read_u8()? != 0;
-
-        // TODO: keep this in sync with get_isq_type_from_uqff!
         let dtype = buffer.read_u32::<LittleEndian>()?;
-        let dtype = match dtype {
-            0 => GgmlDType::F32,
-            1 => GgmlDType::F16,
-            2 => GgmlDType::Q4_0,
-            3 => GgmlDType::Q4_1,
-            6 => GgmlDType::Q5_0,
-            7 => GgmlDType::Q5_1,
-            8 => GgmlDType::Q8_0,
-            9 => GgmlDType::Q8_1,
-            10 => GgmlDType::Q2K,
-            11 => GgmlDType::Q3K,
-            12 => GgmlDType::Q4K,
-            13 => GgmlDType::Q5K,
-            14 => GgmlDType::Q6K,
-            15 => GgmlDType::Q8K,
-            // https://github.com/ggerganov/ggml/blob/29d87fc6676e7ed0cdfdec0804b06001d9c2bb44/include/ggml.h#L389
-            30 => GgmlDType::BF16,
-            _ => candle_core::bail!("unknown dtype for quantized weight tensor {dtype}"),
-        };
+        let dtype = crate::get_isq_type_from_uqff!(gguf, dtype);
 
         let n_dims = buffer.read_u32::<LittleEndian>()? as usize;
 
@@ -529,27 +489,8 @@ impl GgufMatMul {
         let _ = buffer.read_u32::<LittleEndian>()? as usize;
 
         let _ = buffer.read_u8()? != 0;
-
         let dtype = buffer.read_u32::<LittleEndian>()?;
-        let dtype = match dtype {
-            0 => GgmlDType::F32,
-            1 => GgmlDType::F16,
-            2 => GgmlDType::Q4_0,
-            3 => GgmlDType::Q4_1,
-            6 => GgmlDType::Q5_0,
-            7 => GgmlDType::Q5_1,
-            8 => GgmlDType::Q8_0,
-            9 => GgmlDType::Q8_1,
-            10 => GgmlDType::Q2K,
-            11 => GgmlDType::Q3K,
-            12 => GgmlDType::Q4K,
-            13 => GgmlDType::Q5K,
-            14 => GgmlDType::Q6K,
-            15 => GgmlDType::Q8K,
-            // https://github.com/ggerganov/ggml/blob/29d87fc6676e7ed0cdfdec0804b06001d9c2bb44/include/ggml.h#L389
-            30 => GgmlDType::BF16,
-            _ => candle_core::bail!("unknown dtype for quantized weight tensor {dtype}"),
-        };
+        let dtype = crate::get_isq_type_from_uqff!(gguf, dtype);
 
         IsqType::try_from(dtype)
     }

--- a/mistralrs-quant/src/hqq/mod.rs
+++ b/mistralrs-quant/src/hqq/mod.rs
@@ -134,14 +134,7 @@ pub enum HqqBits {
 impl TryFrom<usize> for HqqBits {
     type Error = candle_core::Error;
     fn try_from(value: usize) -> std::result::Result<Self, Self::Error> {
-        match value {
-            8 => Ok(Self::Eight),
-            4 => Ok(Self::Four),
-            3 => Ok(Self::Three),
-            2 => Ok(Self::Two),
-            1 => Ok(Self::One),
-            other => candle_core::bail!("Unexpected value for HQQ bits {other}"),
-        }
+        crate::get_isq_type_from_uqff!(hqq, value)
     }
 }
 
@@ -1138,8 +1131,6 @@ impl QuantizedSerde for HqqLayer {
             dims.push(buffer.read_u32::<LittleEndian>()? as usize)
         }
         let w_shape = Shape::from_dims(&dims);
-
-        // TODO: keep this in sync with get_isq_type_from_uqff!
         let bits = HqqBits::try_from(buffer.read_u8()? as usize)?;
         let group_size = NonZeroUsize::try_from(buffer.read_u32::<LittleEndian>()? as usize)?;
         let axis = HqqAxis::try_from(buffer.read_u8()? as usize)?;
@@ -1211,8 +1202,6 @@ impl QuantizedSerde for HqqLayer {
             dims.push(buffer.read_u32::<LittleEndian>()? as usize)
         }
         let w_shape = Shape::from_dims(&dims);
-
-        // TODO: keep this in sync with get_isq_type_from_uqff!
         let bits = HqqBits::try_from(buffer.read_u8()? as usize)?;
         let group_size = NonZeroUsize::try_from(buffer.read_u32::<LittleEndian>()? as usize)?;
         let axis = HqqAxis::try_from(buffer.read_u8()? as usize)?;
@@ -1282,16 +1271,7 @@ impl HqqLayer {
             dims.push(buffer.read_u32::<LittleEndian>()? as usize)
         }
         let _w_shape = Shape::from_dims(&dims);
-
-        // TODO: keep this in sync with get_isq_type_from_uqff!
         let bits = HqqBits::try_from(buffer.read_u8()? as usize)?;
-
-        match bits {
-            HqqBits::Eight => Ok(IsqType::HQQ8),
-            HqqBits::Four => Ok(IsqType::HQQ4),
-            HqqBits::One | HqqBits::Two | HqqBits::Three => {
-                candle_core::bail!("cannot convert hqq bits to isq type")
-            }
-        }
+        crate::get_isq_type_from_uqff!(hqq_ser, bits)
     }
 }

--- a/mistralrs-quant/src/utils/isq.rs
+++ b/mistralrs-quant/src/utils/isq.rs
@@ -160,3 +160,47 @@ macro_rules! generate_isq_imatrix {
         }
     };
 }
+
+#[macro_export]
+macro_rules! get_isq_type_from_uqff {
+    (gguf, $dtype:expr) => {
+        match $dtype {
+            0 => candle_core::quantized::GgmlDType::F32,
+            1 => candle_core::quantized::GgmlDType::F16,
+            2 => candle_core::quantized::GgmlDType::Q4_0,
+            3 => candle_core::quantized::GgmlDType::Q4_1,
+            6 => candle_core::quantized::GgmlDType::Q5_0,
+            7 => candle_core::quantized::GgmlDType::Q5_1,
+            8 => candle_core::quantized::GgmlDType::Q8_0,
+            9 => candle_core::quantized::GgmlDType::Q8_1,
+            10 => candle_core::quantized::GgmlDType::Q2K,
+            11 => candle_core::quantized::GgmlDType::Q3K,
+            12 => candle_core::quantized::GgmlDType::Q4K,
+            13 => candle_core::quantized::GgmlDType::Q5K,
+            14 => candle_core::quantized::GgmlDType::Q6K,
+            15 => candle_core::quantized::GgmlDType::Q8K,
+            // https://github.com/ggerganov/ggml/blob/29d87fc6676e7ed0cdfdec0804b06001d9c2bb44/include/ggml.h#L389
+            30 => candle_core::quantized::GgmlDType::BF16,
+            _ => candle_core::bail!("unknown dtype for quantized weight tensor {}", $dtype),
+        }
+    };
+    (hqq, $bits:expr) => {
+        match $bits {
+            8 => Ok(Self::Eight),
+            4 => Ok(Self::Four),
+            3 => Ok(Self::Three),
+            2 => Ok(Self::Two),
+            1 => Ok(Self::One),
+            other => candle_core::bail!("Unexpected value for HQQ bits {other}"),
+        }
+    };
+    (hqq_ser, $bits:expr) => {
+        match $bits {
+            crate::HqqBits::Eight => Ok(crate::IsqType::HQQ8),
+            crate::HqqBits::Four => Ok(crate::IsqType::HQQ4),
+            crate::HqqBits::One | crate::HqqBits::Two | crate::HqqBits::Three => {
+                candle_core::bail!("cannot convert hqq bits to isq type")
+            }
+        }
+    };
+}

--- a/mistralrs-quant/tests/uqff_mapping.rs
+++ b/mistralrs-quant/tests/uqff_mapping.rs
@@ -1,0 +1,131 @@
+use std::borrow::Cow;
+
+use mistralrs_quant::{GgufMatMul, HqqBits, HqqLayer, IsqType};
+
+const UQFF_VERSION: u32 = 0x0002_00;
+const UQFF_TYPE_GGUF: u8 = 0;
+const UQFF_TYPE_HQQ: u8 = 2;
+
+fn gguf_uqff_with_dtype(dtype: u32) -> Vec<u8> {
+    let mut data = Vec::new();
+    data.extend(&UQFF_VERSION.to_le_bytes());
+    data.push(UQFF_TYPE_GGUF);
+    data.extend(&0u32.to_le_bytes());
+    data.push(0);
+    data.extend(&dtype.to_le_bytes());
+    data
+}
+
+fn append_empty_u8_tensor(data: &mut Vec<u8>) {
+    data.extend(&0u32.to_le_bytes());
+    data.extend(&0u32.to_le_bytes());
+    data.extend(&0u32.to_le_bytes());
+}
+
+fn hqq_uqff_with_bits(bits: u8) -> Vec<u8> {
+    let mut data = Vec::new();
+    data.extend(&UQFF_VERSION.to_le_bytes());
+    data.push(UQFF_TYPE_HQQ);
+    data.push(0);
+    append_empty_u8_tensor(&mut data);
+    append_empty_u8_tensor(&mut data);
+    append_empty_u8_tensor(&mut data);
+    data.extend(&0u32.to_le_bytes());
+    data.push(bits);
+    data
+}
+
+#[test]
+fn gguf_uqff_dtype_mapping_matches_isq_types() {
+    let cases = [
+        (2, IsqType::Q4_0),
+        (3, IsqType::Q4_1),
+        (6, IsqType::Q5_0),
+        (7, IsqType::Q5_1),
+        (8, IsqType::Q8_0),
+        (9, IsqType::Q8_1),
+        (10, IsqType::Q2K),
+        (11, IsqType::Q3K),
+        (12, IsqType::Q4K),
+        (13, IsqType::Q5K),
+        (14, IsqType::Q6K),
+        (15, IsqType::Q8K),
+    ];
+
+    for (dtype, expected) in cases {
+        let actual =
+            GgufMatMul::get_isq_type_from_uqff(Cow::Owned(gguf_uqff_with_dtype(dtype))).unwrap();
+        assert_eq!(actual, expected, "dtype {dtype}");
+    }
+}
+
+#[test]
+fn gguf_uqff_dtype_mapping_preserves_error_cases() {
+    for dtype in [0, 1, 30] {
+        let err = GgufMatMul::get_isq_type_from_uqff(Cow::Owned(gguf_uqff_with_dtype(dtype)))
+            .unwrap_err();
+        assert!(
+            err.to_string().contains("Expected valid GGML ISQ type"),
+            "dtype {dtype}: {err}"
+        );
+    }
+
+    let err = GgufMatMul::get_isq_type_from_uqff(Cow::Owned(gguf_uqff_with_dtype(99))).unwrap_err();
+    assert!(
+        err.to_string()
+            .contains("unknown dtype for quantized weight tensor 99"),
+        "{err}"
+    );
+}
+
+#[test]
+fn hqq_bits_mapping_preserves_serialized_values() {
+    let cases = [
+        (8, HqqBits::Eight),
+        (4, HqqBits::Four),
+        (3, HqqBits::Three),
+        (2, HqqBits::Two),
+        (1, HqqBits::One),
+    ];
+
+    for (bits, expected) in cases {
+        let actual = HqqBits::try_from(bits).unwrap();
+        assert_eq!(actual as u8, expected as u8, "bits {bits}");
+    }
+
+    let err = HqqBits::try_from(5).unwrap_err();
+    assert!(
+        err.to_string().contains("Unexpected value for HQQ bits 5"),
+        "{err}"
+    );
+}
+
+#[test]
+fn hqq_uqff_bits_mapping_matches_isq_types() {
+    let cases = [(8, IsqType::HQQ8), (4, IsqType::HQQ4)];
+
+    for (bits, expected) in cases {
+        let actual =
+            HqqLayer::get_isq_type_from_uqff(Cow::Owned(hqq_uqff_with_bits(bits))).unwrap();
+        assert_eq!(actual, expected, "bits {bits}");
+    }
+}
+
+#[test]
+fn hqq_uqff_bits_mapping_preserves_error_cases() {
+    for bits in [1, 2, 3] {
+        let err =
+            HqqLayer::get_isq_type_from_uqff(Cow::Owned(hqq_uqff_with_bits(bits))).unwrap_err();
+        assert!(
+            err.to_string()
+                .contains("cannot convert hqq bits to isq type"),
+            "bits {bits}: {err}"
+        );
+    }
+
+    let err = HqqLayer::get_isq_type_from_uqff(Cow::Owned(hqq_uqff_with_bits(5))).unwrap_err();
+    assert!(
+        err.to_string().contains("Unexpected value for HQQ bits 5"),
+        "{err}"
+    );
+}


### PR DESCRIPTION
## Scope

Centralizes UQFF-to-ISQ mapping with GGUF/HQQ UQFF equivalence coverage; no behavior fix is claimed.

- Fork survivor: https://github.com/glaziermag/mistral.rs/pull/10
- Fork evidence: https://github.com/glaziermag/mistral.rs/pull/10#issuecomment-4483019314
- Validated fork head: `ec141bf18e03092350429c1e8728541eaeb7fbf0`
- Upstream base used here: `0ed6f6ca2c1dc835c494f303ed30444b2ad7c83e`

## Changes

- Centralizes UQFF serialized dtype/bits to ISQ mapping.
- Keeps GGUF/HQQ call-site behavior equivalent.
- Includes targeted UQFF mapping equivalence coverage from the validated fork work.

## Validation

Existing fork validation artifacts cover compile/fmt/tests and mapping-equivalence checks. This upstream branch was created from current upstream `master`; no new validation was run in this upstreaming pass.

## Non-Claims

- No behavior fix is claimed.
- No runtime/model issue closure is claimed.
