### PR TITLE
refactor(core): make imatrix_names explicit

### DIFF
--- a/mistralrs-core/src/models/deepseek2.rs
+++ b/mistralrs-core/src/models/deepseek2.rs
@@ -945,6 +945,9 @@ impl DeepSeekV2 {
 }
 
 impl IsqModel for DeepSeekV2 {
+    fn imatrix_names(&self) -> candle_core::Result<Vec<Option<String>>> {
+        candle_core::bail!("This model does not support quantizing with an imatrix.");
+    }
     fn get_layers(
         &mut self,
     ) -> (

--- a/mistralrs-core/src/models/deepseek3.rs
+++ b/mistralrs-core/src/models/deepseek3.rs
@@ -999,6 +999,9 @@ impl DeepSeekV3 {
 }
 
 impl IsqModel for DeepSeekV3 {
+    fn imatrix_names(&self) -> candle_core::Result<Vec<Option<String>>> {
+        candle_core::bail!("This model does not support quantizing with an imatrix.");
+    }
     fn get_layers(
         &mut self,
     ) -> (

--- a/mistralrs-core/src/models/glm4_moe.rs
+++ b/mistralrs-core/src/models/glm4_moe.rs
@@ -872,6 +872,9 @@ impl Glm4Moe {
 }
 
 impl IsqModel for Glm4Moe {
+    fn imatrix_names(&self) -> candle_core::Result<Vec<Option<String>>> {
+        candle_core::bail!("This model does not support quantizing with an imatrix.");
+    }
     fn get_layers(
         &mut self,
     ) -> (

--- a/mistralrs-core/src/models/glm4_moe_lite.rs
+++ b/mistralrs-core/src/models/glm4_moe_lite.rs
@@ -977,6 +977,9 @@ impl Glm4MoeLite {
 }
 
 impl IsqModel for Glm4MoeLite {
+    fn imatrix_names(&self) -> candle_core::Result<Vec<Option<String>>> {
+        candle_core::bail!("This model does not support quantizing with an imatrix.");
+    }
     fn get_layers(
         &mut self,
     ) -> (

--- a/mistralrs-core/src/models/gpt_oss.rs
+++ b/mistralrs-core/src/models/gpt_oss.rs
@@ -804,6 +804,9 @@ impl Model {
 }
 
 impl IsqModel for Model {
+    fn imatrix_names(&self) -> candle_core::Result<Vec<Option<String>>> {
+        candle_core::bail!("This model does not support quantizing with an imatrix.");
+    }
     fn get_layers(
         &mut self,
     ) -> (

--- a/mistralrs-core/src/models/mixtral.rs
+++ b/mistralrs-core/src/models/mixtral.rs
@@ -645,6 +645,9 @@ impl Model {
 }
 
 impl IsqModel for Model {
+    fn imatrix_names(&self) -> candle_core::Result<Vec<Option<String>>> {
+        candle_core::bail!("This model does not support quantizing with an imatrix.");
+    }
     fn get_layers(
         &mut self,
     ) -> (

--- a/mistralrs-core/src/models/phi2.rs
+++ b/mistralrs-core/src/models/phi2.rs
@@ -585,6 +585,9 @@ impl Model {
 }
 
 impl IsqModel for Model {
+    fn imatrix_names(&self) -> candle_core::Result<Vec<Option<String>>> {
+        candle_core::bail!("This model does not support quantizing with an imatrix.");
+    }
     fn get_layers(
         &mut self,
     ) -> (

--- a/mistralrs-core/src/models/phi3_5_moe.rs
+++ b/mistralrs-core/src/models/phi3_5_moe.rs
@@ -729,6 +729,9 @@ impl Model {
 }
 
 impl IsqModel for Model {
+    fn imatrix_names(&self) -> candle_core::Result<Vec<Option<String>>> {
+        candle_core::bail!("This model does not support quantizing with an imatrix.");
+    }
     fn get_layers(
         &mut self,
     ) -> (

--- a/mistralrs-core/src/models/qwen3_moe.rs
+++ b/mistralrs-core/src/models/qwen3_moe.rs
@@ -777,6 +777,9 @@ impl Model {
 }
 
 impl IsqModel for Model {
+    fn imatrix_names(&self) -> candle_core::Result<Vec<Option<String>>> {
+        candle_core::bail!("This model does not support quantizing with an imatrix.");
+    }
     fn get_layers(
         &mut self,
     ) -> (

--- a/mistralrs-core/src/models/qwen3_next.rs
+++ b/mistralrs-core/src/models/qwen3_next.rs
@@ -1001,6 +1001,9 @@ impl Model {
 // ====================== Trait Implementations ======================
 
 impl IsqModel for Model {
+    fn imatrix_names(&self) -> candle_core::Result<Vec<Option<String>>> {
+        candle_core::bail!("This model does not support quantizing with an imatrix.");
+    }
     fn get_layers(
         &mut self,
     ) -> (

--- a/mistralrs-core/src/models/starcoder2.rs
+++ b/mistralrs-core/src/models/starcoder2.rs
@@ -577,6 +577,9 @@ impl Model {
 }
 
 impl IsqModel for Model {
+    fn imatrix_names(&self) -> candle_core::Result<Vec<Option<String>>> {
+        candle_core::bail!("This model does not support quantizing with an imatrix.");
+    }
     fn get_layers(
         &mut self,
     ) -> (

--- a/mistralrs-core/src/pipeline/isq.rs
+++ b/mistralrs-core/src/pipeline/isq.rs
@@ -394,10 +394,7 @@ pub trait IsqModel {
     ///
     /// - This is only for loading from a llama.cpp imatrix file.
     /// - Corresponds to `IsqOrganization::Default`
-    fn imatrix_names(&self) -> candle_core::Result<Vec<Option<String>>> {
-        // TODO: make this required.
-        candle_core::bail!("This model does not support quantizing with an imatrix.");
-    }
+    fn imatrix_names(&self) -> candle_core::Result<Vec<Option<String>>>;
 
     /// Residual tensors for generating a UQFF file. Counterpart to [`get_layers`].
     fn residual_tensors(&self) -> Vec<(String, Tensor)>;

--- a/mistralrs-core/src/vision_models/idefics2/mod.rs
+++ b/mistralrs-core/src/vision_models/idefics2/mod.rs
@@ -1259,6 +1259,9 @@ impl Idefics2 {
 }
 
 impl IsqModel for Idefics2 {
+    fn imatrix_names(&self) -> candle_core::Result<Vec<Option<String>>> {
+        candle_core::bail!("This model does not support quantizing with an imatrix.");
+    }
     fn get_layers(
         &mut self,
     ) -> (

--- a/mistralrs-core/src/vision_models/idefics3/mod.rs
+++ b/mistralrs-core/src/vision_models/idefics3/mod.rs
@@ -264,6 +264,9 @@ impl Idefics3Model {
 }
 
 impl IsqModel for Idefics3Model {
+    fn imatrix_names(&self) -> candle_core::Result<Vec<Option<String>>> {
+        candle_core::bail!("This model does not support quantizing with an imatrix.");
+    }
     fn get_layers(
         &mut self,
     ) -> (

--- a/mistralrs-core/src/vision_models/llama4/mod.rs
+++ b/mistralrs-core/src/vision_models/llama4/mod.rs
@@ -154,6 +154,9 @@ impl Llama4Model {
 }
 
 impl IsqModel for Llama4Model {
+    fn imatrix_names(&self) -> candle_core::Result<Vec<Option<String>>> {
+        candle_core::bail!("This model does not support quantizing with an imatrix.");
+    }
     fn get_layers(
         &mut self,
     ) -> (

--- a/mistralrs-core/src/vision_models/llama4/text.rs
+++ b/mistralrs-core/src/vision_models/llama4/text.rs
@@ -763,6 +763,9 @@ impl TextModel {
 }
 
 impl IsqModel for TextModel {
+    fn imatrix_names(&self) -> candle_core::Result<Vec<Option<String>>> {
+        candle_core::bail!("This model does not support quantizing with an imatrix.");
+    }
     fn get_layers(
         &mut self,
     ) -> (

--- a/mistralrs-core/src/vision_models/llama4/vision.rs
+++ b/mistralrs-core/src/vision_models/llama4/vision.rs
@@ -664,6 +664,9 @@ impl Llama4VisionModel {
 }
 
 impl IsqModel for Llama4VisionModel {
+    fn imatrix_names(&self) -> candle_core::Result<Vec<Option<String>>> {
+        candle_core::bail!("This model does not support quantizing with an imatrix.");
+    }
     fn get_layers(
         &mut self,
     ) -> (

--- a/mistralrs-core/src/vision_models/llava/llava15.rs
+++ b/mistralrs-core/src/vision_models/llava/llava15.rs
@@ -279,6 +279,9 @@ impl Model {
 }
 
 impl IsqModel for Model {
+    fn imatrix_names(&self) -> candle_core::Result<Vec<Option<String>>> {
+        candle_core::bail!("This model does not support quantizing with an imatrix.");
+    }
     fn get_layers(
         &mut self,
     ) -> (

--- a/mistralrs-core/src/vision_models/llava/llava_llm/llama.rs
+++ b/mistralrs-core/src/vision_models/llava/llava_llm/llama.rs
@@ -515,6 +515,9 @@ impl Llama {
 }
 
 impl IsqModel for Llama {
+    fn imatrix_names(&self) -> candle_core::Result<Vec<Option<String>>> {
+        candle_core::bail!("This model does not support quantizing with an imatrix.");
+    }
     fn get_layers(
         &mut self,
     ) -> (

--- a/mistralrs-core/src/vision_models/llava/llava_llm/mistral.rs
+++ b/mistralrs-core/src/vision_models/llava/llava_llm/mistral.rs
@@ -597,6 +597,9 @@ impl Model {
 }
 
 impl IsqModel for Model {
+    fn imatrix_names(&self) -> candle_core::Result<Vec<Option<String>>> {
+        candle_core::bail!("This model does not support quantizing with an imatrix.");
+    }
     fn get_layers(
         &mut self,
     ) -> (

--- a/mistralrs-core/src/vision_models/llava/llava_next.rs
+++ b/mistralrs-core/src/vision_models/llava/llava_next.rs
@@ -413,6 +413,9 @@ impl Model {
 }
 
 impl IsqModel for Model {
+    fn imatrix_names(&self) -> candle_core::Result<Vec<Option<String>>> {
+        candle_core::bail!("This model does not support quantizing with an imatrix.");
+    }
     fn get_layers(
         &mut self,
     ) -> (

--- a/mistralrs-core/src/vision_models/minicpmo/mod.rs
+++ b/mistralrs-core/src/vision_models/minicpmo/mod.rs
@@ -417,6 +417,9 @@ impl MultimodalModel for MiniCpmOModel {
 }
 
 impl IsqModel for MiniCpmOModel {
+    fn imatrix_names(&self) -> candle_core::Result<Vec<Option<String>>> {
+        candle_core::bail!("This model does not support quantizing with an imatrix.");
+    }
     fn get_layers(
         &mut self,
     ) -> (

--- a/mistralrs-core/src/vision_models/mllama/mod.rs
+++ b/mistralrs-core/src/vision_models/mllama/mod.rs
@@ -310,6 +310,9 @@ impl MultimodalModel for MLlamaModel {
 }
 
 impl IsqModel for MLlamaModel {
+    fn imatrix_names(&self) -> candle_core::Result<Vec<Option<String>>> {
+        candle_core::bail!("This model does not support quantizing with an imatrix.");
+    }
     fn get_layers(
         &mut self,
     ) -> (

--- a/mistralrs-core/src/vision_models/mllama/text.rs
+++ b/mistralrs-core/src/vision_models/mllama/text.rs
@@ -706,6 +706,9 @@ impl MLlamaTextModel {
 }
 
 impl IsqModel for MLlamaTextModel {
+    fn imatrix_names(&self) -> candle_core::Result<Vec<Option<String>>> {
+        candle_core::bail!("This model does not support quantizing with an imatrix.");
+    }
     fn get_layers(
         &mut self,
     ) -> (

--- a/mistralrs-core/src/vision_models/mllama/vision.rs
+++ b/mistralrs-core/src/vision_models/mllama/vision.rs
@@ -737,6 +737,9 @@ impl MLlamaVisionModel {
 }
 
 impl IsqModel for MLlamaVisionModel {
+    fn imatrix_names(&self) -> candle_core::Result<Vec<Option<String>>> {
+        candle_core::bail!("This model does not support quantizing with an imatrix.");
+    }
     fn get_layers(
         &mut self,
     ) -> (

--- a/mistralrs-core/src/vision_models/phi3/mod.rs
+++ b/mistralrs-core/src/vision_models/phi3/mod.rs
@@ -1230,6 +1230,9 @@ impl Model {
 }
 
 impl IsqModel for Model {
+    fn imatrix_names(&self) -> candle_core::Result<Vec<Option<String>>> {
+        candle_core::bail!("This model does not support quantizing with an imatrix.");
+    }
     fn get_layers(
         &mut self,
     ) -> (

--- a/mistralrs-core/src/vision_models/phi4/mod.rs
+++ b/mistralrs-core/src/vision_models/phi4/mod.rs
@@ -623,6 +623,9 @@ impl MultimodalModel for Phi4MMModel {
 }
 
 impl IsqModel for Phi4MMModel {
+    fn imatrix_names(&self) -> candle_core::Result<Vec<Option<String>>> {
+        candle_core::bail!("This model does not support quantizing with an imatrix.");
+    }
     fn get_layers(
         &mut self,
     ) -> (

--- a/mistralrs-core/src/vision_models/qwen2_5_vl/mod.rs
+++ b/mistralrs-core/src/vision_models/qwen2_5_vl/mod.rs
@@ -637,6 +637,9 @@ impl MultimodalModel for Qwen2_5VLModel {
 }
 
 impl IsqModel for Qwen2_5VLModel {
+    fn imatrix_names(&self) -> candle_core::Result<Vec<Option<String>>> {
+        candle_core::bail!("This model does not support quantizing with an imatrix.");
+    }
     fn get_layers(
         &mut self,
     ) -> (

--- a/mistralrs-core/src/vision_models/qwen2_5_vl/text.rs
+++ b/mistralrs-core/src/vision_models/qwen2_5_vl/text.rs
@@ -462,6 +462,9 @@ impl Qwen2_5VLTextModel {
 }
 
 impl IsqModel for Qwen2_5VLTextModel {
+    fn imatrix_names(&self) -> candle_core::Result<Vec<Option<String>>> {
+        candle_core::bail!("This model does not support quantizing with an imatrix.");
+    }
     fn get_layers(
         &mut self,
     ) -> (

--- a/mistralrs-core/src/vision_models/qwen2vl/mod.rs
+++ b/mistralrs-core/src/vision_models/qwen2vl/mod.rs
@@ -637,6 +637,9 @@ impl MultimodalModel for Qwen2VLModel {
 }
 
 impl IsqModel for Qwen2VLModel {
+    fn imatrix_names(&self) -> candle_core::Result<Vec<Option<String>>> {
+        candle_core::bail!("This model does not support quantizing with an imatrix.");
+    }
     fn get_layers(
         &mut self,
     ) -> (

--- a/mistralrs-core/src/vision_models/qwen2vl/text.rs
+++ b/mistralrs-core/src/vision_models/qwen2vl/text.rs
@@ -458,6 +458,9 @@ impl Qwen2VLTextModel {
 }
 
 impl IsqModel for Qwen2VLTextModel {
+    fn imatrix_names(&self) -> candle_core::Result<Vec<Option<String>>> {
+        candle_core::bail!("This model does not support quantizing with an imatrix.");
+    }
     fn get_layers(
         &mut self,
     ) -> (

--- a/mistralrs-core/src/vision_models/qwen3_5/mod.rs
+++ b/mistralrs-core/src/vision_models/qwen3_5/mod.rs
@@ -562,6 +562,10 @@ impl MultimodalModel for Qwen3_5Model {
 }
 
 impl IsqModel for Qwen3_5Model {
+    fn imatrix_names(&self) -> candle_core::Result<Vec<Option<String>>> {
+        candle_core::bail!("This model does not support quantizing with an imatrix.");
+    }
+
     fn get_layers(
         &mut self,
     ) -> (

--- a/mistralrs-core/src/vision_models/qwen3_5/text.rs
+++ b/mistralrs-core/src/vision_models/qwen3_5/text.rs
@@ -808,6 +808,10 @@ impl Qwen3_5TextModel {
 }
 
 impl IsqModel for Qwen3_5TextModel {
+    fn imatrix_names(&self) -> candle_core::Result<Vec<Option<String>>> {
+        candle_core::bail!("This model does not support quantizing with an imatrix.");
+    }
+
     fn get_layers(
         &mut self,
     ) -> (

--- a/mistralrs-core/src/vision_models/qwen3_5_moe/mod.rs
+++ b/mistralrs-core/src/vision_models/qwen3_5_moe/mod.rs
@@ -562,6 +562,10 @@ impl MultimodalModel for Qwen3_5MoeModel {
 }
 
 impl IsqModel for Qwen3_5MoeModel {
+    fn imatrix_names(&self) -> candle_core::Result<Vec<Option<String>>> {
+        candle_core::bail!("This model does not support quantizing with an imatrix.");
+    }
+
     fn get_layers(
         &mut self,
     ) -> (

--- a/mistralrs-core/src/vision_models/qwen3_5_moe/text.rs
+++ b/mistralrs-core/src/vision_models/qwen3_5_moe/text.rs
@@ -932,6 +932,10 @@ impl Qwen3_5MoeTextModel {
 }
 
 impl IsqModel for Qwen3_5MoeTextModel {
+    fn imatrix_names(&self) -> candle_core::Result<Vec<Option<String>>> {
+        candle_core::bail!("This model does not support quantizing with an imatrix.");
+    }
+
     fn get_layers(
         &mut self,
     ) -> (

--- a/mistralrs-core/src/vision_models/qwen3_vl/mod.rs
+++ b/mistralrs-core/src/vision_models/qwen3_vl/mod.rs
@@ -882,6 +882,9 @@ impl MultimodalModel for Qwen3VLModel {
 }
 
 impl IsqModel for Qwen3VLModel {
+    fn imatrix_names(&self) -> candle_core::Result<Vec<Option<String>>> {
+        candle_core::bail!("This model does not support quantizing with an imatrix.");
+    }
     fn get_layers(
         &mut self,
     ) -> (

--- a/mistralrs-core/src/vision_models/qwen3_vl/text.rs
+++ b/mistralrs-core/src/vision_models/qwen3_vl/text.rs
@@ -594,6 +594,9 @@ impl Qwen3VLTextModel {
 }
 
 impl IsqModel for Qwen3VLTextModel {
+    fn imatrix_names(&self) -> candle_core::Result<Vec<Option<String>>> {
+        candle_core::bail!("This model does not support quantizing with an imatrix.");
+    }
     fn get_layers(
         &mut self,
     ) -> (

--- a/mistralrs-core/src/vision_models/qwen3_vl_moe/mod.rs
+++ b/mistralrs-core/src/vision_models/qwen3_vl_moe/mod.rs
@@ -565,6 +565,9 @@ impl MultimodalModel for Qwen3VLMoEModel {
 }
 
 impl IsqModel for Qwen3VLMoEModel {
+    fn imatrix_names(&self) -> candle_core::Result<Vec<Option<String>>> {
+        candle_core::bail!("This model does not support quantizing with an imatrix.");
+    }
     fn get_layers(
         &mut self,
     ) -> (

--- a/mistralrs-core/src/vision_models/qwen3_vl_moe/text.rs
+++ b/mistralrs-core/src/vision_models/qwen3_vl_moe/text.rs
@@ -713,6 +713,9 @@ impl Qwen3VLMoETextModel {
 }
 
 impl IsqModel for Qwen3VLMoETextModel {
+    fn imatrix_names(&self) -> candle_core::Result<Vec<Option<String>>> {
+        candle_core::bail!("This model does not support quantizing with an imatrix.");
+    }
     fn get_layers(
         &mut self,
     ) -> (

--- a/mistralrs-core/src/xlora_models/gemma.rs
+++ b/mistralrs-core/src/xlora_models/gemma.rs
@@ -685,6 +685,9 @@ impl XLoraModel {
 }
 
 impl IsqModel for XLoraModel {
+    fn imatrix_names(&self) -> candle_core::Result<Vec<Option<String>>> {
+        candle_core::bail!("This model does not support quantizing with an imatrix.");
+    }
     fn get_layers(
         &mut self,
     ) -> (

--- a/mistralrs-core/src/xlora_models/gemma2.rs
+++ b/mistralrs-core/src/xlora_models/gemma2.rs
@@ -741,6 +741,9 @@ impl Model {
 }
 
 impl IsqModel for Model {
+    fn imatrix_names(&self) -> candle_core::Result<Vec<Option<String>>> {
+        candle_core::bail!("This model does not support quantizing with an imatrix.");
+    }
     fn get_layers(
         &mut self,
     ) -> (

--- a/mistralrs-core/src/xlora_models/llama.rs
+++ b/mistralrs-core/src/xlora_models/llama.rs
@@ -661,6 +661,9 @@ impl XLoraLlama {
 }
 
 impl IsqModel for XLoraLlama {
+    fn imatrix_names(&self) -> candle_core::Result<Vec<Option<String>>> {
+        candle_core::bail!("This model does not support quantizing with an imatrix.");
+    }
     fn get_layers(
         &mut self,
     ) -> (

--- a/mistralrs-core/src/xlora_models/mistral.rs
+++ b/mistralrs-core/src/xlora_models/mistral.rs
@@ -685,6 +685,9 @@ impl XLoraModel {
 }
 
 impl IsqModel for XLoraModel {
+    fn imatrix_names(&self) -> candle_core::Result<Vec<Option<String>>> {
+        candle_core::bail!("This model does not support quantizing with an imatrix.");
+    }
     fn get_layers(
         &mut self,
     ) -> (

--- a/mistralrs-core/src/xlora_models/mixtral.rs
+++ b/mistralrs-core/src/xlora_models/mixtral.rs
@@ -814,6 +814,9 @@ impl XLoraModel {
 }
 
 impl IsqModel for XLoraModel {
+    fn imatrix_names(&self) -> candle_core::Result<Vec<Option<String>>> {
+        candle_core::bail!("This model does not support quantizing with an imatrix.");
+    }
     fn get_layers(
         &mut self,
     ) -> (

--- a/mistralrs-core/src/xlora_models/phi2.rs
+++ b/mistralrs-core/src/xlora_models/phi2.rs
@@ -651,6 +651,9 @@ impl Model {
 }
 
 impl IsqModel for Model {
+    fn imatrix_names(&self) -> candle_core::Result<Vec<Option<String>>> {
+        candle_core::bail!("This model does not support quantizing with an imatrix.");
+    }
     fn get_layers(
         &mut self,
     ) -> (

--- a/mistralrs-core/src/xlora_models/phi3.rs
+++ b/mistralrs-core/src/xlora_models/phi3.rs
@@ -644,6 +644,9 @@ impl Model {
 }
 
 impl IsqModel for Model {
+    fn imatrix_names(&self) -> candle_core::Result<Vec<Option<String>>> {
+        candle_core::bail!("This model does not support quantizing with an imatrix.");
+    }
     fn get_layers(
         &mut self,
     ) -> (

--- a/mistralrs-core/src/xlora_models/starcoder2.rs
+++ b/mistralrs-core/src/xlora_models/starcoder2.rs
@@ -670,6 +670,9 @@ impl Model {
 }
 
 impl IsqModel for Model {
+    fn imatrix_names(&self) -> candle_core::Result<Vec<Option<String>>> {
+        candle_core::bail!("This model does not support quantizing with an imatrix.");
+    }
     fn get_layers(
         &mut self,
     ) -> (


### PR DESCRIPTION
## Scope

Makes `imatrix_names` explicit; no behavior fix is claimed.

- Fork survivor: https://github.com/glaziermag/mistral.rs/pull/25
- Fork evidence: https://github.com/glaziermag/mistral.rs/pull/25#issuecomment-4483019618
- Validated fork head: `54f755bec8ccb87d7074d9cf046acf16008a9cc7`
- Upstream base used here: `0ed6f6ca2c1dc835c494f303ed30444b2ad7c83e`

## Changes

- Makes the `IsqModel::imatrix_names` implementation requirement explicit.
- Preserves unsupported-imatrix behavior.
- Keeps the refactor scoped to explicit trait behavior.

## Validation

Existing fork validation artifacts cover compile/fmt and static behavior-preservation checks. This upstream branch was created from current upstream `master`; no new validation was run in this upstreaming pass.

## Non-Claims

- No behavior fix is claimed.
- No runtime/model issue closure is claimed.
