### PR TITLE
fix(pyo3): sandbox local media paths

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -87,6 +87,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
+name = "ambient-authority"
+version = "0.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9d4ee0d472d1cd2e28c97dfa124b3d8d992e10eb0a035f33f5d12e3a177ba3b"
+
+[[package]]
 name = "android_system_properties"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -733,6 +739,36 @@ dependencies = [
  "ug",
  "ug-cuda",
  "ug-metal",
+]
+
+[[package]]
+name = "cap-primitives"
+version = "4.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdadbd7c002d3a484b35243669abdae85a0ebaded5a61117169dc3400f9a7ff0"
+dependencies = [
+ "ambient-authority",
+ "fs-set-times",
+ "io-extras",
+ "io-lifetimes 3.0.1",
+ "ipnet",
+ "maybe-owned",
+ "rustix 1.1.3",
+ "rustix-linux-procfs",
+ "windows-sys 0.61.2",
+ "winx",
+]
+
+[[package]]
+name = "cap-std"
+version = "4.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7281235d6e96d3544ca18bba9049be92f4190f8d923e3caef1b5f66cfa752608"
+dependencies = [
+ "cap-primitives",
+ "io-extras",
+ "io-lifetimes 3.0.1",
+ "rustix 1.1.3",
 ]
 
 [[package]]
