### PR TITLE
refactor(core): rename xlora_paths parameter to tensors

### DIFF
--- a/mistralrs-core/src/utils/model_config.rs
+++ b/mistralrs-core/src/utils/model_config.rs
@@ -76,7 +76,6 @@ impl<'a> Adapter<'a> {
         }
 
         // Create VarBuilder:
-        // TODO: `from_mmaped_safetensors` has `xlora_paths` as the 2nd param (_valid but params need to be named better_)
         let vb = from_mmaped_safetensors(
             xlora_paths,
             adapter_safetensors

--- a/mistralrs-core/src/utils/varbuilder_utils.rs
+++ b/mistralrs-core/src/utils/varbuilder_utils.rs
@@ -67,7 +67,7 @@ pub enum DeviceForLoadTensor {
 #[allow(clippy::too_many_arguments)]
 pub(crate) fn from_mmaped_safetensors(
     paths: Vec<PathBuf>,
-    xlora_paths: Vec<PathBuf>,
+    tensors: Vec<PathBuf>,
     dtype: Option<DType>,
     base_device: &Device,
     layer_devices: Vec<Option<Device>>,
@@ -77,7 +77,7 @@ pub(crate) fn from_mmaped_safetensors(
     get_device_for_tensor: Arc<dyn Fn(String) -> DeviceForLoadTensor + Send + Sync + 'static>,
 ) -> Result<ShardedVarBuilder> {
     let use_no_mmap = std::env::var(MISTRALRS_NO_MMAP).is_ok_and(|x| x == "1");
-    if xlora_paths.is_empty() && !use_no_mmap {
+    if tensors.is_empty() && !use_no_mmap {
         if !silent {
             tracing::info!("Loading model using mmap strategy.");
         }
@@ -131,7 +131,7 @@ pub(crate) fn from_mmaped_safetensors(
             })));
         }
     }
-    for (i, path) in xlora_paths.into_iter().enumerate() {
+    for (i, path) in tensors.into_iter().enumerate() {
         let base_device = base_device.clone();
         let layer_devices = layer_devices.clone();
         let get_device_for_tensor = get_device_for_tensor.clone();


### PR DESCRIPTION
## Scope

Refactors `xlora_paths` to `tensors`; no behavior fix is claimed.

- Fork survivor: https://github.com/glaziermag/mistral.rs/pull/26
- Fork evidence: https://github.com/glaziermag/mistral.rs/pull/26#issuecomment-4483019702
- Validated fork head: `15dc4d1c0150923190406bdcb7b9c7ddc9a5b483`
- Upstream base used here: `0ed6f6ca2c1dc835c494f303ed30444b2ad7c83e`

## Changes

- Renames the `from_mmaped_safetensors` parameter from `xlora_paths` to `tensors`.
- Keeps call-site behavior unchanged.
- Aligns the parameter name with what the argument represents.

## Validation

Existing fork validation artifacts cover compile/fmt and static behavior-preservation checks. This upstream branch was created from current upstream `master`; no new validation was run in this upstreaming pass.

## Non-Claims

- No behavior fix is claimed.
- No runtime/model issue closure is claimed.