@@ -2091,6 +2127,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "fs-set-times"
+version = "0.20.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94e7099f6313ecacbe1256e8ff9d617b75d1bcb16a6fddef94866d225a01a14a"
+dependencies = [
+ "io-lifetimes 2.0.4",
+ "rustix 1.1.3",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "fs2"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3145,6 +3192,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "io-extras"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20fd6de4ccfcc187e38bc21cfa543cb5a302cb86a8b114eb7f0bf0dc9f8ac00f"
+dependencies = [
+ "io-lifetimes 3.0.1",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
+name = "io-lifetimes"
+version = "2.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06432fb54d3be7964ecd3649233cddf80db2832f47fec34c01f65b3d9d774983"
+
+[[package]]
+name = "io-lifetimes"
+version = "3.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f0fb0570afe1fed943c5c3d4102d5358592d8625fda6a0007fdbe65a92fba96"
+
+[[package]]
 name = "ipnet"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3526,6 +3595,12 @@ dependencies = [
  "autocfg",
  "rawpointer",
 ]
+
+[[package]]
+name = "maybe-owned"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4facc753ae494aeb6e3c22f839b158aebd4f9270f55cd3c79906c45476c47ab4"
 
 [[package]]
 name = "maybe-rayon"
@@ -3990,6 +4065,7 @@ dependencies = [
  "anyhow",
  "base64 0.22.1",
  "candle-core",
+ "cap-std",
  "data-url",
  "either",
  "futures",
@@ -5694,6 +5770,16 @@ dependencies = [
  "libc",
  "linux-raw-sys 0.11.0",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rustix-linux-procfs"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2fc84bf7e9aa16c4f2c758f27412dc9841341e16aa682d9c7ac308fe3ee12056"
+dependencies = [
+ "once_cell",
+ "rustix 1.1.3",
 ]
 
 [[package]]
@@ -8307,6 +8393,16 @@ name = "winsafe"
 version = "0.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d135d17ab770252ad95e9a872d365cf3090e3be864a34ab46f48555993efc904"
+
+[[package]]
+name = "winx"
+version = "0.36.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f3fd376f71958b862e7afb20cfe5a22830e1963462f3a17f49d82a6c1d1f42d"
+dependencies = [
+ "bitflags 2.10.0",
+ "windows-sys 0.59.0",
+]
 
 [[package]]
 name = "wit-bindgen"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -157,6 +157,7 @@ symphonia = { version = "0.5.5", default-features = false, features = ["mp3", "f
 lazy_static = "1.5"
 paste = "1.0.15"
 byteorder = "1.5.0"
+cap-std = "4.0.2"
 yoke = { version = "0.8.1", features = ["derive"] }
 memmap2 = "0.9.9"
 pyo3-build-config = "0.25.1"

--- a/docs/src/content/docs/guides/python/getting-started.mdx
+++ b/docs/src/content/docs/guides/python/getting-started.mdx
@@ -102,6 +102,12 @@ Each chunk is a `ChatCompletionChunkResponse` with the OpenAI streaming shape. `
 
 Full example: [streaming](/mistral.rs/examples/python/streaming/). For async iteration, FastAPI integration, and mid-stream error handling, see [streaming from Python](/mistral.rs/guides/python/streaming/).
 
+## Local media files
+
+Local image, audio, and video sources are confined to the Python process's current working directory. Relative paths resolve inside that directory; absolute paths are accepted only when they remain inside it. Parent traversal and symlink escapes are rejected. HTTP(S) and data URLs are unaffected.
+
+This is a breaking security restriction for applications that previously passed media paths outside the working directory. Start the process in a directory that contains the media you intend to expose, copy the media into that directory, or use an HTTP(S) or data URL. Windows drive-relative paths such as `C:image.png` are rejected because their meaning depends on per-drive process state; use `C:\image.png` or a normal relative path instead.
+
 ## Notes
 
 The Runner keeps the model in memory for the process lifetime. Requests can be sent sequentially or from multiple threads, all reusing the loaded weights. To swap models, construct a new Runner; the old one releases GPU memory when it goes out of scope.

--- a/mistralrs-pyo3/Cargo.toml
+++ b/mistralrs-pyo3/Cargo.toml
@@ -33,6 +33,7 @@ tokio.workspace = true
 image.workspace = true
 reqwest.workspace = true
 base64.workspace = true
+cap-std.workspace = true
 url.workspace = true
 data-url.workspace = true
 anyhow.workspace = true

--- a/mistralrs-pyo3/src/util.rs
+++ b/mistralrs-pyo3/src/util.rs
@@ -2,6 +2,7 @@ use std::{
     cell::RefCell,
     fs::{self, File},
     io::{Cursor, Read},
+    path::{Path, PathBuf},
     sync::{Arc, Mutex},
 };
 
@@ -102,6 +103,65 @@ pub(crate) fn next_request_id() -> usize {
     id
 }
 
+fn resolve_local_media_path(path: &Path) -> PyApiResult<PathBuf> {
+    let cwd = std::env::current_dir()
+        .and_then(|path| path.canonicalize())
+        .map_err(|e| format!("Could not resolve current directory: {e}"))?;
+    let candidate = if path.is_absolute() {
+        path.to_path_buf()
+    } else {
+        cwd.join(path)
+    };
+    let resolved = candidate.canonicalize().map_err(|e| {
+        format!(
+            "Could not resolve local media path `{}`: {e}",
+            path.display()
+        )
+    })?;
+
+    if !resolved.starts_with(&cwd) {
+        return Err(PyApiErr::from(format!(
+            "Access denied: local media path is outside the current working directory: {}",
+            path.display()
+        )));
+    }
+
+    Ok(resolved)
+}
+
+fn parse_media_url(url_unparsed: &str) -> PyApiResult<url::Url> {
+    if let Ok(url) = url::Url::parse(url_unparsed) {
+        if url.scheme() == "file" {
+            let path = url
+                .to_file_path()
+                .map_err(|_| format!("Could not parse file path: {url}"))?;
+            let resolved = resolve_local_media_path(&path)?;
+            return url::Url::from_file_path(&resolved)
+                .map_err(|_| format!("Could not parse file path: {}", resolved.display()).into());
+        }
+
+        return Ok(url);
+    }
+
+    let resolved = resolve_local_media_path(Path::new(url_unparsed))?;
+    url::Url::from_file_path(&resolved)
+        .map_err(|_| format!("Could not parse file path: {}", resolved.display()).into())
+}
+
+fn read_local_media_file(url: &url::Url) -> PyApiResult<Vec<u8>> {
+    let path = url
+        .to_file_path()
+        .map_err(|_| format!("Could not parse file path: {url}"))?;
+    let path = resolve_local_media_path(&path)?;
+
+    let mut file = File::open(&path)
+        .map_err(|e| format!("Could not open file at path: {}: {e}", path.display()))?;
+    let metadata = fs::metadata(&path)?;
+    let mut buffer = vec![0; metadata.len() as usize];
+    file.read_exact(&mut buffer)?;
+    Ok(buffer)
+}
+
 pub(crate) fn send_request_with_optional_stream(
     runner: Arc<MistralRs>,
     model_id: Option<String>,
@@ -193,20 +253,7 @@ pub(crate) fn parse_embedding_response(response: Response) -> Result<Vec<f32>, S
 }
 
 pub(crate) fn parse_image_url(url_unparsed: &str) -> PyApiResult<DynamicImage> {
-    let url = if let Ok(url) = url::Url::parse(url_unparsed) {
-        url
-    } else if File::open(url_unparsed).is_ok() {
-        url::Url::from_file_path(std::path::absolute(url_unparsed)?)
-            .map_err(|_| format!("Could not parse file path: {url_unparsed}"))?
-    } else {
-        url::Url::parse(url_unparsed).map_err(|_| {
-            format!(
-                "Invalid source '{}': not a valid URL (http/https/data) and file not found. \
-                 Use a full URL, a data URL, or a file path that exists.",
-                url_unparsed
-            )
-        })?
-    };
+    let url = parse_media_url(url_unparsed)?;
 
     let bytes = if url.scheme() == "http" || url.scheme() == "https" {
         // Read from http
@@ -215,21 +262,7 @@ pub(crate) fn parse_image_url(url_unparsed: &str) -> PyApiResult<DynamicImage> {
             Err(e) => return Err(PyApiErr::from(format!("{e}"))),
         }
     } else if url.scheme() == "file" {
-        let path = url
-            .to_file_path()
-            .map_err(|_| format!("Could not parse file path: {url}"))?;
-
-        if let Ok(mut f) = File::open(&path) {
-            // Read from local file
-            let metadata = fs::metadata(&path)?;
-            let mut buffer = vec![0; metadata.len() as usize];
-            f.read_exact(&mut buffer)?;
-            buffer
-        } else {
-            return Err(PyApiErr::from(format!(
-                "Could not open file at path: {url}"
-            )));
-        }
+        read_local_media_file(&url)?
     } else if url.scheme() == "data" {
         // Decode with base64
         let data_url = data_url::DataUrl::process(url.as_str()).map_err(|e| format!("{e}"))?;
@@ -247,20 +280,7 @@ pub(crate) fn parse_image_url(url_unparsed: &str) -> PyApiResult<DynamicImage> {
 /// Parses and loads an audio file from a URL, file path, or data URL.
 /// Mirrors `parse_image_url` but returns an `AudioInput`.
 pub(crate) fn parse_audio_url(url_unparsed: &str) -> PyApiResult<AudioInput> {
-    let url = if let Ok(url) = url::Url::parse(url_unparsed) {
-        url
-    } else if File::open(url_unparsed).is_ok() {
-        url::Url::from_file_path(std::path::absolute(url_unparsed)?)
-            .map_err(|_| format!("Could not parse file path: {url_unparsed}"))?
-    } else {
-        url::Url::parse(url_unparsed).map_err(|_| {
-            format!(
-                "Invalid source '{}': not a valid URL (http/https/data) and file not found. \
-                 Use a full URL, a data URL, or a file path that exists.",
-                url_unparsed
-            )
-        })?
-    };
+    let url = parse_media_url(url_unparsed)?;
 
     let bytes = if url.scheme() == "http" || url.scheme() == "https" {
         match reqwest::blocking::get(url.clone()) {
@@ -271,20 +291,7 @@ pub(crate) fn parse_audio_url(url_unparsed: &str) -> PyApiResult<AudioInput> {
             Err(e) => return Err(PyApiErr::from(format!("{e}"))),
         }
     } else if url.scheme() == "file" {
-        let path = url
-            .to_file_path()
-            .map_err(|_| format!("Could not parse file path: {url}"))?;
-
-        if let Ok(mut f) = File::open(&path) {
-            let metadata = fs::metadata(&path)?;
-            let mut buffer = vec![0; metadata.len() as usize];
-            f.read_exact(&mut buffer)?;
-            buffer
-        } else {
-            return Err(PyApiErr::from(format!(
-                "Could not open file at path: {url}"
-            )));
-        }
+        read_local_media_file(&url)?
     } else if url.scheme() == "data" {
         let data_url = data_url::DataUrl::process(url.as_str()).map_err(|e| format!("{e}"))?;
         data_url.decode_to_vec().map_err(|e| format!("{e}"))?.0
@@ -307,20 +314,7 @@ const DEFAULT_FPS: f64 = 24.0;
 /// GIF files are decoded with the `image` crate. All other formats require
 /// FFmpeg on `$PATH`.
 pub(crate) fn parse_video_url(url_unparsed: &str) -> PyApiResult<VideoInput> {
-    let url = if let Ok(url) = url::Url::parse(url_unparsed) {
-        url
-    } else if File::open(url_unparsed).is_ok() {
-        url::Url::from_file_path(std::path::absolute(url_unparsed)?)
-            .map_err(|_| format!("Could not parse file path: {url_unparsed}"))?
-    } else {
-        url::Url::parse(url_unparsed).map_err(|_| {
-            format!(
-                "Invalid source '{}': not a valid URL (http/https/data) and file not found. \
-                 Use a full URL, a data URL, or a file path that exists.",
-                url_unparsed
-            )
-        })?
-    };
+    let url = parse_media_url(url_unparsed)?;
 
     let bytes = if url.scheme() == "http" || url.scheme() == "https" {
         match reqwest::blocking::get(url.clone()) {
@@ -331,20 +325,7 @@ pub(crate) fn parse_video_url(url_unparsed: &str) -> PyApiResult<VideoInput> {
             Err(e) => return Err(PyApiErr::from(format!("{e}"))),
         }
     } else if url.scheme() == "file" {
-        let path = url
-            .to_file_path()
-            .map_err(|_| format!("Could not parse file path: {url}"))?;
-
-        if let Ok(mut f) = File::open(&path) {
-            let metadata = fs::metadata(&path)?;
-            let mut buffer = vec![0; metadata.len() as usize];
-            f.read_exact(&mut buffer)?;
-            buffer
-        } else {
-            return Err(PyApiErr::from(format!(
-                "Could not open file at path: {url}"
-            )));
-        }
+        read_local_media_file(&url)?
     } else if url.scheme() == "data" {
         let data_url = data_url::DataUrl::process(url.as_str()).map_err(|e| format!("{e}"))?;
         data_url.decode_to_vec().map_err(|e| format!("{e}"))?.0
@@ -560,5 +541,147 @@ fn parse_fps_fraction(s: &str) -> Option<f64> {
         }
     } else {
         s.parse().ok()
+    }
+}
+
+#[cfg(test)]
+mod local_media_path_tests {
+    use super::*;
+    use std::{
+        env, fs,
+        path::PathBuf,
+        sync::{Mutex as StdMutex, MutexGuard},
+        time::{SystemTime, UNIX_EPOCH},
+    };
+
+    static CWD_LOCK: StdMutex<()> = StdMutex::new(());
+
+    struct Fixture {
+        _guard: MutexGuard<'static, ()>,
+        old_cwd: PathBuf,
+        base: PathBuf,
+        cwd: PathBuf,
+        outside_file: PathBuf,
+    }
+
+    impl Fixture {
+        fn new(name: &str) -> Self {
+            pyo3::prepare_freethreaded_python();
+            let guard = CWD_LOCK.lock().unwrap();
+            let nonce = SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .unwrap()
+                .as_nanos();
+            let base = env::temp_dir().join(format!(
+                "mistralrs-local-media-{name}-{}-{nonce}",
+                std::process::id()
+            ));
+            let cwd = base.join("root").join("a").join("b").join("c");
+            let outside = base.join("root").join("outside");
+            fs::create_dir_all(&cwd).unwrap();
+            fs::create_dir_all(&outside).unwrap();
+
+            fs::write(cwd.join("inside.bin"), b"inside").unwrap();
+            let outside_file = outside.join("outside.bin");
+            fs::write(&outside_file, b"outside").unwrap();
+
+            #[cfg(unix)]
+            std::os::unix::fs::symlink(&outside_file, cwd.join("link.bin")).unwrap();
+
+            let old_cwd = env::current_dir().unwrap();
+            env::set_current_dir(&cwd).unwrap();
+
+            Self {
+                _guard: guard,
+                old_cwd,
+                base,
+                cwd,
+                outside_file,
+            }
+        }
+
+        fn inside_file_url(&self) -> String {
+            url::Url::from_file_path(self.cwd.join("inside.bin"))
+                .unwrap()
+                .to_string()
+        }
+
+        fn outside_file_url(&self) -> String {
+            url::Url::from_file_path(&self.outside_file)
+                .unwrap()
+                .to_string()
+        }
+    }
+
+    impl Drop for Fixture {
+        fn drop(&mut self) {
+            let _ = env::set_current_dir(&self.old_cwd);
+            let _ = fs::remove_dir_all(&self.base);
+        }
+    }
+
+    fn assert_denied(result: PyApiResult<url::Url>) {
+        let err = result.expect_err("expected local media path to be denied");
+        assert!(
+            err.to_string()
+                .contains("outside the current working directory")
+                || err
+                    .to_string()
+                    .contains("Could not resolve local media path"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn blocks_file_url_etc_passwd() {
+        let _fixture = Fixture::new("etc-passwd");
+        assert_denied(parse_media_url("file:///etc/passwd"));
+    }
+
+    #[test]
+    fn blocks_absolute_path_outside_cwd() {
+        let fixture = Fixture::new("absolute-outside");
+        assert_denied(parse_media_url(&fixture.outside_file.display().to_string()));
+    }
+
+    #[test]
+    fn blocks_parent_traversal_outside_cwd() {
+        let _fixture = Fixture::new("traversal");
+        assert_denied(parse_media_url("../../../outside/outside.bin"));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn blocks_symlink_escape_from_inside_cwd() {
+        let _fixture = Fixture::new("symlink");
+        assert_denied(parse_media_url("link.bin"));
+    }
+
+    #[test]
+    fn allows_valid_local_file_inside_cwd() {
+        let _fixture = Fixture::new("inside");
+        let url = parse_media_url("inside.bin").unwrap();
+        assert_eq!(url.scheme(), "file");
+    }
+
+    #[test]
+    fn allows_file_url_inside_cwd() {
+        let fixture = Fixture::new("inside-file-url");
+        let url = parse_media_url(&fixture.inside_file_url()).unwrap();
+        assert_eq!(url.scheme(), "file");
+    }
+
+    #[test]
+    fn rejects_file_url_outside_cwd() {
+        let fixture = Fixture::new("outside-file-url");
+        assert_denied(parse_media_url(&fixture.outside_file_url()));
+    }
+
+    #[test]
+    fn allows_remote_url() {
+        let _fixture = Fixture::new("remote");
+        let url = parse_media_url("https://example.com/media.png").unwrap();
+        assert_eq!(url.scheme(), "https");
     }
 }

--- a/mistralrs-pyo3/src/util.rs
+++ b/mistralrs-pyo3/src/util.rs
@@ -1,10 +1,12 @@
 use std::{
     cell::RefCell,
-    fs::{self, File},
+    fs,
     io::{Cursor, Read},
+    path::{Path, PathBuf},
     sync::{Arc, Mutex},
 };
 
+use cap_std::{ambient_authority, fs::Dir};
 use either::Either;
 use image::codecs::gif::GifDecoder;
 use image::{AnimationDecoder, DynamicImage};
@@ -198,54 +200,145 @@ pub(crate) fn parse_embedding_response(response: Response) -> Result<Vec<f32>, S
     }
 }
 
-pub(crate) fn parse_image_url(url_unparsed: &str) -> PyApiResult<DynamicImage> {
-    let url = if let Ok(url) = url::Url::parse(url_unparsed) {
-        url
-    } else if File::open(url_unparsed).is_ok() {
-        url::Url::from_file_path(std::path::absolute(url_unparsed)?)
-            .map_err(|_| format!("Could not parse file path: {url_unparsed}"))?
-    } else {
-        url::Url::parse(url_unparsed).map_err(|_| {
-            format!(
-                "Invalid source '{}': not a valid URL (http/https/data) and file not found. \
-                 Use a full URL, a data URL, or a file path that exists.",
-                url_unparsed
+#[derive(Debug)]
+enum MediaSource {
+    Local(PathBuf),
+    Url(url::Url),
+}
+
+struct LocalMediaRoot {
+    dir: Dir,
+    path: PathBuf,
+}
+
+impl LocalMediaRoot {
+    fn current() -> std::io::Result<Self> {
+        // Capture the directory itself before asking the OS for its path.  The
+        // retained capability remains attached to this directory even if the
+        // cwd path is subsequently renamed or replaced.
+        let dir = Dir::open_ambient_dir(".", ambient_authority())?;
+        let path = std::env::current_dir()?;
+        Ok(Self { dir, path })
+    }
+}
+
+fn windows_drive_prefix(source: &str) -> bool {
+    let bytes = source.as_bytes();
+    bytes.len() >= 2 && bytes[0].is_ascii_alphabetic() && bytes[1] == b':'
+}
+
+fn windows_drive_relative_path(source: &str) -> bool {
+    if !windows_drive_prefix(source) {
+        return false;
+    }
+    !matches!(source.as_bytes().get(2), Some(b'/' | b'\\'))
+}
+
+fn windows_unc_path(source: &str) -> bool {
+    source.starts_with("\\\\") || source.starts_with("//")
+}
+
+fn parse_media_source(source: &str) -> Result<MediaSource, String> {
+    // `url` treats `C:\\...` as a URL whose scheme is `c`. Recognize Windows
+    // paths first so the parser behaves consistently on every build host.
+    if windows_drive_relative_path(source) {
+        return Err(format!(
+            "Drive-relative local media path `{source}` is not allowed; use an absolute path such as `C:\\media\\file` or a path relative to the current working directory"
+        ));
+    }
+    if windows_drive_prefix(source) || windows_unc_path(source) {
+        return Ok(MediaSource::Local(PathBuf::from(source)));
+    }
+
+    match url::Url::parse(source) {
+        Ok(url) if url.scheme() == "file" => url
+            .to_file_path()
+            .map(MediaSource::Local)
+            .map_err(|_| format!("Could not parse file path: {url}")),
+        Ok(url) => Ok(MediaSource::Url(url)),
+        Err(_) => Ok(MediaSource::Local(PathBuf::from(source))),
+    }
+}
+
+fn read_local_media_file_from(root: &LocalMediaRoot, path: &Path) -> std::io::Result<Vec<u8>> {
+    let relative_path = if path.is_absolute() {
+        path.strip_prefix(&root.path).map_err(|_| {
+            std::io::Error::new(
+                std::io::ErrorKind::PermissionDenied,
+                format!(
+                    "local media sandbox denied `{}`: absolute paths must remain inside the current working directory `{}`",
+                    path.display(),
+                    root.path.display()
+                ),
             )
         })?
+    } else {
+        path
     };
 
-    let bytes = if url.scheme() == "http" || url.scheme() == "https" {
-        // Read from http
-        match reqwest::blocking::get(url.clone()) {
-            Ok(http_resp) => http_resp.bytes()?.to_vec(),
-            Err(e) => return Err(PyApiErr::from(format!("{e}"))),
-        }
-    } else if url.scheme() == "file" {
-        let path = url
-            .to_file_path()
-            .map_err(|_| format!("Could not parse file path: {url}"))?;
-
-        if let Ok(mut f) = File::open(&path) {
-            // Read from local file
-            let metadata = fs::metadata(&path)?;
-            let mut buffer = vec![0; metadata.len() as usize];
-            f.read_exact(&mut buffer)?;
-            buffer
+    // Resolve and open the user-controlled path relative to one directory
+    // capability. This prevents `..` and symlink escapes without a
+    // check-then-open race.
+    let mut file = root.dir.open(relative_path).map_err(|source| {
+        let context = if matches!(
+            source.kind(),
+            std::io::ErrorKind::PermissionDenied | std::io::ErrorKind::InvalidInput
+        ) {
+            "local media sandbox denied"
         } else {
-            return Err(PyApiErr::from(format!(
-                "Could not open file at path: {url}"
-            )));
+            "could not open local media path"
+        };
+        std::io::Error::new(
+            source.kind(),
+            format!(
+                "{context} `{}` relative to current working directory `{}`: {source}",
+                path.display(),
+                root.path.display()
+            ),
+        )
+    })?;
+    let mut bytes = Vec::new();
+    file.read_to_end(&mut bytes)?;
+    Ok(bytes)
+}
+
+fn read_media_bytes_from(root: &LocalMediaRoot, source: &str) -> PyApiResult<Vec<u8>> {
+    match parse_media_source(source).map_err(PyApiErr::from)? {
+        MediaSource::Local(path) => read_local_media_file_from(root, &path).map_err(|e| {
+            PyApiErr::from(format!(
+                "Could not open local media path `{}`: {e}",
+                path.display()
+            ))
+        }),
+        MediaSource::Url(url) if url.scheme() == "http" || url.scheme() == "https" => {
+            reqwest::blocking::get(url)
+                .map_err(PyApiErr::from)?
+                .bytes()
+                .map(|bytes| bytes.to_vec())
+                .map_err(PyApiErr::from)
         }
-    } else if url.scheme() == "data" {
-        // Decode with base64
-        let data_url = data_url::DataUrl::process(url.as_str()).map_err(|e| format!("{e}"))?;
-        data_url.decode_to_vec().map_err(|e| format!("{e}"))?.0
-    } else {
-        return Err(PyApiErr::from(format!(
+        MediaSource::Url(url) if url.scheme() == "data" => {
+            let data_url = data_url::DataUrl::process(url.as_str()).map_err(|e| format!("{e}"))?;
+            data_url
+                .decode_to_vec()
+                .map(|(bytes, _)| bytes)
+                .map_err(|e| format!("{e}").into())
+        }
+        MediaSource::Url(url) => Err(PyApiErr::from(format!(
             "Unsupported URL scheme: {}",
             url.scheme()
-        )));
-    };
+        ))),
+    }
+}
+
+fn read_media_bytes(source: &str) -> PyApiResult<Vec<u8>> {
+    let root = LocalMediaRoot::current()
+        .map_err(|e| format!("Could not open current working directory sandbox: {e}"))?;
+    read_media_bytes_from(&root, source)
+}
+
+pub(crate) fn parse_image_url(url_unparsed: &str) -> PyApiResult<DynamicImage> {
+    let bytes = read_media_bytes(url_unparsed)?;
 
     image::load_from_memory(&bytes).map_err(|e| PyApiErr::from(format!("{e}")))
 }
@@ -253,53 +346,7 @@ pub(crate) fn parse_image_url(url_unparsed: &str) -> PyApiResult<DynamicImage> {
 /// Parses and loads an audio file from a URL, file path, or data URL.
 /// Mirrors `parse_image_url` but returns an `AudioInput`.
 pub(crate) fn parse_audio_url(url_unparsed: &str) -> PyApiResult<AudioInput> {
-    let url = if let Ok(url) = url::Url::parse(url_unparsed) {
-        url
-    } else if File::open(url_unparsed).is_ok() {
-        url::Url::from_file_path(std::path::absolute(url_unparsed)?)
-            .map_err(|_| format!("Could not parse file path: {url_unparsed}"))?
-    } else {
-        url::Url::parse(url_unparsed).map_err(|_| {
-            format!(
-                "Invalid source '{}': not a valid URL (http/https/data) and file not found. \
-                 Use a full URL, a data URL, or a file path that exists.",
-                url_unparsed
-            )
-        })?
-    };
-
-    let bytes = if url.scheme() == "http" || url.scheme() == "https" {
-        match reqwest::blocking::get(url.clone()) {
-            Ok(http_resp) => http_resp
-                .bytes()
-                .map_err(|e| PyApiErr::from(format!("{e}")))?
-                .to_vec(),
-            Err(e) => return Err(PyApiErr::from(format!("{e}"))),
-        }
-    } else if url.scheme() == "file" {
-        let path = url
-            .to_file_path()
-            .map_err(|_| format!("Could not parse file path: {url}"))?;
-
-        if let Ok(mut f) = File::open(&path) {
-            let metadata = fs::metadata(&path)?;
-            let mut buffer = vec![0; metadata.len() as usize];
-            f.read_exact(&mut buffer)?;
-            buffer
-        } else {
-            return Err(PyApiErr::from(format!(
-                "Could not open file at path: {url}"
-            )));
-        }
-    } else if url.scheme() == "data" {
-        let data_url = data_url::DataUrl::process(url.as_str()).map_err(|e| format!("{e}"))?;
-        data_url.decode_to_vec().map_err(|e| format!("{e}"))?.0
-    } else {
-        return Err(PyApiErr::from(format!(
-            "Unsupported URL scheme: {}",
-            url.scheme()
-        )));
-    };
+    let bytes = read_media_bytes(url_unparsed)?;
 
     AudioInput::from_bytes(&bytes).map_err(|e| PyApiErr::from(format!("{e}")))
 }
@@ -313,53 +360,7 @@ const DEFAULT_FPS: f64 = 24.0;
 /// GIF files are decoded with the `image` crate. All other formats require
 /// FFmpeg on `$PATH`.
 pub(crate) fn parse_video_url(url_unparsed: &str) -> PyApiResult<VideoInput> {
-    let url = if let Ok(url) = url::Url::parse(url_unparsed) {
-        url
-    } else if File::open(url_unparsed).is_ok() {
-        url::Url::from_file_path(std::path::absolute(url_unparsed)?)
-            .map_err(|_| format!("Could not parse file path: {url_unparsed}"))?
-    } else {
-        url::Url::parse(url_unparsed).map_err(|_| {
-            format!(
-                "Invalid source '{}': not a valid URL (http/https/data) and file not found. \
-                 Use a full URL, a data URL, or a file path that exists.",
-                url_unparsed
-            )
-        })?
-    };
-
-    let bytes = if url.scheme() == "http" || url.scheme() == "https" {
-        match reqwest::blocking::get(url.clone()) {
-            Ok(http_resp) => http_resp
-                .bytes()
-                .map_err(|e| PyApiErr::from(format!("{e}")))?
-                .to_vec(),
-            Err(e) => return Err(PyApiErr::from(format!("{e}"))),
-        }
-    } else if url.scheme() == "file" {
-        let path = url
-            .to_file_path()
-            .map_err(|_| format!("Could not parse file path: {url}"))?;
-
-        if let Ok(mut f) = File::open(&path) {
-            let metadata = fs::metadata(&path)?;
-            let mut buffer = vec![0; metadata.len() as usize];
-            f.read_exact(&mut buffer)?;
-            buffer
-        } else {
-            return Err(PyApiErr::from(format!(
-                "Could not open file at path: {url}"
-            )));
-        }
-    } else if url.scheme() == "data" {
-        let data_url = data_url::DataUrl::process(url.as_str()).map_err(|e| format!("{e}"))?;
-        data_url.decode_to_vec().map_err(|e| format!("{e}"))?.0
-    } else {
-        return Err(PyApiErr::from(format!(
-            "Unsupported URL scheme: {}",
-            url.scheme()
-        )));
-    };
+    let bytes = read_media_bytes(url_unparsed)?;
 
     let lower = url_unparsed.to_lowercase();
     let is_gif = lower.ends_with(".gif")
@@ -566,5 +567,200 @@ fn parse_fps_fraction(s: &str) -> Option<f64> {
         }
     } else {
         s.parse().ok()
+    }
+}
+
+#[cfg(test)]
+mod local_media_path_tests {
+    use super::*;
+    use std::{
+        fs,
+        sync::atomic::{AtomicU64, Ordering},
+        time::{SystemTime, UNIX_EPOCH},
+    };
+
+    static FIXTURE_ID: AtomicU64 = AtomicU64::new(0);
+
+    struct Fixture {
+        base: PathBuf,
+        root: PathBuf,
+        outside_file: PathBuf,
+        sandbox: Option<LocalMediaRoot>,
+    }
+
+    impl Fixture {
+        fn new(name: &str) -> Self {
+            let nonce = SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .unwrap()
+                .as_nanos();
+            let id = FIXTURE_ID.fetch_add(1, Ordering::Relaxed);
+            let base = std::env::temp_dir().join(format!(
+                "mistralrs-local-media-{name}-{}-{nonce}-{id}",
+                std::process::id()
+            ));
+            let root = base.join("root").join("a").join("b").join("c");
+            let outside = base.join("root").join("outside");
+            fs::create_dir_all(&root).unwrap();
+            fs::create_dir_all(&outside).unwrap();
+
+            fs::write(root.join("inside.bin"), b"inside").unwrap();
+            let outside_file = outside.join("outside.bin");
+            fs::write(&outside_file, b"outside").unwrap();
+
+            #[cfg(unix)]
+            std::os::unix::fs::symlink(&outside_file, root.join("escape.bin")).unwrap();
+
+            Self {
+                base,
+                sandbox: Some(LocalMediaRoot {
+                    dir: Dir::open_ambient_dir(&root, ambient_authority()).unwrap(),
+                    path: root.clone(),
+                }),
+                root,
+                outside_file,
+            }
+        }
+
+        fn read(&self, path: impl AsRef<Path>) -> std::io::Result<Vec<u8>> {
+            read_local_media_file_from(self.sandbox.as_ref().unwrap(), path.as_ref())
+        }
+    }
+
+    impl Drop for Fixture {
+        fn drop(&mut self) {
+            self.sandbox.take();
+            let _ = fs::remove_dir_all(&self.base);
+        }
+    }
+
+    fn assert_denied(result: std::io::Result<Vec<u8>>) {
+        let error = result.expect_err("expected local media path to be denied");
+        assert!(
+            error.to_string().contains("local media sandbox denied"),
+            "denial should identify the cwd sandbox: {error}"
+        );
+    }
+
+    #[test]
+    fn blocks_absolute_path_outside_root() {
+        let fixture = Fixture::new("absolute-outside");
+        assert_denied(fixture.read(&fixture.outside_file));
+    }
+
+    #[test]
+    fn blocks_parent_traversal_outside_root() {
+        let fixture = Fixture::new("traversal");
+        assert_denied(fixture.read("../../../outside/outside.bin"));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn blocks_symlink_escape_from_inside_root() {
+        let fixture = Fixture::new("symlink");
+        assert_denied(fixture.read("escape.bin"));
+    }
+
+    #[test]
+    fn allows_relative_path_inside_root() {
+        let fixture = Fixture::new("relative-inside");
+        assert_eq!(fixture.read("inside.bin").unwrap(), b"inside");
+    }
+
+    #[test]
+    fn allows_absolute_path_inside_root() {
+        let fixture = Fixture::new("absolute-inside");
+        assert_eq!(
+            fixture.read(fixture.root.join("inside.bin")).unwrap(),
+            b"inside"
+        );
+    }
+
+    #[test]
+    fn reads_relative_source_through_media_dispatch() {
+        let fixture = Fixture::new("media-dispatch");
+        assert_eq!(
+            read_media_bytes_from(fixture.sandbox.as_ref().unwrap(), "inside.bin").unwrap(),
+            b"inside"
+        );
+    }
+
+    #[test]
+    fn parses_file_url_as_a_local_path() {
+        let fixture = Fixture::new("file-url");
+        let url = url::Url::from_file_path(fixture.root.join("inside.bin")).unwrap();
+        let MediaSource::Local(path) = parse_media_source(url.as_str()).unwrap() else {
+            panic!("file URL must be handled as a local path");
+        };
+        assert_eq!(fixture.read(path).unwrap(), b"inside");
+    }
+
+    #[test]
+    fn blocks_file_url_outside_root() {
+        let fixture = Fixture::new("outside-file-url");
+        let url = url::Url::from_file_path(&fixture.outside_file).unwrap();
+        let MediaSource::Local(path) = parse_media_source(url.as_str()).unwrap() else {
+            panic!("file URL must be handled as a local path");
+        };
+        assert_denied(fixture.read(path));
+    }
+
+    #[test]
+    fn parses_remote_url_without_local_file_access() {
+        let MediaSource::Url(url) = parse_media_source("https://example.com/media.png").unwrap()
+        else {
+            panic!("remote URL must remain a URL");
+        };
+        assert_eq!(url.scheme(), "https");
+    }
+
+    #[test]
+    fn parses_windows_drive_absolute_paths_as_local() {
+        assert!(matches!(
+            parse_media_source(r"C:\media\image.png").unwrap(),
+            MediaSource::Local(_)
+        ));
+        assert!(matches!(
+            parse_media_source("D:/media/image.png").unwrap(),
+            MediaSource::Local(_)
+        ));
+    }
+
+    #[test]
+    fn parses_windows_unc_paths_as_local() {
+        assert!(matches!(
+            parse_media_source(r"\\server\share\image.png").unwrap(),
+            MediaSource::Local(_)
+        ));
+        assert!(matches!(
+            parse_media_source("//server/share/image.png").unwrap(),
+            MediaSource::Local(_)
+        ));
+    }
+
+    #[test]
+    fn rejects_windows_drive_relative_paths() {
+        for source in [r"C:image.png", "D:"] {
+            let error = parse_media_source(source).expect_err("drive-relative path must fail");
+            assert!(
+                error.contains("Drive-relative"),
+                "unexpected error: {error}"
+            );
+        }
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn retained_capability_ignores_cwd_root_substitution() {
+        let fixture = Fixture::new("root-substitution");
+        let moved_root = fixture.base.join("original-root");
+
+        fs::rename(&fixture.root, &moved_root).unwrap();
+        fs::create_dir_all(&fixture.root).unwrap();
+        fs::write(fixture.root.join("inside.bin"), b"replacement").unwrap();
+
+        // The path now names an attacker-controlled replacement, but reads
+        // continue through the already-open directory capability.
+        assert_eq!(fixture.read("inside.bin").unwrap(), b"inside");
     }
 }


### PR DESCRIPTION
## Summary

Sandbox local image, audio, and video file inputs beneath the Python process's current working directory without a check-then-open race.

- Open `.` once as a `cap-std` directory capability before resolving the cwd pathname, retain that capability, and never reopen the root by pathname.
- Reject absolute paths outside that root, parent traversal escapes, and symlink escapes during the same capability-scoped open.
- Keep reads bound to the originally opened directory even if its pathname is renamed and replaced.
- Read bytes from the already-open file handle.
- Keep HTTP(S), data URLs, valid relative files, valid in-root absolute paths, and `file:` URLs working.
- Parse Windows drive and UNC paths consistently across build hosts, and reject ambiguous drive-relative paths such as `C:image.png`.
- Share one byte-loading path across the image, audio, and video parsers.

Current head: `66a256d8e24c4951407e58fb5465552116eb1250`.

## Security boundary and compatibility

Local media access is deliberately confined to the process cwd. This is a breaking restriction for callers that previously passed paths outside that directory. The Python guide now documents the boundary and migration options.

## Tests

The tests use explicit temporary roots and do not call `set_current_dir`, so they are safe to run concurrently.

Covered cases include:

- relative and absolute files inside the root;
- absolute paths and `file:` URLs outside the root;
- parent traversal and symlink escapes;
- retained-capability behavior after Unix root-path substitution;
- the shared local-media dispatch path;
- remote URL parsing;
- Windows drive-absolute and UNC parsing;
- Windows drive-relative rejection;
- denial messages that identify the cwd sandbox.

## Validation

Validated on Linux x86_64 with current stable Rust 1.97.0. The published commit points to the exact tested tree `2ecba859facad6b84f882da4718fc6c9330da1f1`.

```bash
cargo +stable fmt --all -- --check
cargo +stable check -p mistralrs-pyo3
cargo +stable clippy -p mistralrs-pyo3 --tests --no-deps -- -D warnings -A clippy::useless_borrows_in_formatting
```

Package-only Clippy passes; the single allowed lint is pre-existing in unchanged `mistralrs-pyo3/src/lib.rs`. Workspace Clippy on current Rust 1.97 also reports new pre-existing lints in `mistralrs-core`.

Because this workspace enables PyO3's `extension-module` feature unconditionally, a normal Linux `cargo test` binary does not link `libpython`. The focused lib-test harness was therefore built with Cargo using an explicit environment `libpython3.12` link and then executed directly: 13 passed, 0 failed.

## Scope

This change protects local media inputs handled by `mistralrs-pyo3`. It does not claim to sandbox unrelated filesystem consumers elsewhere in the repository.