### PR TITLE
feat(gemma4): optimize CUDA prompt and decode performance

### DIFF
--- a/mistralrs-core/src/attention/backends/flash.rs
+++ b/mistralrs-core/src/attention/backends/flash.rs
@@ -3,7 +3,7 @@ use candle_core::{Result, Tensor};
 use crate::attention::SdpaParams;
 
 #[cfg(feature = "flash-attn")]
-pub(crate) fn flash_attn(
+fn flash_attn_v2(
     q: &Tensor,
     k: &Tensor,
     v: &Tensor,
@@ -88,7 +88,7 @@ pub(crate) fn flash_attn(
 }
 
 #[cfg(feature = "flash-attn-v3")]
-pub(crate) fn flash_attn(
+fn flash_attn_v3(
     q: &Tensor,
     k: &Tensor,
     v: &Tensor,
@@ -136,6 +136,37 @@ pub(crate) fn flash_attn(
     // Non-varlen path: use flash_params.causal if provided, otherwise default (seq_len > 1).
     let causal = flash_params.map_or(default_causal, |p| p.causal);
     candle_flash_attn_v3::flash_attn(q, k, v, sdpa_params.softmax_scale, causal, true)
+}
+
+#[cfg(feature = "flash-attn-v3")]
+pub(crate) fn flash_attn(
+    q: &Tensor,
+    k: &Tensor,
+    v: &Tensor,
+    flash_params: Option<&crate::pipeline::text_models_inputs_processor::FlashParams>,
+    sdpa_params: &SdpaParams,
+) -> Result<Tensor> {
+    let q_dims = q.dims4()?;
+    let head_dim = q_dims.3;
+    if head_dim <= 512 {
+        #[cfg(feature = "flash-attn")]
+        {
+            return flash_attn_v2(q, k, v, flash_params, sdpa_params);
+        }
+    }
+
+    flash_attn_v3(q, k, v, flash_params, sdpa_params)
+}
+
+#[cfg(all(feature = "flash-attn", not(feature = "flash-attn-v3")))]
+pub(crate) fn flash_attn(
+    q: &Tensor,
+    k: &Tensor,
+    v: &Tensor,
+    flash_params: Option<&crate::pipeline::text_models_inputs_processor::FlashParams>,
+    sdpa_params: &SdpaParams,
+) -> Result<Tensor> {
+    flash_attn_v2(q, k, v, flash_params, sdpa_params)
 }
 
 #[cfg(not(any(feature = "flash-attn", feature = "flash-attn-v3")))]

--- a/mistralrs-core/src/cuda/ffi.rs
+++ b/mistralrs-core/src/cuda/ffi.rs
@@ -339,6 +339,20 @@ extern "C" {
         inv_temperature: f32,
         stream: i64,
     );
+    pub(crate) fn topk_large_f32_packed(
+        input: *const f32,
+        block_values: *mut f32,
+        block_indices: *mut u32,
+        block_maxes: *mut f32,
+        block_sums: *mut f32,
+        packed_out: *mut f32,
+        ncols: i32,
+        k: i32,
+        chunk_size: i32,
+        nblocks: i32,
+        inv_temperature: f32,
+        stream: i64,
+    );
 
     // Mamba SSM selective scan kernel
     pub(crate) fn selective_scan_cuda(

--- a/mistralrs-core/src/cuda/ffi.rs
+++ b/mistralrs-core/src/cuda/ffi.rs
@@ -2,6 +2,8 @@ use std::ffi::c_void;
 
 #[allow(dead_code)]
 extern "C" {
+    pub(crate) fn softcap_f32(x: *const c_void, dst: *mut c_void, n: i32, cap: f32, stream: i64);
+
     pub(crate) fn asort_asc_f32(
         x: *const c_void,
         dst: *mut c_void,
@@ -273,6 +275,23 @@ extern "C" {
         nrows: i32,
         ncols: i32,
         k: i32,
+        stream: i64,
+    );
+
+    pub(crate) fn topk_large_f32(
+        input: *const f32,
+        block_values: *mut f32,
+        block_indices: *mut u32,
+        block_maxes: *mut f32,
+        block_sums: *mut f32,
+        values_out: *mut f32,
+        indices_out: *mut u32,
+        softmax_info_out: *mut f32,
+        ncols: i32,
+        k: i32,
+        chunk_size: i32,
+        nblocks: i32,
+        inv_temperature: f32,
         stream: i64,
     );
 

--- a/mistralrs-core/src/cuda/ffi.rs
+++ b/mistralrs-core/src/cuda/ffi.rs
@@ -3,6 +3,51 @@ use std::ffi::c_void;
 #[allow(dead_code)]
 extern "C" {
     pub(crate) fn softcap_f32(x: *const c_void, dst: *mut c_void, n: i32, cap: f32, stream: i64);
+    pub(crate) fn apply_sparse_penalties_f32(
+        x: *const c_void,
+        dst: *mut c_void,
+        token_ids: *const u32,
+        counts: *const f32,
+        n: i32,
+        n_tokens: i32,
+        frequency_penalty: f32,
+        presence_penalty: f32,
+        repetition_penalty: f32,
+        stream: i64,
+    );
+    pub(crate) fn rms_norm_residual_f32(
+        x: *const c_void,
+        residual: *const c_void,
+        weight: *const c_void,
+        scale: *const c_void,
+        dst: *mut c_void,
+        nrows: i32,
+        ncols: i32,
+        eps: f32,
+        stream: i64,
+    );
+    pub(crate) fn rms_norm_residual_f16(
+        x: *const c_void,
+        residual: *const c_void,
+        weight: *const c_void,
+        scale: *const c_void,
+        dst: *mut c_void,
+        nrows: i32,
+        ncols: i32,
+        eps: f32,
+        stream: i64,
+    );
+    pub(crate) fn rms_norm_residual_bf16(
+        x: *const c_void,
+        residual: *const c_void,
+        weight: *const c_void,
+        scale: *const c_void,
+        dst: *mut c_void,
+        nrows: i32,
+        ncols: i32,
+        eps: f32,
+        stream: i64,
+    );
 
     pub(crate) fn asort_asc_f32(
         x: *const c_void,

--- a/mistralrs-core/src/cuda/sort.cu
+++ b/mistralrs-core/src/cuda/sort.cu
@@ -2,6 +2,27 @@
 #include "cuda_fp16.h"
 #include <limits>
 #include <stdint.h>
+
+__global__ void softcap_f32_kernel(const float *__restrict__ x,
+                                   float *__restrict__ dst, const int n,
+                                   const float cap) {
+  const int idx = blockIdx.x * blockDim.x + threadIdx.x;
+  if (idx >= n) {
+    return;
+  }
+  dst[idx] = tanhf(x[idx] / cap) * cap;
+}
+
+extern "C" void softcap_f32(const void *x, void *dst, const int n,
+                            const float cap, int64_t stream) {
+  const cudaStream_t custream = (cudaStream_t)stream;
+  const int block = 256;
+  const int grid = (n + block - 1) / block;
+  softcap_f32_kernel<<<grid, block, 0, custream>>>(
+      reinterpret_cast<const float *>(x), reinterpret_cast<float *>(dst), n,
+      cap);
+}
+
 template <typename T> inline __device__ void swap(T &a, T &b) {
   T tmp = a;
   a = b;
@@ -471,4 +492,249 @@ extern "C" void topk_softmax_f16(const __half *input, __half *weights_out,
                      k * sizeof(__half) + k * sizeof(int) + k * sizeof(float);
   topk_softmax_kernel<__half><<<nrows, block_size, smem_size, custream>>>(
       input, weights_out, indices_out, nrows, ncols, k);
+}
+
+__device__ __forceinline__ float warp_reduce_sum_f32(float val) {
+#pragma unroll
+  for (int offset = 16; offset > 0; offset /= 2) {
+    val += __shfl_down_sync(0xffffffff, val, offset);
+  }
+  return val;
+}
+
+__device__ __forceinline__ float block_reduce_sum_f32(float val) {
+  __shared__ float warp_sums[32];
+  const int tid = threadIdx.x;
+  const int warp_id = tid / 32;
+  const int lane_id = tid % 32;
+  const int num_warps = (blockDim.x + 31) / 32;
+
+  val = warp_reduce_sum_f32(val);
+  if (lane_id == 0) {
+    warp_sums[warp_id] = val;
+  }
+  __syncthreads();
+
+  val = (tid < num_warps) ? warp_sums[tid] : 0.0f;
+  if (warp_id == 0) {
+    val = warp_reduce_sum_f32(val);
+  }
+  return val;
+}
+
+// Large-vocabulary top-k for token sampling. The MoE top-k kernel above stages
+// a full row in shared memory, which is not viable for 100k+ vocabularies. This
+// kernel scans fixed-size chunks, emits per-chunk top-k candidates, and computes
+// each chunk's contribution to the full softmax denominator.
+__global__ void topk_large_stage1_f32(
+    const float *__restrict__ input, float *__restrict__ block_values,
+    uint32_t *__restrict__ block_indices, float *__restrict__ block_maxes,
+    float *__restrict__ block_sums, const int ncols, const int k,
+    const int chunk_size, const float inv_temperature) {
+  const int chunk = blockIdx.x;
+  const int start = chunk * chunk_size;
+  const int end = min(start + chunk_size, ncols);
+  const int width = max(0, end - start);
+  const int tid = threadIdx.x;
+  const int block_size = blockDim.x;
+
+  extern __shared__ char smem[];
+  bool *s_used = reinterpret_cast<bool *>(smem);
+
+  for (int i = tid; i < chunk_size; i += block_size) {
+    s_used[i] = false;
+  }
+  __syncthreads();
+
+  for (int ki = 0; ki < k; ++ki) {
+    float local_max = -INFINITY;
+    int local_idx = -1;
+
+    for (int local = tid; local < width; local += block_size) {
+      const float candidate = input[start + local];
+      if (!s_used[local] && candidate == candidate && candidate > local_max) {
+        local_max = candidate;
+        local_idx = start + local;
+      }
+    }
+
+    int warp_max_idx;
+    float warp_max =
+        warp_reduce_max_with_idx<float>(local_max, local_idx, warp_max_idx);
+
+    __shared__ float warp_maxes[32];
+    __shared__ int warp_indices[32];
+
+    const int warp_id = tid / 32;
+    const int lane_id = tid % 32;
+    const int num_warps = (block_size + 31) / 32;
+
+    if (lane_id == 0) {
+      warp_maxes[warp_id] = warp_max;
+      warp_indices[warp_id] = warp_max_idx;
+    }
+    __syncthreads();
+
+    if (tid < 32) {
+      float val = (tid < num_warps) ? warp_maxes[tid] : -INFINITY;
+      int idx = (tid < num_warps) ? warp_indices[tid] : -1;
+      int final_idx;
+      float final_max =
+          warp_reduce_max_with_idx<float>(val, idx, final_idx);
+
+      if (tid == 0) {
+        block_values[chunk * k + ki] = final_max;
+        block_indices[chunk * k + ki] =
+            final_idx >= 0 ? static_cast<uint32_t>(final_idx) : 0;
+        if (final_idx >= start && final_idx < end) {
+          s_used[final_idx - start] = true;
+        }
+      }
+    }
+    __syncthreads();
+  }
+
+  const float block_max =
+      width > 0 ? block_values[chunk * k] * inv_temperature : -INFINITY;
+  float local_sum = 0.0f;
+  if (block_max != -INFINITY) {
+    for (int local = tid; local < width; local += block_size) {
+      const float candidate = input[start + local];
+      if (candidate == candidate) {
+        local_sum += expf(candidate * inv_temperature - block_max);
+      }
+    }
+  }
+
+  const float block_sum = block_reduce_sum_f32(local_sum);
+  if (tid == 0) {
+    block_maxes[chunk] = block_max;
+    block_sums[chunk] = block_sum;
+  }
+}
+
+__global__ void topk_large_stage2_f32(
+    const float *__restrict__ block_values,
+    const uint32_t *__restrict__ block_indices,
+    const float *__restrict__ block_maxes,
+    const float *__restrict__ block_sums, float *__restrict__ values_out,
+    uint32_t *__restrict__ indices_out, float *__restrict__ softmax_info_out,
+    const int nblocks, const int k) {
+  const int tid = threadIdx.x;
+  const int block_size = blockDim.x;
+  const int n_candidates = nblocks * k;
+
+  extern __shared__ char smem[];
+  bool *s_used = reinterpret_cast<bool *>(smem);
+
+  for (int i = tid; i < n_candidates; i += block_size) {
+    s_used[i] = false;
+  }
+  __syncthreads();
+
+  float local_global_max = -INFINITY;
+  for (int block = tid; block < nblocks; block += block_size) {
+    local_global_max = fmaxf(local_global_max, block_maxes[block]);
+  }
+
+  int unused_idx;
+  float warp_global_max =
+      warp_reduce_max_with_idx<float>(local_global_max, tid, unused_idx);
+
+  __shared__ float warp_maxes[32];
+  const int warp_id = tid / 32;
+  const int lane_id = tid % 32;
+  const int num_warps = (block_size + 31) / 32;
+
+  if (lane_id == 0) {
+    warp_maxes[warp_id] = warp_global_max;
+  }
+  __syncthreads();
+
+  __shared__ float s_global_max;
+  if (tid < 32) {
+    float val = (tid < num_warps) ? warp_maxes[tid] : -INFINITY;
+    int final_idx;
+    float final_max = warp_reduce_max_with_idx<float>(val, tid, final_idx);
+    if (tid == 0) {
+      s_global_max = final_max;
+    }
+  }
+  __syncthreads();
+
+  float local_denom = 0.0f;
+  if (s_global_max != -INFINITY) {
+    for (int block = tid; block < nblocks; block += block_size) {
+      local_denom += block_sums[block] * expf(block_maxes[block] - s_global_max);
+    }
+  }
+  const float denom = block_reduce_sum_f32(local_denom);
+  if (tid == 0) {
+    softmax_info_out[0] = denom;
+    softmax_info_out[1] = s_global_max;
+  }
+  __syncthreads();
+
+  for (int ki = 0; ki < k; ++ki) {
+    float local_max = -INFINITY;
+    int local_pos = -1;
+
+    for (int pos = tid; pos < n_candidates; pos += block_size) {
+      const float candidate = block_values[pos];
+      if (!s_used[pos] && candidate == candidate && candidate > local_max) {
+        local_max = candidate;
+        local_pos = pos;
+      }
+    }
+
+    int warp_max_pos;
+    float warp_max =
+        warp_reduce_max_with_idx<float>(local_max, local_pos, warp_max_pos);
+
+    __shared__ float merge_warp_maxes[32];
+    __shared__ int merge_warp_indices[32];
+
+    if (lane_id == 0) {
+      merge_warp_maxes[warp_id] = warp_max;
+      merge_warp_indices[warp_id] = warp_max_pos;
+    }
+    __syncthreads();
+
+    if (tid < 32) {
+      float val = (tid < num_warps) ? merge_warp_maxes[tid] : -INFINITY;
+      int idx = (tid < num_warps) ? merge_warp_indices[tid] : -1;
+      int final_pos;
+      float final_max =
+          warp_reduce_max_with_idx<float>(val, idx, final_pos);
+
+      if (tid == 0) {
+        values_out[ki] = final_max;
+        indices_out[ki] =
+            final_pos >= 0 ? block_indices[final_pos] : static_cast<uint32_t>(0);
+        if (final_pos >= 0) {
+          s_used[final_pos] = true;
+        }
+      }
+    }
+    __syncthreads();
+  }
+}
+
+extern "C" void topk_large_f32(
+    const float *input, float *block_values, uint32_t *block_indices,
+    float *block_maxes, float *block_sums, float *values_out,
+    uint32_t *indices_out, float *softmax_info_out, int ncols, int k,
+    int chunk_size, int nblocks, float inv_temperature, int64_t stream) {
+  const cudaStream_t custream = (cudaStream_t)stream;
+  constexpr int block_size = 256;
+  const size_t stage1_smem = static_cast<size_t>(chunk_size) * sizeof(bool);
+  const size_t stage2_smem =
+      static_cast<size_t>(nblocks) * static_cast<size_t>(k) * sizeof(bool);
+
+  topk_large_stage1_f32<<<nblocks, block_size, stage1_smem, custream>>>(
+      input, block_values, block_indices, block_maxes, block_sums, ncols, k,
+      chunk_size, inv_temperature);
+  topk_large_stage2_f32<<<1, block_size, stage2_smem, custream>>>(
+      block_values, block_indices, block_maxes, block_sums, values_out,
+      indices_out, softmax_info_out, nblocks, k);
 }

--- a/mistralrs-core/src/cuda/sort.cu
+++ b/mistralrs-core/src/cuda/sort.cu
@@ -900,6 +900,113 @@ __global__ void topk_large_stage2_f32(
   }
 }
 
+__global__ void topk_large_stage2_f32_packed(
+    const float *__restrict__ block_values,
+    const uint32_t *__restrict__ block_indices,
+    const float *__restrict__ block_maxes,
+    const float *__restrict__ block_sums, float *__restrict__ packed_out,
+    const int nblocks, const int k) {
+  const int tid = threadIdx.x;
+  const int block_size = blockDim.x;
+  const int n_candidates = nblocks * k;
+
+  extern __shared__ char smem[];
+  bool *s_used = reinterpret_cast<bool *>(smem);
+
+  for (int i = tid; i < n_candidates; i += block_size) {
+    s_used[i] = false;
+  }
+  __syncthreads();
+
+  float local_global_max = -INFINITY;
+  for (int block = tid; block < nblocks; block += block_size) {
+    local_global_max = fmaxf(local_global_max, block_maxes[block]);
+  }
+
+  int unused_idx;
+  float warp_global_max =
+      warp_reduce_max_with_idx<float>(local_global_max, tid, unused_idx);
+
+  __shared__ float warp_maxes[32];
+  const int warp_id = tid / 32;
+  const int lane_id = tid % 32;
+  const int num_warps = (block_size + 31) / 32;
+
+  if (lane_id == 0) {
+    warp_maxes[warp_id] = warp_global_max;
+  }
+  __syncthreads();
+
+  __shared__ float s_global_max;
+  if (tid < 32) {
+    float val = (tid < num_warps) ? warp_maxes[tid] : -INFINITY;
+    int final_idx;
+    float final_max = warp_reduce_max_with_idx<float>(val, tid, final_idx);
+    if (tid == 0) {
+      s_global_max = final_max;
+    }
+  }
+  __syncthreads();
+
+  float local_denom = 0.0f;
+  if (s_global_max != -INFINITY) {
+    for (int block = tid; block < nblocks; block += block_size) {
+      local_denom += block_sums[block] * expf(block_maxes[block] - s_global_max);
+    }
+  }
+  const float denom = block_reduce_sum_f32(local_denom);
+  if (tid == 0) {
+    packed_out[2 * k] = denom;
+    packed_out[2 * k + 1] = s_global_max;
+  }
+  __syncthreads();
+
+  for (int ki = 0; ki < k; ++ki) {
+    float local_max = -INFINITY;
+    int local_pos = -1;
+
+    for (int pos = tid; pos < n_candidates; pos += block_size) {
+      const float candidate = block_values[pos];
+      if (!s_used[pos] && candidate == candidate && candidate > local_max) {
+        local_max = candidate;
+        local_pos = pos;
+      }
+    }
+
+    int warp_max_pos;
+    float warp_max =
+        warp_reduce_max_with_idx<float>(local_max, local_pos, warp_max_pos);
+
+    __shared__ float merge_warp_maxes[32];
+    __shared__ int merge_warp_indices[32];
+
+    if (lane_id == 0) {
+      merge_warp_maxes[warp_id] = warp_max;
+      merge_warp_indices[warp_id] = warp_max_pos;
+    }
+    __syncthreads();
+
+    if (tid < 32) {
+      float val = (tid < num_warps) ? merge_warp_maxes[tid] : -INFINITY;
+      int idx = (tid < num_warps) ? merge_warp_indices[tid] : -1;
+      int final_pos;
+      float final_max =
+          warp_reduce_max_with_idx<float>(val, idx, final_pos);
+
+      if (tid == 0) {
+        packed_out[ki] = final_max;
+        packed_out[k + ki] =
+            final_pos >= 0 ? static_cast<float>(block_indices[final_pos])
+                           : 0.0f;
+        if (final_pos >= 0) {
+          s_used[final_pos] = true;
+        }
+      }
+    }
+    __syncthreads();
+  }
+}
+
 extern "C" void topk_large_f32(
     const float *input, float *block_values, uint32_t *block_indices,
     float *block_maxes, float *block_sums, float *values_out,
@@ -917,4 +1024,22 @@ extern "C" void topk_large_f32(
   topk_large_stage2_f32<<<1, block_size, stage2_smem, custream>>>(
       block_values, block_indices, block_maxes, block_sums, values_out,
       indices_out, softmax_info_out, nblocks, k);
+}
+
+extern "C" void topk_large_f32_packed(
+    const float *input, float *block_values, uint32_t *block_indices,
+    float *block_maxes, float *block_sums, float *packed_out, int ncols, int k,
+    int chunk_size, int nblocks, float inv_temperature, int64_t stream) {
+  const cudaStream_t custream = (cudaStream_t)stream;
+  constexpr int block_size = 256;
+  const size_t stage1_smem = static_cast<size_t>(chunk_size) * sizeof(bool);
+  const size_t stage2_smem =
+      static_cast<size_t>(nblocks) * static_cast<size_t>(k) * sizeof(bool);
+
+  topk_large_stage1_f32<<<nblocks, block_size, stage1_smem, custream>>>(
+      input, block_values, block_indices, block_maxes, block_sums, ncols, k,
+      chunk_size, inv_temperature);
+  topk_large_stage2_f32_packed<<<1, block_size, stage2_smem, custream>>>(
+      block_values, block_indices, block_maxes, block_sums, packed_out, nblocks,
+      k);
 }

--- a/mistralrs-core/src/cuda/sort.cu
+++ b/mistralrs-core/src/cuda/sort.cu
@@ -23,6 +23,186 @@ extern "C" void softcap_f32(const void *x, void *dst, const int n,
       cap);
 }
 
+__global__ void copy_f32_kernel(const float *__restrict__ x,
+                                float *__restrict__ dst, const int n) {
+  const int idx = blockIdx.x * blockDim.x + threadIdx.x;
+  if (idx >= n) {
+    return;
+  }
+  dst[idx] = x[idx];
+}
+
+__global__ void apply_sparse_penalties_f32_kernel(
+    float *__restrict__ logits, const uint32_t *__restrict__ token_ids,
+    const float *__restrict__ counts, const int n, const int n_tokens,
+    const float frequency_penalty, const float presence_penalty,
+    const float repetition_penalty) {
+  const int idx = blockIdx.x * blockDim.x + threadIdx.x;
+  if (idx >= n_tokens) {
+    return;
+  }
+
+  const uint32_t token_id = token_ids[idx];
+  if (token_id >= static_cast<uint32_t>(n)) {
+    return;
+  }
+
+  const float count = counts[idx];
+  if (count <= 0.0f) {
+    return;
+  }
+
+  float value = logits[token_id];
+  value -= count * frequency_penalty + presence_penalty;
+
+  if (repetition_penalty != 1.0f) {
+    value = value > 0.0f ? value / repetition_penalty
+                         : value * repetition_penalty;
+  }
+
+  logits[token_id] = value;
+}
+
+extern "C" void apply_sparse_penalties_f32(
+    const void *x, void *dst, const uint32_t *token_ids, const float *counts,
+    const int n, const int n_tokens, const float frequency_penalty,
+    const float presence_penalty, const float repetition_penalty,
+    int64_t stream) {
+  if (n <= 0) {
+    return;
+  }
+
+  const cudaStream_t custream = (cudaStream_t)stream;
+  const int block = 256;
+  const int copy_grid = (n + block - 1) / block;
+  copy_f32_kernel<<<copy_grid, block, 0, custream>>>(
+      reinterpret_cast<const float *>(x), reinterpret_cast<float *>(dst), n);
+
+  if (n_tokens <= 0) {
+    return;
+  }
+
+  const int penalty_grid = (n_tokens + block - 1) / block;
+  apply_sparse_penalties_f32_kernel<<<penalty_grid, block, 0, custream>>>(
+      reinterpret_cast<float *>(dst), token_ids, counts, n, n_tokens,
+      frequency_penalty, presence_penalty, repetition_penalty);
+}
+
+template <typename T>
+__device__ __forceinline__ float rms_residual_to_float(T value) {
+  return static_cast<float>(value);
+}
+
+template <>
+__device__ __forceinline__ float
+rms_residual_to_float<__half>(__half value) {
+  return __half2float(value);
+}
+
+template <>
+__device__ __forceinline__ float
+rms_residual_to_float<__nv_bfloat16>(__nv_bfloat16 value) {
+  return __bfloat162float(value);
+}
+
+template <typename T>
+__device__ __forceinline__ T rms_residual_from_float(float value) {
+  return static_cast<T>(value);
+}
+
+template <>
+__device__ __forceinline__ __half
+rms_residual_from_float<__half>(float value) {
+  return __float2half(value);
+}
+
+template <>
+__device__ __forceinline__ __nv_bfloat16
+rms_residual_from_float<__nv_bfloat16>(float value) {
+  return __float2bfloat16(value);
+}
+
+template <typename T>
+__global__ void rms_norm_residual_kernel(
+    const T *__restrict__ x, const T *__restrict__ residual,
+    const T *__restrict__ weight, const T *__restrict__ scale,
+    T *__restrict__ dst, const int ncols, const float eps) {
+  __shared__ float reduce[1024];
+  const int row = blockIdx.x;
+  const int tid = threadIdx.x;
+  const int row_offset = row * ncols;
+  const float scale_value = scale == nullptr ? 1.0f : rms_residual_to_float(scale[0]);
+
+  float sum = 0.0f;
+  for (int col = tid; col < ncols; col += blockDim.x) {
+    const float value = rms_residual_to_float(x[row_offset + col]);
+    sum += value * value;
+  }
+  reduce[tid] = sum;
+  __syncthreads();
+
+  for (int stride = blockDim.x / 2; stride > 0; stride >>= 1) {
+    if (tid < stride) {
+      reduce[tid] += reduce[tid + stride];
+    }
+    __syncthreads();
+  }
+
+  const float inv_rms = rsqrtf(reduce[0] / static_cast<float>(ncols) + eps);
+  for (int col = tid; col < ncols; col += blockDim.x) {
+    const float normed = rms_residual_to_float(x[row_offset + col]) * inv_rms *
+                         rms_residual_to_float(weight[col]);
+    const float value =
+        (rms_residual_to_float(residual[row_offset + col]) + normed) *
+        scale_value;
+    dst[row_offset + col] = rms_residual_from_float<T>(value);
+  }
+}
+
+template <typename T>
+void launch_rms_norm_residual(const void *x, const void *residual,
+                              const void *weight, const void *scale, void *dst,
+                              const int nrows, const int ncols,
+                              const float eps, int64_t stream) {
+  if (nrows <= 0 || ncols <= 0) {
+    return;
+  }
+
+  const cudaStream_t custream = (cudaStream_t)stream;
+  const int block = ncols < 1024 ? 32 : 1024;
+  rms_norm_residual_kernel<T><<<nrows, block, 0, custream>>>(
+      reinterpret_cast<const T *>(x), reinterpret_cast<const T *>(residual),
+      reinterpret_cast<const T *>(weight), reinterpret_cast<const T *>(scale),
+      reinterpret_cast<T *>(dst), ncols, eps);
+}
+
+extern "C" void rms_norm_residual_f32(const void *x, const void *residual,
+                                      const void *weight, const void *scale,
+                                      void *dst, const int nrows,
+                                      const int ncols, const float eps,
+                                      int64_t stream) {
+  launch_rms_norm_residual<float>(x, residual, weight, scale, dst, nrows, ncols,
+                                  eps, stream);
+}
+
+extern "C" void rms_norm_residual_f16(const void *x, const void *residual,
+                                      const void *weight, const void *scale,
+                                      void *dst, const int nrows,
+                                      const int ncols, const float eps,
+                                      int64_t stream) {
+  launch_rms_norm_residual<__half>(x, residual, weight, scale, dst, nrows,
+                                   ncols, eps, stream);
+}
+
+extern "C" void rms_norm_residual_bf16(const void *x, const void *residual,
+                                       const void *weight, const void *scale,
+                                       void *dst, const int nrows,
+                                       const int ncols, const float eps,
+                                       int64_t stream) {
+  launch_rms_norm_residual<__nv_bfloat16>(x, residual, weight, scale, dst,
+                                          nrows, ncols, eps, stream);
+}
+
 template <typename T> inline __device__ void swap(T &a, T &b) {
   T tmp = a;
   a = b;

--- a/mistralrs-core/src/layers.rs
+++ b/mistralrs-core/src/layers.rs
@@ -254,6 +254,53 @@ impl RmsNorm {
     pub fn weight(&self) -> &Tensor {
         &self.weight
     }
+
+    pub fn forward_residual(&self, x: &Tensor, residual: &Tensor) -> Result<Tensor> {
+        self.forward_residual_inner(x, residual, None)
+    }
+
+    pub fn forward_residual_scaled(
+        &self,
+        x: &Tensor,
+        residual: &Tensor,
+        scale: &Tensor,
+    ) -> Result<Tensor> {
+        self.forward_residual_inner(x, residual, Some(scale))
+    }
+
+    fn forward_residual_inner(
+        &self,
+        x: &Tensor,
+        residual: &Tensor,
+        scale: Option<&Tensor>,
+    ) -> Result<Tensor> {
+        #[cfg(feature = "cuda")]
+        if x.device().is_cuda()
+            && residual.device().same_device(x.device())
+            && self.weight.device().same_device(x.device())
+            && scale.is_none_or(|scale| scale.device().same_device(x.device()))
+            && x.dtype() == residual.dtype()
+            && x.dtype() == self.weight.dtype()
+            && scale.is_none_or(|scale| scale.dtype() == x.dtype())
+            && matches!(x.dtype(), DType::BF16 | DType::F16 | DType::F32)
+        {
+            return crate::ops::cuda_rms_norm_residual(
+                x,
+                residual,
+                &self.weight,
+                scale,
+                self.eps as f32,
+            );
+        }
+
+        let normed = self.forward(x)?;
+        let out = (residual + normed)?;
+        if let Some(scale) = scale {
+            out.broadcast_mul(scale)
+        } else {
+            Ok(out)
+        }
+    }
 }
 
 impl Module for RmsNorm {

--- a/mistralrs-core/src/layers.rs
+++ b/mistralrs-core/src/layers.rs
@@ -256,7 +256,7 @@ impl RmsNorm {
     }
 
     pub fn forward_residual(&self, x: &Tensor, residual: &Tensor) -> Result<Tensor> {
-        self.forward_residual_inner(x, residual, None)
+        rms_norm_forward_residual(x, residual, &self.weight, self.eps, None)
     }
 
     pub fn forward_residual_scaled(
@@ -265,47 +265,42 @@ impl RmsNorm {
         residual: &Tensor,
         scale: &Tensor,
     ) -> Result<Tensor> {
-        self.forward_residual_inner(x, residual, Some(scale))
-    }
-
-    fn forward_residual_inner(
-        &self,
-        x: &Tensor,
-        residual: &Tensor,
-        scale: Option<&Tensor>,
-    ) -> Result<Tensor> {
-        #[cfg(feature = "cuda")]
-        if x.device().is_cuda()
-            && residual.device().same_device(x.device())
-            && self.weight.device().same_device(x.device())
-            && scale.is_none_or(|scale| scale.device().same_device(x.device()))
-            && x.dtype() == residual.dtype()
-            && x.dtype() == self.weight.dtype()
-            && scale.is_none_or(|scale| scale.dtype() == x.dtype())
-            && matches!(x.dtype(), DType::BF16 | DType::F16 | DType::F32)
-        {
-            return crate::ops::cuda_rms_norm_residual(
-                x,
-                residual,
-                &self.weight,
-                scale,
-                self.eps as f32,
-            );
-        }
-
-        let normed = self.forward(x)?;
-        let out = (residual + normed)?;
-        if let Some(scale) = scale {
-            out.broadcast_mul(scale)
-        } else {
-            Ok(out)
-        }
+        rms_norm_forward_residual(x, residual, &self.weight, self.eps, Some(scale))
     }
 }
 
 impl Module for RmsNorm {
     fn forward(&self, x: &Tensor) -> Result<Tensor> {
         candle_nn::ops::rms_norm(&x.contiguous()?, &self.weight, self.eps as f32)
+    }
+}
+
+fn rms_norm_forward_residual(
+    x: &Tensor,
+    residual: &Tensor,
+    weight: &Tensor,
+    eps: f64,
+    scale: Option<&Tensor>,
+) -> Result<Tensor> {
+    #[cfg(feature = "cuda")]
+    if x.device().is_cuda()
+        && residual.device().same_device(x.device())
+        && weight.device().same_device(x.device())
+        && scale.is_none_or(|scale| scale.device().same_device(x.device()))
+        && x.dtype() == residual.dtype()
+        && x.dtype() == weight.dtype()
+        && scale.is_none_or(|scale| scale.dtype() == x.dtype())
+        && matches!(x.dtype(), DType::BF16 | DType::F16 | DType::F32)
+    {
+        return crate::ops::cuda_rms_norm_residual(x, residual, weight, scale, eps as f32);
+    }
+
+    let normed = candle_nn::ops::rms_norm(&x.contiguous()?, weight, eps as f32)?;
+    let out = (residual + normed)?;
+    if let Some(scale) = scale {
+        out.broadcast_mul(scale)
+    } else {
+        Ok(out)
     }
 }
 
@@ -339,6 +334,19 @@ impl GemmaRmsNorm {
 
     pub fn original_weight(&self) -> &Tensor {
         &self.original_weight
+    }
+
+    pub fn forward_residual(&self, x: &Tensor, residual: &Tensor) -> Result<Tensor> {
+        rms_norm_forward_residual(x, residual, &self.weight, self.eps, None)
+    }
+
+    pub fn forward_residual_scaled(
+        &self,
+        x: &Tensor,
+        residual: &Tensor,
+        scale: &Tensor,
+    ) -> Result<Tensor> {
+        rms_norm_forward_residual(x, residual, &self.weight, self.eps, Some(scale))
     }
 }
 

--- a/mistralrs-core/src/models/gemma.rs
+++ b/mistralrs-core/src/models/gemma.rs
@@ -172,9 +172,8 @@ impl Attention {
     ) -> Result<Tensor> {
         let (b_sz, q_len, _) = xs.dims3()?;
 
-        let q = self.q_proj.forward(xs)?;
-        let k = self.k_proj.forward(xs)?;
-        let v = self.v_proj.forward(xs)?;
+        let (q, k, v) =
+            crate::ops::qkv_projections(xs, &*self.q_proj, &*self.k_proj, &*self.v_proj)?;
         let (q, k, v) = if q_len != 1 {
             let q = q
                 .reshape((b_sz, q_len, self.num_heads, self.head_dim))?

--- a/mistralrs-core/src/models/gemma2.rs
+++ b/mistralrs-core/src/models/gemma2.rs
@@ -180,9 +180,8 @@ impl Attention {
     ) -> Result<Tensor> {
         let (b_sz, q_len, _) = xs.dims3()?;
 
-        let q = self.q_proj.forward(xs)?;
-        let k = self.k_proj.forward(xs)?;
-        let v = self.v_proj.forward(xs)?;
+        let (q, k, v) =
+            crate::ops::qkv_projections(xs, &*self.q_proj, &*self.k_proj, &*self.v_proj)?;
         let (q, k, v) = if q_len != 1 {
             let q = q
                 .reshape((b_sz, q_len, self.num_heads, self.head_dim))?

--- a/mistralrs-core/src/models/gemma2.rs
+++ b/mistralrs-core/src/models/gemma2.rs
@@ -339,25 +339,24 @@ impl DecoderLayer {
     ) -> Result<Tensor> {
         let residual = xs;
         let xs = self.input_layernorm.forward(xs)?;
+        let xs = self.self_attn.forward(
+            &xs,
+            attention_mask,
+            sliding_attention_mask,
+            seqlen_offsets,
+            kv_cache,
+            metadata,
+            flash_params,
+        )?;
         let xs = self
-            .self_attn
-            .forward(
-                &xs,
-                attention_mask,
-                sliding_attention_mask,
-                seqlen_offsets,
-                kv_cache,
-                metadata,
-                flash_params,
-            )?
-            .apply(&self.post_attention_layernorm)?;
-        let xs = (xs + residual)?;
+            .post_attention_layernorm
+            .forward_residual(&xs, residual)?;
         let residual = &xs;
         let xs = self
             .mlp
-            .forward(&xs.apply(&self.pre_feedforward_layernorm)?)?
-            .apply(&self.post_feedforward_layernorm)?;
-        residual + xs
+            .forward(&xs.apply(&self.pre_feedforward_layernorm)?)?;
+        self.post_feedforward_layernorm
+            .forward_residual(&xs, residual)
     }
 }
 

--- a/mistralrs-core/src/models/glm4.rs
+++ b/mistralrs-core/src/models/glm4.rs
@@ -228,9 +228,8 @@ impl Attention {
     ) -> Result<Tensor> {
         let (b_sz, q_len, _) = xs.dims3()?;
 
-        let mut q = self.q_proj.forward(xs)?;
-        let mut k = self.k_proj.forward(xs)?;
-        let mut v = self.v_proj.forward(xs)?;
+        let (mut q, mut k, mut v) =
+            crate::ops::qkv_projections(xs, &*self.q_proj, &*self.k_proj, &*self.v_proj)?;
 
         (q, k, v) = if q_len != 1 {
             let q = q

--- a/mistralrs-core/src/models/glm4_moe.rs
+++ b/mistralrs-core/src/models/glm4_moe.rs
@@ -265,9 +265,8 @@ impl Attention {
     ) -> Result<Tensor> {
         let (b_sz, q_len, _) = xs.dims3()?;
 
-        let mut q = self.q_proj.forward(xs)?;
-        let mut k = self.k_proj.forward(xs)?;
-        let mut v = self.v_proj.forward(xs)?;
+        let (mut q, mut k, mut v) =
+            crate::ops::qkv_projections(xs, &*self.q_proj, &*self.k_proj, &*self.v_proj)?;
         (q, k, v) = if q_len != 1 {
             let q = q
                 .reshape((b_sz, q_len, self.num_heads, self.head_dim))?

--- a/mistralrs-core/src/models/gpt_oss.rs
+++ b/mistralrs-core/src/models/gpt_oss.rs
@@ -256,9 +256,8 @@ impl Attention {
     ) -> Result<Tensor> {
         let (b_sz, q_len, _) = xs.dims3()?;
 
-        let mut q = self.q_proj.forward(xs)?;
-        let mut k = self.k_proj.forward(xs)?;
-        let mut v = self.v_proj.forward(xs)?;
+        let (mut q, mut k, mut v) =
+            crate::ops::qkv_projections(xs, &*self.q_proj, &*self.k_proj, &*self.v_proj)?;
         (q, k, v) = if q_len != 1 {
             let q = q
                 .reshape((b_sz, q_len, self.num_heads, self.head_dim))?

--- a/mistralrs-core/src/models/granite.rs
+++ b/mistralrs-core/src/models/granite.rs
@@ -1278,9 +1278,8 @@ impl CausalSelfAttention {
     ) -> Result<Tensor> {
         let (b_sz, seq_len, _) = x.dims3()?;
 
-        let mut q = self.q_proj.forward(x)?;
-        let mut k = self.k_proj.forward(x)?;
-        let mut v = self.v_proj.forward(x)?;
+        let (mut q, mut k, mut v) =
+            crate::ops::qkv_projections(x, &*self.q_proj, &*self.k_proj, &*self.v_proj)?;
         (q, k, v) = if seq_len != 1 {
             let q = q
                 .reshape((b_sz, seq_len, self.num_attention_heads, self.head_dim))?

--- a/mistralrs-core/src/models/llama.rs
+++ b/mistralrs-core/src/models/llama.rs
@@ -77,9 +77,8 @@ impl CausalSelfAttention {
     ) -> Result<Tensor> {
         let (b_sz, seq_len, _) = x.dims3()?;
 
-        let q = self.q_proj.forward(x)?;
-        let k = self.k_proj.forward(x)?;
-        let v = self.v_proj.forward(x)?;
+        let (q, k, v) =
+            crate::ops::qkv_projections(x, &*self.q_proj, &*self.k_proj, &*self.v_proj)?;
         let (q, k, v) = if seq_len != 1 {
             let q = q
                 .reshape((b_sz, seq_len, self.num_attention_heads, self.head_dim))?

--- a/mistralrs-core/src/models/mistral.rs
+++ b/mistralrs-core/src/models/mistral.rs
@@ -194,9 +194,8 @@ impl Attention {
     ) -> Result<Tensor> {
         let (b_sz, q_len, _) = xs.dims3()?;
 
-        let q = self.q_proj.forward(xs)?;
-        let k = self.k_proj.forward(xs)?;
-        let v = self.v_proj.forward(xs)?;
+        let (q, k, v) =
+            crate::ops::qkv_projections(xs, &*self.q_proj, &*self.k_proj, &*self.v_proj)?;
         let (q, k, v) = if q_len != 1 {
             let q = q
                 .reshape((b_sz, q_len, self.num_heads, self.head_dim))?

--- a/mistralrs-core/src/models/mixtral.rs
+++ b/mistralrs-core/src/models/mixtral.rs
@@ -151,9 +151,8 @@ impl Attention {
     ) -> Result<Tensor> {
         let (b_sz, q_len, _) = xs.dims3()?;
 
-        let q = self.q_proj.forward(xs)?;
-        let k = self.k_proj.forward(xs)?;
-        let v = self.v_proj.forward(xs)?;
+        let (q, k, v) =
+            crate::ops::qkv_projections(xs, &*self.q_proj, &*self.k_proj, &*self.v_proj)?;
         let (q, k, v) = if q_len != 1 {
             let q = q
                 .reshape((b_sz, q_len, self.num_heads, self.head_dim))?

--- a/mistralrs-core/src/models/phi2.rs
+++ b/mistralrs-core/src/models/phi2.rs
@@ -260,9 +260,8 @@ impl Attention {
     ) -> Result<Tensor> {
         let (b_size, seq_len, _n_embd) = xs.dims3()?;
 
-        let q = self.q_proj.forward(xs)?;
-        let k = self.k_proj.forward(xs)?;
-        let v = self.v_proj.forward(xs)?;
+        let (q, k, v) =
+            crate::ops::qkv_projections(xs, &*self.q_proj, &*self.k_proj, &*self.v_proj)?;
         let q = match &self.q_layernorm {
             None => q,
             Some(ln) => q.apply(ln)?,

--- a/mistralrs-core/src/models/phi3.rs
+++ b/mistralrs-core/src/models/phi3.rs
@@ -276,9 +276,7 @@ impl AnyMoeTrainableLayer for Mlp {}
 impl MlpLayer for Mlp {
     fn forward(&self, xs: &Tensor) -> Result<Tensor> {
         let up_states = self.gate_up_proj.forward(xs)?;
-        let gate = up_states.narrow(D::Minus1, 0, self.i_size)?;
-        let up_states = up_states.narrow(D::Minus1, self.i_size, self.i_size)?;
-        let up_states = crate::ops::mul_and_act(&gate, &up_states, self.act_fn)?;
+        let up_states = crate::ops::split_mul_and_act(&up_states, self.i_size, self.act_fn)?;
         let res = self.down_proj.forward(&up_states)?;
         Ok(res)
     }

--- a/mistralrs-core/src/models/phi3_5_moe.rs
+++ b/mistralrs-core/src/models/phi3_5_moe.rs
@@ -177,9 +177,8 @@ impl Attention {
     ) -> Result<Tensor> {
         let (b_sz, q_len, _) = xs.dims3()?;
 
-        let q = self.q_proj.forward(xs)?;
-        let k = self.k_proj.forward(xs)?;
-        let v = self.v_proj.forward(xs)?;
+        let (q, k, v) =
+            crate::ops::qkv_projections(xs, &*self.q_proj, &*self.k_proj, &*self.v_proj)?;
         let (q, k, v) = if q_len != 1 {
             let q = q
                 .reshape((b_sz, q_len, self.num_heads, self.head_dim))?

--- a/mistralrs-core/src/models/quantized_phi3.rs
+++ b/mistralrs-core/src/models/quantized_phi3.rs
@@ -29,10 +29,11 @@ struct Mlp {
 impl Module for Mlp {
     fn forward(&self, xs: &Tensor) -> Result<Tensor> {
         let up_states = self.ffn_up.forward(xs)?;
-        let gate = up_states.narrow(D::Minus1, 0, self.i_size)?;
-        let up_states = up_states.narrow(D::Minus1, self.i_size, self.i_size)?;
-        let up_states =
-            crate::ops::mul_and_act(&gate, &up_states, crate::layers::Activation::Silu)?;
+        let up_states = crate::ops::split_mul_and_act(
+            &up_states,
+            self.i_size,
+            crate::layers::Activation::Silu,
+        )?;
         self.ffn_down.forward(&up_states)
     }
 }

--- a/mistralrs-core/src/models/qwen2.rs
+++ b/mistralrs-core/src/models/qwen2.rs
@@ -146,9 +146,8 @@ impl Attention {
     ) -> Result<Tensor> {
         let (b_sz, q_len, _) = xs.dims3()?;
 
-        let q = self.q_proj.forward(xs)?;
-        let k = self.k_proj.forward(xs)?;
-        let v = self.v_proj.forward(xs)?;
+        let (q, k, v) =
+            crate::ops::qkv_projections(xs, &*self.q_proj, &*self.k_proj, &*self.v_proj)?;
         let (q, k, v) = if q_len != 1 {
             let q = q
                 .reshape((b_sz, q_len, self.num_heads, self.head_dim))?

--- a/mistralrs-core/src/models/qwen3.rs
+++ b/mistralrs-core/src/models/qwen3.rs
@@ -190,9 +190,8 @@ impl Attention {
     ) -> Result<Tensor> {
         let (b_sz, q_len, _) = xs.dims3()?;
 
-        let mut q = self.q_proj.forward(xs)?;
-        let mut k = self.k_proj.forward(xs)?;
-        let mut v = self.v_proj.forward(xs)?;
+        let (mut q, mut k, mut v) =
+            crate::ops::qkv_projections(xs, &*self.q_proj, &*self.k_proj, &*self.v_proj)?;
         (q, k, v) = if q_len != 1 {
             let q = q
                 .reshape((b_sz, q_len, self.num_heads, self.head_dim))?

--- a/mistralrs-core/src/models/qwen3_moe.rs
+++ b/mistralrs-core/src/models/qwen3_moe.rs
@@ -196,9 +196,8 @@ impl Attention {
     ) -> Result<Tensor> {
         let (b_sz, q_len, _) = xs.dims3()?;
 
-        let mut q = self.q_proj.forward(xs)?;
-        let mut k = self.k_proj.forward(xs)?;
-        let mut v = self.v_proj.forward(xs)?;
+        let (mut q, mut k, mut v) =
+            crate::ops::qkv_projections(xs, &*self.q_proj, &*self.k_proj, &*self.v_proj)?;
         (q, k, v) = if q_len != 1 {
             let q = q
                 .reshape((b_sz, q_len, self.num_heads, self.head_dim))?

--- a/mistralrs-core/src/models/qwen3_next.rs
+++ b/mistralrs-core/src/models/qwen3_next.rs
@@ -263,9 +263,8 @@ impl FullAttention {
         flash_params: &FlashParams,
     ) -> Result<Tensor> {
         let (b_sz, seq_len, _) = x.dims3()?;
-        let q_gate = self.q_proj.forward(x)?;
-        let k = self.k_proj.forward(x)?;
-        let v = self.v_proj.forward(x)?;
+        let (q_gate, k, v) =
+            crate::ops::qkv_projections(x, &*self.q_proj, &*self.k_proj, &*self.v_proj)?;
         // Split q_gate into q and gate: first reshape to per-head (head_dim*2), then chunk
         // Reference: view(*input_shape, -1, head_dim*2), chunk(2, dim=-1)
         let q_gate = q_gate.reshape((b_sz, seq_len, self.num_heads, self.head_dim * 2))?;

--- a/mistralrs-core/src/models/smollm3.rs
+++ b/mistralrs-core/src/models/smollm3.rs
@@ -93,9 +93,8 @@ impl CausalSelfAttention {
     ) -> Result<Tensor> {
         let (b_sz, seq_len, _) = x.dims3()?;
 
-        let mut q = self.q_proj.forward(x)?;
-        let mut k = self.k_proj.forward(x)?;
-        let mut v = self.v_proj.forward(x)?;
+        let (mut q, mut k, mut v) =
+            crate::ops::qkv_projections(x, &*self.q_proj, &*self.k_proj, &*self.v_proj)?;
         (q, k, v) = if seq_len != 1 {
             let q = q
                 .reshape((b_sz, seq_len, self.num_attention_heads, self.head_dim))?

--- a/mistralrs-core/src/models/starcoder2.rs
+++ b/mistralrs-core/src/models/starcoder2.rs
@@ -234,9 +234,8 @@ impl Attention {
     ) -> Result<Tensor> {
         let (b_sz, q_len, _) = xs.dims3()?;
 
-        let q = self.q_proj.forward(xs)?;
-        let k = self.k_proj.forward(xs)?;
-        let v = self.v_proj.forward(xs)?;
+        let (q, k, v) =
+            crate::ops::qkv_projections(xs, &*self.q_proj, &*self.k_proj, &*self.v_proj)?;
         let (q, k, v) = if q_len != 1 {
             let q = q
                 .reshape((b_sz, q_len, self.num_heads, self.head_dim))?

--- a/mistralrs-core/src/ops.rs
+++ b/mistralrs-core/src/ops.rs
@@ -1450,6 +1450,28 @@ fn glu_activation_type(act: Activation) -> Option<mistralrs_quant::GluActivation
     }
 }
 
+fn candle_glu_activation_type(
+    act: candle_nn::Activation,
+) -> Option<mistralrs_quant::GluActivationType> {
+    match act {
+        candle_nn::Activation::Silu | candle_nn::Activation::Swish => {
+            Some(mistralrs_quant::GluActivationType::Silu)
+        }
+        candle_nn::Activation::NewGelu | candle_nn::Activation::GeluPytorchTanh => {
+            Some(mistralrs_quant::GluActivationType::Gelu)
+        }
+        candle_nn::Activation::Gelu => Some(mistralrs_quant::GluActivationType::GeluErf),
+        candle_nn::Activation::Relu => Some(mistralrs_quant::GluActivationType::Relu),
+        _ => None,
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum GatedActivationOrder {
+    GateUp,
+    UpGate,
+}
+
 pub fn mul_and_act(a: &Tensor, b: &Tensor, act: Activation) -> Result<Tensor> {
     // Check if we can use the fused kernel (works on CUDA, Metal, and CPU)
     if matches!(a.dtype(), DType::F16 | DType::BF16 | DType::F32) && a.dtype() == b.dtype() {
@@ -1459,6 +1481,45 @@ pub fn mul_and_act(a: &Tensor, b: &Tensor, act: Activation) -> Result<Tensor> {
     }
 
     a.apply(&act)? * b
+}
+
+pub fn mul_and_candle_act(a: &Tensor, b: &Tensor, act: candle_nn::Activation) -> Result<Tensor> {
+    // Check if we can use the fused kernel (works on CUDA, Metal, and CPU)
+    if matches!(a.dtype(), DType::F16 | DType::BF16 | DType::F32) && a.dtype() == b.dtype() {
+        if let Some(activation_type) = candle_glu_activation_type(act) {
+            return mistralrs_quant::fused_glu(a, b, activation_type);
+        }
+    }
+
+    a.apply(&act)? * b
+}
+
+pub fn split_mul_and_act(xs: &Tensor, split_size: usize, act: Activation) -> Result<Tensor> {
+    split_mul_and_act_order(xs, split_size, act, GatedActivationOrder::GateUp)
+}
+
+pub fn split_mul_and_act_order(
+    xs: &Tensor,
+    split_size: usize,
+    act: Activation,
+    order: GatedActivationOrder,
+) -> Result<Tensor> {
+    let last_dim = xs.dim(D::Minus1)?;
+    let Some(expected_last_dim) = split_size.checked_mul(2) else {
+        candle_core::bail!("split_mul_and_act split size overflow: {split_size}");
+    };
+    if last_dim != expected_last_dim {
+        candle_core::bail!(
+            "split_mul_and_act expected last dim {expected_last_dim}, got {last_dim}"
+        );
+    }
+
+    let first = xs.narrow(D::Minus1, 0, split_size)?;
+    let second = xs.narrow(D::Minus1, split_size, split_size)?;
+    match order {
+        GatedActivationOrder::GateUp => mul_and_act(&first, &second, act),
+        GatedActivationOrder::UpGate => mul_and_act(&second, &first, act),
+    }
 }
 
 /// Feed-forward path for quantized gate/up/down projections.

--- a/mistralrs-core/src/ops.rs
+++ b/mistralrs-core/src/ops.rs
@@ -760,6 +760,316 @@ pub fn cuda_softcap_f32(input: &Tensor, cap: f32) -> Result<Tensor> {
     )))
 }
 
+#[cfg(feature = "cuda")]
+pub fn cuda_apply_sparse_penalties_f32(
+    input: &Tensor,
+    token_ids: &Tensor,
+    counts: &Tensor,
+    frequency_penalty: f32,
+    presence_penalty: f32,
+    repetition_penalty: f32,
+) -> Result<Tensor> {
+    use candle_core::backend::BackendStorage;
+    use candle_core::cuda_backend::cudarc::driver::DevicePtr;
+    use candle_core::cuda_backend::{CudaStorage, CudaStorageSlice};
+    use std::ffi::c_void;
+
+    if input.dtype() != DType::F32 {
+        candle_core::bail!("cuda_apply_sparse_penalties_f32 requires F32 logits");
+    }
+    if token_ids.dtype() != DType::U32 {
+        candle_core::bail!("cuda_apply_sparse_penalties_f32 requires U32 token ids");
+    }
+    if counts.dtype() != DType::F32 {
+        candle_core::bail!("cuda_apply_sparse_penalties_f32 requires F32 counts");
+    }
+    if token_ids.elem_count() != counts.elem_count() {
+        candle_core::bail!(
+            "cuda_apply_sparse_penalties_f32 token ids/counts length mismatch: {} vs {}",
+            token_ids.elem_count(),
+            counts.elem_count()
+        );
+    }
+    if !token_ids.device().same_device(input.device())
+        || !counts.device().same_device(input.device())
+    {
+        candle_core::bail!(
+            "cuda_apply_sparse_penalties_f32 tensors must be on the same CUDA device"
+        );
+    }
+
+    let input = input.contiguous()?;
+    let token_ids = token_ids.contiguous()?;
+    let counts = counts.contiguous()?;
+
+    let elem_count = input.elem_count();
+    let n_tokens = token_ids.elem_count();
+    if elem_count == 0 {
+        candle_core::bail!("cuda_apply_sparse_penalties_f32 got empty logits");
+    }
+    if elem_count > i32::MAX as usize {
+        candle_core::bail!(
+            "cuda_apply_sparse_penalties_f32 input is too large: {elem_count} elements"
+        );
+    }
+    if n_tokens > i32::MAX as usize {
+        candle_core::bail!(
+            "cuda_apply_sparse_penalties_f32 token list is too large: {n_tokens} elements"
+        );
+    }
+
+    let (input_storage, input_layout) = input.storage_and_layout();
+    let input_storage = match &*input_storage {
+        candle_core::Storage::Cuda(s) => s,
+        _ => candle_core::bail!("cuda_apply_sparse_penalties_f32 requires CUDA logits"),
+    };
+    let CudaStorageSlice::F32(src) = &input_storage.slice else {
+        candle_core::bail!("cuda_apply_sparse_penalties_f32 only supports F32 logits");
+    };
+
+    let (token_storage, token_layout) = token_ids.storage_and_layout();
+    let token_storage = match &*token_storage {
+        candle_core::Storage::Cuda(s) => s,
+        _ => candle_core::bail!("cuda_apply_sparse_penalties_f32 requires CUDA token ids"),
+    };
+    let CudaStorageSlice::U32(token_src) = &token_storage.slice else {
+        candle_core::bail!("cuda_apply_sparse_penalties_f32 only supports U32 token ids");
+    };
+
+    let (count_storage, count_layout) = counts.storage_and_layout();
+    let count_storage = match &*count_storage {
+        candle_core::Storage::Cuda(s) => s,
+        _ => candle_core::bail!("cuda_apply_sparse_penalties_f32 requires CUDA counts"),
+    };
+    let CudaStorageSlice::F32(count_src) = &count_storage.slice else {
+        candle_core::bail!("cuda_apply_sparse_penalties_f32 only supports F32 counts");
+    };
+
+    let dev = input_storage.device();
+    let out = unsafe { dev.alloc::<f32>(elem_count) }?;
+
+    let (src_ptr, src_guard) = src.device_ptr(src.stream());
+    let (token_ptr, token_guard) = token_src.device_ptr(token_src.stream());
+    let (count_ptr, count_guard) = count_src.device_ptr(count_src.stream());
+    let (out_ptr, out_guard) = out.device_ptr(out.stream());
+
+    let src_ptr = unsafe { (src_ptr as *const f32).add(input_layout.start_offset()) };
+    let token_ptr = unsafe { (token_ptr as *const u32).add(token_layout.start_offset()) };
+    let count_ptr = unsafe { (count_ptr as *const f32).add(count_layout.start_offset()) };
+
+    unsafe {
+        ffi::apply_sparse_penalties_f32(
+            src_ptr as *const c_void,
+            out_ptr as *mut c_void,
+            token_ptr,
+            count_ptr,
+            elem_count as i32,
+            n_tokens as i32,
+            frequency_penalty,
+            presence_penalty,
+            repetition_penalty,
+            dev.cuda_stream().cu_stream() as i64,
+        );
+    }
+
+    drop(src_guard);
+    drop(token_guard);
+    drop(count_guard);
+    drop(out_guard);
+
+    let out_storage = CudaStorage {
+        slice: CudaStorageSlice::F32(out),
+        device: dev.clone(),
+    };
+    Ok(Tensor::from((
+        candle_core::Storage::Cuda(out_storage),
+        input.shape().clone(),
+    )))
+}
+
+#[cfg(feature = "cuda")]
+pub fn cuda_rms_norm_residual(
+    input: &Tensor,
+    residual: &Tensor,
+    weight: &Tensor,
+    scale: Option<&Tensor>,
+    eps: f32,
+) -> Result<Tensor> {
+    use candle_core::backend::BackendStorage;
+    use candle_core::cuda_backend::cudarc::driver::DevicePtr;
+    use candle_core::cuda_backend::{CudaStorage, CudaStorageSlice};
+    use std::ffi::c_void;
+
+    if input.shape() != residual.shape() {
+        candle_core::bail!(
+            "cuda_rms_norm_residual input/residual shape mismatch: {:?} vs {:?}",
+            input.shape(),
+            residual.shape()
+        );
+    }
+    if input.dtype() != residual.dtype() || input.dtype() != weight.dtype() {
+        candle_core::bail!(
+            "cuda_rms_norm_residual dtype mismatch: input {:?}, residual {:?}, weight {:?}",
+            input.dtype(),
+            residual.dtype(),
+            weight.dtype()
+        );
+    }
+    if !matches!(input.dtype(), DType::BF16 | DType::F16 | DType::F32) {
+        candle_core::bail!(
+            "cuda_rms_norm_residual only supports BF16/F16/F32, got {:?}",
+            input.dtype()
+        );
+    }
+    if !residual.device().same_device(input.device())
+        || !weight.device().same_device(input.device())
+    {
+        candle_core::bail!("cuda_rms_norm_residual tensors must be on the same CUDA device");
+    }
+    if let Some(scale) = scale {
+        if scale.elem_count() != 1 {
+            candle_core::bail!(
+                "cuda_rms_norm_residual scale must have one element, got {}",
+                scale.elem_count()
+            );
+        }
+        if scale.dtype() != input.dtype() {
+            candle_core::bail!(
+                "cuda_rms_norm_residual scale dtype mismatch: input {:?}, scale {:?}",
+                input.dtype(),
+                scale.dtype()
+            );
+        }
+        if !scale.device().same_device(input.device()) {
+            candle_core::bail!("cuda_rms_norm_residual scale must be on the same CUDA device");
+        }
+    }
+
+    let ncols = input.dim(D::Minus1)?;
+    if weight.dims1()? != ncols {
+        candle_core::bail!(
+            "cuda_rms_norm_residual weight size {} does not match last dim {ncols}",
+            weight.dims1()?
+        );
+    }
+    let elem_count = input.elem_count();
+    if elem_count == 0 {
+        candle_core::bail!("cuda_rms_norm_residual got empty input");
+    }
+    let nrows = elem_count / ncols;
+    if nrows > i32::MAX as usize || ncols > i32::MAX as usize {
+        candle_core::bail!(
+            "cuda_rms_norm_residual input is too large: nrows={nrows}, ncols={ncols}"
+        );
+    }
+
+    let input = input.contiguous()?;
+    let residual = residual.contiguous()?;
+    let weight = weight.contiguous()?;
+    let scale = scale.map(Tensor::contiguous).transpose()?;
+
+    let (input_storage, input_layout) = input.storage_and_layout();
+    let input_storage = match &*input_storage {
+        candle_core::Storage::Cuda(s) => s,
+        _ => candle_core::bail!("cuda_rms_norm_residual requires CUDA input"),
+    };
+    let (residual_storage, residual_layout) = residual.storage_and_layout();
+    let residual_storage = match &*residual_storage {
+        candle_core::Storage::Cuda(s) => s,
+        _ => candle_core::bail!("cuda_rms_norm_residual requires CUDA residual"),
+    };
+    let (weight_storage, weight_layout) = weight.storage_and_layout();
+    let weight_storage = match &*weight_storage {
+        candle_core::Storage::Cuda(s) => s,
+        _ => candle_core::bail!("cuda_rms_norm_residual requires CUDA weight"),
+    };
+    let scale_storage_and_layout = scale.as_ref().map(|scale| scale.storage_and_layout());
+
+    let dev = input_storage.device();
+    let stream = dev.cuda_stream().cu_stream() as i64;
+    let shape = input.shape().clone();
+
+    macro_rules! launch {
+        ($variant:ident, $ty:ty, $ffi_fn:ident) => {{
+            let CudaStorageSlice::$variant(src) = &input_storage.slice else {
+                candle_core::bail!("cuda_rms_norm_residual input dtype mismatch");
+            };
+            let CudaStorageSlice::$variant(residual_src) = &residual_storage.slice else {
+                candle_core::bail!("cuda_rms_norm_residual residual dtype mismatch");
+            };
+            let CudaStorageSlice::$variant(weight_src) = &weight_storage.slice else {
+                candle_core::bail!("cuda_rms_norm_residual weight dtype mismatch");
+            };
+            let (scale_ptr, scale_guard) =
+                if let Some((scale_storage, scale_layout)) = &scale_storage_and_layout {
+                    let scale_storage = match &**scale_storage {
+                        candle_core::Storage::Cuda(s) => s,
+                        _ => candle_core::bail!("cuda_rms_norm_residual requires CUDA scale"),
+                    };
+                    let CudaStorageSlice::$variant(scale_src) = &scale_storage.slice else {
+                        candle_core::bail!("cuda_rms_norm_residual scale dtype mismatch");
+                    };
+                    let (scale_ptr, scale_guard) = scale_src.device_ptr(scale_src.stream());
+                    (
+                        unsafe { (scale_ptr as *const $ty).add(scale_layout.start_offset()) }
+                            as *const c_void,
+                        Some(scale_guard),
+                    )
+                } else {
+                    (std::ptr::null(), None)
+                };
+
+            let out = unsafe { dev.alloc::<$ty>(elem_count) }?;
+            let (src_ptr, src_guard) = src.device_ptr(src.stream());
+            let (residual_ptr, residual_guard) = residual_src.device_ptr(residual_src.stream());
+            let (weight_ptr, weight_guard) = weight_src.device_ptr(weight_src.stream());
+            let (out_ptr, out_guard) = out.device_ptr(out.stream());
+
+            let src_ptr = unsafe { (src_ptr as *const $ty).add(input_layout.start_offset()) };
+            let residual_ptr =
+                unsafe { (residual_ptr as *const $ty).add(residual_layout.start_offset()) };
+            let weight_ptr =
+                unsafe { (weight_ptr as *const $ty).add(weight_layout.start_offset()) };
+
+            unsafe {
+                ffi::$ffi_fn(
+                    src_ptr as *const c_void,
+                    residual_ptr as *const c_void,
+                    weight_ptr as *const c_void,
+                    scale_ptr,
+                    out_ptr as *mut c_void,
+                    nrows as i32,
+                    ncols as i32,
+                    eps,
+                    stream,
+                );
+            }
+
+            drop(src_guard);
+            drop(residual_guard);
+            drop(weight_guard);
+            drop(scale_guard);
+            drop(out_guard);
+
+            let out_storage = CudaStorage {
+                slice: CudaStorageSlice::$variant(out),
+                device: dev.clone(),
+            };
+            Ok(Tensor::from((
+                candle_core::Storage::Cuda(out_storage),
+                shape,
+            )))
+        }};
+    }
+
+    match input.dtype() {
+        DType::BF16 => launch!(BF16, half::bf16, rms_norm_residual_bf16),
+        DType::F16 => launch!(F16, half::f16, rms_norm_residual_f16),
+        DType::F32 => launch!(F32, f32, rms_norm_residual_f32),
+        dtype => candle_core::bail!("cuda_rms_norm_residual unsupported dtype {dtype:?}"),
+    }
+}
+
 pub trait TopKLastDimOp {
     /// Topk in the last dim. `values` retains a gradient but `indices` has none w.r.t self.
     /// This expects a contiguous tensor.

--- a/mistralrs-core/src/ops.rs
+++ b/mistralrs-core/src/ops.rs
@@ -179,6 +179,167 @@ fn cuda_topk(input: &Tensor, k: usize) -> Result<TopKOutput> {
     })
 }
 
+#[cfg(feature = "cuda")]
+#[allow(clippy::cast_possible_truncation)]
+pub fn cuda_topk_logits_f32(
+    input: &Tensor,
+    k: usize,
+    temperature: f64,
+) -> Result<TopKLogitsOutput> {
+    use candle_core::backend::BackendStorage;
+    use candle_core::cuda_backend::cudarc::driver::DevicePtr;
+    use candle_core::cuda_backend::CudaStorageSlice;
+
+    const MAX_K: usize = 128;
+    const CHUNK_SIZE: usize = 2048;
+    const MAX_STAGE2_CANDIDATES: usize = 48 * 1024;
+
+    if temperature <= 0.0 || !temperature.is_finite() {
+        candle_core::bail!("cuda_topk_logits_f32 requires a positive finite temperature");
+    }
+
+    let input = input.contiguous()?;
+    if input.dtype() != DType::F32 {
+        candle_core::bail!("cuda_topk_logits_f32 requires F32 logits");
+    }
+
+    let ncols = input.elem_count();
+    if ncols == 0 {
+        candle_core::bail!("cuda_topk_logits_f32 got empty logits");
+    }
+    let k = k.min(ncols);
+    if k == 0 || k > MAX_K {
+        candle_core::bail!("cuda_topk_logits_f32 k={} must be in [1, {}]", k, MAX_K);
+    }
+
+    let nblocks = (ncols + CHUNK_SIZE - 1) / CHUNK_SIZE;
+    let stage2_candidates = nblocks * k;
+    if stage2_candidates > MAX_STAGE2_CANDIDATES {
+        candle_core::bail!(
+            "cuda_topk_logits_f32 workspace too large: {} candidates",
+            stage2_candidates
+        );
+    }
+
+    let (storage, _layout) = input.storage_and_layout();
+    let storage = match &*storage {
+        candle_core::Storage::Cuda(s) => s,
+        _ => candle_core::bail!("cuda_topk_logits_f32 requires CUDA tensor"),
+    };
+
+    let dev = storage.device();
+    let stream = dev.cuda_stream().cu_stream() as i64;
+
+    let (src_ptr, _src_guard) = match &storage.slice {
+        CudaStorageSlice::F32(inp) => inp.device_ptr(inp.stream()),
+        _ => candle_core::bail!("cuda_topk_logits_f32 only supports F32"),
+    };
+
+    let workspace_elems = nblocks * k;
+    let block_values = unsafe { dev.alloc::<f32>(workspace_elems) }?;
+    let block_indices = unsafe { dev.alloc::<u32>(workspace_elems) }?;
+    let block_maxes = unsafe { dev.alloc::<f32>(nblocks) }?;
+    let block_sums = unsafe { dev.alloc::<f32>(nblocks) }?;
+    let values_dst = unsafe { dev.alloc::<f32>(k) }?;
+    let indices_dst = unsafe { dev.alloc::<u32>(k) }?;
+    let softmax_info_dst = unsafe { dev.alloc::<f32>(2) }?;
+
+    let (block_values_ptr, block_values_guard) = block_values.device_ptr(block_values.stream());
+    let (block_indices_ptr, block_indices_guard) = block_indices.device_ptr(block_indices.stream());
+    let (block_maxes_ptr, block_maxes_guard) = block_maxes.device_ptr(block_maxes.stream());
+    let (block_sums_ptr, block_sums_guard) = block_sums.device_ptr(block_sums.stream());
+    let (values_ptr, values_guard) = values_dst.device_ptr(values_dst.stream());
+    let (indices_ptr, indices_guard) = indices_dst.device_ptr(indices_dst.stream());
+    let (softmax_info_ptr, softmax_info_guard) =
+        softmax_info_dst.device_ptr(softmax_info_dst.stream());
+
+    unsafe {
+        ffi::topk_large_f32(
+            src_ptr as *const f32,
+            block_values_ptr as *mut f32,
+            block_indices_ptr as *mut u32,
+            block_maxes_ptr as *mut f32,
+            block_sums_ptr as *mut f32,
+            values_ptr as *mut f32,
+            indices_ptr as *mut u32,
+            softmax_info_ptr as *mut f32,
+            ncols as i32,
+            k as i32,
+            CHUNK_SIZE as i32,
+            nblocks as i32,
+            (1.0 / temperature) as f32,
+            stream,
+        );
+    }
+
+    drop(block_values_guard);
+    drop(block_indices_guard);
+    drop(block_maxes_guard);
+    drop(block_sums_guard);
+    drop(values_guard);
+    drop(indices_guard);
+    drop(softmax_info_guard);
+
+    let values_storage = candle_core::cuda_backend::CudaStorage {
+        slice: CudaStorageSlice::F32(values_dst),
+        device: dev.clone(),
+    };
+    let indices_storage = candle_core::cuda_backend::CudaStorage {
+        slice: CudaStorageSlice::U32(indices_dst),
+        device: dev.clone(),
+    };
+    let softmax_info_storage = candle_core::cuda_backend::CudaStorage {
+        slice: CudaStorageSlice::F32(softmax_info_dst),
+        device: dev.clone(),
+    };
+    let workspace = vec![
+        Tensor::from((
+            candle_core::Storage::Cuda(candle_core::cuda_backend::CudaStorage {
+                slice: CudaStorageSlice::F32(block_values),
+                device: dev.clone(),
+            }),
+            Shape::from_dims(&[workspace_elems]),
+        )),
+        Tensor::from((
+            candle_core::Storage::Cuda(candle_core::cuda_backend::CudaStorage {
+                slice: CudaStorageSlice::U32(block_indices),
+                device: dev.clone(),
+            }),
+            Shape::from_dims(&[workspace_elems]),
+        )),
+        Tensor::from((
+            candle_core::Storage::Cuda(candle_core::cuda_backend::CudaStorage {
+                slice: CudaStorageSlice::F32(block_maxes),
+                device: dev.clone(),
+            }),
+            Shape::from_dims(&[nblocks]),
+        )),
+        Tensor::from((
+            candle_core::Storage::Cuda(candle_core::cuda_backend::CudaStorage {
+                slice: CudaStorageSlice::F32(block_sums),
+                device: dev.clone(),
+            }),
+            Shape::from_dims(&[nblocks]),
+        )),
+    ];
+
+    Ok(TopKLogitsOutput {
+        values: Tensor::from((
+            candle_core::Storage::Cuda(values_storage),
+            Shape::from_dims(&[k]),
+        )),
+        indices: Tensor::from((
+            candle_core::Storage::Cuda(indices_storage),
+            Shape::from_dims(&[k]),
+        )),
+        softmax_info: Tensor::from((
+            candle_core::Storage::Cuda(softmax_info_storage),
+            Shape::from_dims(&[2]),
+        )),
+        _workspace: workspace,
+    })
+}
+
 /// Fused topk + softmax for MoE routing
 /// Returns softmax weights (not raw logits) and indices in a single kernel call
 /// This eliminates intermediate tensor allocations and the separate softmax kernel
@@ -533,6 +694,72 @@ pub struct TopKOutput {
     pub indices: Tensor,
 }
 
+#[allow(dead_code)]
+pub struct TopKLogitsOutput {
+    pub values: Tensor,
+    pub indices: Tensor,
+    /// `[softmax_denominator, global_max]` for the full-vocabulary softmax at
+    /// the temperature used for top-k selection.
+    pub softmax_info: Tensor,
+    _workspace: Vec<Tensor>,
+}
+
+#[cfg(feature = "cuda")]
+pub fn cuda_softcap_f32(input: &Tensor, cap: f32) -> Result<Tensor> {
+    use candle_core::backend::BackendStorage;
+    use candle_core::cuda_backend::cudarc::driver::DevicePtr;
+    use candle_core::cuda_backend::{CudaStorage, CudaStorageSlice};
+    use std::ffi::c_void;
+
+    if input.dtype() != DType::F32 {
+        candle_core::bail!("cuda_softcap_f32 requires F32 input");
+    }
+    if !cap.is_finite() || cap <= 0.0 {
+        candle_core::bail!("cuda_softcap_f32 requires a positive finite cap");
+    }
+
+    let input = input.contiguous()?;
+    let elem_count = input.elem_count();
+    if elem_count > i32::MAX as usize {
+        candle_core::bail!("cuda_softcap_f32 input is too large: {elem_count} elements");
+    }
+
+    let (storage, layout) = input.storage_and_layout();
+    let storage = match &*storage {
+        candle_core::Storage::Cuda(s) => s,
+        _ => candle_core::bail!("cuda_softcap_f32 requires CUDA tensor"),
+    };
+    let CudaStorageSlice::F32(src) = &storage.slice else {
+        candle_core::bail!("cuda_softcap_f32 only supports F32");
+    };
+    let dev = storage.device();
+    let out = unsafe { dev.alloc::<f32>(elem_count) }?;
+
+    let (src_ptr, _src_guard) = src.device_ptr(src.stream());
+    let (out_ptr, _out_guard) = out.device_ptr(out.stream());
+    let src_ptr = unsafe { (src_ptr as *const f32).add(layout.start_offset()) };
+    unsafe {
+        ffi::softcap_f32(
+            src_ptr as *const c_void,
+            out_ptr as *mut c_void,
+            elem_count as i32,
+            cap,
+            dev.cuda_stream().cu_stream() as i64,
+        );
+    }
+    drop(_src_guard);
+    drop(_out_guard);
+
+    let out_storage = CudaStorage {
+        slice: CudaStorageSlice::F32(out),
+        device: dev.clone(),
+    };
+    Ok(Tensor::from((
+        candle_core::Storage::Cuda(out_storage),
+        input.shape().clone(),
+    )))
+}
+
 pub trait TopKLastDimOp {
     /// Topk in the last dim. `values` retains a gradient but `indices` has none w.r.t self.
     /// This expects a contiguous tensor.
@@ -750,21 +977,22 @@ pub fn apply_triangular(xs: &Tensor, diagonal: isize, upper: bool) -> Result<Ten
 /// - CUDA: Custom CUDA kernel with vec4 optimization
 /// - Metal: Native Metal kernel
 /// - CPU: Rayon-parallelized implementation
+fn glu_activation_type(act: Activation) -> Option<mistralrs_quant::GluActivationType> {
+    match act {
+        Activation::Silu | Activation::Swish => Some(mistralrs_quant::GluActivationType::Silu),
+        Activation::NewGelu | Activation::GeluPytorchTanh => {
+            Some(mistralrs_quant::GluActivationType::Gelu)
+        }
+        Activation::Gelu => Some(mistralrs_quant::GluActivationType::GeluErf),
+        Activation::Relu => Some(mistralrs_quant::GluActivationType::Relu),
+        _ => None,
+    }
+}
+
 pub fn mul_and_act(a: &Tensor, b: &Tensor, act: Activation) -> Result<Tensor> {
     // Check if we can use the fused kernel (works on CUDA, Metal, and CPU)
     if matches!(a.dtype(), DType::F16 | DType::BF16 | DType::F32) && a.dtype() == b.dtype() {
-        // Map Activation to GluActivationType
-        let glu_act = match act {
-            Activation::Silu | Activation::Swish => Some(mistralrs_quant::GluActivationType::Silu),
-            Activation::NewGelu | Activation::GeluPytorchTanh => {
-                Some(mistralrs_quant::GluActivationType::Gelu)
-            }
-            Activation::Gelu => Some(mistralrs_quant::GluActivationType::GeluErf),
-            Activation::Relu => Some(mistralrs_quant::GluActivationType::Relu),
-            _ => None,
-        };
-
-        if let Some(activation_type) = glu_act {
+        if let Some(activation_type) = glu_activation_type(act) {
             return mistralrs_quant::fused_glu(a, b, activation_type);
         }
     }
@@ -780,6 +1008,15 @@ pub(crate) fn quantized_ffn(
     down: &dyn mistralrs_quant::QuantMethod,
     act: Activation,
 ) -> Result<Tensor> {
+    #[cfg(feature = "cuda")]
+    if let Some(activation_type) = glu_activation_type(act) {
+        if let Some(inter) =
+            mistralrs_quant::try_fused_quantized_gate_up(xs, gate, up, activation_type)?
+        {
+            return down.forward(&inter);
+        }
+    }
+
     let lhs = gate.forward(xs)?;
     let rhs = up.forward(xs)?;
     let inter = mul_and_act(&lhs, &rhs, act)?;

--- a/mistralrs-core/src/ops.rs
+++ b/mistralrs-core/src/ops.rs
@@ -1545,6 +1545,24 @@ pub(crate) fn quantized_ffn(
     down.forward(&inter)
 }
 
+pub(crate) fn qkv_projections(
+    xs: &Tensor,
+    q_proj: &dyn mistralrs_quant::QuantMethod,
+    k_proj: &dyn mistralrs_quant::QuantMethod,
+    v_proj: &dyn mistralrs_quant::QuantMethod,
+) -> Result<(Tensor, Tensor, Tensor)> {
+    #[cfg(feature = "cuda")]
+    if let Some(qkv) = mistralrs_quant::try_fused_quantized_qkv(xs, q_proj, k_proj, v_proj)? {
+        return Ok(qkv);
+    }
+
+    Ok((
+        q_proj.forward(xs)?,
+        k_proj.forward(xs)?,
+        v_proj.forward(xs)?,
+    ))
+}
+
 mod tests {
     #[test]
     fn test_topk() {

--- a/mistralrs-core/src/ops.rs
+++ b/mistralrs-core/src/ops.rs
@@ -180,6 +180,7 @@ fn cuda_topk(input: &Tensor, k: usize) -> Result<TopKOutput> {
 }
 
 #[cfg(feature = "cuda")]
+#[allow(dead_code)]
 #[allow(clippy::cast_possible_truncation)]
 pub fn cuda_topk_logits_f32(
     input: &Tensor,
@@ -336,6 +337,148 @@ pub fn cuda_topk_logits_f32(
             candle_core::Storage::Cuda(softmax_info_storage),
             Shape::from_dims(&[2]),
         )),
+        _workspace: workspace,
+    })
+}
+
+#[cfg(feature = "cuda")]
+#[allow(clippy::cast_possible_truncation)]
+pub fn cuda_topk_logits_f32_packed(
+    input: &Tensor,
+    k: usize,
+    temperature: f64,
+) -> Result<TopKLogitsPackedOutput> {
+    use candle_core::backend::BackendStorage;
+    use candle_core::cuda_backend::cudarc::driver::DevicePtr;
+    use candle_core::cuda_backend::CudaStorageSlice;
+
+    const MAX_K: usize = 128;
+    const CHUNK_SIZE: usize = 2048;
+    const MAX_STAGE2_CANDIDATES: usize = 48 * 1024;
+
+    if temperature <= 0.0 || !temperature.is_finite() {
+        candle_core::bail!("cuda_topk_logits_f32_packed requires a positive finite temperature");
+    }
+
+    let input = input.contiguous()?;
+    if input.dtype() != DType::F32 {
+        candle_core::bail!("cuda_topk_logits_f32_packed requires F32 logits");
+    }
+
+    let ncols = input.elem_count();
+    if ncols == 0 {
+        candle_core::bail!("cuda_topk_logits_f32_packed got empty logits");
+    }
+    let k = k.min(ncols);
+    if k == 0 || k > MAX_K {
+        candle_core::bail!(
+            "cuda_topk_logits_f32_packed k={} must be in [1, {}]",
+            k,
+            MAX_K
+        );
+    }
+
+    let nblocks = (ncols + CHUNK_SIZE - 1) / CHUNK_SIZE;
+    let stage2_candidates = nblocks * k;
+    if stage2_candidates > MAX_STAGE2_CANDIDATES {
+        candle_core::bail!(
+            "cuda_topk_logits_f32_packed workspace too large: {} candidates",
+            stage2_candidates
+        );
+    }
+
+    let (storage, _layout) = input.storage_and_layout();
+    let storage = match &*storage {
+        candle_core::Storage::Cuda(s) => s,
+        _ => candle_core::bail!("cuda_topk_logits_f32_packed requires CUDA tensor"),
+    };
+
+    let dev = storage.device();
+    let stream = dev.cuda_stream().cu_stream() as i64;
+
+    let (src_ptr, src_guard) = match &storage.slice {
+        CudaStorageSlice::F32(inp) => inp.device_ptr(inp.stream()),
+        _ => candle_core::bail!("cuda_topk_logits_f32_packed only supports F32"),
+    };
+
+    let workspace_elems = nblocks * k;
+    let block_values = unsafe { dev.alloc::<f32>(workspace_elems) }?;
+    let block_indices = unsafe { dev.alloc::<u32>(workspace_elems) }?;
+    let block_maxes = unsafe { dev.alloc::<f32>(nblocks) }?;
+    let block_sums = unsafe { dev.alloc::<f32>(nblocks) }?;
+    let packed_dst = unsafe { dev.alloc::<f32>(2 * k + 2) }?;
+
+    let (block_values_ptr, block_values_guard) = block_values.device_ptr(block_values.stream());
+    let (block_indices_ptr, block_indices_guard) = block_indices.device_ptr(block_indices.stream());
+    let (block_maxes_ptr, block_maxes_guard) = block_maxes.device_ptr(block_maxes.stream());
+    let (block_sums_ptr, block_sums_guard) = block_sums.device_ptr(block_sums.stream());
+    let (packed_ptr, packed_guard) = packed_dst.device_ptr(packed_dst.stream());
+
+    unsafe {
+        ffi::topk_large_f32_packed(
+            src_ptr as *const f32,
+            block_values_ptr as *mut f32,
+            block_indices_ptr as *mut u32,
+            block_maxes_ptr as *mut f32,
+            block_sums_ptr as *mut f32,
+            packed_ptr as *mut f32,
+            ncols as i32,
+            k as i32,
+            CHUNK_SIZE as i32,
+            nblocks as i32,
+            (1.0 / temperature) as f32,
+            stream,
+        );
+    }
+
+    drop(src_guard);
+    drop(block_values_guard);
+    drop(block_indices_guard);
+    drop(block_maxes_guard);
+    drop(block_sums_guard);
+    drop(packed_guard);
+
+    let packed_storage = candle_core::cuda_backend::CudaStorage {
+        slice: CudaStorageSlice::F32(packed_dst),
+        device: dev.clone(),
+    };
+    let workspace = vec![
+        Tensor::from((
+            candle_core::Storage::Cuda(candle_core::cuda_backend::CudaStorage {
+                slice: CudaStorageSlice::F32(block_values),
+                device: dev.clone(),
+            }),
+            Shape::from_dims(&[workspace_elems]),
+        )),
+        Tensor::from((
+            candle_core::Storage::Cuda(candle_core::cuda_backend::CudaStorage {
+                slice: CudaStorageSlice::U32(block_indices),
+                device: dev.clone(),
+            }),
+            Shape::from_dims(&[workspace_elems]),
+        )),
+        Tensor::from((
+            candle_core::Storage::Cuda(candle_core::cuda_backend::CudaStorage {
+                slice: CudaStorageSlice::F32(block_maxes),
+                device: dev.clone(),
+            }),
+            Shape::from_dims(&[nblocks]),
+        )),
+        Tensor::from((
+            candle_core::Storage::Cuda(candle_core::cuda_backend::CudaStorage {
+                slice: CudaStorageSlice::F32(block_sums),
+                device: dev.clone(),
+            }),
+            Shape::from_dims(&[nblocks]),
+        )),
+    ];
+
+    Ok(TopKLogitsPackedOutput {
+        packed: Tensor::from((
+            candle_core::Storage::Cuda(packed_storage),
+            Shape::from_dims(&[2 * k + 2]),
+        )),
+        k,
         _workspace: workspace,
     })
 }
@@ -701,6 +844,14 @@ pub struct TopKLogitsOutput {
     /// `[softmax_denominator, global_max]` for the full-vocabulary softmax at
     /// the temperature used for top-k selection.
     pub softmax_info: Tensor,
+    _workspace: Vec<Tensor>,
+}
+
+#[allow(dead_code)]
+pub struct TopKLogitsPackedOutput {
+    /// Packed as `[values; indices_as_f32; softmax_denominator; global_max]`.
+    pub packed: Tensor,
+    pub k: usize,
     _workspace: Vec<Tensor>,
 }
 

--- a/mistralrs-core/src/ops.rs
+++ b/mistralrs-core/src/ops.rs
@@ -213,7 +213,7 @@ pub fn cuda_topk_logits_f32(
         candle_core::bail!("cuda_topk_logits_f32 k={} must be in [1, {}]", k, MAX_K);
     }
 
-    let nblocks = (ncols + CHUNK_SIZE - 1) / CHUNK_SIZE;
+    let nblocks = ncols.div_ceil(CHUNK_SIZE);
     let stage2_candidates = nblocks * k;
     if stage2_candidates > MAX_STAGE2_CANDIDATES {
         candle_core::bail!(
@@ -378,7 +378,7 @@ pub fn cuda_topk_logits_f32_packed(
         );
     }
 
-    let nblocks = (ncols + CHUNK_SIZE - 1) / CHUNK_SIZE;
+    let nblocks = ncols.div_ceil(CHUNK_SIZE);
     let stage2_candidates = nblocks * k;
     if stage2_candidates > MAX_STAGE2_CANDIDATES {
         candle_core::bail!(
@@ -874,6 +874,7 @@ pub fn cuda_softcap_f32(input: &Tensor, cap: f32) -> Result<Tensor> {
     if elem_count > i32::MAX as usize {
         candle_core::bail!("cuda_softcap_f32 input is too large: {elem_count} elements");
     }
+    let elem_count_i32 = i32::try_from(elem_count).map_err(candle_core::Error::wrap)?;
 
     let (storage, layout) = input.storage_and_layout();
     let storage = match &*storage {
@@ -893,7 +894,7 @@ pub fn cuda_softcap_f32(input: &Tensor, cap: f32) -> Result<Tensor> {
         ffi::softcap_f32(
             src_ptr as *const c_void,
             out_ptr as *mut c_void,
-            elem_count as i32,
+            elem_count_i32,
             cap,
             dev.cuda_stream().cu_stream() as i64,
         );
@@ -968,6 +969,8 @@ pub fn cuda_apply_sparse_penalties_f32(
             "cuda_apply_sparse_penalties_f32 token list is too large: {n_tokens} elements"
         );
     }
+    let elem_count_i32 = i32::try_from(elem_count).map_err(candle_core::Error::wrap)?;
+    let n_tokens_i32 = i32::try_from(n_tokens).map_err(candle_core::Error::wrap)?;
 
     let (input_storage, input_layout) = input.storage_and_layout();
     let input_storage = match &*input_storage {
@@ -1014,8 +1017,8 @@ pub fn cuda_apply_sparse_penalties_f32(
             out_ptr as *mut c_void,
             token_ptr,
             count_ptr,
-            elem_count as i32,
-            n_tokens as i32,
+            elem_count_i32,
+            n_tokens_i32,
             frequency_penalty,
             presence_penalty,
             repetition_penalty,
@@ -1113,6 +1116,8 @@ pub fn cuda_rms_norm_residual(
             "cuda_rms_norm_residual input is too large: nrows={nrows}, ncols={ncols}"
         );
     }
+    let nrows_i32 = i32::try_from(nrows).map_err(candle_core::Error::wrap)?;
+    let ncols_i32 = i32::try_from(ncols).map_err(candle_core::Error::wrap)?;
 
     let input = input.contiguous()?;
     let residual = residual.contiguous()?;
@@ -1189,8 +1194,8 @@ pub fn cuda_rms_norm_residual(
                     weight_ptr as *const c_void,
                     scale_ptr,
                     out_ptr as *mut c_void,
-                    nrows as i32,
-                    ncols as i32,
+                    nrows_i32,
+                    ncols_i32,
                     eps,
                     stream,
                 );

--- a/mistralrs-core/src/pipeline/inputs_processor.rs
+++ b/mistralrs-core/src/pipeline/inputs_processor.rs
@@ -171,7 +171,7 @@ pub mod text_models_inputs_processor {
                     query_lens.len()
                 );
             }
-            if query_lens.is_empty() || query_lens.iter().any(|len| *len == 0) {
+            if query_lens.is_empty() || query_lens.contains(&0) {
                 anyhow::bail!("reduced prefill metadata requires at least one query token");
             }
 

--- a/mistralrs-core/src/pipeline/inputs_processor.rs
+++ b/mistralrs-core/src/pipeline/inputs_processor.rs
@@ -153,6 +153,99 @@ pub mod text_models_inputs_processor {
                 cu_seqlens_kv: None,
             })
         }
+
+        /// Build metadata for a prefill whose query tensor has been reduced to
+        /// selected logits positions while K/V still live in the original paged
+        /// cache. This is used by KV-sharing models that can skip hidden-state
+        /// work for prompt tokens that will not produce logits.
+        pub(crate) fn for_reduced_prefill_queries(
+            &self,
+            devices: &[Device],
+            num_cached_tokens: &[usize],
+            query_lens: &[usize],
+        ) -> Result<Self> {
+            if num_cached_tokens.len() != query_lens.len() {
+                anyhow::bail!(
+                    "reduced prefill metadata length mismatch: cached={} query={}",
+                    num_cached_tokens.len(),
+                    query_lens.len()
+                );
+            }
+            if query_lens.is_empty() || query_lens.iter().any(|len| *len == 0) {
+                anyhow::bail!("reduced prefill metadata requires at least one query token");
+            }
+
+            let batch_size = query_lens.len();
+            let max_query_len = query_lens.iter().copied().max().unwrap_or(0);
+            let slot_mappings_cpu = _make_tensor_with_pad(
+                query_lens.iter().map(|len| vec![0i64; *len]).collect(),
+                max_query_len,
+                _PAD_SLOT_ID,
+                &Device::Cpu,
+            )?
+            .reshape((batch_size, max_query_len))?;
+
+            let context_lens = num_cached_tokens
+                .iter()
+                .zip(query_lens.iter())
+                .map(|(cached, query)| cached + query)
+                .collect::<Vec<_>>();
+            let context_lens_cpu = Tensor::from_vec(
+                context_lens
+                    .iter()
+                    .map(|len| *len as u32)
+                    .collect::<Vec<_>>(),
+                (batch_size,),
+                &Device::Cpu,
+            )?;
+
+            let mut cu_q = Vec::with_capacity(batch_size + 1);
+            cu_q.push(0u32);
+            for &query_len in query_lens {
+                cu_q.push(cu_q.last().copied().unwrap_or(0) + query_len as u32);
+            }
+            let cu_q_cpu = Tensor::from_vec(cu_q, (batch_size + 1,), &Device::Cpu)?;
+
+            let mut cu_kv = Vec::with_capacity(batch_size + 1);
+            cu_kv.push(0u32);
+            for (&cached, &query_len) in num_cached_tokens.iter().zip(query_lens.iter()) {
+                cu_kv.push(cu_kv.last().copied().unwrap_or(0) + (cached + query_len) as u32);
+            }
+            let cu_kv_cpu = Tensor::from_vec(cu_kv, (batch_size + 1,), &Device::Cpu)?;
+
+            let mut slot_mappings = HashMap::new();
+            let mut context_lens_map = HashMap::new();
+            let mut cu_q_map = HashMap::new();
+            let mut cu_kv_map = HashMap::new();
+            for device in devices {
+                slot_mappings.insert(device.location(), slot_mappings_cpu.to_device(device)?);
+                context_lens_map.insert(device.location(), context_lens_cpu.to_device(device)?);
+                cu_q_map.insert(device.location(), cu_q_cpu.to_device(device)?);
+                cu_kv_map.insert(device.location(), cu_kv_cpu.to_device(device)?);
+            }
+
+            Ok(PagedAttentionInputMetadata {
+                block_tables: self.block_tables.clone(),
+                context_lens: Some(context_lens_map),
+                slot_mappings,
+                max_context_len: context_lens.iter().copied().max(),
+                full_block_tables: None,
+                full_context_lens: None,
+                full_max_context_len: None,
+                is_first_prompt_chunk: self.is_first_prompt_chunk,
+                paged_kv_indptr: None,
+                paged_kv_indices: None,
+                paged_kv_last_page_len: None,
+                paged_kv_request_indices: None,
+                paged_kv_tile_indices: None,
+                paged_kv_o_indptr: None,
+                paged_kv_chunk_size: None,
+                num_cached_tokens: Some(num_cached_tokens.to_vec()),
+                query_lens: Some(query_lens.to_vec()),
+                cu_seqlens_q: Some(cu_q_map),
+                cu_seqlens_kv: Some(cu_kv_map),
+            })
+        }
     }
 
     /// Flash attention sequence length metadata.

--- a/mistralrs-core/src/sampler.rs
+++ b/mistralrs-core/src/sampler.rs
@@ -886,10 +886,23 @@ impl Sampler {
         temperature: f64,
         rng: Arc<Mutex<Isaac64Rng>>,
     ) -> Result<Logprobs> {
-        let topk = crate::ops::cuda_topk_logits_f32(&logits, self.top_k as usize, temperature)?;
-        let top_values = topk.values.to_vec1::<f32>()?;
-        let top_indices = topk.indices.to_vec1::<u32>()?;
-        let softmax_info = topk.softmax_info.to_vec1::<f32>()?;
+        let topk =
+            crate::ops::cuda_topk_logits_f32_packed(&logits, self.top_k as usize, temperature)?;
+        let packed = topk.packed.to_vec1::<f32>()?;
+        let k = topk.k;
+        if packed.len() != 2 * k + 2 {
+            candle_core::bail!(
+                "invalid CUDA top-k packed output length {}, expected {}",
+                packed.len(),
+                2 * k + 2
+            );
+        }
+        let top_values = &packed[..k];
+        let top_indices = packed[k..2 * k]
+            .iter()
+            .map(|idx| *idx as u32)
+            .collect::<Vec<_>>();
+        let softmax_info = &packed[2 * k..2 * k + 2];
 
         let denom = softmax_info[0];
         let global_max = softmax_info[1];

--- a/mistralrs-core/src/sampler.rs
+++ b/mistralrs-core/src/sampler.rs
@@ -820,18 +820,63 @@ impl Sampler {
             && self.top_k <= MAX_DEVICE_TOP_K
             && self.logits_processors.is_empty()
             && self
-                .frequency_penalty
-                .is_none_or(|penalty| penalty.abs() <= f32::EPSILON)
-            && self
-                .presence_penalty
-                .is_none_or(|penalty| penalty.abs() <= f32::EPSILON)
-            && self
-                .repetition_penalty
-                .is_none_or(|penalty| (penalty - 1.0).abs() <= f32::EPSILON)
-            && self
                 .dry_params
                 .as_ref()
                 .is_none_or(|params| params.multiplier.abs() <= f32::EPSILON)
+    }
+
+    #[cfg(feature = "cuda")]
+    fn apply_device_sparse_penalties_if_needed(
+        &self,
+        logits: Tensor,
+        context: &[u32],
+    ) -> Result<Tensor> {
+        let frequency_penalty = self.frequency_penalty.unwrap_or(0.0);
+        let presence_penalty = self.presence_penalty.unwrap_or(0.0);
+        let repetition_penalty = self.repetition_penalty.unwrap_or(1.0);
+        let needs_penalty = frequency_penalty.abs() > f32::EPSILON
+            || presence_penalty.abs() > f32::EPSILON
+            || (repetition_penalty - 1.0).abs() > f32::EPSILON;
+
+        if !needs_penalty {
+            return Ok(logits);
+        }
+        if context.is_empty() {
+            candle_core::bail!("Penalty context is empty, this should not happen.");
+        }
+
+        let vocab_size = logits.elem_count();
+        let mut counts = HashMap::<u32, f32>::with_capacity(context.len().min(vocab_size));
+        for &token_id in context {
+            if token_id as usize >= vocab_size {
+                continue;
+            }
+            *counts.entry(token_id).or_insert(0.0) += 1.0;
+        }
+
+        if counts.is_empty() {
+            return Ok(logits);
+        }
+
+        let n_tokens = counts.len();
+        let mut token_ids = Vec::with_capacity(n_tokens);
+        let mut token_counts = Vec::with_capacity(n_tokens);
+        for (token_id, count) in counts {
+            token_ids.push(token_id);
+            token_counts.push(count);
+        }
+
+        let device = logits.device();
+        let token_ids = Tensor::from_vec(token_ids, n_tokens, device)?;
+        let token_counts = Tensor::from_vec(token_counts, n_tokens, device)?;
+        crate::ops::cuda_apply_sparse_penalties_f32(
+            &logits,
+            &token_ids,
+            &token_counts,
+            frequency_penalty,
+            presence_penalty,
+            repetition_penalty,
+        )
     }
 
     #[cfg(feature = "cuda")]
@@ -1290,6 +1335,7 @@ impl Sampler {
             )
         {
             if let Some(temperature) = self.temperature {
+                let logits = self.apply_device_sparse_penalties_if_needed(logits, context)?;
                 return self.sample_topk_on_device(logits, temperature, rng);
             }
         }

--- a/mistralrs-core/src/sampler.rs
+++ b/mistralrs-core/src/sampler.rs
@@ -803,6 +803,127 @@ impl Sampler {
         })
     }
 
+    #[cfg(feature = "cuda")]
+    fn can_sample_topk_on_device(
+        &self,
+        return_logprobs: bool,
+        sample_speculative: bool,
+        multiple_sequences: bool,
+    ) -> bool {
+        const MAX_DEVICE_TOP_K: i64 = 128;
+
+        !return_logprobs
+            && !sample_speculative
+            && !multiple_sequences
+            && self.temperature.is_some()
+            && self.top_k > 0
+            && self.top_k <= MAX_DEVICE_TOP_K
+            && self.logits_processors.is_empty()
+            && self
+                .frequency_penalty
+                .is_none_or(|penalty| penalty.abs() <= f32::EPSILON)
+            && self
+                .presence_penalty
+                .is_none_or(|penalty| penalty.abs() <= f32::EPSILON)
+            && self
+                .repetition_penalty
+                .is_none_or(|penalty| (penalty - 1.0).abs() <= f32::EPSILON)
+            && self
+                .dry_params
+                .as_ref()
+                .is_none_or(|params| params.multiplier.abs() <= f32::EPSILON)
+    }
+
+    #[cfg(feature = "cuda")]
+    fn sample_topk_on_device(
+        &self,
+        logits: Tensor,
+        temperature: f64,
+        rng: Arc<Mutex<Isaac64Rng>>,
+    ) -> Result<Logprobs> {
+        let topk = crate::ops::cuda_topk_logits_f32(&logits, self.top_k as usize, temperature)?;
+        let top_values = topk.values.to_vec1::<f32>()?;
+        let top_indices = topk.indices.to_vec1::<u32>()?;
+        let softmax_info = topk.softmax_info.to_vec1::<f32>()?;
+
+        let denom = softmax_info[0];
+        let global_max = softmax_info[1];
+        if denom <= 0.0 || !denom.is_finite() || !global_max.is_finite() {
+            candle_core::bail!("invalid CUDA top-k softmax normalizer");
+        }
+
+        let inv_temperature = (1.0 / temperature) as f32;
+        let mut probs = top_values
+            .iter()
+            .map(|value| ((*value * inv_temperature - global_max).exp()) / denom)
+            .collect::<Vec<_>>();
+
+        if self.top_p > 0.0 && self.top_p < 1.0 {
+            let mut cumsum = 0.0f32;
+            for prob in &mut probs {
+                if cumsum >= self.top_p as f32 {
+                    *prob = 0.0;
+                } else {
+                    cumsum += *prob;
+                }
+            }
+
+            if self.min_p > 0.0 && self.min_p < 1.0 {
+                let max_p = probs.first().copied().unwrap_or(0.0);
+                let min_p_threshold = max_p * self.min_p as f32;
+                for prob in &mut probs {
+                    if min_p_threshold >= *prob {
+                        *prob = 0.0;
+                    }
+                }
+            }
+        }
+
+        let distr = match WeightedIndex::new(&probs) {
+            Ok(distr) => distr,
+            Err(e) => {
+                let positive_weight_sum: f64 = probs
+                    .iter()
+                    .copied()
+                    .filter(|prob| prob.is_finite() && *prob > 0.0)
+                    .map(f64::from)
+                    .sum();
+                if positive_weight_sum == 0.0 {
+                    return Err(Error::Msg(
+                        "All sampling probabilities are zero after CUDA top-k filtering."
+                            .to_string(),
+                    ));
+                }
+
+                return Err(Error::Msg(format!(
+                    "Failed to construct CUDA top-k multinomial sampler: {e}"
+                )));
+            }
+        };
+
+        let mut mut_ref_rng = &mut *rng.lock().expect("could not lock rng mutex");
+        let selected = distr.sample(&mut mut_ref_rng);
+        let next_token = top_indices[selected];
+        let logprob = probs[selected].log(10.0);
+
+        let bytes = if let Some(tokenizer) = &self.tokenizer {
+            Some(
+                tokenizer
+                    .decode(&[next_token], false)
+                    .map_err(|x| Error::Msg(x.to_string()))?,
+            )
+        } else {
+            None
+        };
+
+        Ok(Logprobs {
+            token: next_token,
+            logprob,
+            top_logprobs: None,
+            bytes,
+        })
+    }
+
     fn filter_top_kp_min_p(&self, probs: &mut [f32]) {
         let k = if self.top_k > 0 {
             self.top_k as usize
@@ -1160,6 +1281,19 @@ impl Sampler {
         sample_speculative: bool,
         multiple_sequences: bool,
     ) -> Result<Logprobs> {
+        #[cfg(feature = "cuda")]
+        if logits.device().is_cuda()
+            && self.can_sample_topk_on_device(
+                return_logprobs,
+                sample_speculative,
+                multiple_sequences,
+            )
+        {
+            if let Some(temperature) = self.temperature {
+                return self.sample_topk_on_device(logits, temperature, rng);
+            }
+        }
+
         // if cfg!(feature = "metal") && !multiple_sequences {
         //     return self.sample_fast(
         //         logits,

--- a/mistralrs-core/src/vision_models/clip.rs
+++ b/mistralrs-core/src/vision_models/clip.rs
@@ -161,16 +161,16 @@ impl ClipAttention {
     fn forward(&self, xs: &Tensor, causal_attention_mask: &AttentionMask) -> Result<Tensor> {
         let (bsz, seq_len, hidden_size) = xs.dims3()?;
 
-        let query_states = (self.q_proj.forward(xs)? * self.scale)?;
+        let (query_states, key_states, value_states) =
+            crate::ops::qkv_projections(xs, &*self.q_proj, &*self.k_proj, &*self.v_proj)?;
+        let query_states = (query_states * self.scale)?;
         let proj_shape = (bsz * self.num_attention_heads, seq_len, self.head_dim);
         let query_states = self
             .shape(&query_states, seq_len, bsz)?
             .reshape(proj_shape)?;
-        let key_states = self
-            .shape(&self.k_proj.forward(xs)?, seq_len, bsz)?
-            .reshape(proj_shape)?;
+        let key_states = self.shape(&key_states, seq_len, bsz)?.reshape(proj_shape)?;
         let value_states = self
-            .shape(&self.v_proj.forward(xs)?, seq_len, bsz)?
+            .shape(&value_states, seq_len, bsz)?
             .reshape(proj_shape)?;
         let attn_weights = MatMul.matmul(&query_states, &key_states.transpose(1, 2)?)?;
 

--- a/mistralrs-core/src/vision_models/conformer/encoder.rs
+++ b/mistralrs-core/src/vision_models/conformer/encoder.rs
@@ -160,10 +160,12 @@ impl FeedForward {
         let projected = normed.apply(&self.up)?;
 
         // GLU: split in half and gate
-        let chunks = projected.chunk(2, D::Minus1)?;
-        let x = &chunks[0];
-        let gate = chunks[1].apply(&self.act)?;
-        let gated = (x * gate)?;
+        let gated = crate::ops::split_mul_and_act_order(
+            &projected,
+            projected.dim(D::Minus1)? / 2,
+            self.act,
+            crate::ops::GatedActivationOrder::UpGate,
+        )?;
 
         gated.apply(&self.down)
     }
@@ -298,9 +300,9 @@ impl GLUPointWiseConv {
         let result = if let Some((b1, b2)) = &self.b1_b2 {
             let first_with_bias = first_half.broadcast_add(b1)?;
             let second_with_bias = second_half.broadcast_add(b2)?;
-            first_with_bias.mul(&second_with_bias.apply(&self.act)?)?
+            crate::ops::mul_and_act(&second_with_bias, &first_with_bias, self.act)?
         } else {
-            first_half.mul(&second_half.apply(&self.act)?)?
+            crate::ops::mul_and_act(second_half, first_half, self.act)?
         };
 
         // Back to (B, T, D)

--- a/mistralrs-core/src/vision_models/conformer/encoder.rs
+++ b/mistralrs-core/src/vision_models/conformer/encoder.rs
@@ -76,9 +76,8 @@ impl Attention {
     ) -> Result<Tensor> {
         let (b_sz, q_len, _) = xs.dims3()?;
 
-        let mut q = self.q_proj.forward(xs)?;
-        let mut k = self.k_proj.forward(xs)?;
-        let mut v = self.v_proj.forward(xs)?;
+        let (mut q, mut k, mut v) =
+            crate::ops::qkv_projections(xs, &*self.q_proj, &*self.k_proj, &*self.v_proj)?;
 
         q = q
             .reshape((b_sz, q_len, self.num_heads, self.head_dim))?

--- a/mistralrs-core/src/vision_models/gemma3/text.rs
+++ b/mistralrs-core/src/vision_models/gemma3/text.rs
@@ -347,25 +347,24 @@ impl DecoderLayer {
     ) -> Result<Tensor> {
         let residual = xs;
         let xs = self.input_layernorm.forward(xs)?;
+        let xs = self.self_attn.forward(
+            &xs,
+            attention_mask,
+            sliding_attention_mask,
+            seqlen_offsets,
+            kv_cache,
+            metadata,
+            flash_params,
+        )?;
         let xs = self
-            .self_attn
-            .forward(
-                &xs,
-                attention_mask,
-                sliding_attention_mask,
-                seqlen_offsets,
-                kv_cache,
-                metadata,
-                flash_params,
-            )?
-            .apply(&self.post_attention_layernorm)?;
-        let xs = (xs + residual)?;
+            .post_attention_layernorm
+            .forward_residual(&xs, residual)?;
         let residual = &xs;
         let xs = self
             .mlp
-            .forward(&xs.apply(&self.pre_feedforward_layernorm)?)?
-            .apply(&self.post_feedforward_layernorm)?;
-        residual + xs
+            .forward(&xs.apply(&self.pre_feedforward_layernorm)?)?;
+        self.post_feedforward_layernorm
+            .forward_residual(&xs, residual)
     }
 }
 

--- a/mistralrs-core/src/vision_models/gemma3/text.rs
+++ b/mistralrs-core/src/vision_models/gemma3/text.rs
@@ -163,9 +163,8 @@ impl Attention {
     ) -> Result<Tensor> {
         let (b_sz, q_len, _) = xs.dims3()?;
 
-        let mut q = self.q_proj.forward(xs)?;
-        let mut k = self.k_proj.forward(xs)?;
-        let mut v = self.v_proj.forward(xs)?;
+        let (mut q, mut k, mut v) =
+            crate::ops::qkv_projections(xs, &*self.q_proj, &*self.k_proj, &*self.v_proj)?;
         (q, k, v) = if q_len != 1 {
             let q = q
                 .reshape((b_sz, q_len, self.num_heads, self.head_dim))?

--- a/mistralrs-core/src/vision_models/gemma3n/audio.rs
+++ b/mistralrs-core/src/vision_models/gemma3n/audio.rs
@@ -585,9 +585,8 @@ impl Gemma3nAudioAttention {
     }
 
     pub fn forward(&self, x: &Tensor, mask: &Tensor) -> Result<Tensor> {
-        let query_states = self.q_proj.forward(x)?;
-        let key_states = self.k_proj.forward(x)?;
-        let value_states = self.v_proj.forward(x)?;
+        let (query_states, key_states, value_states) =
+            crate::ops::qkv_projections(x, &*self.q_proj, &*self.k_proj, &*self.v_proj)?;
 
         let (b, t) = match x.dims() {
             &[b, t, _] => (b, t),

--- a/mistralrs-core/src/vision_models/gemma3n/text.rs
+++ b/mistralrs-core/src/vision_models/gemma3n/text.rs
@@ -169,12 +169,9 @@ impl Mlp {
             gate = self.gaussian_topk(&gate)?;
         }
         let up = self.up.forward(xs)?;
-        // let mut res = self.down.forward(&crate::ops::mul_and_act(
-        //     &gate,
-        //     &up,
-        //     self.act.try_into()?,
-        // )?)?;
-        let res = self.down.forward(&(&gate.apply(&self.act)? * &up)?)?;
+        let res = self
+            .down
+            .forward(&crate::ops::mul_and_act(&gate, &up, self.act)?)?;
         Ok(res)
     }
 }

--- a/mistralrs-core/src/vision_models/gemma3n/text.rs
+++ b/mistralrs-core/src/vision_models/gemma3n/text.rs
@@ -384,7 +384,23 @@ impl Attention {
     ) -> Result<Tensor> {
         let (b_sz, q_len, _) = xs.dims3()?;
 
-        let mut q = self.q_proj.forward(xs)?;
+        let is_shared = self.kv_shared_layer_index.is_some();
+        let qkv = if !is_shared {
+            Some(crate::ops::qkv_projections(
+                xs,
+                &*self.q_proj,
+                &*self.k_proj,
+                &*self.v_proj,
+            )?)
+        } else {
+            None
+        };
+
+        let mut q = if let Some((q, _, _)) = qkv.as_ref() {
+            q.clone()
+        } else {
+            self.q_proj.forward(xs)?
+        };
         q = q.reshape((b_sz, q_len, self.num_heads, self.head_dim))?;
         q = q.apply(&self.q_norm)?;
         q = self.apply_rope(&q, seqlen_offsets, q_len)?;
@@ -403,13 +419,17 @@ impl Attention {
                 true,
             )
         } else {
-            let mut k = self.k_proj.forward(xs)?;
+            let (mut k, mut v) = if let Some((_, k, v)) = qkv {
+                (k, v)
+            } else {
+                (self.k_proj.forward(xs)?, self.v_proj.forward(xs)?)
+            };
+
             k = k.reshape((b_sz, q_len, self.num_kv_heads, self.head_dim))?;
             k = k.apply(&self.k_norm)?;
             k = self.apply_rope(&k, seqlen_offsets, q_len)?;
             k = k.transpose(1, 2)?;
 
-            let mut v = self.v_proj.forward(xs)?;
             v = v.reshape((b_sz, q_len, self.num_kv_heads, self.head_dim))?;
             v = v.apply(&self.v_norm)?;
             v = v.transpose(1, 2)?;

--- a/mistralrs-core/src/vision_models/gemma4/mtp.rs
+++ b/mistralrs-core/src/vision_models/gemma4/mtp.rs
@@ -755,9 +755,9 @@ impl Gemma4MtpMlp {
     }
 
     fn forward(&self, xs: &Tensor) -> Result<Tensor> {
-        let lhs = xs.apply(&self.gate_proj)?.apply(&self.activation)?;
+        let lhs = xs.apply(&self.gate_proj)?;
         let rhs = xs.apply(&self.up_proj)?;
-        (lhs * rhs)?.apply(&self.down_proj)
+        crate::ops::mul_and_act(&lhs, &rhs, self.activation)?.apply(&self.down_proj)
     }
 }
 

--- a/mistralrs-core/src/vision_models/gemma4/text.rs
+++ b/mistralrs-core/src/vision_models/gemma4/text.rs
@@ -1119,6 +1119,60 @@ pub struct TextModel {
     model_config: Arc<dyn ModelConfigLike + Send + Sync>,
 }
 
+#[derive(Clone)]
+struct PrefillQuerySelection {
+    source_context_lens: Vec<(usize, usize)>,
+    reduced_context_lens: Vec<(usize, usize)>,
+    seqlen_offsets: Vec<usize>,
+    num_cached_tokens: Vec<usize>,
+    query_lens: Vec<usize>,
+}
+
+impl PrefillQuerySelection {
+    fn from_logits_context(
+        q_len: usize,
+        context_lens: &[(usize, usize)],
+        seqlen_offsets: &[usize],
+    ) -> Option<Self> {
+        if context_lens.is_empty() || context_lens.len() != seqlen_offsets.len() {
+            return None;
+        }
+
+        let mut reduced_context_lens = Vec::with_capacity(context_lens.len());
+        let mut tail_offsets = Vec::with_capacity(context_lens.len());
+        let mut num_cached_tokens = Vec::with_capacity(context_lens.len());
+        let mut query_lens = Vec::with_capacity(context_lens.len());
+
+        for ((start, len), offset) in context_lens.iter().zip(seqlen_offsets.iter()) {
+            if *len != 1 || start.checked_add(*len)? != q_len {
+                return None;
+            }
+            reduced_context_lens.push((0, *len));
+            tail_offsets.push(offset + start);
+            num_cached_tokens.push(offset + start);
+            query_lens.push(*len);
+        }
+
+        Some(Self {
+            source_context_lens: context_lens.to_vec(),
+            reduced_context_lens,
+            seqlen_offsets: tail_offsets,
+            num_cached_tokens,
+            query_lens,
+        })
+    }
+
+    fn reduce(&self, tensor: &Tensor) -> Result<Tensor> {
+        extract_logits(tensor, self.source_context_lens.clone())
+    }
+}
+
+struct KvSharingFastPrefillPlan {
+    first_shared_layer: usize,
+    query_selection: PrefillQuerySelection,
+    paged_metadata: Option<PagedAttentionInputMetadata>,
+}
+
 impl TextModel {
     pub fn new(
         cfg: &Gemma4TextConfig,
@@ -1500,31 +1554,60 @@ impl TextModel {
         Ok(Some(per_layer_inputs))
     }
 
-    fn fast_prefill_tail_enabled(
+    fn kv_sharing_fast_prefill_plan(
         &self,
         input_ids: &Tensor,
         context_lens: &[(usize, usize)],
         seqlen_offsets: &[usize],
+        metadata: Option<&PagedAttentionInputMetadata>,
         has_bidirectional: bool,
-    ) -> Result<bool> {
+    ) -> Result<Option<KvSharingFastPrefillPlan>> {
         if std::env::var("MISTRALRS_GEMMA4_DISABLE_FAST_PREFILL").is_ok() || has_bidirectional {
-            return Ok(false);
+            return Ok(None);
         }
         let (b_sz, q_len) = input_ids.dims2()?;
-        if q_len <= 1 || b_sz != 1 || context_lens.len() != b_sz || seqlen_offsets.len() != b_sz {
-            return Ok(false);
+        if q_len <= 1 || context_lens.len() != b_sz || seqlen_offsets.len() != b_sz {
+            return Ok(None);
         }
         let first_shared = self.first_kv_shared_layer_idx();
         if first_shared == 0 || first_shared >= self.layers.len() {
-            return Ok(false);
+            return Ok(None);
         }
         if !self.layers[first_shared..]
             .iter()
             .all(|layer| layer.self_attn.kv_shared_layer_index.is_some())
         {
-            return Ok(false);
+            return Ok(None);
         }
-        Ok(context_lens.iter().all(|(_, len)| *len == 1))
+
+        let Some(query_selection) =
+            PrefillQuerySelection::from_logits_context(q_len, context_lens, seqlen_offsets)
+        else {
+            return Ok(None);
+        };
+
+        let paged_metadata = if let Some(metadata) = metadata {
+            if metadata.block_tables.is_none() {
+                return Ok(None);
+            }
+            Some(
+                metadata
+                    .for_reduced_prefill_queries(
+                        &self.mapper.get_unique_devices(),
+                        &query_selection.num_cached_tokens,
+                        &query_selection.query_lens,
+                    )
+                    .map_err(|err| candle_core::Error::Msg(err.to_string()))?,
+            )
+        } else {
+            None
+        };
+
+        Ok(Some(KvSharingFastPrefillPlan {
+            first_shared_layer: first_shared,
+            query_selection,
+            paged_metadata,
+        }))
     }
 
     fn first_kv_shared_layer_idx(&self) -> usize {
@@ -1532,94 +1615,6 @@ impl TextModel {
             .iter()
             .position(|layer| layer.self_attn.kv_shared_layer_index.is_some())
             .unwrap_or(self.layers.len())
-    }
-
-    fn fast_prefill_tail_offsets(
-        seqlen_offsets: &[usize],
-        context_lens: &[(usize, usize)],
-    ) -> Vec<usize> {
-        seqlen_offsets
-            .iter()
-            .zip(context_lens.iter())
-            .map(|(offset, (start, _))| offset + start)
-            .collect()
-    }
-
-    fn make_fast_prefill_tail_metadata(
-        &self,
-        metadata: &PagedAttentionInputMetadata,
-        seqlen_offsets: &[usize],
-        context_lens: &[(usize, usize)],
-    ) -> Result<PagedAttentionInputMetadata> {
-        let full_context_lens = seqlen_offsets
-            .iter()
-            .zip(context_lens.iter())
-            .map(|(offset, (start, _))| offset + start + 1)
-            .collect::<Vec<_>>();
-        let b_sz = full_context_lens.len();
-        let devices = self.mapper.get_unique_devices();
-
-        let slot_mappings_cpu = Tensor::from_vec(vec![0i64; b_sz], (b_sz, 1), &Device::Cpu)?;
-        let context_lens_cpu = Tensor::from_vec(
-            full_context_lens
-                .iter()
-                .map(|len| *len as u32)
-                .collect::<Vec<_>>(),
-            (b_sz,),
-            &Device::Cpu,
-        )?;
-
-        let mut cu_q = Vec::with_capacity(b_sz + 1);
-        cu_q.push(0u32);
-        for idx in 0..b_sz {
-            cu_q.push((idx + 1) as u32);
-        }
-        let cu_q_cpu = Tensor::from_vec(cu_q, (b_sz + 1,), &Device::Cpu)?;
-
-        let mut cu_kv = Vec::with_capacity(b_sz + 1);
-        cu_kv.push(0u32);
-        for &len in &full_context_lens {
-            cu_kv.push(cu_kv.last().copied().unwrap_or(0) + len as u32);
-        }
-        let cu_kv_cpu = Tensor::from_vec(cu_kv, (b_sz + 1,), &Device::Cpu)?;
-
-        let mut slot_mappings = HashMap::new();
-        let mut context_lens_map = HashMap::new();
-        let mut cu_q_map = HashMap::new();
-        let mut cu_kv_map = HashMap::new();
-        for device in devices {
-            slot_mappings.insert(device.location(), slot_mappings_cpu.to_device(&device)?);
-            context_lens_map.insert(device.location(), context_lens_cpu.to_device(&device)?);
-            cu_q_map.insert(device.location(), cu_q_cpu.to_device(&device)?);
-            cu_kv_map.insert(device.location(), cu_kv_cpu.to_device(&device)?);
-        }
-
-        Ok(PagedAttentionInputMetadata {
-            block_tables: metadata.block_tables.clone(),
-            context_lens: Some(context_lens_map),
-            slot_mappings,
-            max_context_len: full_context_lens.iter().copied().max(),
-            full_block_tables: None,
-            full_context_lens: None,
-            full_max_context_len: None,
-            is_first_prompt_chunk: metadata.is_first_prompt_chunk,
-            paged_kv_indptr: None,
-            paged_kv_indices: None,
-            paged_kv_last_page_len: None,
-            paged_kv_request_indices: None,
-            paged_kv_tile_indices: None,
-            paged_kv_o_indptr: None,
-            paged_kv_chunk_size: None,
-            num_cached_tokens: Some(
-                full_context_lens
-                    .iter()
-                    .map(|len| len.saturating_sub(1))
-                    .collect(),
-            ),
-            query_lens: Some(vec![1; b_sz]),
-            cu_seqlens_q: Some(cu_q_map),
-            cu_seqlens_kv: Some(cu_kv_map),
-        })
     }
 
     #[allow(clippy::too_many_arguments)]
@@ -1753,36 +1748,24 @@ impl TextModel {
         let attention_mask = DeviceMappedMask::new(attention_mask, &*self.mapper)?;
         let sliding_attention_mask = DeviceMappedMask::new(sliding_attention_mask, &*self.mapper)?;
 
-        let fast_prefill_tail = self.fast_prefill_tail_enabled(
+        let fast_prefill_tail = self.kv_sharing_fast_prefill_plan(
             input_ids,
             &context_lens,
             seqlen_offsets,
+            metadata.as_ref().map(|(_, metadata)| *metadata),
             has_bidirectional,
-        )? && metadata
-            .as_ref()
-            .map(|(_, meta)| meta.block_tables.is_some())
-            .unwrap_or(true);
-        let first_shared = self.first_kv_shared_layer_idx();
-        let original_context_lens = context_lens.clone();
-        let mut tail_seqlen_offsets = Vec::new();
-        let mut tail_metadata = None;
+        )?;
         let mut reduced_to_logits = false;
         let no_attention_mask = AttentionMask::None;
         let tail_prefill_mask = AttentionMask::CausalFlash;
 
         for (i, layer) in self.layers.iter().enumerate() {
-            if fast_prefill_tail && i == first_shared {
-                xs = extract_logits(&xs, original_context_lens.clone())?;
-                tail_seqlen_offsets =
-                    Self::fast_prefill_tail_offsets(seqlen_offsets, &original_context_lens);
-                if let Some((_, input_metadata)) = metadata.as_ref() {
-                    tail_metadata = Some(self.make_fast_prefill_tail_metadata(
-                        input_metadata,
-                        seqlen_offsets,
-                        &original_context_lens,
-                    )?);
-                }
-                context_lens = vec![(0, 1); original_context_lens.len()];
+            if let Some(plan) = fast_prefill_tail
+                .as_ref()
+                .filter(|plan| i == plan.first_shared_layer)
+            {
+                xs = plan.query_selection.reduce(&xs)?;
+                context_lens = plan.query_selection.reduced_context_lens.clone();
                 reduced_to_logits = true;
             }
 
@@ -1791,7 +1774,11 @@ impl TextModel {
                 .as_ref()
                 .map(|pli| {
                     let pli = if reduced_to_logits {
-                        extract_logits(&pli[i], original_context_lens.clone())?
+                        fast_prefill_tail
+                            .as_ref()
+                            .expect("missing active fast prefill plan")
+                            .query_selection
+                            .reduce(&pli[i])?
                     } else {
                         pli[i].clone()
                     };
@@ -1809,12 +1796,21 @@ impl TextModel {
                 layer_flash_params
             };
             let layer_seqlen_offsets = if reduced_to_logits {
-                tail_seqlen_offsets.as_slice()
+                fast_prefill_tail
+                    .as_ref()
+                    .expect("missing active fast prefill plan")
+                    .query_selection
+                    .seqlen_offsets
+                    .as_slice()
             } else {
                 seqlen_offsets
             };
             let (layer_attention_mask, layer_sliding_attention_mask) = if reduced_to_logits {
-                if tail_metadata.is_some() {
+                if fast_prefill_tail
+                    .as_ref()
+                    .and_then(|plan| plan.paged_metadata.as_ref())
+                    .is_some()
+                {
                     (&tail_prefill_mask, &tail_prefill_mask)
                 } else {
                     (&no_attention_mask, &no_attention_mask)
@@ -1834,7 +1830,14 @@ impl TextModel {
                 cache,
                 metadata.as_ref().map(|(kv_cache, metadata)| {
                     let cache_idx = layer.self_attn.kv_shared_layer_index.unwrap_or(i);
-                    let metadata = tail_metadata.as_ref().map_or(*metadata, |m| m);
+                    let metadata = if reduced_to_logits {
+                        fast_prefill_tail
+                            .as_ref()
+                            .and_then(|plan| plan.paged_metadata.as_ref())
+                            .unwrap_or(*metadata)
+                    } else {
+                        *metadata
+                    };
                     (kv_cache[cache_idx].clone(), metadata)
                 }),
                 this_layer_flash,

--- a/mistralrs-core/src/vision_models/gemma4/text.rs
+++ b/mistralrs-core/src/vision_models/gemma4/text.rs
@@ -1500,6 +1500,128 @@ impl TextModel {
         Ok(Some(per_layer_inputs))
     }
 
+    fn fast_prefill_tail_enabled(
+        &self,
+        input_ids: &Tensor,
+        context_lens: &[(usize, usize)],
+        seqlen_offsets: &[usize],
+        has_bidirectional: bool,
+    ) -> Result<bool> {
+        if std::env::var("MISTRALRS_GEMMA4_DISABLE_FAST_PREFILL").is_ok() || has_bidirectional {
+            return Ok(false);
+        }
+        let (b_sz, q_len) = input_ids.dims2()?;
+        if q_len <= 1 || b_sz != 1 || context_lens.len() != b_sz || seqlen_offsets.len() != b_sz {
+            return Ok(false);
+        }
+        let first_shared = self.first_kv_shared_layer_idx();
+        if first_shared == 0 || first_shared >= self.layers.len() {
+            return Ok(false);
+        }
+        if !self.layers[first_shared..]
+            .iter()
+            .all(|layer| layer.self_attn.kv_shared_layer_index.is_some())
+        {
+            return Ok(false);
+        }
+        Ok(context_lens.iter().all(|(_, len)| *len == 1))
+    }
+
+    fn first_kv_shared_layer_idx(&self) -> usize {
+        self.layers
+            .iter()
+            .position(|layer| layer.self_attn.kv_shared_layer_index.is_some())
+            .unwrap_or(self.layers.len())
+    }
+
+    fn fast_prefill_tail_offsets(
+        seqlen_offsets: &[usize],
+        context_lens: &[(usize, usize)],
+    ) -> Vec<usize> {
+        seqlen_offsets
+            .iter()
+            .zip(context_lens.iter())
+            .map(|(offset, (start, _))| offset + start)
+            .collect()
+    }
+
+    fn make_fast_prefill_tail_metadata(
+        &self,
+        metadata: &PagedAttentionInputMetadata,
+        seqlen_offsets: &[usize],
+        context_lens: &[(usize, usize)],
+    ) -> Result<PagedAttentionInputMetadata> {
+        let full_context_lens = seqlen_offsets
+            .iter()
+            .zip(context_lens.iter())
+            .map(|(offset, (start, _))| offset + start + 1)
+            .collect::<Vec<_>>();
+        let b_sz = full_context_lens.len();
+        let devices = self.mapper.get_unique_devices();
+
+        let slot_mappings_cpu = Tensor::from_vec(vec![0i64; b_sz], (b_sz, 1), &Device::Cpu)?;
+        let context_lens_cpu = Tensor::from_vec(
+            full_context_lens
+                .iter()
+                .map(|len| *len as u32)
+                .collect::<Vec<_>>(),
+            (b_sz,),
+            &Device::Cpu,
+        )?;
+
+        let mut cu_q = Vec::with_capacity(b_sz + 1);
+        cu_q.push(0u32);
+        for idx in 0..b_sz {
+            cu_q.push((idx + 1) as u32);
+        }
+        let cu_q_cpu = Tensor::from_vec(cu_q, (b_sz + 1,), &Device::Cpu)?;
+
+        let mut cu_kv = Vec::with_capacity(b_sz + 1);
+        cu_kv.push(0u32);
+        for &len in &full_context_lens {
+            cu_kv.push(cu_kv.last().copied().unwrap_or(0) + len as u32);
+        }
+        let cu_kv_cpu = Tensor::from_vec(cu_kv, (b_sz + 1,), &Device::Cpu)?;
+
+        let mut slot_mappings = HashMap::new();
+        let mut context_lens_map = HashMap::new();
+        let mut cu_q_map = HashMap::new();
+        let mut cu_kv_map = HashMap::new();
+        for device in devices {
+            slot_mappings.insert(device.location(), slot_mappings_cpu.to_device(&device)?);
+            context_lens_map.insert(device.location(), context_lens_cpu.to_device(&device)?);
+            cu_q_map.insert(device.location(), cu_q_cpu.to_device(&device)?);
+            cu_kv_map.insert(device.location(), cu_kv_cpu.to_device(&device)?);
+        }
+
+        Ok(PagedAttentionInputMetadata {
+            block_tables: metadata.block_tables.clone(),
+            context_lens: Some(context_lens_map),
+            slot_mappings,
+            max_context_len: full_context_lens.iter().copied().max(),
+            full_block_tables: None,
+            full_context_lens: None,
+            full_max_context_len: None,
+            is_first_prompt_chunk: metadata.is_first_prompt_chunk,
+            paged_kv_indptr: None,
+            paged_kv_indices: None,
+            paged_kv_last_page_len: None,
+            paged_kv_request_indices: None,
+            paged_kv_tile_indices: None,
+            paged_kv_o_indptr: None,
+            paged_kv_chunk_size: None,
+            num_cached_tokens: Some(
+                full_context_lens
+                    .iter()
+                    .map(|len| len.saturating_sub(1))
+                    .collect(),
+            ),
+            query_lens: Some(vec![1; b_sz]),
+            cu_seqlens_q: Some(cu_q_map),
+            cu_seqlens_kv: Some(cu_kv_map),
+        })
+    }
+
     #[allow(clippy::too_many_arguments)]
     pub fn forward_embeds(
         &self,
@@ -1507,7 +1629,7 @@ impl TextModel {
         ple_input_ids: &Tensor,
         mut xs: Tensor,
         seqlen_offsets: &[usize],
-        context_lens: Vec<(usize, usize)>,
+        mut context_lens: Vec<(usize, usize)>,
         metadata: Option<(Vec<(Tensor, Tensor)>, &PagedAttentionInputMetadata)>,
         flash_params: &FlashParams,
         has_images: bool,
@@ -1631,30 +1753,89 @@ impl TextModel {
         let attention_mask = DeviceMappedMask::new(attention_mask, &*self.mapper)?;
         let sliding_attention_mask = DeviceMappedMask::new(sliding_attention_mask, &*self.mapper)?;
 
+        let fast_prefill_tail = self.fast_prefill_tail_enabled(
+            input_ids,
+            &context_lens,
+            seqlen_offsets,
+            has_bidirectional,
+        )? && metadata
+            .as_ref()
+            .map(|(_, meta)| meta.block_tables.is_some())
+            .unwrap_or(true);
+        let first_shared = self.first_kv_shared_layer_idx();
+        let original_context_lens = context_lens.clone();
+        let mut tail_seqlen_offsets = Vec::new();
+        let mut tail_metadata = None;
+        let mut reduced_to_logits = false;
+        let no_attention_mask = AttentionMask::None;
+        let tail_prefill_mask = AttentionMask::CausalFlash;
+
         for (i, layer) in self.layers.iter().enumerate() {
+            if fast_prefill_tail && i == first_shared {
+                xs = extract_logits(&xs, original_context_lens.clone())?;
+                tail_seqlen_offsets =
+                    Self::fast_prefill_tail_offsets(seqlen_offsets, &original_context_lens);
+                if let Some((_, input_metadata)) = metadata.as_ref() {
+                    tail_metadata = Some(self.make_fast_prefill_tail_metadata(
+                        input_metadata,
+                        seqlen_offsets,
+                        &original_context_lens,
+                    )?);
+                }
+                context_lens = vec![(0, 1); original_context_lens.len()];
+                reduced_to_logits = true;
+            }
+
             xs = self.mapper.map(xs, i)?;
             let per_layer_input = per_layer_inputs
                 .as_ref()
-                .map(|pli| self.mapper.map(pli[i].clone(), i))
+                .map(|pli| {
+                    let pli = if reduced_to_logits {
+                        extract_logits(&pli[i], original_context_lens.clone())?
+                    } else {
+                        pli[i].clone()
+                    };
+                    self.mapper.map(pli, i)
+                })
                 .transpose()?;
             // In the bidirectional path, only sliding-attention layers use the
             // non-causal flash params (matching HF which only applies the
             // bidirectional mask override to sliding_attention, not full_attention).
-            let this_layer_flash = if has_bidirectional && !layer.self_attn.is_sliding {
+            let this_layer_flash = if reduced_to_logits {
+                None
+            } else if has_bidirectional && !layer.self_attn.is_sliding {
                 Some(flash_params)
             } else {
                 layer_flash_params
             };
+            let layer_seqlen_offsets = if reduced_to_logits {
+                tail_seqlen_offsets.as_slice()
+            } else {
+                seqlen_offsets
+            };
+            let (layer_attention_mask, layer_sliding_attention_mask) = if reduced_to_logits {
+                if tail_metadata.is_some() {
+                    (&tail_prefill_mask, &tail_prefill_mask)
+                } else {
+                    (&no_attention_mask, &no_attention_mask)
+                }
+            } else {
+                (
+                    &attention_mask.get(xs.device()),
+                    &sliding_attention_mask.get(xs.device()),
+                )
+            };
             xs = layer.forward(
                 &xs,
                 per_layer_input.as_ref(),
-                &attention_mask.get(xs.device()),
-                &sliding_attention_mask.get(xs.device()),
-                seqlen_offsets,
+                layer_attention_mask,
+                layer_sliding_attention_mask,
+                layer_seqlen_offsets,
                 cache,
                 metadata.as_ref().map(|(kv_cache, metadata)| {
                     let cache_idx = layer.self_attn.kv_shared_layer_index.unwrap_or(i);
-                    (kv_cache[cache_idx].clone(), *metadata)
+                    let metadata = tail_metadata.as_ref().map_or(*metadata, |m| m);
+                    (kv_cache[cache_idx].clone(), metadata)
                 }),
                 this_layer_flash,
             )?;

--- a/mistralrs-core/src/vision_models/gemma4/text.rs
+++ b/mistralrs-core/src/vision_models/gemma4/text.rs
@@ -1532,6 +1532,10 @@ impl TextModel {
         // that the paged-attention gather path does NOT force causal=true (which
         // would undo the bidirectional overrides in the materialized masks).
         let bidir_flash = FlashParams::empty(false);
+        let force_eager_full_attention = self
+            .layers
+            .iter()
+            .any(|layer| !layer.self_attn.is_sliding && layer.self_attn.head_dim > 512);
 
         let (attention_mask, sliding_attention_mask, layer_flash_params) = if has_bidirectional {
             let attention_mask = CausalMasker.make_causal_mask(
@@ -1572,15 +1576,16 @@ impl TextModel {
 
             (attention_mask, sliding_attention_mask, Some(&bidir_flash))
         } else {
-            // Full-attention layers (head_dim=512) use eager attention because
-            // flash-attn v2 produces incorrect results for head_dim > 256.
-            // Eager attention needs a real causal mask (not the 1x1 flash dummy).
+            // Keep full-attention layers on flash-attn when their head dim is
+            // supported. PagedAttention still needs a non-None prompt mask
+            // (CausalFlash is enough) to route prompt chunks through SDPA
+            // before writing to the paged cache.
             let attention_mask = CausalMasker.make_causal_mask(
                 input_ids,
                 mask_cache,
                 xs.dtype(),
                 &CausalMaskConfig {
-                    force_custom: true,
+                    force_custom: force_eager_full_attention,
                     ..Default::default()
                 },
             )?;
@@ -1588,11 +1593,11 @@ impl TextModel {
                 AttentionMask::Custom(m) => AttentionMask::Custom(m.to_device(&Device::Cpu)?),
                 other => other,
             };
-            let is_first = metadata
+            let attention_mask = if metadata
                 .as_ref()
                 .map(|(_, meta)| meta.is_first_prompt_chunk)
-                .unwrap_or(true);
-            let attention_mask = if is_first {
+                .unwrap_or(true)
+            {
                 attention_mask
             } else {
                 AttentionMask::None
@@ -1664,12 +1669,21 @@ impl TextModel {
         let mut xs = self.lm_head.forward(&xs)?;
 
         if let Some(final_logit_softcapping) = self.final_logit_softcapping {
-            let original_dtype = xs.dtype();
             xs = xs.to_dtype(DType::F32)?;
-            xs = (xs / final_logit_softcapping)?;
-            xs = xs.tanh()?;
-            xs = (xs * final_logit_softcapping)?;
-            xs = xs.to_dtype(original_dtype)?;
+            #[cfg(feature = "cuda")]
+            if xs.device().is_cuda() {
+                xs = crate::ops::cuda_softcap_f32(&xs, final_logit_softcapping as f32)?;
+            } else {
+                xs = (xs / final_logit_softcapping)?;
+                xs = xs.tanh()?;
+                xs = (xs * final_logit_softcapping)?;
+            }
+            #[cfg(not(feature = "cuda"))]
+            {
+                xs = (xs / final_logit_softcapping)?;
+                xs = xs.tanh()?;
+                xs = (xs * final_logit_softcapping)?;
+            }
         }
 
         Ok(xs)

--- a/mistralrs-core/src/vision_models/gemma4/text.rs
+++ b/mistralrs-core/src/vision_models/gemma4/text.rs
@@ -897,20 +897,19 @@ impl DecoderLayer {
 
         let residual = xs.clone();
         let normed = self.input_layernorm.forward(&xs)?;
-        let attn_out = self
-            .self_attn
-            .forward(
-                &normed,
-                attention_mask,
-                sliding_attention_mask,
-                seqlen_offsets,
-                kv_caches,
-                metadata,
-                flash_params,
-            )?
-            .apply(&self.post_attention_layernorm)?;
+        let attn_out = self.self_attn.forward(
+            &normed,
+            attention_mask,
+            sliding_attention_mask,
+            seqlen_offsets,
+            kv_caches,
+            metadata,
+            flash_params,
+        )?;
 
-        xs = (attn_out + &residual)?;
+        xs = self
+            .post_attention_layernorm
+            .forward_residual(&attn_out, &residual)?;
 
         // Feedforward
         let residual = xs.clone();
@@ -965,11 +964,13 @@ impl DecoderLayer {
             // Dense path: MLP only
             let normed_in = xs.apply(&self.pre_feedforward_layernorm)?;
             let mlp_out = self.mlp.forward(&normed_in)?;
-            let mlp_out = mlp_out.apply(&self.post_feedforward_layernorm)?;
-            xs = (&residual + mlp_out)?;
+            xs = self
+                .post_feedforward_layernorm
+                .forward_residual(&mlp_out, &residual)?;
         };
 
         // PLE: per-layer embedding injection (after feedforward, before layer scalar)
+        let mut layer_scalar_applied = false;
         if let (Some(ref gate), Some(ref proj), Some(ref norm)) = (
             &self.per_layer_input_gate,
             &self.per_layer_projection,
@@ -979,21 +980,26 @@ impl DecoderLayer {
                 let residual_ple = xs.clone();
                 // gate: Linear(hidden_size -> ple_dim)
                 let gate_in = xs;
-                let mut gated = gate.forward(&gate_in)?;
+                let gated = gate.forward(&gate_in)?;
                 // activation + elementwise multiply with per_layer_input
-                gated = gated.apply(&self.act)?;
-                gated = (gated * pli)?;
+                let gated = crate::ops::mul_and_act(&gated, pli, self.act)?;
                 // projection: Linear(ple_dim -> hidden_size)
                 let projected = proj.forward(&gated)?;
                 // post-norm + residual
-                let normed = norm.forward(&projected)?;
-                xs = (residual_ple + normed)?;
+                xs = if let Some(ref scalar) = self.layer_scalar {
+                    layer_scalar_applied = true;
+                    norm.forward_residual_scaled(&projected, &residual_ple, scalar)?
+                } else {
+                    norm.forward_residual(&projected, &residual_ple)?
+                };
             }
         }
 
         // Apply layer scalar
-        if let Some(ref scalar) = self.layer_scalar {
-            xs = xs.broadcast_mul(scalar)?;
+        if !layer_scalar_applied {
+            if let Some(ref scalar) = self.layer_scalar {
+                xs = xs.broadcast_mul(scalar)?;
+            }
         }
 
         Ok(xs)

--- a/mistralrs-core/src/vision_models/gemma4/text.rs
+++ b/mistralrs-core/src/vision_models/gemma4/text.rs
@@ -413,9 +413,23 @@ impl Attention {
     ) -> Result<Tensor> {
         let (b_sz, q_len, _) = xs.dims3()?;
         let is_shared = self.kv_shared_layer_index.is_some();
+        let qkv = if !is_shared {
+            self.v_proj
+                .as_ref()
+                .map(|v_proj| {
+                    crate::ops::qkv_projections(xs, &*self.q_proj, &*self.k_proj, &**v_proj)
+                })
+                .transpose()?
+        } else {
+            None
+        };
 
         // Q projection (always needed)
-        let mut q = self.q_proj.forward(xs)?;
+        let mut q = if let Some((q, _, _)) = qkv.as_ref() {
+            q.clone()
+        } else {
+            self.q_proj.forward(xs)?
+        };
         q = if q_len != 1 {
             q.reshape((b_sz, q_len, self.num_heads, self.head_dim))?
                 .transpose(1, 2)?
@@ -426,11 +440,16 @@ impl Attention {
 
         // K/V projection, reshape, norms (skip for shared layers that reuse donor KV)
         let (mut k, v) = if !is_shared {
-            let k = self.k_proj.forward(xs)?;
-            let v = if let Some(ref v_proj) = self.v_proj {
-                v_proj.forward(xs)?
+            let (k, v) = if let Some((_, k, v)) = qkv {
+                (k, v)
             } else {
-                k.clone()
+                let k = self.k_proj.forward(xs)?;
+                let v = if let Some(ref v_proj) = self.v_proj {
+                    v_proj.forward(xs)?
+                } else {
+                    k.clone()
+                };
+                (k, v)
             };
             let (k, v) = if q_len != 1 {
                 (

--- a/mistralrs-core/src/vision_models/gemma4/vision.rs
+++ b/mistralrs-core/src/vision_models/gemma4/vision.rs
@@ -458,9 +458,10 @@ impl VisionMlp {
     }
 
     fn forward(&self, xs: &Tensor) -> Result<Tensor> {
-        let gate = self.act.forward(&self.gate_proj.forward(xs)?)?;
+        let gate = self.gate_proj.forward(xs)?;
         let up = self.up_proj.forward(xs)?;
-        self.down_proj.forward(&(gate * up)?)
+        self.down_proj
+            .forward(&crate::ops::mul_and_act(&gate, &up, self.act)?)
     }
 
     fn residual_tensors(&self) -> Vec<(String, Tensor)> {

--- a/mistralrs-core/src/vision_models/idefics3/vision.rs
+++ b/mistralrs-core/src/vision_models/idefics3/vision.rs
@@ -271,9 +271,8 @@ impl Attention {
     fn forward(&self, xs: &Tensor, attention_mask: &AttentionMask) -> Result<Tensor> {
         let (b_sz, q_len, _) = xs.dims3()?;
 
-        let mut q = self.q_proj.forward(xs)?;
-        let mut k = self.k_proj.forward(xs)?;
-        let mut v = self.v_proj.forward(xs)?;
+        let (mut q, mut k, mut v) =
+            crate::ops::qkv_projections(xs, &*self.q_proj, &*self.k_proj, &*self.v_proj)?;
 
         q = q
             .reshape((b_sz, q_len, self.num_heads, self.head_dim))?

--- a/mistralrs-core/src/vision_models/llama4/text.rs
+++ b/mistralrs-core/src/vision_models/llama4/text.rs
@@ -156,9 +156,8 @@ impl CausalSelfAttention {
     ) -> Result<Tensor> {
         let (b_sz, seq_len, _) = x.dims3()?;
 
-        let mut q = self.q_proj.forward(x)?;
-        let mut k = self.k_proj.forward(x)?;
-        let mut v = self.v_proj.forward(x)?;
+        let (mut q, mut k, mut v) =
+            crate::ops::qkv_projections(x, &*self.q_proj, &*self.k_proj, &*self.v_proj)?;
 
         q = q
             .reshape((b_sz, seq_len, self.num_attention_heads, self.head_dim))?

--- a/mistralrs-core/src/vision_models/llama4/vision.rs
+++ b/mistralrs-core/src/vision_models/llama4/vision.rs
@@ -161,9 +161,8 @@ impl Llama4VisionAttention {
     }
 
     fn forward(&self, hidden_state: &Tensor, attention_mask: &AttentionMask) -> Result<Tensor> {
-        let mut q = self.q_proj.forward(hidden_state)?;
-        let mut k = self.k_proj.forward(hidden_state)?;
-        let mut v = self.v_proj.forward(hidden_state)?;
+        let (mut q, mut k, mut v) =
+            crate::ops::qkv_projections(hidden_state, &*self.q_proj, &*self.k_proj, &*self.v_proj)?;
         // Should be same, no caching...
         let (bs, q_sq, _) = q.dims3()?;
         let (_, k_sq, _) = k.dims3()?;

--- a/mistralrs-core/src/vision_models/llava/llava_llm/llama.rs
+++ b/mistralrs-core/src/vision_models/llava/llava_llm/llama.rs
@@ -64,9 +64,8 @@ impl CausalSelfAttention {
     ) -> Result<Tensor> {
         let (b_sz, seq_len, _) = x.dims3()?;
 
-        let q = self.q_proj.forward(x)?;
-        let k = self.k_proj.forward(x)?;
-        let v = self.v_proj.forward(x)?;
+        let (q, k, v) =
+            crate::ops::qkv_projections(x, &*self.q_proj, &*self.k_proj, &*self.v_proj)?;
         let mut q = q
             .reshape((b_sz, seq_len, self.num_attention_heads, self.head_dim))?
             .transpose(1, 2)?

--- a/mistralrs-core/src/vision_models/llava/llava_llm/llama.rs
+++ b/mistralrs-core/src/vision_models/llava/llava_llm/llama.rs
@@ -262,7 +262,9 @@ impl AnyMoeTrainableLayer for Mlp {}
 
 impl MlpLayer for Mlp {
     fn forward(&self, x: &Tensor) -> Result<Tensor> {
-        let x = (candle_nn::ops::silu(&self.c_fc1.forward(x)?)? * self.c_fc2.forward(x)?)?;
+        let lhs = self.c_fc1.forward(x)?;
+        let rhs = self.c_fc2.forward(x)?;
+        let x = crate::ops::mul_and_act(&lhs, &rhs, crate::layers::Activation::Silu)?;
         let res = self.c_proj.forward(&x)?;
         Ok(res)
     }

--- a/mistralrs-core/src/vision_models/llava/llava_llm/mistral.rs
+++ b/mistralrs-core/src/vision_models/llava/llava_llm/mistral.rs
@@ -233,9 +233,8 @@ impl Attention {
     ) -> Result<Tensor> {
         let (b_sz, q_len, _) = xs.dims3()?;
 
-        let q = self.q_proj.forward(xs)?;
-        let k = self.k_proj.forward(xs)?;
-        let v = self.v_proj.forward(xs)?;
+        let (q, k, v) =
+            crate::ops::qkv_projections(xs, &*self.q_proj, &*self.k_proj, &*self.v_proj)?;
         let mut q = q
             .reshape((b_sz, q_len, self.num_heads, self.head_dim))?
             .transpose(1, 2)?

--- a/mistralrs-core/src/vision_models/llava/llava_llm/mistral.rs
+++ b/mistralrs-core/src/vision_models/llava/llava_llm/mistral.rs
@@ -82,9 +82,11 @@ impl AnyMoeTrainableLayer for MLP {}
 
 impl MlpLayer for MLP {
     fn forward(&self, xs: &Tensor) -> Result<Tensor> {
-        let lhs = self.gate_proj.forward(xs)?.apply(&self.act_fn)?;
+        let lhs = self.gate_proj.forward(xs)?;
         let rhs = self.up_proj.forward(xs)?;
-        let res = self.down_proj.forward(&(lhs * rhs)?)?;
+        let res = self
+            .down_proj
+            .forward(&crate::ops::mul_and_act(&lhs, &rhs, self.act_fn)?)?;
         Ok(res)
     }
     fn get_isq_layers(&mut self) -> Vec<&mut Arc<dyn QuantMethod>> {

--- a/mistralrs-core/src/vision_models/mistral3/vision.rs
+++ b/mistralrs-core/src/vision_models/mistral3/vision.rs
@@ -177,9 +177,10 @@ impl Mlp {
 
 impl Module for Mlp {
     fn forward(&self, xs: &Tensor) -> Result<Tensor> {
-        self.down_proj.forward(
-            &(self.gate_proj.forward(xs)?.apply(&self.act_fn)? * self.up_proj.forward(xs)?)?,
-        )
+        let lhs = self.gate_proj.forward(xs)?;
+        let rhs = self.up_proj.forward(xs)?;
+        self.down_proj
+            .forward(&crate::ops::mul_and_candle_act(&lhs, &rhs, self.act_fn)?)
     }
 }
 

--- a/mistralrs-core/src/vision_models/mistral3/vision.rs
+++ b/mistralrs-core/src/vision_models/mistral3/vision.rs
@@ -123,9 +123,8 @@ impl Attention {
         attention_mask: &AttentionMask,
     ) -> Result<Tensor> {
         let (b, patches, _) = xs.dims3()?;
-        let query_states = self.q_proj.forward(xs)?;
-        let key_states = self.k_proj.forward(xs)?;
-        let value_states = self.v_proj.forward(xs)?;
+        let (query_states, key_states, value_states) =
+            crate::ops::qkv_projections(xs, &*self.q_proj, &*self.k_proj, &*self.v_proj)?;
 
         let shape = (b, patches, self.num_heads, self.head_dim);
         let query_states = query_states.reshape(shape)?.transpose(1, 2)?.contiguous()?;

--- a/mistralrs-core/src/vision_models/mllama/text.rs
+++ b/mistralrs-core/src/vision_models/mllama/text.rs
@@ -153,9 +153,12 @@ impl MLlamaTextSelfAttention {
     ) -> Result<Tensor> {
         let (bs, q_len, _) = hidden_states.dims3()?;
 
-        let q = self.q_proj.forward(hidden_states)?;
-        let k = self.k_proj.forward(hidden_states)?;
-        let v = self.v_proj.forward(hidden_states)?;
+        let (q, k, v) = crate::ops::qkv_projections(
+            hidden_states,
+            &*self.q_proj,
+            &*self.k_proj,
+            &*self.v_proj,
+        )?;
         let (q, k, mut v) = if q_len != 1 {
             let q = q
                 .reshape((bs, q_len, self.num_heads, self.head_dim))?

--- a/mistralrs-core/src/vision_models/mllama/vision.rs
+++ b/mistralrs-core/src/vision_models/mllama/vision.rs
@@ -193,9 +193,8 @@ impl MLlamaVisionAttention {
 
     // https://github.com/huggingface/transformers/blob/f2c388e3f946862f657acc1e21b272ec946fc66c/src/transformers/models/mllama/modeling_mllama.py#L243
     fn forward(&self, hidden_state: &Tensor, attention_mask: &AttentionMask) -> Result<Tensor> {
-        let mut q = self.q_proj.forward(hidden_state)?;
-        let mut k = self.k_proj.forward(hidden_state)?;
-        let mut v = self.v_proj.forward(hidden_state)?;
+        let (mut q, mut k, mut v) =
+            crate::ops::qkv_projections(hidden_state, &*self.q_proj, &*self.k_proj, &*self.v_proj)?;
         // Should be same, no caching...
         let (bs, q_sq, _) = q.dims3()?;
         let (_, k_sq, _) = k.dims3()?;

--- a/mistralrs-core/src/vision_models/phi3/mod.rs
+++ b/mistralrs-core/src/vision_models/phi3/mod.rs
@@ -365,9 +365,7 @@ impl AnyMoeTrainableLayer for Mlp {}
 impl MlpLayer for Mlp {
     fn forward(&self, xs: &Tensor) -> Result<Tensor> {
         let up_states = self.gate_up_proj.forward(xs)?;
-        let gate = up_states.narrow(D::Minus1, 0, self.i_size)?;
-        let up_states = up_states.narrow(D::Minus1, self.i_size, self.i_size)?;
-        let up_states = (up_states * gate.apply(&self.act_fn))?;
+        let up_states = crate::ops::split_mul_and_act(&up_states, self.i_size, self.act_fn)?;
         let res = self.down_proj.forward(&up_states)?;
         Ok(res)
     }

--- a/mistralrs-core/src/vision_models/phi4/mod.rs
+++ b/mistralrs-core/src/vision_models/phi4/mod.rs
@@ -234,9 +234,7 @@ impl Mlp {
 
     fn forward(&self, xs: &Tensor) -> Result<Tensor> {
         let up_states = self.gate_up_proj.forward(xs)?;
-        let gate = up_states.narrow(D::Minus1, 0, self.i_size)?;
-        let up_states = up_states.narrow(D::Minus1, self.i_size, self.i_size)?;
-        let up_states = (up_states * gate.apply(&self.act_fn))?;
+        let up_states = crate::ops::split_mul_and_act(&up_states, self.i_size, self.act_fn)?;
         let res = self.down_proj.forward(&up_states)?;
         Ok(res)
     }

--- a/mistralrs-core/src/vision_models/qwen2_5_vl/text.rs
+++ b/mistralrs-core/src/vision_models/qwen2_5_vl/text.rs
@@ -65,10 +65,10 @@ impl Mlp {
     fn forward(&self, xs: &Tensor) -> Result<Tensor> {
         let original_dtype = xs.dtype();
         let xs = xs.clone();
-        let lhs = self.gate_proj.forward(&xs)?.apply(&self.act_fn)?;
+        let lhs = self.gate_proj.forward(&xs)?;
         let rhs = self.up_proj.forward(&xs)?;
         self.down_proj
-            .forward(&(lhs * rhs)?)?
+            .forward(&crate::ops::mul_and_act(&lhs, &rhs, self.act_fn)?)?
             .to_dtype(original_dtype)
     }
 }

--- a/mistralrs-core/src/vision_models/qwen2_5_vl/text.rs
+++ b/mistralrs-core/src/vision_models/qwen2_5_vl/text.rs
@@ -169,9 +169,8 @@ impl Attention {
     ) -> Result<Tensor> {
         let (b_sz, q_len, _) = xs.dims3()?;
 
-        let q = self.q_proj.forward(xs)?;
-        let k = self.k_proj.forward(xs)?;
-        let v = self.v_proj.forward(xs)?;
+        let (q, k, v) =
+            crate::ops::qkv_projections(xs, &*self.q_proj, &*self.k_proj, &*self.v_proj)?;
         let (mut q, mut k, v) = if q_len != 1 {
             let q = q
                 .reshape((b_sz, q_len, self.num_heads, self.head_dim))?

--- a/mistralrs-core/src/vision_models/qwen2_5_vl/vision.rs
+++ b/mistralrs-core/src/vision_models/qwen2_5_vl/vision.rs
@@ -102,12 +102,12 @@ impl VisionMlp {
     }
 
     fn forward(&self, xs: &Tensor) -> Result<Tensor> {
-        let lhs = self
-            .gate_proj
-            .forward(&xs.unsqueeze(0)?)?
-            .apply(&self.act)?;
-        let rhs = self.up_proj.forward(&xs.unsqueeze(0)?)?;
-        let res = self.down_proj.forward(&(lhs * rhs)?)?;
+        let xs = xs.unsqueeze(0)?;
+        let lhs = self.gate_proj.forward(&xs)?;
+        let rhs = self.up_proj.forward(&xs)?;
+        let res = self
+            .down_proj
+            .forward(&crate::ops::mul_and_act(&lhs, &rhs, self.act)?)?;
         res.squeeze(0)
     }
 }

--- a/mistralrs-core/src/vision_models/qwen2vl/text.rs
+++ b/mistralrs-core/src/vision_models/qwen2vl/text.rs
@@ -170,9 +170,8 @@ impl Attention {
     ) -> Result<Tensor> {
         let (b_sz, q_len, _) = xs.dims3()?;
 
-        let q = self.q_proj.forward(xs)?;
-        let k = self.k_proj.forward(xs)?;
-        let v = self.v_proj.forward(xs)?;
+        let (q, k, v) =
+            crate::ops::qkv_projections(xs, &*self.q_proj, &*self.k_proj, &*self.v_proj)?;
         let (mut q, mut k, v) = if q_len != 1 {
             let q = q
                 .reshape((b_sz, q_len, self.num_heads, self.head_dim))?

--- a/mistralrs-core/src/vision_models/qwen2vl/text.rs
+++ b/mistralrs-core/src/vision_models/qwen2vl/text.rs
@@ -66,10 +66,10 @@ impl Mlp {
     fn forward(&self, xs: &Tensor) -> Result<Tensor> {
         let original_dtype = xs.dtype();
         let xs = xs.clone();
-        let lhs = self.gate_proj.forward(&xs)?.apply(&self.act_fn)?;
+        let lhs = self.gate_proj.forward(&xs)?;
         let rhs = self.up_proj.forward(&xs)?;
         self.down_proj
-            .forward(&(lhs * rhs)?)?
+            .forward(&crate::ops::mul_and_act(&lhs, &rhs, self.act_fn)?)?
             .to_dtype(original_dtype)
     }
 }

--- a/mistralrs-core/src/vision_models/qwen3_5/text.rs
+++ b/mistralrs-core/src/vision_models/qwen3_5/text.rs
@@ -170,9 +170,8 @@ impl FullAttention {
         flash_params: &FlashParams,
     ) -> Result<Tensor> {
         let (b_sz, seq_len, _) = x.dims3()?;
-        let q_gate = self.q_proj.forward(x)?;
-        let k = self.k_proj.forward(x)?;
-        let v = self.v_proj.forward(x)?;
+        let (q_gate, k, v) =
+            crate::ops::qkv_projections(x, &*self.q_proj, &*self.k_proj, &*self.v_proj)?;
         // Split q_gate into q and gate
         let q_gate = q_gate.reshape((b_sz, seq_len, self.num_heads, self.head_dim * 2))?;
         let q = q_gate.narrow(D::Minus1, 0, self.head_dim)?;

--- a/mistralrs-core/src/vision_models/qwen3_5_moe/text.rs
+++ b/mistralrs-core/src/vision_models/qwen3_5_moe/text.rs
@@ -171,9 +171,8 @@ impl FullAttention {
         flash_params: &FlashParams,
     ) -> Result<Tensor> {
         let (b_sz, seq_len, _) = x.dims3()?;
-        let q_gate = self.q_proj.forward(x)?;
-        let k = self.k_proj.forward(x)?;
-        let v = self.v_proj.forward(x)?;
+        let (q_gate, k, v) =
+            crate::ops::qkv_projections(x, &*self.q_proj, &*self.k_proj, &*self.v_proj)?;
         // Split q_gate into q and gate
         let q_gate = q_gate.reshape((b_sz, seq_len, self.num_heads, self.head_dim * 2))?;
         let q = q_gate.narrow(D::Minus1, 0, self.head_dim)?;

--- a/mistralrs-core/src/vision_models/qwen3_vl/text.rs
+++ b/mistralrs-core/src/vision_models/qwen3_vl/text.rs
@@ -195,9 +195,8 @@ impl Attention {
     ) -> Result<Tensor> {
         let (b_sz, q_len, _) = xs.dims3()?;
 
-        let mut q = self.q_proj.forward(xs)?;
-        let mut k = self.k_proj.forward(xs)?;
-        let mut v = self.v_proj.forward(xs)?;
+        let (mut q, mut k, mut v) =
+            crate::ops::qkv_projections(xs, &*self.q_proj, &*self.k_proj, &*self.v_proj)?;
         (q, k, v) = if q_len != 1 {
             let q = q
                 .reshape((b_sz, q_len, self.num_heads, self.head_dim))?

--- a/mistralrs-core/src/vision_models/qwen3_vl/text.rs
+++ b/mistralrs-core/src/vision_models/qwen3_vl/text.rs
@@ -70,10 +70,10 @@ impl Mlp {
     fn forward(&self, xs: &Tensor) -> Result<Tensor> {
         let original_dtype = xs.dtype();
         let xs = xs.clone();
-        let lhs = self.gate_proj.forward(&xs)?.apply(&self.act_fn)?;
+        let lhs = self.gate_proj.forward(&xs)?;
         let rhs = self.up_proj.forward(&xs)?;
         self.down_proj
-            .forward(&(lhs * rhs)?)?
+            .forward(&crate::ops::mul_and_act(&lhs, &rhs, self.act_fn)?)?
             .to_dtype(original_dtype)
     }
 }

--- a/mistralrs-core/src/vision_models/qwen3_vl_moe/text.rs
+++ b/mistralrs-core/src/vision_models/qwen3_vl_moe/text.rs
@@ -300,9 +300,8 @@ impl Attention {
     ) -> Result<Tensor> {
         let (b_sz, q_len, _) = xs.dims3()?;
 
-        let mut q = self.q_proj.forward(xs)?;
-        let mut k = self.k_proj.forward(xs)?;
-        let mut v = self.v_proj.forward(xs)?;
+        let (mut q, mut k, mut v) =
+            crate::ops::qkv_projections(xs, &*self.q_proj, &*self.k_proj, &*self.v_proj)?;
         (q, k, v) = if q_len != 1 {
             let q = q
                 .reshape((b_sz, q_len, self.num_heads, self.head_dim))?

--- a/mistralrs-core/src/vision_models/qwen3_vl_moe/text.rs
+++ b/mistralrs-core/src/vision_models/qwen3_vl_moe/text.rs
@@ -75,9 +75,11 @@ impl Mlp {
     }
 
     fn forward(&self, xs: &Tensor) -> Result<Tensor> {
-        let lhs = self.gate_proj.forward(xs)?.apply(&self.act_fn)?;
+        let lhs = self.gate_proj.forward(xs)?;
         let rhs = self.up_proj.forward(xs)?;
-        let res = self.down_proj.forward(&(lhs * rhs)?)?;
+        let res = self
+            .down_proj
+            .forward(&crate::ops::mul_and_act(&lhs, &rhs, self.act_fn)?)?;
         Ok(res)
     }
 }

--- a/mistralrs-core/src/vision_models/siglip.rs
+++ b/mistralrs-core/src/vision_models/siglip.rs
@@ -269,9 +269,8 @@ impl Attention {
     fn forward(&self, xs: &Tensor, attention_mask: &AttentionMask) -> Result<Tensor> {
         let (b_sz, q_len, _) = xs.dims3()?;
 
-        let mut q = self.q_proj.forward(xs)?;
-        let mut k = self.k_proj.forward(xs)?;
-        let mut v = self.v_proj.forward(xs)?;
+        let (mut q, mut k, mut v) =
+            crate::ops::qkv_projections(xs, &*self.q_proj, &*self.k_proj, &*self.v_proj)?;
 
         q = q
             .reshape((b_sz, q_len, self.num_heads, self.head_dim))?

--- a/mistralrs-core/src/vision_models/voxtral/encoder.rs
+++ b/mistralrs-core/src/vision_models/voxtral/encoder.rs
@@ -146,9 +146,8 @@ impl EncoderMlp {
     fn forward(&self, xs: &Tensor) -> Result<Tensor> {
         // SwiGLU: silu(w1(x)) * w3(x), then w2
         let gate = self.w1.forward(xs)?;
-        let gate = candle_nn::ops::silu(&gate)?;
         let up = self.w3.forward(xs)?;
-        let xs = (gate * up)?;
+        let xs = crate::ops::mul_and_act(&gate, &up, crate::layers::Activation::Silu)?;
         self.w2.forward(&xs)
     }
 }

--- a/mistralrs-core/src/vision_models/voxtral/mod.rs
+++ b/mistralrs-core/src/vision_models/voxtral/mod.rs
@@ -190,9 +190,8 @@ impl DecoderMlp {
 
     fn forward(&self, xs: &Tensor) -> Result<Tensor> {
         let gate = self.w1.forward(xs)?;
-        let gate = candle_nn::ops::silu(&gate)?;
         let up = self.w3.forward(xs)?;
-        let xs = (gate * up)?;
+        let xs = crate::ops::mul_and_act(&gate, &up, crate::layers::Activation::Silu)?;
         let res = self.w2.forward(&xs)?;
         Ok(res)
     }

--- a/mistralrs-paged-attn/src/cuda/backend/paged_attention.rs
+++ b/mistralrs-paged-attn/src/cuda/backend/paged_attention.rs
@@ -5,13 +5,59 @@ use crate::cuda::ffi::{
     paged_attention_v2_bf16, paged_attention_v2_f16, paged_attention_v2_f32,
 };
 use candle::backend::BackendStorage;
-use candle::cuda_backend::cudarc::driver::DevicePtr;
+use candle::cuda_backend::cudarc::driver::{CudaSlice, DevicePtr};
 use candle::{CpuStorage, CudaStorage, DType, Layout, Result, Shape, Storage, Tensor};
 use candle_core as candle;
 use candle_core::cuda::cudarc::driver::DeviceSlice;
 use float8::F8E4M3;
 use half::{bf16, f16};
+use std::collections::HashMap;
 use std::ffi::c_int;
+use std::sync::{Mutex, OnceLock};
+
+struct WorkspaceSlot {
+    slice: CudaSlice<u8>,
+    cap: usize,
+}
+
+type WsMap = Mutex<HashMap<candle::cuda_backend::DeviceId, &'static Mutex<WorkspaceSlot>>>;
+
+static PAGED_ATTN_V2_WORKSPACE: OnceLock<WsMap> = OnceLock::new();
+
+fn align_up(value: usize, alignment: usize) -> usize {
+    value.div_ceil(alignment) * alignment
+}
+
+fn workspace_ensure(
+    dev: &candle::cuda_backend::CudaDevice,
+    bytes: usize,
+) -> Result<(u64, std::sync::MutexGuard<'static, WorkspaceSlot>)> {
+    let map = PAGED_ATTN_V2_WORKSPACE.get_or_init(|| Mutex::new(HashMap::new()));
+    let device_key = dev.id();
+    let device_mtx: &'static Mutex<WorkspaceSlot> = {
+        let mut guard = map.lock().unwrap();
+        match guard.get(&device_key).copied() {
+            Some(mtx) => mtx,
+            None => {
+                let slice = unsafe { dev.alloc::<u8>(bytes.max(1))? };
+                let leaked = Box::leak(Box::new(Mutex::new(WorkspaceSlot {
+                    slice,
+                    cap: bytes.max(1),
+                })));
+                guard.insert(device_key, leaked);
+                leaked
+            }
+        }
+    };
+
+    let mut slot = device_mtx.lock().unwrap();
+    if slot.cap < bytes {
+        slot.slice = unsafe { dev.alloc::<u8>(bytes)? };
+        slot.cap = bytes;
+    }
+    let ptr = slot.slice.device_ptr(slot.slice.stream()).0;
+    Ok((ptr, slot))
+}
 
 struct PagedAttention {
     softmax_scale: f32,
@@ -223,7 +269,9 @@ impl PagedAttention {
         let kv_head_stride = kc_l.stride()[1];
 
         let partition_size = 512;
-        let max_num_partitions = self.max_context_len.div_ceil(partition_size);
+        let effective_max_context_len =
+            (max_num_blocks_per_seq * block_size).min(self.max_context_len);
+        let max_num_partitions = effective_max_context_len.div_ceil(partition_size);
         let use_v1 = (max_num_partitions == 1 || num_seqs * num_heads > 512)
             && partition_size % block_size == 0;
 
@@ -255,7 +303,7 @@ impl PagedAttention {
                     bt_ptr as *const i32,
                     cl_ptr as *const i32,
                     block_size as c_int,
-                    self.max_context_len as c_int,
+                    effective_max_context_len as c_int,
                     num_seqs as c_int,
                     num_heads as c_int,
                     head_size as c_int,
@@ -273,13 +321,17 @@ impl PagedAttention {
         } else {
             let tmp_out_shape = Shape::from((num_seqs, num_heads, max_num_partitions, head_size));
             let exp_sums_shape = Shape::from((num_seqs, num_heads, max_num_partitions));
-            let tmp_out = unsafe { dev.alloc::<T>(tmp_out_shape.elem_count()) }?;
-            let exp_sums = unsafe { dev.alloc::<f32>(exp_sums_shape.elem_count()) }?;
-            let max_logits = unsafe { dev.alloc::<f32>(exp_sums_shape.elem_count()) }?;
+            let tmp_out_bytes = tmp_out_shape.elem_count() * std::mem::size_of::<T>();
+            let exp_sums_bytes = exp_sums_shape.elem_count() * std::mem::size_of::<f32>();
+            let tmp_out_offset = 0;
+            let exp_sums_offset = align_up(tmp_out_offset + tmp_out_bytes, 16);
+            let max_logits_offset = align_up(exp_sums_offset + exp_sums_bytes, 16);
+            let workspace_bytes = max_logits_offset + exp_sums_bytes;
+            let (workspace_ptr, _workspace_guard) = workspace_ensure(dev, workspace_bytes)?;
 
-            let (tmp_out_ptr, _tmp_out_guard) = tmp_out.device_ptr(tmp_out.stream());
-            let (exp_sums_ptr, _exp_sums_guard) = exp_sums.device_ptr(exp_sums.stream());
-            let (max_logits_ptr, _max_logits_guard) = max_logits.device_ptr(max_logits.stream());
+            let tmp_out_ptr = (workspace_ptr + tmp_out_offset as u64) as *mut std::ffi::c_void;
+            let exp_sums_ptr = (workspace_ptr + exp_sums_offset as u64) as *mut f32;
+            let max_logits_ptr = (workspace_ptr + max_logits_offset as u64) as *mut f32;
 
             let paged_attention_v2_func = match dtype {
                 DType::F16 => paged_attention_v2_f16,
@@ -303,7 +355,7 @@ impl PagedAttention {
                     bt_ptr as *const i32,
                     cl_ptr as *const i32,
                     block_size as c_int,
-                    self.max_context_len as c_int,
+                    effective_max_context_len as c_int,
                     num_seqs as c_int,
                     num_heads as c_int,
                     head_size as c_int,

--- a/mistralrs-quant/kernels/mmq_gguf/mmq_common.cuh
+++ b/mistralrs-quant/kernels/mmq_gguf/mmq_common.cuh
@@ -5,6 +5,7 @@
 #include <cstdint>
 #include <cstdio>
 #include <climits>
+#include <limits>
 
 #include "cuda_fp16.h"
 #include "cuda_bf16.h"
@@ -346,6 +347,43 @@ static __device__ void no_device_code(
 #define GGML_ABORT(msg) do { fprintf(stderr, "GGML_ABORT: %s\n", msg); abort(); } while(0)
 #define GGML_ASSERT(x)  do { if (!(x)) { fprintf(stderr, "GGML_ASSERT failed: %s\n", #x); abort(); } } while(0)
 #endif
+
+// Fast unsigned division helpers, matching llama.cpp's CUDA MMQ kernels.
+// Divisors are invariant for a launch, so the host precomputes <mp, L, d>
+// and the device replaces integer div/rem with multiply-high arithmetic.
+static const uint3 init_fastdiv_values(uint64_t d_64) {
+    GGML_ASSERT(d_64 != 0);
+    GGML_ASSERT(d_64 <= std::numeric_limits<uint32_t>::max());
+
+    const uint32_t d = static_cast<uint32_t>(d_64);
+
+    uint32_t L = 0;
+    while (L < 32 && (uint32_t{1} << L) < d) {
+        ++L;
+    }
+
+    const uint32_t mp =
+        static_cast<uint32_t>(((uint64_t{1} << 32) * ((uint64_t{1} << L) - d)) / d + 1);
+    return make_uint3(mp, L, d);
+}
+
+static __device__ __forceinline__ uint32_t fastdiv(
+    uint32_t n, const uint3 fastdiv_values) {
+    const uint32_t hi = __umulhi(n, fastdiv_values.x);
+    return (hi + n) >> fastdiv_values.y;
+}
+
+static __device__ __forceinline__ uint32_t fastmodulo(
+    uint32_t n, const uint3 fastdiv_values) {
+    return n - fastdiv(n, fastdiv_values) * fastdiv_values.z;
+}
+
+static __device__ __forceinline__ uint2 fast_div_modulo(
+    uint32_t n, const uint3 fastdiv_values) {
+    const uint32_t div_val = fastdiv(n, fastdiv_values);
+    const uint32_t mod_val = n - div_val * fastdiv_values.z;
+    return make_uint2(div_val, mod_val);
+}
 
 // dp4a intrinsic
 static __device__ __forceinline__ int ggml_cuda_dp4a(const int a, const int b, int c) {

--- a/mistralrs-quant/kernels/mmq_gguf/mmq_gguf.cuh
+++ b/mistralrs-quant/kernels/mmq_gguf/mmq_gguf.cuh
@@ -3538,10 +3538,10 @@ template <ggml_type type, int mmq_x, bool need_check>
 static __global__ void mul_mat_q(
         const char * __restrict__ x, const int * __restrict__ y, const int32_t * __restrict__ ids_dst,
         const int32_t * __restrict__ expert_bounds, float * __restrict__ dst, float * __restrict__ tmp_fixup,
-        const int ncols_x, const int nrows_x, const int ncols_dst, const int stride_row_x, const int ncols_y, const int stride_col_dst,
-        const int channel_ratio, const int nchannels_y, const int stride_channel_x, const int stride_channel_y, const int stride_channel_dst,
-        const int sample_ratio, const int nsamples_y, const int stride_sample_x, const int stride_sample_y, const int stride_sample_dst,
-        const int ncols_max) {
+        const uint3 blocks_per_ne00, const int nrows_x, const int ncols_dst, const int stride_row_x, const int ncols_y, const int stride_col_dst,
+        const uint3 channel_ratio, const uint3 nchannels_y, const int stride_channel_x, const int stride_channel_y, const int stride_channel_dst,
+        const uint3 sample_ratio, const uint3 nsamples_y, const int stride_sample_x, const int stride_sample_y, const int stride_sample_dst,
+        const uint3 ntx) {
 
     // Skip unused template specializations for faster compilation:
     if (mmq_x > get_mmq_x_max_device() || mmq_x % mmq_get_granularity_device(mmq_x) != 0) {
@@ -3552,11 +3552,9 @@ static __global__ void mul_mat_q(
     constexpr int nwarps = mmq_get_nwarps_device();
     constexpr int warp_size = ggml_cuda_get_physical_warp_size();
 
-    constexpr int qk    = ggml_cuda_type_traits<type>::qk;
     constexpr int mmq_y = get_mmq_y_device();
 
-    const int ntx = (ncols_max + mmq_x - 1) / mmq_x; // Number of tiles x
-    const int nty = (nrows_x   + mmq_y - 1) / mmq_y; // Number of tiles y
+    const uint32_t nty = (nrows_x + mmq_y - 1) / mmq_y; // Number of tiles y
 
     // Initialize the ids for writing back data with just the index.
     // For regular matrix multiplications this is never changed.
@@ -3577,8 +3575,9 @@ static __global__ void mul_mat_q(
     // On non-CDNA AMD or old CUDA the performance with stream-k was worse, use conventional tiling instead:
 #if (defined(GGML_USE_HIP) && !defined(CDNA)) || __CUDA_ARCH__ < GGML_CUDA_CC_VOLTA
     {
-        const int wt = blockIdx.z / nchannels_y;
-        const int zt = blockIdx.z - wt*nchannels_y;
+        const uint2 tmp2 = fast_div_modulo(blockIdx.z, nchannels_y);
+        const int wt = tmp2.x;
+        const int zt = tmp2.y;
         const int jt = blockIdx.y;
         const int it = blockIdx.x;
 
@@ -3621,40 +3620,42 @@ static __global__ void mul_mat_q(
         const int tile_x_max_i = nrows_x  - it*mmq_y - 1;
         const int tile_y_max_j = col_diff - jt*mmq_x - 1;
 
-        const int offset_x = (wt/sample_ratio)*stride_sample_x + (zt/channel_ratio)*stride_channel_x + it*mmq_y*stride_row_x;
+        const int offset_x = fastdiv(wt, sample_ratio)*stride_sample_x + fastdiv(zt, channel_ratio)*stride_channel_x + it*mmq_y*stride_row_x;
 
         constexpr bool fixup = false;
         mul_mat_q_process_tile<type, mmq_x, need_check, fixup>
             (x, offset_x, y + offset_y, ids_dst_shared, dst + offset_dst, tmp_fixup, stride_row_x, ncols_y, stride_col_dst,
-             tile_x_max_i, tile_y_max_j, 0, ncols_x/qk);
+             tile_x_max_i, tile_y_max_j, 0, blocks_per_ne00.z);
         return;
     }
 #endif // (defined(GGML_USE_HIP) && !defined(CDNA3)) || __CUDA_ARCH__ < GGML_CUDA_CC_VOLTA
 
     constexpr int ITER_K = get_iter_k(type);
 
-    const     int64_t blocks_per_ne00 = ncols_x / qk;
+    constexpr int     qk              = ggml_cuda_type_traits<type>::qk;
     constexpr int     blocks_per_iter = ITER_K / qk;
 
     // kbc == k block continuous, current index in continuous ijk space.
-    int64_t kbc      = (int64_t) blockIdx.x     *nsamples_y*nchannels_y*ntx*nty*blocks_per_ne00 / gridDim.x;
-    int64_t kbc_stop = (int64_t)(blockIdx.x + 1)*nsamples_y*nchannels_y*ntx*nty*blocks_per_ne00 / gridDim.x;
+    int kbc      = int64_t(blockIdx.x)    *(nsamples_y.z*nchannels_y.z*ntx.z*nty*blocks_per_ne00.z) / gridDim.x;
+    int kbc_stop = int64_t(blockIdx.x + 1)*(nsamples_y.z*nchannels_y.z*ntx.z*nty*blocks_per_ne00.z) / gridDim.x;
 
-    kbc      -= (kbc      % blocks_per_ne00) % blocks_per_iter;
-    kbc_stop -= (kbc_stop % blocks_per_ne00) % blocks_per_iter;
+    kbc      -= fastmodulo(kbc,      blocks_per_ne00) % blocks_per_iter;
+    kbc_stop -= fastmodulo(kbc_stop, blocks_per_ne00) % blocks_per_iter;
 
     // kb0 == k index when doing the matrix multiplication for an output tile.
-    int kb0_start = kbc % blocks_per_ne00;
-    int kb0_stop  = min(blocks_per_ne00, kb0_start + kbc_stop - kbc);
-    while (kbc < kbc_stop && kb0_stop == blocks_per_ne00) {
-        int tmp = kbc;
-        const int it = tmp / (nsamples_y*nchannels_y*ntx*blocks_per_ne00);
-        tmp -= it * (nsamples_y*nchannels_y*ntx*blocks_per_ne00);
-        const int wt = tmp / (nchannels_y*ntx*blocks_per_ne00);
-        tmp -= wt * (nchannels_y*ntx*blocks_per_ne00);
-        const int zt = tmp / (ntx*blocks_per_ne00);
-        tmp -= zt * (ntx*blocks_per_ne00);
-        const int jt = tmp / blocks_per_ne00;
+    int kb0_start = fastmodulo(kbc, blocks_per_ne00);
+    int kb0_stop  = min(blocks_per_ne00.z, uint32_t(kb0_start + kbc_stop - kbc));
+    while (kbc < kbc_stop && kb0_stop == int(blocks_per_ne00.z)) {
+        int tmp = fastdiv(kbc, blocks_per_ne00);
+        uint2 tmp2 = fast_div_modulo(tmp, ntx);
+        const int jt = tmp2.y;
+        tmp = tmp2.x;
+        tmp2 = fast_div_modulo(tmp, nchannels_y);
+        const int zt = tmp2.y;
+        tmp = tmp2.x;
+        tmp2 = fast_div_modulo(tmp, nsamples_y);
+        const int wt = tmp2.y;
+        const int it = tmp2.x;
 
         // Defaults for regular matrix multiplication:
         int col_low    = 0;
@@ -3672,11 +3673,11 @@ static __global__ void mul_mat_q(
             offset_dst = 0;
 
             if (jt*mmq_x >= col_diff) {
-                kbc += blocks_per_ne00;
-                kbc -= kbc % blocks_per_ne00;
+                kbc += blocks_per_ne00.z;
+                kbc -= fastmodulo(kbc, blocks_per_ne00);
 
                 kb0_start = 0;
-                kb0_stop  = min(blocks_per_ne00, kbc_stop - kbc);
+                kb0_stop  = min(blocks_per_ne00.z, uint32_t(kbc_stop - kbc));
 
                 continue;
             }
@@ -3701,32 +3702,34 @@ static __global__ void mul_mat_q(
         const int tile_x_max_i = nrows_x  - it*mmq_y - 1;
         const int tile_y_max_j = col_diff - jt*mmq_x - 1;
 
-        const int offset_x = (wt/sample_ratio)*stride_sample_x + (zt/channel_ratio)*stride_channel_x + it*mmq_y*stride_row_x;
+        const int offset_x = fastdiv(wt, sample_ratio)*stride_sample_x + fastdiv(zt, channel_ratio)*stride_channel_x + it*mmq_y*stride_row_x;
 
         constexpr bool fixup = false; // All but (potentially) the last iterations write their data to dst rather than the fixup buffer.
         mul_mat_q_process_tile<type, mmq_x, need_check, fixup>
             (x, offset_x, y + offset_y, ids_dst_shared, dst + offset_dst, tmp_fixup, stride_row_x, ncols_y, stride_col_dst,
              tile_x_max_i, tile_y_max_j, kb0_start, kb0_stop);
 
-        kbc += blocks_per_ne00;
-        kbc -= kbc % blocks_per_ne00;
+        kbc += blocks_per_ne00.z;
+        kbc -= fastmodulo(kbc, blocks_per_ne00);
 
         kb0_start = 0;
-        kb0_stop  = min(blocks_per_ne00, kbc_stop - kbc);
+        kb0_stop  = min(blocks_per_ne00.z, uint32_t(kbc_stop - kbc));
     }
 
     if (kbc >= kbc_stop) {
         return;
     }
 
-    int tmp = kbc;
-    const int it = tmp / (nsamples_y*nchannels_y*ntx*blocks_per_ne00);
-    tmp -= it * (nsamples_y*nchannels_y*ntx*blocks_per_ne00);
-    const int wt = tmp / (nchannels_y*ntx*blocks_per_ne00);
-    tmp -= wt * (nchannels_y*ntx*blocks_per_ne00);
-    const int zt = tmp / (ntx*blocks_per_ne00);
-    tmp -= zt * (ntx*blocks_per_ne00);
-    const int jt = tmp / blocks_per_ne00;
+    int tmp = fastdiv(kbc, blocks_per_ne00);
+    uint2 tmp2 = fast_div_modulo(tmp, ntx);
+    const int jt = tmp2.y;
+    tmp = tmp2.x;
+    tmp2 = fast_div_modulo(tmp, nchannels_y);
+    const int zt = tmp2.y;
+    tmp = tmp2.x;
+    tmp2 = fast_div_modulo(tmp, nsamples_y);
+    const int wt = tmp2.y;
+    const int it = tmp2.x;
 
     // Defaults for regular matrix multiplication:
     int col_low    = 0;
@@ -3768,7 +3771,7 @@ static __global__ void mul_mat_q(
     const int tile_x_max_i = nrows_x  - it*mmq_y - 1;
     const int tile_y_max_j = col_diff - jt*mmq_x - 1;
 
-    const int offset_x = (wt/sample_ratio)*stride_sample_x + (zt/channel_ratio)*stride_channel_x + it*mmq_y*stride_row_x;
+    const int offset_x = fastdiv(wt, sample_ratio)*stride_sample_x + fastdiv(zt, channel_ratio)*stride_channel_x + it*mmq_y*stride_row_x;
 
     constexpr bool fixup = true; // Last index writes its data to fixup buffer to avoid data races with other blocks.
     mul_mat_q_process_tile<type, mmq_x, need_check, fixup>
@@ -3777,46 +3780,36 @@ static __global__ void mul_mat_q(
 }
 
 template <ggml_type type, int mmq_x, bool need_check>
-static __global__ void mul_mat_q_stream_k_fixup(const int32_t * ids_dst,
-                                                const int32_t * expert_bounds,
-                                                float * __restrict__ dst,
-                                                const float * __restrict__ tmp_last_tile,
-                                                const int    ncols_x,
-                                                const int    nrows_x,
-                                                const int    ncols_dst,
-                                                const size_t stride_col_dst,
-                                                const int    nchannels_y,
-                                                const size_t stride_channel_dst,
-                                                const int    nsamples_y,
-                                                const size_t stride_sample_dst,
-                                                const int    ncols_max) {
-    constexpr int     mmq_y           = get_mmq_y_device();
-    constexpr int     qk              = ggml_cuda_type_traits<type>::qk;
-    constexpr int     ITER_K          = get_iter_k(type);
+static __global__ void mul_mat_q_stream_k_fixup(
+        const int32_t * __restrict__ ids_dst, const int32_t * __restrict__ expert_bounds,
+        float * __restrict__ dst, float * __restrict__ tmp_last_tile,
+        const uint3 blocks_per_ne00, const int nrows_x, const int ncols_dst,
+        const int stride_col_dst, const uint3 nchannels_y, const int stride_channel_dst,
+        const uint3 nsamples_y, const int stride_sample_dst, const uint3 ntx) {
+    constexpr int mmq_y           = get_mmq_y_device();
+    constexpr int qk              = ggml_cuda_type_traits<type>::qk;
+    constexpr int ITER_K          = get_iter_k(type);
+    constexpr int blocks_per_iter = ITER_K / qk;
 
-    constexpr int     blocks_per_iter = ITER_K / qk;
-    const     int64_t blocks_per_ne00 = ncols_x / qk;
-
-    constexpr int nwarps = mmq_get_nwarps_device();
+    constexpr int nwarps = mmq_get_nwarps_device()/2;
     constexpr int warp_size = ggml_cuda_get_physical_warp_size();
 
-    float sum[mmq_x*mmq_y / (nwarps*warp_size)] = {0.0f};
+    float sum[mmq_x / nwarps] = {0.0f};
+    const int i = blockIdx.y*warp_size + threadIdx.x;
 
-    const int ntx  = (ncols_max + mmq_x - 1) / mmq_x;
-    const int nty  = (nrows_x   + mmq_y - 1) / mmq_y;
-
+    const int nty = (nrows_x + mmq_y - 1) / mmq_y;
     const int bidx0 = blockIdx.x;
 
     // kbc == k block continuous, current index in continuous ijk space.
-    int64_t kbc0      = (int64_t) bidx0     *nsamples_y*nchannels_y*ntx*nty*blocks_per_ne00 / gridDim.x;
-    int64_t kbc0_stop = (int64_t)(bidx0 + 1)*nsamples_y*nchannels_y*ntx*nty*blocks_per_ne00 / gridDim.x;
+    int kbc0      = int64_t(blockIdx.x)    *(nsamples_y.z*nchannels_y.z*ntx.z*nty*blocks_per_ne00.z) / gridDim.x;
+    int kbc0_stop = int64_t(blockIdx.x + 1)*(nsamples_y.z*nchannels_y.z*ntx.z*nty*blocks_per_ne00.z) / gridDim.x;
 
-    kbc0      -= (kbc0      % blocks_per_ne00) % blocks_per_iter;
-    kbc0_stop -= (kbc0_stop % blocks_per_ne00) % blocks_per_iter;
+    kbc0      -= fastmodulo(kbc0,      blocks_per_ne00) % blocks_per_iter;
+    kbc0_stop -= fastmodulo(kbc0_stop, blocks_per_ne00) % blocks_per_iter;
 
     const bool did_not_have_any_data   = kbc0 == kbc0_stop;
-    const bool wrote_beginning_of_tile = kbc0 % blocks_per_ne00 == 0;
-    const bool did_not_write_last      = kbc0/blocks_per_ne00 == kbc0_stop/blocks_per_ne00 && kbc0_stop % blocks_per_ne00 != 0;
+    const bool wrote_beginning_of_tile = fastmodulo(kbc0, blocks_per_ne00) == 0;
+    const bool did_not_write_last      = fastdiv(kbc0, blocks_per_ne00) == fastdiv(kbc0_stop, blocks_per_ne00) && fastmodulo(kbc0_stop, blocks_per_ne00) != 0;
     if (did_not_have_any_data || wrote_beginning_of_tile || did_not_write_last) {
         return;
     }
@@ -3825,13 +3818,13 @@ static __global__ void mul_mat_q_stream_k_fixup(const int32_t * ids_dst,
 
     // Iterate over previous blocks and sum up partial sums written to fixup buffer.
     // All CUDA blocks that get here must have a previous block that needs a fixup.
-    int64_t bidx = bidx0 - 1;
-    int64_t kbc_stop = kbc0;
-    while(true) {
-        int64_t kbc = bidx*nsamples_y*nchannels_y*ntx*nty*blocks_per_ne00 / gridDim.x;
-        kbc -= (kbc % blocks_per_ne00) % blocks_per_iter;
+    int bidx = bidx0 - 1;
+    int kbc_stop = kbc0;
+    while (true) {
+        int kbc = int64_t(bidx)*(nsamples_y.z*nchannels_y.z*ntx.z*nty*blocks_per_ne00.z) / gridDim.x;
+        kbc -= fastmodulo(kbc, blocks_per_ne00) % blocks_per_iter;
 
-        if (kbc == kbc_stop) { // Did not have any data.
+        if (kbc == kbc_stop) {
             bidx--;
             kbc_stop = kbc;
             continue;
@@ -3843,16 +3836,10 @@ static __global__ void mul_mat_q_stream_k_fixup(const int32_t * ids_dst,
         for (int j0 = 0; j0 < mmq_x; j0 += nwarps) {
             const int j = j0 + threadIdx.y;
 
-#pragma unroll
-            for (int i0 = 0; i0 < mmq_y; i0 += warp_size) {
-                const int i = i0 + threadIdx.x;
-
-                sum[(j0/nwarps) * (mmq_y/warp_size) + i0/warp_size] += tmp_last_tile[bidx*(mmq_x*mmq_y) + j*mmq_y + i];
-            }
+            sum[j0/nwarps] += tmp_last_tile[bidx*(mmq_x*mmq_y) + j*mmq_y + i];
         }
 
-        // If this block started in a previous tile we are done and don't need to combine additional partial results.
-        if (kbc % blocks_per_ne00 == 0 || kbc/blocks_per_ne00 < kbc0/blocks_per_ne00) {
+        if (fastmodulo(kbc, blocks_per_ne00) == 0 || fastdiv(kbc, blocks_per_ne00) < fastdiv(kbc0, blocks_per_ne00)) {
             break;
         }
         bidx--;
@@ -3863,14 +3850,16 @@ static __global__ void mul_mat_q_stream_k_fixup(const int32_t * ids_dst,
         return;
     }
 
-    int tmp = kbc0;
-    const int it = tmp / (nsamples_y*nchannels_y*ntx*blocks_per_ne00);
-    tmp -= it * (nsamples_y*nchannels_y*ntx*blocks_per_ne00);
-    const int wt = tmp / (nchannels_y*ntx*blocks_per_ne00);
-    tmp -= wt * (nchannels_y*ntx*blocks_per_ne00);
-    const int zt = tmp / (ntx*blocks_per_ne00);
-    tmp -= zt * (ntx*blocks_per_ne00);
-    const int jt = tmp / blocks_per_ne00;
+    int tmp = fastdiv(kbc0, blocks_per_ne00);
+    uint2 tmp2 = fast_div_modulo(tmp, ntx);
+    const int jt = tmp2.y;
+    tmp = tmp2.x;
+    tmp2 = fast_div_modulo(tmp, nchannels_y);
+    const int zt = tmp2.y;
+    tmp = tmp2.x;
+    tmp2 = fast_div_modulo(tmp, nsamples_y);
+    const int wt = tmp2.y;
+    const int it = tmp2.x;
 
     if (!ids_dst) {
         const int offset_dst = wt*stride_sample_dst + zt*stride_channel_dst + jt*mmq_x*stride_col_dst + it*mmq_y;
@@ -3878,6 +3867,9 @@ static __global__ void mul_mat_q_stream_k_fixup(const int32_t * ids_dst,
 
         const int i_max = nrows_x   - it*mmq_y - 1;
         const int j_max = ncols_dst - jt*mmq_x - 1;
+        if (need_check && i > i_max) {
+            return;
+        }
 
 #pragma unroll
         for (int j0 = 0; j0 < mmq_x; j0 += nwarps) {
@@ -3887,16 +3879,7 @@ static __global__ void mul_mat_q_stream_k_fixup(const int32_t * ids_dst,
                 return;
             }
 
-#pragma unroll
-            for (int i0 = 0; i0 < mmq_y; i0 += warp_size) {
-                const int i = i0 + threadIdx.x;
-
-                if (need_check && i > i_max) {
-                    continue;
-                }
-
-                dst[j*stride_col_dst + i] += sum[(j0/nwarps) * (mmq_y/warp_size) + i0/warp_size];
-            }
+            dst[j*stride_col_dst + i] += sum[j0/nwarps];
         }
         return;
     }
@@ -3916,6 +3899,9 @@ static __global__ void mul_mat_q_stream_k_fixup(const int32_t * ids_dst,
 
     const int i_max = nrows_x  - it*mmq_y - 1;
     const int j_max = col_diff - jt*mmq_x - 1;
+    if (need_check && i > i_max) {
+        return;
+    }
 
 #pragma unroll
     for (int j0 = 0; j0 < mmq_x; j0 += nwarps) {
@@ -3925,16 +3911,7 @@ static __global__ void mul_mat_q_stream_k_fixup(const int32_t * ids_dst,
             return;
         }
 
-#pragma unroll
-        for (int i0 = 0; i0 < mmq_y; i0 += warp_size) {
-            const int i = i0 + threadIdx.x;
-
-            if (need_check && i > i_max) {
-                continue;
-            }
-
-            dst[ids_dst_shared[j]*stride_col_dst + i] += sum[(j0/nwarps) * (mmq_y/warp_size) + i0/warp_size];
-        }
+        dst[ids_dst_shared[j]*stride_col_dst + i] += sum[j0/nwarps];
     }
 }
 

--- a/mistralrs-quant/kernels/mmq_gguf/mmq_instance_q2_k.cu
+++ b/mistralrs-quant/kernels/mmq_gguf/mmq_instance_q2_k.cu
@@ -21,6 +21,14 @@ static void instantiate_mmq_q2_k(float *tmp_fixup, const mmq_args &args,
   const int channel_ratio = args.nchannels_y / args.nchannels_x;
   const int sample_ratio = args.nsamples_y / args.nsamples_x;
 
+  const uint3 blocks_per_ne00_fd = init_fastdiv_values(
+      args.ncols_x / ggml_cuda_type_traits<GGML_TYPE_Q2_K>::qk);
+  const uint3 ntx_fd = init_fastdiv_values(ntx);
+  const uint3 nchannels_y_fd = init_fastdiv_values(args.nchannels_y);
+  const uint3 nsamples_y_fd = init_fastdiv_values(args.nsamples_y);
+  const uint3 channel_ratio_fd = init_fastdiv_values(channel_ratio);
+  const uint3 sample_ratio_fd = init_fastdiv_values(sample_ratio);
+
   CUDA_SET_SHARED_MEMORY_LIMIT((mul_mat_q<GGML_TYPE_Q2_K, mmq_x, false>),
                                nbytes_shared);
   CUDA_SET_SHARED_MEMORY_LIMIT((mul_mat_q<GGML_TYPE_Q2_K, mmq_x, true>),
@@ -32,65 +40,69 @@ static void instantiate_mmq_q2_k(float *tmp_fixup, const mmq_args &args,
       mul_mat_q<GGML_TYPE_Q2_K, mmq_x, false>
           <<<grid, block_dims, nbytes_shared, stream>>>(
               args.x, args.y, args.ids_dst, args.expert_bounds, args.dst,
-              nullptr, args.ncols_x, args.nrows_x, args.ncols_dst,
-              args.stride_row_x, args.ncols_y, args.nrows_dst, channel_ratio,
-              args.nchannels_y, args.stride_channel_x, args.stride_channel_y,
-              args.stride_channel_dst, sample_ratio, args.nsamples_y,
+              nullptr, blocks_per_ne00_fd, args.nrows_x, args.ncols_dst,
+              args.stride_row_x, args.ncols_y, args.nrows_dst, channel_ratio_fd,
+              nchannels_y_fd, args.stride_channel_x, args.stride_channel_y,
+              args.stride_channel_dst, sample_ratio_fd, nsamples_y_fd,
               args.stride_sample_x, args.stride_sample_y,
-              args.stride_sample_dst, args.ncols_max);
+              args.stride_sample_dst, ntx_fd);
     } else {
       mul_mat_q<GGML_TYPE_Q2_K, mmq_x, true>
           <<<grid, block_dims, nbytes_shared, stream>>>(
               args.x, args.y, args.ids_dst, args.expert_bounds, args.dst,
-              nullptr, args.ncols_x, args.nrows_x, args.ncols_dst,
-              args.stride_row_x, args.ncols_y, args.nrows_dst, channel_ratio,
-              args.nchannels_y, args.stride_channel_x, args.stride_channel_y,
-              args.stride_channel_dst, sample_ratio, args.nsamples_y,
+              nullptr, blocks_per_ne00_fd, args.nrows_x, args.ncols_dst,
+              args.stride_row_x, args.ncols_y, args.nrows_dst, channel_ratio_fd,
+              nchannels_y_fd, args.stride_channel_x, args.stride_channel_y,
+              args.stride_channel_dst, sample_ratio_fd, nsamples_y_fd,
               args.stride_sample_x, args.stride_sample_y,
-              args.stride_sample_dst, args.ncols_max);
+              args.stride_sample_dst, ntx_fd);
     }
     return;
   }
 
   // Stream-k
+  const int ntiles_dst = ntx * nty * ntzw;
   const dim3 grid_sk(nsm, 1, 1);
-  const bool fixup_needed = ntx * nty * ntzw % nsm != 0;
+  const bool fixup_needed = ntiles_dst % nsm != 0;
+  GGML_ASSERT(ntiles_dst * blocks_per_ne00_fd.z < (1 << 30));
+  const dim3 block_nums_fixup(grid_sk.x, mmq_y / warp_size_host, 1);
+  const dim3 block_dims_fixup(block_dims.x, block_dims.y / 2, block_dims.z);
 
   if (args.nrows_x % mmq_y == 0) {
     mul_mat_q<GGML_TYPE_Q2_K, mmq_x, false>
         <<<grid_sk, block_dims, nbytes_shared, stream>>>(
             args.x, args.y, args.ids_dst, args.expert_bounds, args.dst,
-            tmp_fixup, args.ncols_x, args.nrows_x, args.ncols_dst,
-            args.stride_row_x, args.ncols_y, args.nrows_dst, channel_ratio,
-            args.nchannels_y, args.stride_channel_x, args.stride_channel_y,
-            args.stride_channel_dst, sample_ratio, args.nsamples_y,
+            tmp_fixup, blocks_per_ne00_fd, args.nrows_x, args.ncols_dst,
+            args.stride_row_x, args.ncols_y, args.nrows_dst, channel_ratio_fd,
+            nchannels_y_fd, args.stride_channel_x, args.stride_channel_y,
+            args.stride_channel_dst, sample_ratio_fd, nsamples_y_fd,
             args.stride_sample_x, args.stride_sample_y, args.stride_sample_dst,
-            args.ncols_max);
+            ntx_fd);
     if (fixup_needed) {
       mul_mat_q_stream_k_fixup<GGML_TYPE_Q2_K, mmq_x, false>
-          <<<grid_sk, block_dims, 0, stream>>>(
+          <<<block_nums_fixup, block_dims_fixup, 0, stream>>>(
               args.ids_dst, args.expert_bounds, args.dst, tmp_fixup,
-              args.ncols_x, args.nrows_x, args.ncols_dst, args.nrows_dst,
-              args.nchannels_y, args.stride_channel_dst, args.nsamples_y,
-              args.stride_sample_dst, args.ncols_max);
+              blocks_per_ne00_fd, args.nrows_x, args.ncols_dst, args.nrows_dst,
+              nchannels_y_fd, args.stride_channel_dst, nsamples_y_fd,
+              args.stride_sample_dst, ntx_fd);
     }
   } else {
     mul_mat_q<GGML_TYPE_Q2_K, mmq_x, true>
         <<<grid_sk, block_dims, nbytes_shared, stream>>>(
             args.x, args.y, args.ids_dst, args.expert_bounds, args.dst,
-            tmp_fixup, args.ncols_x, args.nrows_x, args.ncols_dst,
-            args.stride_row_x, args.ncols_y, args.nrows_dst, channel_ratio,
-            args.nchannels_y, args.stride_channel_x, args.stride_channel_y,
-            args.stride_channel_dst, sample_ratio, args.nsamples_y,
+            tmp_fixup, blocks_per_ne00_fd, args.nrows_x, args.ncols_dst,
+            args.stride_row_x, args.ncols_y, args.nrows_dst, channel_ratio_fd,
+            nchannels_y_fd, args.stride_channel_x, args.stride_channel_y,
+            args.stride_channel_dst, sample_ratio_fd, nsamples_y_fd,
             args.stride_sample_x, args.stride_sample_y, args.stride_sample_dst,
-            args.ncols_max);
+            ntx_fd);
     if (fixup_needed) {
       mul_mat_q_stream_k_fixup<GGML_TYPE_Q2_K, mmq_x, true>
-          <<<grid_sk, block_dims, 0, stream>>>(
+          <<<block_nums_fixup, block_dims_fixup, 0, stream>>>(
               args.ids_dst, args.expert_bounds, args.dst, tmp_fixup,
-              args.ncols_x, args.nrows_x, args.ncols_dst, args.nrows_dst,
-              args.nchannels_y, args.stride_channel_dst, args.nsamples_y,
-              args.stride_sample_dst, args.ncols_max);
+              blocks_per_ne00_fd, args.nrows_x, args.ncols_dst, args.nrows_dst,
+              nchannels_y_fd, args.stride_channel_dst, nsamples_y_fd,
+              args.stride_sample_dst, ntx_fd);
     }
   }
 }

--- a/mistralrs-quant/kernels/mmq_gguf/mmq_instance_q3_k.cu
+++ b/mistralrs-quant/kernels/mmq_gguf/mmq_instance_q3_k.cu
@@ -21,6 +21,14 @@ static void instantiate_mmq_q3_k(float *tmp_fixup, const mmq_args &args,
   const int channel_ratio = args.nchannels_y / args.nchannels_x;
   const int sample_ratio = args.nsamples_y / args.nsamples_x;
 
+  const uint3 blocks_per_ne00_fd = init_fastdiv_values(
+      args.ncols_x / ggml_cuda_type_traits<GGML_TYPE_Q3_K>::qk);
+  const uint3 ntx_fd = init_fastdiv_values(ntx);
+  const uint3 nchannels_y_fd = init_fastdiv_values(args.nchannels_y);
+  const uint3 nsamples_y_fd = init_fastdiv_values(args.nsamples_y);
+  const uint3 channel_ratio_fd = init_fastdiv_values(channel_ratio);
+  const uint3 sample_ratio_fd = init_fastdiv_values(sample_ratio);
+
   CUDA_SET_SHARED_MEMORY_LIMIT((mul_mat_q<GGML_TYPE_Q3_K, mmq_x, false>),
                                nbytes_shared);
   CUDA_SET_SHARED_MEMORY_LIMIT((mul_mat_q<GGML_TYPE_Q3_K, mmq_x, true>),
@@ -32,65 +40,69 @@ static void instantiate_mmq_q3_k(float *tmp_fixup, const mmq_args &args,
       mul_mat_q<GGML_TYPE_Q3_K, mmq_x, false>
           <<<grid, block_dims, nbytes_shared, stream>>>(
               args.x, args.y, args.ids_dst, args.expert_bounds, args.dst,
-              nullptr, args.ncols_x, args.nrows_x, args.ncols_dst,
-              args.stride_row_x, args.ncols_y, args.nrows_dst, channel_ratio,
-              args.nchannels_y, args.stride_channel_x, args.stride_channel_y,
-              args.stride_channel_dst, sample_ratio, args.nsamples_y,
+              nullptr, blocks_per_ne00_fd, args.nrows_x, args.ncols_dst,
+              args.stride_row_x, args.ncols_y, args.nrows_dst, channel_ratio_fd,
+              nchannels_y_fd, args.stride_channel_x, args.stride_channel_y,
+              args.stride_channel_dst, sample_ratio_fd, nsamples_y_fd,
               args.stride_sample_x, args.stride_sample_y,
-              args.stride_sample_dst, args.ncols_max);
+              args.stride_sample_dst, ntx_fd);
     } else {
       mul_mat_q<GGML_TYPE_Q3_K, mmq_x, true>
           <<<grid, block_dims, nbytes_shared, stream>>>(
               args.x, args.y, args.ids_dst, args.expert_bounds, args.dst,
-              nullptr, args.ncols_x, args.nrows_x, args.ncols_dst,
-              args.stride_row_x, args.ncols_y, args.nrows_dst, channel_ratio,
-              args.nchannels_y, args.stride_channel_x, args.stride_channel_y,
-              args.stride_channel_dst, sample_ratio, args.nsamples_y,
+              nullptr, blocks_per_ne00_fd, args.nrows_x, args.ncols_dst,
+              args.stride_row_x, args.ncols_y, args.nrows_dst, channel_ratio_fd,
+              nchannels_y_fd, args.stride_channel_x, args.stride_channel_y,
+              args.stride_channel_dst, sample_ratio_fd, nsamples_y_fd,
               args.stride_sample_x, args.stride_sample_y,
-              args.stride_sample_dst, args.ncols_max);
+              args.stride_sample_dst, ntx_fd);
     }
     return;
   }
 
   // Stream-k
+  const int ntiles_dst = ntx * nty * ntzw;
   const dim3 grid_sk(nsm, 1, 1);
-  const bool fixup_needed = ntx * nty * ntzw % nsm != 0;
+  const bool fixup_needed = ntiles_dst % nsm != 0;
+  GGML_ASSERT(ntiles_dst * blocks_per_ne00_fd.z < (1 << 30));
+  const dim3 block_nums_fixup(grid_sk.x, mmq_y / warp_size_host, 1);
+  const dim3 block_dims_fixup(block_dims.x, block_dims.y / 2, block_dims.z);
 
   if (args.nrows_x % mmq_y == 0) {
     mul_mat_q<GGML_TYPE_Q3_K, mmq_x, false>
         <<<grid_sk, block_dims, nbytes_shared, stream>>>(
             args.x, args.y, args.ids_dst, args.expert_bounds, args.dst,
-            tmp_fixup, args.ncols_x, args.nrows_x, args.ncols_dst,
-            args.stride_row_x, args.ncols_y, args.nrows_dst, channel_ratio,
-            args.nchannels_y, args.stride_channel_x, args.stride_channel_y,
-            args.stride_channel_dst, sample_ratio, args.nsamples_y,
+            tmp_fixup, blocks_per_ne00_fd, args.nrows_x, args.ncols_dst,
+            args.stride_row_x, args.ncols_y, args.nrows_dst, channel_ratio_fd,
+            nchannels_y_fd, args.stride_channel_x, args.stride_channel_y,
+            args.stride_channel_dst, sample_ratio_fd, nsamples_y_fd,
             args.stride_sample_x, args.stride_sample_y, args.stride_sample_dst,
-            args.ncols_max);
+            ntx_fd);
     if (fixup_needed) {
       mul_mat_q_stream_k_fixup<GGML_TYPE_Q3_K, mmq_x, false>
-          <<<grid_sk, block_dims, 0, stream>>>(
+          <<<block_nums_fixup, block_dims_fixup, 0, stream>>>(
               args.ids_dst, args.expert_bounds, args.dst, tmp_fixup,
-              args.ncols_x, args.nrows_x, args.ncols_dst, args.nrows_dst,
-              args.nchannels_y, args.stride_channel_dst, args.nsamples_y,
-              args.stride_sample_dst, args.ncols_max);
+              blocks_per_ne00_fd, args.nrows_x, args.ncols_dst, args.nrows_dst,
+              nchannels_y_fd, args.stride_channel_dst, nsamples_y_fd,
+              args.stride_sample_dst, ntx_fd);
     }
   } else {
     mul_mat_q<GGML_TYPE_Q3_K, mmq_x, true>
         <<<grid_sk, block_dims, nbytes_shared, stream>>>(
             args.x, args.y, args.ids_dst, args.expert_bounds, args.dst,
-            tmp_fixup, args.ncols_x, args.nrows_x, args.ncols_dst,
-            args.stride_row_x, args.ncols_y, args.nrows_dst, channel_ratio,
-            args.nchannels_y, args.stride_channel_x, args.stride_channel_y,
-            args.stride_channel_dst, sample_ratio, args.nsamples_y,
+            tmp_fixup, blocks_per_ne00_fd, args.nrows_x, args.ncols_dst,
+            args.stride_row_x, args.ncols_y, args.nrows_dst, channel_ratio_fd,
+            nchannels_y_fd, args.stride_channel_x, args.stride_channel_y,
+            args.stride_channel_dst, sample_ratio_fd, nsamples_y_fd,
             args.stride_sample_x, args.stride_sample_y, args.stride_sample_dst,
-            args.ncols_max);
+            ntx_fd);
     if (fixup_needed) {
       mul_mat_q_stream_k_fixup<GGML_TYPE_Q3_K, mmq_x, true>
-          <<<grid_sk, block_dims, 0, stream>>>(
+          <<<block_nums_fixup, block_dims_fixup, 0, stream>>>(
               args.ids_dst, args.expert_bounds, args.dst, tmp_fixup,
-              args.ncols_x, args.nrows_x, args.ncols_dst, args.nrows_dst,
-              args.nchannels_y, args.stride_channel_dst, args.nsamples_y,
-              args.stride_sample_dst, args.ncols_max);
+              blocks_per_ne00_fd, args.nrows_x, args.ncols_dst, args.nrows_dst,
+              nchannels_y_fd, args.stride_channel_dst, nsamples_y_fd,
+              args.stride_sample_dst, ntx_fd);
     }
   }
 }

--- a/mistralrs-quant/kernels/mmq_gguf/mmq_instance_q4_0.cu
+++ b/mistralrs-quant/kernels/mmq_gguf/mmq_instance_q4_0.cu
@@ -21,6 +21,14 @@ static void instantiate_mmq_q4_0(float *tmp_fixup, const mmq_args &args,
   const int channel_ratio = args.nchannels_y / args.nchannels_x;
   const int sample_ratio = args.nsamples_y / args.nsamples_x;
 
+  const uint3 blocks_per_ne00_fd = init_fastdiv_values(
+      args.ncols_x / ggml_cuda_type_traits<GGML_TYPE_Q4_0>::qk);
+  const uint3 ntx_fd = init_fastdiv_values(ntx);
+  const uint3 nchannels_y_fd = init_fastdiv_values(args.nchannels_y);
+  const uint3 nsamples_y_fd = init_fastdiv_values(args.nsamples_y);
+  const uint3 channel_ratio_fd = init_fastdiv_values(channel_ratio);
+  const uint3 sample_ratio_fd = init_fastdiv_values(sample_ratio);
+
   CUDA_SET_SHARED_MEMORY_LIMIT((mul_mat_q<GGML_TYPE_Q4_0, mmq_x, false>),
                                nbytes_shared);
   CUDA_SET_SHARED_MEMORY_LIMIT((mul_mat_q<GGML_TYPE_Q4_0, mmq_x, true>),
@@ -32,65 +40,69 @@ static void instantiate_mmq_q4_0(float *tmp_fixup, const mmq_args &args,
       mul_mat_q<GGML_TYPE_Q4_0, mmq_x, false>
           <<<grid, block_dims, nbytes_shared, stream>>>(
               args.x, args.y, args.ids_dst, args.expert_bounds, args.dst,
-              nullptr, args.ncols_x, args.nrows_x, args.ncols_dst,
-              args.stride_row_x, args.ncols_y, args.nrows_dst, channel_ratio,
-              args.nchannels_y, args.stride_channel_x, args.stride_channel_y,
-              args.stride_channel_dst, sample_ratio, args.nsamples_y,
+              nullptr, blocks_per_ne00_fd, args.nrows_x, args.ncols_dst,
+              args.stride_row_x, args.ncols_y, args.nrows_dst, channel_ratio_fd,
+              nchannels_y_fd, args.stride_channel_x, args.stride_channel_y,
+              args.stride_channel_dst, sample_ratio_fd, nsamples_y_fd,
               args.stride_sample_x, args.stride_sample_y,
-              args.stride_sample_dst, args.ncols_max);
+              args.stride_sample_dst, ntx_fd);
     } else {
       mul_mat_q<GGML_TYPE_Q4_0, mmq_x, true>
           <<<grid, block_dims, nbytes_shared, stream>>>(
               args.x, args.y, args.ids_dst, args.expert_bounds, args.dst,
-              nullptr, args.ncols_x, args.nrows_x, args.ncols_dst,
-              args.stride_row_x, args.ncols_y, args.nrows_dst, channel_ratio,
-              args.nchannels_y, args.stride_channel_x, args.stride_channel_y,
-              args.stride_channel_dst, sample_ratio, args.nsamples_y,
+              nullptr, blocks_per_ne00_fd, args.nrows_x, args.ncols_dst,
+              args.stride_row_x, args.ncols_y, args.nrows_dst, channel_ratio_fd,
+              nchannels_y_fd, args.stride_channel_x, args.stride_channel_y,
+              args.stride_channel_dst, sample_ratio_fd, nsamples_y_fd,
               args.stride_sample_x, args.stride_sample_y,
-              args.stride_sample_dst, args.ncols_max);
+              args.stride_sample_dst, ntx_fd);
     }
     return;
   }
 
   // Stream-k
+  const int ntiles_dst = ntx * nty * ntzw;
   const dim3 grid_sk(nsm, 1, 1);
-  const bool fixup_needed = ntx * nty * ntzw % nsm != 0;
+  const bool fixup_needed = ntiles_dst % nsm != 0;
+  GGML_ASSERT(ntiles_dst * blocks_per_ne00_fd.z < (1 << 30));
+  const dim3 block_nums_fixup(grid_sk.x, mmq_y / warp_size_host, 1);
+  const dim3 block_dims_fixup(block_dims.x, block_dims.y / 2, block_dims.z);
 
   if (args.nrows_x % mmq_y == 0) {
     mul_mat_q<GGML_TYPE_Q4_0, mmq_x, false>
         <<<grid_sk, block_dims, nbytes_shared, stream>>>(
             args.x, args.y, args.ids_dst, args.expert_bounds, args.dst,
-            tmp_fixup, args.ncols_x, args.nrows_x, args.ncols_dst,
-            args.stride_row_x, args.ncols_y, args.nrows_dst, channel_ratio,
-            args.nchannels_y, args.stride_channel_x, args.stride_channel_y,
-            args.stride_channel_dst, sample_ratio, args.nsamples_y,
+            tmp_fixup, blocks_per_ne00_fd, args.nrows_x, args.ncols_dst,
+            args.stride_row_x, args.ncols_y, args.nrows_dst, channel_ratio_fd,
+            nchannels_y_fd, args.stride_channel_x, args.stride_channel_y,
+            args.stride_channel_dst, sample_ratio_fd, nsamples_y_fd,
             args.stride_sample_x, args.stride_sample_y, args.stride_sample_dst,
-            args.ncols_max);
+            ntx_fd);
     if (fixup_needed) {
       mul_mat_q_stream_k_fixup<GGML_TYPE_Q4_0, mmq_x, false>
-          <<<grid_sk, block_dims, 0, stream>>>(
+          <<<block_nums_fixup, block_dims_fixup, 0, stream>>>(
               args.ids_dst, args.expert_bounds, args.dst, tmp_fixup,
-              args.ncols_x, args.nrows_x, args.ncols_dst, args.nrows_dst,
-              args.nchannels_y, args.stride_channel_dst, args.nsamples_y,
-              args.stride_sample_dst, args.ncols_max);
+              blocks_per_ne00_fd, args.nrows_x, args.ncols_dst, args.nrows_dst,
+              nchannels_y_fd, args.stride_channel_dst, nsamples_y_fd,
+              args.stride_sample_dst, ntx_fd);
     }
   } else {
     mul_mat_q<GGML_TYPE_Q4_0, mmq_x, true>
         <<<grid_sk, block_dims, nbytes_shared, stream>>>(
             args.x, args.y, args.ids_dst, args.expert_bounds, args.dst,
-            tmp_fixup, args.ncols_x, args.nrows_x, args.ncols_dst,
-            args.stride_row_x, args.ncols_y, args.nrows_dst, channel_ratio,
-            args.nchannels_y, args.stride_channel_x, args.stride_channel_y,
-            args.stride_channel_dst, sample_ratio, args.nsamples_y,
+            tmp_fixup, blocks_per_ne00_fd, args.nrows_x, args.ncols_dst,
+            args.stride_row_x, args.ncols_y, args.nrows_dst, channel_ratio_fd,
+            nchannels_y_fd, args.stride_channel_x, args.stride_channel_y,
+            args.stride_channel_dst, sample_ratio_fd, nsamples_y_fd,
             args.stride_sample_x, args.stride_sample_y, args.stride_sample_dst,
-            args.ncols_max);
+            ntx_fd);
     if (fixup_needed) {
       mul_mat_q_stream_k_fixup<GGML_TYPE_Q4_0, mmq_x, true>
-          <<<grid_sk, block_dims, 0, stream>>>(
+          <<<block_nums_fixup, block_dims_fixup, 0, stream>>>(
               args.ids_dst, args.expert_bounds, args.dst, tmp_fixup,
-              args.ncols_x, args.nrows_x, args.ncols_dst, args.nrows_dst,
-              args.nchannels_y, args.stride_channel_dst, args.nsamples_y,
-              args.stride_sample_dst, args.ncols_max);
+              blocks_per_ne00_fd, args.nrows_x, args.ncols_dst, args.nrows_dst,
+              nchannels_y_fd, args.stride_channel_dst, nsamples_y_fd,
+              args.stride_sample_dst, ntx_fd);
     }
   }
 }

--- a/mistralrs-quant/kernels/mmq_gguf/mmq_instance_q4_1.cu
+++ b/mistralrs-quant/kernels/mmq_gguf/mmq_instance_q4_1.cu
@@ -21,6 +21,14 @@ static void instantiate_mmq_q4_1(float *tmp_fixup, const mmq_args &args,
   const int channel_ratio = args.nchannels_y / args.nchannels_x;
   const int sample_ratio = args.nsamples_y / args.nsamples_x;
 
+  const uint3 blocks_per_ne00_fd = init_fastdiv_values(
+      args.ncols_x / ggml_cuda_type_traits<GGML_TYPE_Q4_1>::qk);
+  const uint3 ntx_fd = init_fastdiv_values(ntx);
+  const uint3 nchannels_y_fd = init_fastdiv_values(args.nchannels_y);
+  const uint3 nsamples_y_fd = init_fastdiv_values(args.nsamples_y);
+  const uint3 channel_ratio_fd = init_fastdiv_values(channel_ratio);
+  const uint3 sample_ratio_fd = init_fastdiv_values(sample_ratio);
+
   CUDA_SET_SHARED_MEMORY_LIMIT((mul_mat_q<GGML_TYPE_Q4_1, mmq_x, false>),
                                nbytes_shared);
   CUDA_SET_SHARED_MEMORY_LIMIT((mul_mat_q<GGML_TYPE_Q4_1, mmq_x, true>),
@@ -32,65 +40,69 @@ static void instantiate_mmq_q4_1(float *tmp_fixup, const mmq_args &args,
       mul_mat_q<GGML_TYPE_Q4_1, mmq_x, false>
           <<<grid, block_dims, nbytes_shared, stream>>>(
               args.x, args.y, args.ids_dst, args.expert_bounds, args.dst,
-              nullptr, args.ncols_x, args.nrows_x, args.ncols_dst,
-              args.stride_row_x, args.ncols_y, args.nrows_dst, channel_ratio,
-              args.nchannels_y, args.stride_channel_x, args.stride_channel_y,
-              args.stride_channel_dst, sample_ratio, args.nsamples_y,
+              nullptr, blocks_per_ne00_fd, args.nrows_x, args.ncols_dst,
+              args.stride_row_x, args.ncols_y, args.nrows_dst, channel_ratio_fd,
+              nchannels_y_fd, args.stride_channel_x, args.stride_channel_y,
+              args.stride_channel_dst, sample_ratio_fd, nsamples_y_fd,
               args.stride_sample_x, args.stride_sample_y,
-              args.stride_sample_dst, args.ncols_max);
+              args.stride_sample_dst, ntx_fd);
     } else {
       mul_mat_q<GGML_TYPE_Q4_1, mmq_x, true>
           <<<grid, block_dims, nbytes_shared, stream>>>(
               args.x, args.y, args.ids_dst, args.expert_bounds, args.dst,
-              nullptr, args.ncols_x, args.nrows_x, args.ncols_dst,
-              args.stride_row_x, args.ncols_y, args.nrows_dst, channel_ratio,
-              args.nchannels_y, args.stride_channel_x, args.stride_channel_y,
-              args.stride_channel_dst, sample_ratio, args.nsamples_y,
+              nullptr, blocks_per_ne00_fd, args.nrows_x, args.ncols_dst,
+              args.stride_row_x, args.ncols_y, args.nrows_dst, channel_ratio_fd,
+              nchannels_y_fd, args.stride_channel_x, args.stride_channel_y,
+              args.stride_channel_dst, sample_ratio_fd, nsamples_y_fd,
               args.stride_sample_x, args.stride_sample_y,
-              args.stride_sample_dst, args.ncols_max);
+              args.stride_sample_dst, ntx_fd);
     }
     return;
   }
 
   // Stream-k
+  const int ntiles_dst = ntx * nty * ntzw;
   const dim3 grid_sk(nsm, 1, 1);
-  const bool fixup_needed = ntx * nty * ntzw % nsm != 0;
+  const bool fixup_needed = ntiles_dst % nsm != 0;
+  GGML_ASSERT(ntiles_dst * blocks_per_ne00_fd.z < (1 << 30));
+  const dim3 block_nums_fixup(grid_sk.x, mmq_y / warp_size_host, 1);
+  const dim3 block_dims_fixup(block_dims.x, block_dims.y / 2, block_dims.z);
 
   if (args.nrows_x % mmq_y == 0) {
     mul_mat_q<GGML_TYPE_Q4_1, mmq_x, false>
         <<<grid_sk, block_dims, nbytes_shared, stream>>>(
             args.x, args.y, args.ids_dst, args.expert_bounds, args.dst,
-            tmp_fixup, args.ncols_x, args.nrows_x, args.ncols_dst,
-            args.stride_row_x, args.ncols_y, args.nrows_dst, channel_ratio,
-            args.nchannels_y, args.stride_channel_x, args.stride_channel_y,
-            args.stride_channel_dst, sample_ratio, args.nsamples_y,
+            tmp_fixup, blocks_per_ne00_fd, args.nrows_x, args.ncols_dst,
+            args.stride_row_x, args.ncols_y, args.nrows_dst, channel_ratio_fd,
+            nchannels_y_fd, args.stride_channel_x, args.stride_channel_y,
+            args.stride_channel_dst, sample_ratio_fd, nsamples_y_fd,
             args.stride_sample_x, args.stride_sample_y, args.stride_sample_dst,
-            args.ncols_max);
+            ntx_fd);
     if (fixup_needed) {
       mul_mat_q_stream_k_fixup<GGML_TYPE_Q4_1, mmq_x, false>
-          <<<grid_sk, block_dims, 0, stream>>>(
+          <<<block_nums_fixup, block_dims_fixup, 0, stream>>>(
               args.ids_dst, args.expert_bounds, args.dst, tmp_fixup,
-              args.ncols_x, args.nrows_x, args.ncols_dst, args.nrows_dst,
-              args.nchannels_y, args.stride_channel_dst, args.nsamples_y,
-              args.stride_sample_dst, args.ncols_max);
+              blocks_per_ne00_fd, args.nrows_x, args.ncols_dst, args.nrows_dst,
+              nchannels_y_fd, args.stride_channel_dst, nsamples_y_fd,
+              args.stride_sample_dst, ntx_fd);
     }
   } else {
     mul_mat_q<GGML_TYPE_Q4_1, mmq_x, true>
         <<<grid_sk, block_dims, nbytes_shared, stream>>>(
             args.x, args.y, args.ids_dst, args.expert_bounds, args.dst,
-            tmp_fixup, args.ncols_x, args.nrows_x, args.ncols_dst,
-            args.stride_row_x, args.ncols_y, args.nrows_dst, channel_ratio,
-            args.nchannels_y, args.stride_channel_x, args.stride_channel_y,
-            args.stride_channel_dst, sample_ratio, args.nsamples_y,
+            tmp_fixup, blocks_per_ne00_fd, args.nrows_x, args.ncols_dst,
+            args.stride_row_x, args.ncols_y, args.nrows_dst, channel_ratio_fd,
+            nchannels_y_fd, args.stride_channel_x, args.stride_channel_y,
+            args.stride_channel_dst, sample_ratio_fd, nsamples_y_fd,
             args.stride_sample_x, args.stride_sample_y, args.stride_sample_dst,
-            args.ncols_max);
+            ntx_fd);
     if (fixup_needed) {
       mul_mat_q_stream_k_fixup<GGML_TYPE_Q4_1, mmq_x, true>
-          <<<grid_sk, block_dims, 0, stream>>>(
+          <<<block_nums_fixup, block_dims_fixup, 0, stream>>>(
               args.ids_dst, args.expert_bounds, args.dst, tmp_fixup,
-              args.ncols_x, args.nrows_x, args.ncols_dst, args.nrows_dst,
-              args.nchannels_y, args.stride_channel_dst, args.nsamples_y,
-              args.stride_sample_dst, args.ncols_max);
+              blocks_per_ne00_fd, args.nrows_x, args.ncols_dst, args.nrows_dst,
+              nchannels_y_fd, args.stride_channel_dst, nsamples_y_fd,
+              args.stride_sample_dst, ntx_fd);
     }
   }
 }

--- a/mistralrs-quant/kernels/mmq_gguf/mmq_instance_q4_k.cu
+++ b/mistralrs-quant/kernels/mmq_gguf/mmq_instance_q4_k.cu
@@ -21,6 +21,14 @@ static void instantiate_mmq_q4_k(float *tmp_fixup, const mmq_args &args,
   const int channel_ratio = args.nchannels_y / args.nchannels_x;
   const int sample_ratio = args.nsamples_y / args.nsamples_x;
 
+  const uint3 blocks_per_ne00_fd = init_fastdiv_values(
+      args.ncols_x / ggml_cuda_type_traits<GGML_TYPE_Q4_K>::qk);
+  const uint3 ntx_fd = init_fastdiv_values(ntx);
+  const uint3 nchannels_y_fd = init_fastdiv_values(args.nchannels_y);
+  const uint3 nsamples_y_fd = init_fastdiv_values(args.nsamples_y);
+  const uint3 channel_ratio_fd = init_fastdiv_values(channel_ratio);
+  const uint3 sample_ratio_fd = init_fastdiv_values(sample_ratio);
+
   CUDA_SET_SHARED_MEMORY_LIMIT((mul_mat_q<GGML_TYPE_Q4_K, mmq_x, false>),
                                nbytes_shared);
   CUDA_SET_SHARED_MEMORY_LIMIT((mul_mat_q<GGML_TYPE_Q4_K, mmq_x, true>),
@@ -32,65 +40,69 @@ static void instantiate_mmq_q4_k(float *tmp_fixup, const mmq_args &args,
       mul_mat_q<GGML_TYPE_Q4_K, mmq_x, false>
           <<<grid, block_dims, nbytes_shared, stream>>>(
               args.x, args.y, args.ids_dst, args.expert_bounds, args.dst,
-              nullptr, args.ncols_x, args.nrows_x, args.ncols_dst,
-              args.stride_row_x, args.ncols_y, args.nrows_dst, channel_ratio,
-              args.nchannels_y, args.stride_channel_x, args.stride_channel_y,
-              args.stride_channel_dst, sample_ratio, args.nsamples_y,
+              nullptr, blocks_per_ne00_fd, args.nrows_x, args.ncols_dst,
+              args.stride_row_x, args.ncols_y, args.nrows_dst, channel_ratio_fd,
+              nchannels_y_fd, args.stride_channel_x, args.stride_channel_y,
+              args.stride_channel_dst, sample_ratio_fd, nsamples_y_fd,
               args.stride_sample_x, args.stride_sample_y,
-              args.stride_sample_dst, args.ncols_max);
+              args.stride_sample_dst, ntx_fd);
     } else {
       mul_mat_q<GGML_TYPE_Q4_K, mmq_x, true>
           <<<grid, block_dims, nbytes_shared, stream>>>(
               args.x, args.y, args.ids_dst, args.expert_bounds, args.dst,
-              nullptr, args.ncols_x, args.nrows_x, args.ncols_dst,
-              args.stride_row_x, args.ncols_y, args.nrows_dst, channel_ratio,
-              args.nchannels_y, args.stride_channel_x, args.stride_channel_y,
-              args.stride_channel_dst, sample_ratio, args.nsamples_y,
+              nullptr, blocks_per_ne00_fd, args.nrows_x, args.ncols_dst,
+              args.stride_row_x, args.ncols_y, args.nrows_dst, channel_ratio_fd,
+              nchannels_y_fd, args.stride_channel_x, args.stride_channel_y,
+              args.stride_channel_dst, sample_ratio_fd, nsamples_y_fd,
               args.stride_sample_x, args.stride_sample_y,
-              args.stride_sample_dst, args.ncols_max);
+              args.stride_sample_dst, ntx_fd);
     }
     return;
   }
 
   // Stream-k
+  const int ntiles_dst = ntx * nty * ntzw;
   const dim3 grid_sk(nsm, 1, 1);
-  const bool fixup_needed = ntx * nty * ntzw % nsm != 0;
+  const bool fixup_needed = ntiles_dst % nsm != 0;
+  GGML_ASSERT(ntiles_dst * blocks_per_ne00_fd.z < (1 << 30));
+  const dim3 block_nums_fixup(grid_sk.x, mmq_y / warp_size_host, 1);
+  const dim3 block_dims_fixup(block_dims.x, block_dims.y / 2, block_dims.z);
 
   if (args.nrows_x % mmq_y == 0) {
     mul_mat_q<GGML_TYPE_Q4_K, mmq_x, false>
         <<<grid_sk, block_dims, nbytes_shared, stream>>>(
             args.x, args.y, args.ids_dst, args.expert_bounds, args.dst,
-            tmp_fixup, args.ncols_x, args.nrows_x, args.ncols_dst,
-            args.stride_row_x, args.ncols_y, args.nrows_dst, channel_ratio,
-            args.nchannels_y, args.stride_channel_x, args.stride_channel_y,
-            args.stride_channel_dst, sample_ratio, args.nsamples_y,
+            tmp_fixup, blocks_per_ne00_fd, args.nrows_x, args.ncols_dst,
+            args.stride_row_x, args.ncols_y, args.nrows_dst, channel_ratio_fd,
+            nchannels_y_fd, args.stride_channel_x, args.stride_channel_y,
+            args.stride_channel_dst, sample_ratio_fd, nsamples_y_fd,
             args.stride_sample_x, args.stride_sample_y, args.stride_sample_dst,
-            args.ncols_max);
+            ntx_fd);
     if (fixup_needed) {
       mul_mat_q_stream_k_fixup<GGML_TYPE_Q4_K, mmq_x, false>
-          <<<grid_sk, block_dims, 0, stream>>>(
+          <<<block_nums_fixup, block_dims_fixup, 0, stream>>>(
               args.ids_dst, args.expert_bounds, args.dst, tmp_fixup,
-              args.ncols_x, args.nrows_x, args.ncols_dst, args.nrows_dst,
-              args.nchannels_y, args.stride_channel_dst, args.nsamples_y,
-              args.stride_sample_dst, args.ncols_max);
+              blocks_per_ne00_fd, args.nrows_x, args.ncols_dst, args.nrows_dst,
+              nchannels_y_fd, args.stride_channel_dst, nsamples_y_fd,
+              args.stride_sample_dst, ntx_fd);
     }
   } else {
     mul_mat_q<GGML_TYPE_Q4_K, mmq_x, true>
         <<<grid_sk, block_dims, nbytes_shared, stream>>>(
             args.x, args.y, args.ids_dst, args.expert_bounds, args.dst,
-            tmp_fixup, args.ncols_x, args.nrows_x, args.ncols_dst,
-            args.stride_row_x, args.ncols_y, args.nrows_dst, channel_ratio,
-            args.nchannels_y, args.stride_channel_x, args.stride_channel_y,
-            args.stride_channel_dst, sample_ratio, args.nsamples_y,
+            tmp_fixup, blocks_per_ne00_fd, args.nrows_x, args.ncols_dst,
+            args.stride_row_x, args.ncols_y, args.nrows_dst, channel_ratio_fd,
+            nchannels_y_fd, args.stride_channel_x, args.stride_channel_y,
+            args.stride_channel_dst, sample_ratio_fd, nsamples_y_fd,
             args.stride_sample_x, args.stride_sample_y, args.stride_sample_dst,
-            args.ncols_max);
+            ntx_fd);
     if (fixup_needed) {
       mul_mat_q_stream_k_fixup<GGML_TYPE_Q4_K, mmq_x, true>
-          <<<grid_sk, block_dims, 0, stream>>>(
+          <<<block_nums_fixup, block_dims_fixup, 0, stream>>>(
               args.ids_dst, args.expert_bounds, args.dst, tmp_fixup,
-              args.ncols_x, args.nrows_x, args.ncols_dst, args.nrows_dst,
-              args.nchannels_y, args.stride_channel_dst, args.nsamples_y,
-              args.stride_sample_dst, args.ncols_max);
+              blocks_per_ne00_fd, args.nrows_x, args.ncols_dst, args.nrows_dst,
+              nchannels_y_fd, args.stride_channel_dst, nsamples_y_fd,
+              args.stride_sample_dst, ntx_fd);
     }
   }
 }

--- a/mistralrs-quant/kernels/mmq_gguf/mmq_instance_q5_0.cu
+++ b/mistralrs-quant/kernels/mmq_gguf/mmq_instance_q5_0.cu
@@ -21,6 +21,14 @@ static void instantiate_mmq_q5_0(float *tmp_fixup, const mmq_args &args,
   const int channel_ratio = args.nchannels_y / args.nchannels_x;
   const int sample_ratio = args.nsamples_y / args.nsamples_x;
 
+  const uint3 blocks_per_ne00_fd = init_fastdiv_values(
+      args.ncols_x / ggml_cuda_type_traits<GGML_TYPE_Q5_0>::qk);
+  const uint3 ntx_fd = init_fastdiv_values(ntx);
+  const uint3 nchannels_y_fd = init_fastdiv_values(args.nchannels_y);
+  const uint3 nsamples_y_fd = init_fastdiv_values(args.nsamples_y);
+  const uint3 channel_ratio_fd = init_fastdiv_values(channel_ratio);
+  const uint3 sample_ratio_fd = init_fastdiv_values(sample_ratio);
+
   CUDA_SET_SHARED_MEMORY_LIMIT((mul_mat_q<GGML_TYPE_Q5_0, mmq_x, false>),
                                nbytes_shared);
   CUDA_SET_SHARED_MEMORY_LIMIT((mul_mat_q<GGML_TYPE_Q5_0, mmq_x, true>),
@@ -32,65 +40,69 @@ static void instantiate_mmq_q5_0(float *tmp_fixup, const mmq_args &args,
       mul_mat_q<GGML_TYPE_Q5_0, mmq_x, false>
           <<<grid, block_dims, nbytes_shared, stream>>>(
               args.x, args.y, args.ids_dst, args.expert_bounds, args.dst,
-              nullptr, args.ncols_x, args.nrows_x, args.ncols_dst,
-              args.stride_row_x, args.ncols_y, args.nrows_dst, channel_ratio,
-              args.nchannels_y, args.stride_channel_x, args.stride_channel_y,
-              args.stride_channel_dst, sample_ratio, args.nsamples_y,
+              nullptr, blocks_per_ne00_fd, args.nrows_x, args.ncols_dst,
+              args.stride_row_x, args.ncols_y, args.nrows_dst, channel_ratio_fd,
+              nchannels_y_fd, args.stride_channel_x, args.stride_channel_y,
+              args.stride_channel_dst, sample_ratio_fd, nsamples_y_fd,
               args.stride_sample_x, args.stride_sample_y,
-              args.stride_sample_dst, args.ncols_max);
+              args.stride_sample_dst, ntx_fd);
     } else {
       mul_mat_q<GGML_TYPE_Q5_0, mmq_x, true>
           <<<grid, block_dims, nbytes_shared, stream>>>(
               args.x, args.y, args.ids_dst, args.expert_bounds, args.dst,
-              nullptr, args.ncols_x, args.nrows_x, args.ncols_dst,
-              args.stride_row_x, args.ncols_y, args.nrows_dst, channel_ratio,
-              args.nchannels_y, args.stride_channel_x, args.stride_channel_y,
-              args.stride_channel_dst, sample_ratio, args.nsamples_y,
+              nullptr, blocks_per_ne00_fd, args.nrows_x, args.ncols_dst,
+              args.stride_row_x, args.ncols_y, args.nrows_dst, channel_ratio_fd,
+              nchannels_y_fd, args.stride_channel_x, args.stride_channel_y,
+              args.stride_channel_dst, sample_ratio_fd, nsamples_y_fd,
               args.stride_sample_x, args.stride_sample_y,
-              args.stride_sample_dst, args.ncols_max);
+              args.stride_sample_dst, ntx_fd);
     }
     return;
   }
 
   // Stream-k
+  const int ntiles_dst = ntx * nty * ntzw;
   const dim3 grid_sk(nsm, 1, 1);
-  const bool fixup_needed = ntx * nty * ntzw % nsm != 0;
+  const bool fixup_needed = ntiles_dst % nsm != 0;
+  GGML_ASSERT(ntiles_dst * blocks_per_ne00_fd.z < (1 << 30));
+  const dim3 block_nums_fixup(grid_sk.x, mmq_y / warp_size_host, 1);
+  const dim3 block_dims_fixup(block_dims.x, block_dims.y / 2, block_dims.z);
 
   if (args.nrows_x % mmq_y == 0) {
     mul_mat_q<GGML_TYPE_Q5_0, mmq_x, false>
         <<<grid_sk, block_dims, nbytes_shared, stream>>>(
             args.x, args.y, args.ids_dst, args.expert_bounds, args.dst,
-            tmp_fixup, args.ncols_x, args.nrows_x, args.ncols_dst,
-            args.stride_row_x, args.ncols_y, args.nrows_dst, channel_ratio,
-            args.nchannels_y, args.stride_channel_x, args.stride_channel_y,
-            args.stride_channel_dst, sample_ratio, args.nsamples_y,
+            tmp_fixup, blocks_per_ne00_fd, args.nrows_x, args.ncols_dst,
+            args.stride_row_x, args.ncols_y, args.nrows_dst, channel_ratio_fd,
+            nchannels_y_fd, args.stride_channel_x, args.stride_channel_y,
+            args.stride_channel_dst, sample_ratio_fd, nsamples_y_fd,
             args.stride_sample_x, args.stride_sample_y, args.stride_sample_dst,
-            args.ncols_max);
+            ntx_fd);
     if (fixup_needed) {
       mul_mat_q_stream_k_fixup<GGML_TYPE_Q5_0, mmq_x, false>
-          <<<grid_sk, block_dims, 0, stream>>>(
+          <<<block_nums_fixup, block_dims_fixup, 0, stream>>>(
               args.ids_dst, args.expert_bounds, args.dst, tmp_fixup,
-              args.ncols_x, args.nrows_x, args.ncols_dst, args.nrows_dst,
-              args.nchannels_y, args.stride_channel_dst, args.nsamples_y,
-              args.stride_sample_dst, args.ncols_max);
+              blocks_per_ne00_fd, args.nrows_x, args.ncols_dst, args.nrows_dst,
+              nchannels_y_fd, args.stride_channel_dst, nsamples_y_fd,
+              args.stride_sample_dst, ntx_fd);
     }
   } else {
     mul_mat_q<GGML_TYPE_Q5_0, mmq_x, true>
         <<<grid_sk, block_dims, nbytes_shared, stream>>>(
             args.x, args.y, args.ids_dst, args.expert_bounds, args.dst,
-            tmp_fixup, args.ncols_x, args.nrows_x, args.ncols_dst,
-            args.stride_row_x, args.ncols_y, args.nrows_dst, channel_ratio,
-            args.nchannels_y, args.stride_channel_x, args.stride_channel_y,
-            args.stride_channel_dst, sample_ratio, args.nsamples_y,
+            tmp_fixup, blocks_per_ne00_fd, args.nrows_x, args.ncols_dst,
+            args.stride_row_x, args.ncols_y, args.nrows_dst, channel_ratio_fd,
+            nchannels_y_fd, args.stride_channel_x, args.stride_channel_y,
+            args.stride_channel_dst, sample_ratio_fd, nsamples_y_fd,
             args.stride_sample_x, args.stride_sample_y, args.stride_sample_dst,
-            args.ncols_max);
+            ntx_fd);
     if (fixup_needed) {
       mul_mat_q_stream_k_fixup<GGML_TYPE_Q5_0, mmq_x, true>
-          <<<grid_sk, block_dims, 0, stream>>>(
+          <<<block_nums_fixup, block_dims_fixup, 0, stream>>>(
               args.ids_dst, args.expert_bounds, args.dst, tmp_fixup,
-              args.ncols_x, args.nrows_x, args.ncols_dst, args.nrows_dst,
-              args.nchannels_y, args.stride_channel_dst, args.nsamples_y,
-              args.stride_sample_dst, args.ncols_max);
+              blocks_per_ne00_fd, args.nrows_x, args.ncols_dst, args.nrows_dst,
+              nchannels_y_fd, args.stride_channel_dst, nsamples_y_fd,
+              args.stride_sample_dst, ntx_fd);
     }
   }
 }

--- a/mistralrs-quant/kernels/mmq_gguf/mmq_instance_q5_1.cu
+++ b/mistralrs-quant/kernels/mmq_gguf/mmq_instance_q5_1.cu
@@ -21,6 +21,14 @@ static void instantiate_mmq_q5_1(float *tmp_fixup, const mmq_args &args,
   const int channel_ratio = args.nchannels_y / args.nchannels_x;
   const int sample_ratio = args.nsamples_y / args.nsamples_x;
 
+  const uint3 blocks_per_ne00_fd = init_fastdiv_values(
+      args.ncols_x / ggml_cuda_type_traits<GGML_TYPE_Q5_1>::qk);
+  const uint3 ntx_fd = init_fastdiv_values(ntx);
+  const uint3 nchannels_y_fd = init_fastdiv_values(args.nchannels_y);
+  const uint3 nsamples_y_fd = init_fastdiv_values(args.nsamples_y);
+  const uint3 channel_ratio_fd = init_fastdiv_values(channel_ratio);
+  const uint3 sample_ratio_fd = init_fastdiv_values(sample_ratio);
+
   CUDA_SET_SHARED_MEMORY_LIMIT((mul_mat_q<GGML_TYPE_Q5_1, mmq_x, false>),
                                nbytes_shared);
   CUDA_SET_SHARED_MEMORY_LIMIT((mul_mat_q<GGML_TYPE_Q5_1, mmq_x, true>),
@@ -32,65 +40,69 @@ static void instantiate_mmq_q5_1(float *tmp_fixup, const mmq_args &args,
       mul_mat_q<GGML_TYPE_Q5_1, mmq_x, false>
           <<<grid, block_dims, nbytes_shared, stream>>>(
               args.x, args.y, args.ids_dst, args.expert_bounds, args.dst,
-              nullptr, args.ncols_x, args.nrows_x, args.ncols_dst,
-              args.stride_row_x, args.ncols_y, args.nrows_dst, channel_ratio,
-              args.nchannels_y, args.stride_channel_x, args.stride_channel_y,
-              args.stride_channel_dst, sample_ratio, args.nsamples_y,
+              nullptr, blocks_per_ne00_fd, args.nrows_x, args.ncols_dst,
+              args.stride_row_x, args.ncols_y, args.nrows_dst, channel_ratio_fd,
+              nchannels_y_fd, args.stride_channel_x, args.stride_channel_y,
+              args.stride_channel_dst, sample_ratio_fd, nsamples_y_fd,
               args.stride_sample_x, args.stride_sample_y,
-              args.stride_sample_dst, args.ncols_max);
+              args.stride_sample_dst, ntx_fd);
     } else {
       mul_mat_q<GGML_TYPE_Q5_1, mmq_x, true>
           <<<grid, block_dims, nbytes_shared, stream>>>(
               args.x, args.y, args.ids_dst, args.expert_bounds, args.dst,
-              nullptr, args.ncols_x, args.nrows_x, args.ncols_dst,
-              args.stride_row_x, args.ncols_y, args.nrows_dst, channel_ratio,
-              args.nchannels_y, args.stride_channel_x, args.stride_channel_y,
-              args.stride_channel_dst, sample_ratio, args.nsamples_y,
+              nullptr, blocks_per_ne00_fd, args.nrows_x, args.ncols_dst,
+              args.stride_row_x, args.ncols_y, args.nrows_dst, channel_ratio_fd,
+              nchannels_y_fd, args.stride_channel_x, args.stride_channel_y,
+              args.stride_channel_dst, sample_ratio_fd, nsamples_y_fd,
               args.stride_sample_x, args.stride_sample_y,
-              args.stride_sample_dst, args.ncols_max);
+              args.stride_sample_dst, ntx_fd);
     }
     return;
   }
 
   // Stream-k
+  const int ntiles_dst = ntx * nty * ntzw;
   const dim3 grid_sk(nsm, 1, 1);
-  const bool fixup_needed = ntx * nty * ntzw % nsm != 0;
+  const bool fixup_needed = ntiles_dst % nsm != 0;
+  GGML_ASSERT(ntiles_dst * blocks_per_ne00_fd.z < (1 << 30));
+  const dim3 block_nums_fixup(grid_sk.x, mmq_y / warp_size_host, 1);
+  const dim3 block_dims_fixup(block_dims.x, block_dims.y / 2, block_dims.z);
 
   if (args.nrows_x % mmq_y == 0) {
     mul_mat_q<GGML_TYPE_Q5_1, mmq_x, false>
         <<<grid_sk, block_dims, nbytes_shared, stream>>>(
             args.x, args.y, args.ids_dst, args.expert_bounds, args.dst,
-            tmp_fixup, args.ncols_x, args.nrows_x, args.ncols_dst,
-            args.stride_row_x, args.ncols_y, args.nrows_dst, channel_ratio,
-            args.nchannels_y, args.stride_channel_x, args.stride_channel_y,
-            args.stride_channel_dst, sample_ratio, args.nsamples_y,
+            tmp_fixup, blocks_per_ne00_fd, args.nrows_x, args.ncols_dst,
+            args.stride_row_x, args.ncols_y, args.nrows_dst, channel_ratio_fd,
+            nchannels_y_fd, args.stride_channel_x, args.stride_channel_y,
+            args.stride_channel_dst, sample_ratio_fd, nsamples_y_fd,
             args.stride_sample_x, args.stride_sample_y, args.stride_sample_dst,
-            args.ncols_max);
+            ntx_fd);
     if (fixup_needed) {
       mul_mat_q_stream_k_fixup<GGML_TYPE_Q5_1, mmq_x, false>
-          <<<grid_sk, block_dims, 0, stream>>>(
+          <<<block_nums_fixup, block_dims_fixup, 0, stream>>>(
               args.ids_dst, args.expert_bounds, args.dst, tmp_fixup,
-              args.ncols_x, args.nrows_x, args.ncols_dst, args.nrows_dst,
-              args.nchannels_y, args.stride_channel_dst, args.nsamples_y,
-              args.stride_sample_dst, args.ncols_max);
+              blocks_per_ne00_fd, args.nrows_x, args.ncols_dst, args.nrows_dst,
+              nchannels_y_fd, args.stride_channel_dst, nsamples_y_fd,
+              args.stride_sample_dst, ntx_fd);
     }
   } else {
     mul_mat_q<GGML_TYPE_Q5_1, mmq_x, true>
         <<<grid_sk, block_dims, nbytes_shared, stream>>>(
             args.x, args.y, args.ids_dst, args.expert_bounds, args.dst,
-            tmp_fixup, args.ncols_x, args.nrows_x, args.ncols_dst,
-            args.stride_row_x, args.ncols_y, args.nrows_dst, channel_ratio,
-            args.nchannels_y, args.stride_channel_x, args.stride_channel_y,
-            args.stride_channel_dst, sample_ratio, args.nsamples_y,
+            tmp_fixup, blocks_per_ne00_fd, args.nrows_x, args.ncols_dst,
+            args.stride_row_x, args.ncols_y, args.nrows_dst, channel_ratio_fd,
+            nchannels_y_fd, args.stride_channel_x, args.stride_channel_y,
+            args.stride_channel_dst, sample_ratio_fd, nsamples_y_fd,
             args.stride_sample_x, args.stride_sample_y, args.stride_sample_dst,
-            args.ncols_max);
+            ntx_fd);
     if (fixup_needed) {
       mul_mat_q_stream_k_fixup<GGML_TYPE_Q5_1, mmq_x, true>
-          <<<grid_sk, block_dims, 0, stream>>>(
+          <<<block_nums_fixup, block_dims_fixup, 0, stream>>>(
               args.ids_dst, args.expert_bounds, args.dst, tmp_fixup,
-              args.ncols_x, args.nrows_x, args.ncols_dst, args.nrows_dst,
-              args.nchannels_y, args.stride_channel_dst, args.nsamples_y,
-              args.stride_sample_dst, args.ncols_max);
+              blocks_per_ne00_fd, args.nrows_x, args.ncols_dst, args.nrows_dst,
+              nchannels_y_fd, args.stride_channel_dst, nsamples_y_fd,
+              args.stride_sample_dst, ntx_fd);
     }
   }
 }

--- a/mistralrs-quant/kernels/mmq_gguf/mmq_instance_q5_k.cu
+++ b/mistralrs-quant/kernels/mmq_gguf/mmq_instance_q5_k.cu
@@ -21,6 +21,14 @@ static void instantiate_mmq_q5_k(float *tmp_fixup, const mmq_args &args,
   const int channel_ratio = args.nchannels_y / args.nchannels_x;
   const int sample_ratio = args.nsamples_y / args.nsamples_x;
 
+  const uint3 blocks_per_ne00_fd = init_fastdiv_values(
+      args.ncols_x / ggml_cuda_type_traits<GGML_TYPE_Q5_K>::qk);
+  const uint3 ntx_fd = init_fastdiv_values(ntx);
+  const uint3 nchannels_y_fd = init_fastdiv_values(args.nchannels_y);
+  const uint3 nsamples_y_fd = init_fastdiv_values(args.nsamples_y);
+  const uint3 channel_ratio_fd = init_fastdiv_values(channel_ratio);
+  const uint3 sample_ratio_fd = init_fastdiv_values(sample_ratio);
+
   CUDA_SET_SHARED_MEMORY_LIMIT((mul_mat_q<GGML_TYPE_Q5_K, mmq_x, false>),
                                nbytes_shared);
   CUDA_SET_SHARED_MEMORY_LIMIT((mul_mat_q<GGML_TYPE_Q5_K, mmq_x, true>),
@@ -32,65 +40,69 @@ static void instantiate_mmq_q5_k(float *tmp_fixup, const mmq_args &args,
       mul_mat_q<GGML_TYPE_Q5_K, mmq_x, false>
           <<<grid, block_dims, nbytes_shared, stream>>>(
               args.x, args.y, args.ids_dst, args.expert_bounds, args.dst,
-              nullptr, args.ncols_x, args.nrows_x, args.ncols_dst,
-              args.stride_row_x, args.ncols_y, args.nrows_dst, channel_ratio,
-              args.nchannels_y, args.stride_channel_x, args.stride_channel_y,
-              args.stride_channel_dst, sample_ratio, args.nsamples_y,
+              nullptr, blocks_per_ne00_fd, args.nrows_x, args.ncols_dst,
+              args.stride_row_x, args.ncols_y, args.nrows_dst, channel_ratio_fd,
+              nchannels_y_fd, args.stride_channel_x, args.stride_channel_y,
+              args.stride_channel_dst, sample_ratio_fd, nsamples_y_fd,
               args.stride_sample_x, args.stride_sample_y,
-              args.stride_sample_dst, args.ncols_max);
+              args.stride_sample_dst, ntx_fd);
     } else {
       mul_mat_q<GGML_TYPE_Q5_K, mmq_x, true>
           <<<grid, block_dims, nbytes_shared, stream>>>(
               args.x, args.y, args.ids_dst, args.expert_bounds, args.dst,
-              nullptr, args.ncols_x, args.nrows_x, args.ncols_dst,
-              args.stride_row_x, args.ncols_y, args.nrows_dst, channel_ratio,
-              args.nchannels_y, args.stride_channel_x, args.stride_channel_y,
-              args.stride_channel_dst, sample_ratio, args.nsamples_y,
+              nullptr, blocks_per_ne00_fd, args.nrows_x, args.ncols_dst,
+              args.stride_row_x, args.ncols_y, args.nrows_dst, channel_ratio_fd,
+              nchannels_y_fd, args.stride_channel_x, args.stride_channel_y,
+              args.stride_channel_dst, sample_ratio_fd, nsamples_y_fd,
               args.stride_sample_x, args.stride_sample_y,
-              args.stride_sample_dst, args.ncols_max);
+              args.stride_sample_dst, ntx_fd);
     }
     return;
   }
 
   // Stream-k
+  const int ntiles_dst = ntx * nty * ntzw;
   const dim3 grid_sk(nsm, 1, 1);
-  const bool fixup_needed = ntx * nty * ntzw % nsm != 0;
+  const bool fixup_needed = ntiles_dst % nsm != 0;
+  GGML_ASSERT(ntiles_dst * blocks_per_ne00_fd.z < (1 << 30));
+  const dim3 block_nums_fixup(grid_sk.x, mmq_y / warp_size_host, 1);
+  const dim3 block_dims_fixup(block_dims.x, block_dims.y / 2, block_dims.z);
 
   if (args.nrows_x % mmq_y == 0) {
     mul_mat_q<GGML_TYPE_Q5_K, mmq_x, false>
         <<<grid_sk, block_dims, nbytes_shared, stream>>>(
             args.x, args.y, args.ids_dst, args.expert_bounds, args.dst,
-            tmp_fixup, args.ncols_x, args.nrows_x, args.ncols_dst,
-            args.stride_row_x, args.ncols_y, args.nrows_dst, channel_ratio,
-            args.nchannels_y, args.stride_channel_x, args.stride_channel_y,
-            args.stride_channel_dst, sample_ratio, args.nsamples_y,
+            tmp_fixup, blocks_per_ne00_fd, args.nrows_x, args.ncols_dst,
+            args.stride_row_x, args.ncols_y, args.nrows_dst, channel_ratio_fd,
+            nchannels_y_fd, args.stride_channel_x, args.stride_channel_y,
+            args.stride_channel_dst, sample_ratio_fd, nsamples_y_fd,
             args.stride_sample_x, args.stride_sample_y, args.stride_sample_dst,
-            args.ncols_max);
+            ntx_fd);
     if (fixup_needed) {
       mul_mat_q_stream_k_fixup<GGML_TYPE_Q5_K, mmq_x, false>
-          <<<grid_sk, block_dims, 0, stream>>>(
+          <<<block_nums_fixup, block_dims_fixup, 0, stream>>>(
               args.ids_dst, args.expert_bounds, args.dst, tmp_fixup,
-              args.ncols_x, args.nrows_x, args.ncols_dst, args.nrows_dst,
-              args.nchannels_y, args.stride_channel_dst, args.nsamples_y,
-              args.stride_sample_dst, args.ncols_max);
+              blocks_per_ne00_fd, args.nrows_x, args.ncols_dst, args.nrows_dst,
+              nchannels_y_fd, args.stride_channel_dst, nsamples_y_fd,
+              args.stride_sample_dst, ntx_fd);
     }
   } else {
     mul_mat_q<GGML_TYPE_Q5_K, mmq_x, true>
         <<<grid_sk, block_dims, nbytes_shared, stream>>>(
             args.x, args.y, args.ids_dst, args.expert_bounds, args.dst,
-            tmp_fixup, args.ncols_x, args.nrows_x, args.ncols_dst,
-            args.stride_row_x, args.ncols_y, args.nrows_dst, channel_ratio,
-            args.nchannels_y, args.stride_channel_x, args.stride_channel_y,
-            args.stride_channel_dst, sample_ratio, args.nsamples_y,
+            tmp_fixup, blocks_per_ne00_fd, args.nrows_x, args.ncols_dst,
+            args.stride_row_x, args.ncols_y, args.nrows_dst, channel_ratio_fd,
+            nchannels_y_fd, args.stride_channel_x, args.stride_channel_y,
+            args.stride_channel_dst, sample_ratio_fd, nsamples_y_fd,
             args.stride_sample_x, args.stride_sample_y, args.stride_sample_dst,
-            args.ncols_max);
+            ntx_fd);
     if (fixup_needed) {
       mul_mat_q_stream_k_fixup<GGML_TYPE_Q5_K, mmq_x, true>
-          <<<grid_sk, block_dims, 0, stream>>>(
+          <<<block_nums_fixup, block_dims_fixup, 0, stream>>>(
               args.ids_dst, args.expert_bounds, args.dst, tmp_fixup,
-              args.ncols_x, args.nrows_x, args.ncols_dst, args.nrows_dst,
-              args.nchannels_y, args.stride_channel_dst, args.nsamples_y,
-              args.stride_sample_dst, args.ncols_max);
+              blocks_per_ne00_fd, args.nrows_x, args.ncols_dst, args.nrows_dst,
+              nchannels_y_fd, args.stride_channel_dst, nsamples_y_fd,
+              args.stride_sample_dst, ntx_fd);
     }
   }
 }

--- a/mistralrs-quant/kernels/mmq_gguf/mmq_instance_q6_k.cu
+++ b/mistralrs-quant/kernels/mmq_gguf/mmq_instance_q6_k.cu
@@ -21,6 +21,14 @@ static void instantiate_mmq_q6_k(float *tmp_fixup, const mmq_args &args,
   const int channel_ratio = args.nchannels_y / args.nchannels_x;
   const int sample_ratio = args.nsamples_y / args.nsamples_x;
 
+  const uint3 blocks_per_ne00_fd = init_fastdiv_values(
+      args.ncols_x / ggml_cuda_type_traits<GGML_TYPE_Q6_K>::qk);
+  const uint3 ntx_fd = init_fastdiv_values(ntx);
+  const uint3 nchannels_y_fd = init_fastdiv_values(args.nchannels_y);
+  const uint3 nsamples_y_fd = init_fastdiv_values(args.nsamples_y);
+  const uint3 channel_ratio_fd = init_fastdiv_values(channel_ratio);
+  const uint3 sample_ratio_fd = init_fastdiv_values(sample_ratio);
+
   CUDA_SET_SHARED_MEMORY_LIMIT((mul_mat_q<GGML_TYPE_Q6_K, mmq_x, false>),
                                nbytes_shared);
   CUDA_SET_SHARED_MEMORY_LIMIT((mul_mat_q<GGML_TYPE_Q6_K, mmq_x, true>),
@@ -32,65 +40,69 @@ static void instantiate_mmq_q6_k(float *tmp_fixup, const mmq_args &args,
       mul_mat_q<GGML_TYPE_Q6_K, mmq_x, false>
           <<<grid, block_dims, nbytes_shared, stream>>>(
               args.x, args.y, args.ids_dst, args.expert_bounds, args.dst,
-              nullptr, args.ncols_x, args.nrows_x, args.ncols_dst,
-              args.stride_row_x, args.ncols_y, args.nrows_dst, channel_ratio,
-              args.nchannels_y, args.stride_channel_x, args.stride_channel_y,
-              args.stride_channel_dst, sample_ratio, args.nsamples_y,
+              nullptr, blocks_per_ne00_fd, args.nrows_x, args.ncols_dst,
+              args.stride_row_x, args.ncols_y, args.nrows_dst, channel_ratio_fd,
+              nchannels_y_fd, args.stride_channel_x, args.stride_channel_y,
+              args.stride_channel_dst, sample_ratio_fd, nsamples_y_fd,
               args.stride_sample_x, args.stride_sample_y,
-              args.stride_sample_dst, args.ncols_max);
+              args.stride_sample_dst, ntx_fd);
     } else {
       mul_mat_q<GGML_TYPE_Q6_K, mmq_x, true>
           <<<grid, block_dims, nbytes_shared, stream>>>(
               args.x, args.y, args.ids_dst, args.expert_bounds, args.dst,
-              nullptr, args.ncols_x, args.nrows_x, args.ncols_dst,
-              args.stride_row_x, args.ncols_y, args.nrows_dst, channel_ratio,
-              args.nchannels_y, args.stride_channel_x, args.stride_channel_y,
-              args.stride_channel_dst, sample_ratio, args.nsamples_y,
+              nullptr, blocks_per_ne00_fd, args.nrows_x, args.ncols_dst,
+              args.stride_row_x, args.ncols_y, args.nrows_dst, channel_ratio_fd,
+              nchannels_y_fd, args.stride_channel_x, args.stride_channel_y,
+              args.stride_channel_dst, sample_ratio_fd, nsamples_y_fd,
               args.stride_sample_x, args.stride_sample_y,
-              args.stride_sample_dst, args.ncols_max);
+              args.stride_sample_dst, ntx_fd);
     }
     return;
   }
 
   // Stream-k
+  const int ntiles_dst = ntx * nty * ntzw;
   const dim3 grid_sk(nsm, 1, 1);
-  const bool fixup_needed = ntx * nty * ntzw % nsm != 0;
+  const bool fixup_needed = ntiles_dst % nsm != 0;
+  GGML_ASSERT(ntiles_dst * blocks_per_ne00_fd.z < (1 << 30));
+  const dim3 block_nums_fixup(grid_sk.x, mmq_y / warp_size_host, 1);
+  const dim3 block_dims_fixup(block_dims.x, block_dims.y / 2, block_dims.z);
 
   if (args.nrows_x % mmq_y == 0) {
     mul_mat_q<GGML_TYPE_Q6_K, mmq_x, false>
         <<<grid_sk, block_dims, nbytes_shared, stream>>>(
             args.x, args.y, args.ids_dst, args.expert_bounds, args.dst,
-            tmp_fixup, args.ncols_x, args.nrows_x, args.ncols_dst,
-            args.stride_row_x, args.ncols_y, args.nrows_dst, channel_ratio,
-            args.nchannels_y, args.stride_channel_x, args.stride_channel_y,
-            args.stride_channel_dst, sample_ratio, args.nsamples_y,
+            tmp_fixup, blocks_per_ne00_fd, args.nrows_x, args.ncols_dst,
+            args.stride_row_x, args.ncols_y, args.nrows_dst, channel_ratio_fd,
+            nchannels_y_fd, args.stride_channel_x, args.stride_channel_y,
+            args.stride_channel_dst, sample_ratio_fd, nsamples_y_fd,
             args.stride_sample_x, args.stride_sample_y, args.stride_sample_dst,
-            args.ncols_max);
+            ntx_fd);
     if (fixup_needed) {
       mul_mat_q_stream_k_fixup<GGML_TYPE_Q6_K, mmq_x, false>
-          <<<grid_sk, block_dims, 0, stream>>>(
+          <<<block_nums_fixup, block_dims_fixup, 0, stream>>>(
               args.ids_dst, args.expert_bounds, args.dst, tmp_fixup,
-              args.ncols_x, args.nrows_x, args.ncols_dst, args.nrows_dst,
-              args.nchannels_y, args.stride_channel_dst, args.nsamples_y,
-              args.stride_sample_dst, args.ncols_max);
+              blocks_per_ne00_fd, args.nrows_x, args.ncols_dst, args.nrows_dst,
+              nchannels_y_fd, args.stride_channel_dst, nsamples_y_fd,
+              args.stride_sample_dst, ntx_fd);
     }
   } else {
     mul_mat_q<GGML_TYPE_Q6_K, mmq_x, true>
         <<<grid_sk, block_dims, nbytes_shared, stream>>>(
             args.x, args.y, args.ids_dst, args.expert_bounds, args.dst,
-            tmp_fixup, args.ncols_x, args.nrows_x, args.ncols_dst,
-            args.stride_row_x, args.ncols_y, args.nrows_dst, channel_ratio,
-            args.nchannels_y, args.stride_channel_x, args.stride_channel_y,
-            args.stride_channel_dst, sample_ratio, args.nsamples_y,
+            tmp_fixup, blocks_per_ne00_fd, args.nrows_x, args.ncols_dst,
+            args.stride_row_x, args.ncols_y, args.nrows_dst, channel_ratio_fd,
+            nchannels_y_fd, args.stride_channel_x, args.stride_channel_y,
+            args.stride_channel_dst, sample_ratio_fd, nsamples_y_fd,
             args.stride_sample_x, args.stride_sample_y, args.stride_sample_dst,
-            args.ncols_max);
+            ntx_fd);
     if (fixup_needed) {
       mul_mat_q_stream_k_fixup<GGML_TYPE_Q6_K, mmq_x, true>
-          <<<grid_sk, block_dims, 0, stream>>>(
+          <<<block_nums_fixup, block_dims_fixup, 0, stream>>>(
               args.ids_dst, args.expert_bounds, args.dst, tmp_fixup,
-              args.ncols_x, args.nrows_x, args.ncols_dst, args.nrows_dst,
-              args.nchannels_y, args.stride_channel_dst, args.nsamples_y,
-              args.stride_sample_dst, args.ncols_max);
+              blocks_per_ne00_fd, args.nrows_x, args.ncols_dst, args.nrows_dst,
+              nchannels_y_fd, args.stride_channel_dst, nsamples_y_fd,
+              args.stride_sample_dst, ntx_fd);
     }
   }
 }

--- a/mistralrs-quant/kernels/mmq_gguf/mmq_instance_q8_0.cu
+++ b/mistralrs-quant/kernels/mmq_gguf/mmq_instance_q8_0.cu
@@ -21,6 +21,14 @@ static void instantiate_mmq_q8_0(float *tmp_fixup, const mmq_args &args,
   const int channel_ratio = args.nchannels_y / args.nchannels_x;
   const int sample_ratio = args.nsamples_y / args.nsamples_x;
 
+  const uint3 blocks_per_ne00_fd = init_fastdiv_values(
+      args.ncols_x / ggml_cuda_type_traits<GGML_TYPE_Q8_0>::qk);
+  const uint3 ntx_fd = init_fastdiv_values(ntx);
+  const uint3 nchannels_y_fd = init_fastdiv_values(args.nchannels_y);
+  const uint3 nsamples_y_fd = init_fastdiv_values(args.nsamples_y);
+  const uint3 channel_ratio_fd = init_fastdiv_values(channel_ratio);
+  const uint3 sample_ratio_fd = init_fastdiv_values(sample_ratio);
+
   CUDA_SET_SHARED_MEMORY_LIMIT((mul_mat_q<GGML_TYPE_Q8_0, mmq_x, false>),
                                nbytes_shared);
   CUDA_SET_SHARED_MEMORY_LIMIT((mul_mat_q<GGML_TYPE_Q8_0, mmq_x, true>),
@@ -32,65 +40,77 @@ static void instantiate_mmq_q8_0(float *tmp_fixup, const mmq_args &args,
       mul_mat_q<GGML_TYPE_Q8_0, mmq_x, false>
           <<<grid, block_dims, nbytes_shared, stream>>>(
               args.x, args.y, args.ids_dst, args.expert_bounds, args.dst,
-              nullptr, args.ncols_x, args.nrows_x, args.ncols_dst,
-              args.stride_row_x, args.ncols_y, args.nrows_dst, channel_ratio,
-              args.nchannels_y, args.stride_channel_x, args.stride_channel_y,
-              args.stride_channel_dst, sample_ratio, args.nsamples_y,
+              nullptr, blocks_per_ne00_fd, args.nrows_x, args.ncols_dst,
+              args.stride_row_x, args.ncols_y, args.nrows_dst, channel_ratio_fd,
+              nchannels_y_fd, args.stride_channel_x, args.stride_channel_y,
+              args.stride_channel_dst, sample_ratio_fd, nsamples_y_fd,
               args.stride_sample_x, args.stride_sample_y,
-              args.stride_sample_dst, args.ncols_max);
+              args.stride_sample_dst, ntx_fd);
     } else {
       mul_mat_q<GGML_TYPE_Q8_0, mmq_x, true>
           <<<grid, block_dims, nbytes_shared, stream>>>(
               args.x, args.y, args.ids_dst, args.expert_bounds, args.dst,
-              nullptr, args.ncols_x, args.nrows_x, args.ncols_dst,
-              args.stride_row_x, args.ncols_y, args.nrows_dst, channel_ratio,
-              args.nchannels_y, args.stride_channel_x, args.stride_channel_y,
-              args.stride_channel_dst, sample_ratio, args.nsamples_y,
+              nullptr, blocks_per_ne00_fd, args.nrows_x, args.ncols_dst,
+              args.stride_row_x, args.ncols_y, args.nrows_dst, channel_ratio_fd,
+              nchannels_y_fd, args.stride_channel_x, args.stride_channel_y,
+              args.stride_channel_dst, sample_ratio_fd, nsamples_y_fd,
               args.stride_sample_x, args.stride_sample_y,
-              args.stride_sample_dst, args.ncols_max);
+              args.stride_sample_dst, ntx_fd);
     }
     return;
   }
 
-  // Stream-k
-  const dim3 grid_sk(nsm, 1, 1);
-  const bool fixup_needed = ntx * nty * ntzw % nsm != 0;
+  // Stream-k. When tiling efficiency is high, run one block per output tile
+  // and avoid the stream-k fixup pass. This matches llama.cpp's launch policy
+  // and is faster for large Gemma prompt batches where ntiles >> SM count.
+  const int ntiles_dst = ntx * nty * ntzw;
+  const int tiles_nwaves = (ntiles_dst + nsm - 1) / nsm;
+  const int tiles_efficiency_percent = 100 * ntiles_dst / (nsm * tiles_nwaves);
+  const dim3 grid_sk(GGML_CUDA_CC_IS_NVIDIA(cc) && args.ncols_dst <= 4096 &&
+                             tiles_efficiency_percent >= 90
+                         ? ntiles_dst
+                         : nsm,
+                     1, 1);
+  const bool fixup_needed = ntiles_dst % grid_sk.x != 0;
+  GGML_ASSERT(ntiles_dst * blocks_per_ne00_fd.z < (1 << 30));
+  const dim3 block_nums_fixup(grid_sk.x, mmq_y / warp_size_host, 1);
+  const dim3 block_dims_fixup(block_dims.x, block_dims.y / 2, block_dims.z);
 
   if (args.nrows_x % mmq_y == 0) {
     mul_mat_q<GGML_TYPE_Q8_0, mmq_x, false>
         <<<grid_sk, block_dims, nbytes_shared, stream>>>(
             args.x, args.y, args.ids_dst, args.expert_bounds, args.dst,
-            tmp_fixup, args.ncols_x, args.nrows_x, args.ncols_dst,
-            args.stride_row_x, args.ncols_y, args.nrows_dst, channel_ratio,
-            args.nchannels_y, args.stride_channel_x, args.stride_channel_y,
-            args.stride_channel_dst, sample_ratio, args.nsamples_y,
+            tmp_fixup, blocks_per_ne00_fd, args.nrows_x, args.ncols_dst,
+            args.stride_row_x, args.ncols_y, args.nrows_dst, channel_ratio_fd,
+            nchannels_y_fd, args.stride_channel_x, args.stride_channel_y,
+            args.stride_channel_dst, sample_ratio_fd, nsamples_y_fd,
             args.stride_sample_x, args.stride_sample_y, args.stride_sample_dst,
-            args.ncols_max);
+            ntx_fd);
     if (fixup_needed) {
       mul_mat_q_stream_k_fixup<GGML_TYPE_Q8_0, mmq_x, false>
-          <<<grid_sk, block_dims, 0, stream>>>(
+          <<<block_nums_fixup, block_dims_fixup, 0, stream>>>(
               args.ids_dst, args.expert_bounds, args.dst, tmp_fixup,
-              args.ncols_x, args.nrows_x, args.ncols_dst, args.nrows_dst,
-              args.nchannels_y, args.stride_channel_dst, args.nsamples_y,
-              args.stride_sample_dst, args.ncols_max);
+              blocks_per_ne00_fd, args.nrows_x, args.ncols_dst, args.nrows_dst,
+              nchannels_y_fd, args.stride_channel_dst, nsamples_y_fd,
+              args.stride_sample_dst, ntx_fd);
     }
   } else {
     mul_mat_q<GGML_TYPE_Q8_0, mmq_x, true>
         <<<grid_sk, block_dims, nbytes_shared, stream>>>(
             args.x, args.y, args.ids_dst, args.expert_bounds, args.dst,
-            tmp_fixup, args.ncols_x, args.nrows_x, args.ncols_dst,
-            args.stride_row_x, args.ncols_y, args.nrows_dst, channel_ratio,
-            args.nchannels_y, args.stride_channel_x, args.stride_channel_y,
-            args.stride_channel_dst, sample_ratio, args.nsamples_y,
+            tmp_fixup, blocks_per_ne00_fd, args.nrows_x, args.ncols_dst,
+            args.stride_row_x, args.ncols_y, args.nrows_dst, channel_ratio_fd,
+            nchannels_y_fd, args.stride_channel_x, args.stride_channel_y,
+            args.stride_channel_dst, sample_ratio_fd, nsamples_y_fd,
             args.stride_sample_x, args.stride_sample_y, args.stride_sample_dst,
-            args.ncols_max);
+            ntx_fd);
     if (fixup_needed) {
       mul_mat_q_stream_k_fixup<GGML_TYPE_Q8_0, mmq_x, true>
-          <<<grid_sk, block_dims, 0, stream>>>(
+          <<<block_nums_fixup, block_dims_fixup, 0, stream>>>(
               args.ids_dst, args.expert_bounds, args.dst, tmp_fixup,
-              args.ncols_x, args.nrows_x, args.ncols_dst, args.nrows_dst,
-              args.nchannels_y, args.stride_channel_dst, args.nsamples_y,
-              args.stride_sample_dst, args.ncols_max);
+              blocks_per_ne00_fd, args.nrows_x, args.ncols_dst, args.nrows_dst,
+              nchannels_y_fd, args.stride_channel_dst, nsamples_y_fd,
+              args.stride_sample_dst, ntx_fd);
     }
   }
 }

--- a/mistralrs-quant/kernels/mmq_gguf/mmq_quantize.cu
+++ b/mistralrs-quant/kernels/mmq_gguf/mmq_quantize.cu
@@ -1,4 +1,4 @@
-// MMQ quantize kernel: f32 -> block_q8_1_mmq
+// MMQ quantize kernel: f32/f16/bf16 -> block_q8_1_mmq
 // Adapted from llama.cpp quantize.cu
 
 #include "mmq_common.cuh"
@@ -9,9 +9,96 @@
 static_assert(MATRIX_ROW_PADDING % (4 * CUDA_QUANTIZE_BLOCK_SIZE_MMQ) == 0,
               "Risk of out-of-bounds access.");
 
-template <mmq_q8_1_ds_layout ds_layout>
+template <typename input_t>
+static __device__ __forceinline__ float mmq_to_float(const input_t v) {
+  return (float)v;
+}
+
+template <>
+__device__ __forceinline__ float mmq_to_float<half>(const half v) {
+  return __half2float(v);
+}
+
+template <>
+__device__ __forceinline__ float
+mmq_to_float<__nv_bfloat16>(const __nv_bfloat16 v) {
+  return __bfloat162float(v);
+}
+
+template <typename input_t>
+static __device__ __forceinline__ float4 load_mmq4_scalar(
+    const input_t *__restrict__ x, const int64_t base, const int64_t i0,
+    const int64_t ne00) {
+  float4 xi = make_float4(0.0f, 0.0f, 0.0f, 0.0f);
+
+  if (i0 + 0 < ne00) {
+    xi.x = mmq_to_float(x[base + 0]);
+  }
+  if (i0 + 1 < ne00) {
+    xi.y = mmq_to_float(x[base + 1]);
+  }
+  if (i0 + 2 < ne00) {
+    xi.z = mmq_to_float(x[base + 2]);
+  }
+  if (i0 + 3 < ne00) {
+    xi.w = mmq_to_float(x[base + 3]);
+  }
+
+  return xi;
+}
+
+template <typename input_t>
+static __device__ __forceinline__ float4
+load_mmq4(const input_t *__restrict__ x, const int64_t base, const int64_t i0,
+          const int64_t ne00) {
+  return load_mmq4_scalar(x, base, i0, ne00);
+}
+
+template <>
+__device__ __forceinline__ float4
+load_mmq4<float>(const float *__restrict__ x, const int64_t base,
+                 const int64_t i0, const int64_t ne00) {
+  if (i0 + 3 < ne00) {
+    const float4 *x4 = (const float4 *)x;
+    return x4[base / 4];
+  }
+
+  return load_mmq4_scalar(x, base, i0, ne00);
+}
+
+template <>
+__device__ __forceinline__ float4
+load_mmq4<half>(const half *__restrict__ x, const int64_t base,
+                const int64_t i0, const int64_t ne00) {
+  if (i0 + 3 < ne00) {
+    const half2 *x2 = (const half2 *)x;
+    const float2 x01 = __half22float2(x2[base / 2]);
+    const float2 x23 = __half22float2(x2[base / 2 + 1]);
+    return make_float4(x01.x, x01.y, x23.x, x23.y);
+  }
+
+  return load_mmq4_scalar(x, base, i0, ne00);
+}
+
+template <>
+__device__ __forceinline__ float4
+load_mmq4<__nv_bfloat16>(const __nv_bfloat16 *__restrict__ x,
+                         const int64_t base, const int64_t i0,
+                         const int64_t ne00) {
+  if (i0 + 3 < ne00) {
+    const __nv_bfloat162 *x2 = (const __nv_bfloat162 *)x;
+    const float2 x01 = __bfloat1622float2(x2[base / 2]);
+    const float2 x23 = __bfloat1622float2(x2[base / 2 + 1]);
+    return make_float4(x01.x, x01.y, x23.x, x23.y);
+  }
+
+  return load_mmq4_scalar(x, base, i0, ne00);
+}
+
+template <typename input_t, mmq_q8_1_ds_layout ds_layout>
 static __global__ void
-quantize_mmq_q8_1(const float *__restrict__ x, const int32_t *__restrict__ ids,
+quantize_mmq_q8_1(const input_t *__restrict__ x,
+                  const int32_t *__restrict__ ids,
                   void *__restrict__ vy, const int64_t ne00, const int64_t s01,
                   const int64_t s02, const int64_t s03, const int64_t ne0,
                   const int ne1, const int ne2) {
@@ -34,8 +121,6 @@ quantize_mmq_q8_1(const float *__restrict__ x, const int32_t *__restrict__ ids,
   const int64_t i02 = i2;
   const int64_t i03 = i3;
 
-  const float4 *x4 = (const float4 *)x;
-
   block_q8_1_mmq *y = (block_q8_1_mmq *)vy;
 
   const int64_t ib0 =
@@ -46,9 +131,8 @@ quantize_mmq_q8_1(const float *__restrict__ x, const int32_t *__restrict__ ids,
   const int64_t iqs = i0 % (4 * QK8_1);            // quant index in block
 
   // Load 4 floats per thread and calculate max. abs. value between them:
-  const float4 xi = i0 < ne00
-                        ? x4[(i03 * s03 + i02 * s02 + i01 * s01 + i00) / 4]
-                        : make_float4(0.0f, 0.0f, 0.0f, 0.0f);
+  const int64_t base = i03 * s03 + i02 * s02 + i01 * s01 + i00;
+  const float4 xi = load_mmq4(x, base, i0, ne00);
   float amax = fabsf(xi.x);
   amax = fmaxf(amax, fabsf(xi.y));
   amax = fmaxf(amax, fabsf(xi.z));
@@ -114,45 +198,62 @@ quantize_mmq_q8_1(const float *__restrict__ x, const int32_t *__restrict__ ids,
   }
 }
 
-// C-linkage quantize launchers
-
-extern "C" void
-launch_mmq_quantize_q8_1_D4(const void *x_f32, const int32_t *ids, void *vy,
-                            int type_x, int64_t ne00, int64_t s01, int64_t s02,
-                            int64_t s03, int64_t ne0, int64_t ne1, int64_t ne2,
-                            int64_t ne3, void *stream) {
-  const int64_t block_num_y = (ne0 + 4 * CUDA_QUANTIZE_BLOCK_SIZE_MMQ - 1) /
-                              (4 * CUDA_QUANTIZE_BLOCK_SIZE_MMQ);
-  const dim3 num_blocks(ne1, block_num_y, ne2 * ne3);
-  const dim3 block_size(CUDA_QUANTIZE_BLOCK_SIZE_MMQ, 1, 1);
-  quantize_mmq_q8_1<MMQ_Q8_1_DS_LAYOUT_D4>
-      <<<num_blocks, block_size, 0, (cudaStream_t)stream>>>(
-          (const float *)x_f32, ids, vy, ne00, s01, s02, s03, ne0, ne1, ne2);
-}
-
-extern "C" void
-launch_mmq_quantize_q8_1_DS4(const void *x_f32, const int32_t *ids, void *vy,
-                             int type_x, int64_t ne00, int64_t s01, int64_t s02,
-                             int64_t s03, int64_t ne0, int64_t ne1, int64_t ne2,
-                             int64_t ne3, void *stream) {
-  const int64_t block_num_y = (ne0 + 4 * CUDA_QUANTIZE_BLOCK_SIZE_MMQ - 1) /
-                              (4 * CUDA_QUANTIZE_BLOCK_SIZE_MMQ);
-  const dim3 num_blocks(ne1, block_num_y, ne2 * ne3);
-  const dim3 block_size(CUDA_QUANTIZE_BLOCK_SIZE_MMQ, 1, 1);
-  quantize_mmq_q8_1<MMQ_Q8_1_DS_LAYOUT_DS4>
-      <<<num_blocks, block_size, 0, (cudaStream_t)stream>>>(
-          (const float *)x_f32, ids, vy, ne00, s01, s02, s03, ne0, ne1, ne2);
-}
-
-extern "C" void launch_mmq_quantize_q8_1_D2S6(
-    const void *x_f32, const int32_t *ids, void *vy, int type_x, int64_t ne00,
+template <mmq_q8_1_ds_layout ds_layout>
+static void launch_mmq_quantize_q8_1_typed(
+    const void *x, const int32_t *ids, void *vy, int type_x, int64_t ne00,
     int64_t s01, int64_t s02, int64_t s03, int64_t ne0, int64_t ne1,
     int64_t ne2, int64_t ne3, void *stream) {
   const int64_t block_num_y = (ne0 + 4 * CUDA_QUANTIZE_BLOCK_SIZE_MMQ - 1) /
                               (4 * CUDA_QUANTIZE_BLOCK_SIZE_MMQ);
   const dim3 num_blocks(ne1, block_num_y, ne2 * ne3);
   const dim3 block_size(CUDA_QUANTIZE_BLOCK_SIZE_MMQ, 1, 1);
-  quantize_mmq_q8_1<MMQ_Q8_1_DS_LAYOUT_D2S6>
-      <<<num_blocks, block_size, 0, (cudaStream_t)stream>>>(
-          (const float *)x_f32, ids, vy, ne00, s01, s02, s03, ne0, ne1, ne2);
+  const cudaStream_t s = (cudaStream_t)stream;
+
+  switch ((ggml_type)type_x) {
+  case GGML_TYPE_F32:
+    quantize_mmq_q8_1<float, ds_layout><<<num_blocks, block_size, 0, s>>>(
+        (const float *)x, ids, vy, ne00, s01, s02, s03, ne0, ne1, ne2);
+    break;
+  case GGML_TYPE_F16:
+    quantize_mmq_q8_1<half, ds_layout><<<num_blocks, block_size, 0, s>>>(
+        (const half *)x, ids, vy, ne00, s01, s02, s03, ne0, ne1, ne2);
+    break;
+  case GGML_TYPE_BF16:
+    quantize_mmq_q8_1<__nv_bfloat16, ds_layout>
+        <<<num_blocks, block_size, 0, s>>>((const __nv_bfloat16 *)x, ids, vy,
+                                           ne00, s01, s02, s03, ne0, ne1,
+                                           ne2);
+    break;
+  default:
+    break;
+  }
+}
+
+// C-linkage quantize launchers
+
+extern "C" void
+launch_mmq_quantize_q8_1_D4(const void *x, const int32_t *ids, void *vy,
+                            int type_x, int64_t ne00, int64_t s01, int64_t s02,
+                            int64_t s03, int64_t ne0, int64_t ne1, int64_t ne2,
+                            int64_t ne3, void *stream) {
+  launch_mmq_quantize_q8_1_typed<MMQ_Q8_1_DS_LAYOUT_D4>(
+      x, ids, vy, type_x, ne00, s01, s02, s03, ne0, ne1, ne2, ne3, stream);
+}
+
+extern "C" void
+launch_mmq_quantize_q8_1_DS4(const void *x, const int32_t *ids, void *vy,
+                             int type_x, int64_t ne00, int64_t s01, int64_t s02,
+                             int64_t s03, int64_t ne0, int64_t ne1, int64_t ne2,
+                             int64_t ne3, void *stream) {
+  launch_mmq_quantize_q8_1_typed<MMQ_Q8_1_DS_LAYOUT_DS4>(
+      x, ids, vy, type_x, ne00, s01, s02, s03, ne0, ne1, ne2, ne3, stream);
+}
+
+extern "C" void
+launch_mmq_quantize_q8_1_D2S6(const void *x, const int32_t *ids, void *vy,
+                              int type_x, int64_t ne00,
+    int64_t s01, int64_t s02, int64_t s03, int64_t ne0, int64_t ne1,
+    int64_t ne2, int64_t ne3, void *stream) {
+  launch_mmq_quantize_q8_1_typed<MMQ_Q8_1_DS_LAYOUT_D2S6>(
+      x, ids, vy, type_x, ne00, s01, s02, s03, ne0, ne1, ne2, ne3, stream);
 }

--- a/mistralrs-quant/kernels/mmvq_gguf/mmvq_gguf.cu
+++ b/mistralrs-quant/kernels/mmvq_gguf/mmvq_gguf.cu
@@ -838,6 +838,102 @@ static __device__ void mmvq_core_fused_glu_impl(
   }
 }
 
+template <typename dst_t, int qk, int qi, typename block_q_t, int vdr,
+          vec_dot_q_cuda_t vec_dot_q_cuda, int ncols_dst>
+static __device__ void mmvq_core_fused_qkv_impl(
+    const void *__restrict__ vx_q, const void *__restrict__ vx_k,
+    const void *__restrict__ vx_v, const block_q8_1 *__restrict__ y,
+    dst_t *__restrict__ q_dst, dst_t *__restrict__ k_dst,
+    dst_t *__restrict__ v_dst, const int ncols_x, const int nrows_q,
+    const int nrows_k, const int nrows_v, const int stride_col_y) {
+
+  constexpr int nwarps = mmvq_nwarps_for(ncols_dst);
+  constexpr int rows_per_cuda_block = mmvq_rows_per_cuda_block_for(ncols_dst);
+
+  const int projection = blockIdx.y;
+  const void *vx;
+  dst_t *dst;
+  int nrows_x;
+  if (projection == 0) {
+    vx = vx_q;
+    dst = q_dst;
+    nrows_x = nrows_q;
+  } else if (projection == 1) {
+    vx = vx_k;
+    dst = k_dst;
+    nrows_x = nrows_k;
+  } else {
+    vx = vx_v;
+    dst = v_dst;
+    nrows_x = nrows_v;
+  }
+
+  const int tid = WARP_SIZE * threadIdx.y + threadIdx.x;
+  const int row0 = rows_per_cuda_block * blockIdx.x;
+  if (row0 >= nrows_x) {
+    return;
+  }
+
+  const int blocks_per_row_x = ncols_x / qk;
+  constexpr int blocks_per_iter = vdr * nwarps * WARP_SIZE / qi;
+
+  float tmp[ncols_dst][rows_per_cuda_block] = {{0.0f}};
+
+  for (int kbx = tid / (qi / vdr); kbx < blocks_per_row_x;
+       kbx += blocks_per_iter) {
+    const int kby = kbx * (qk / QK8_1);
+    const int kqs = vdr * (tid % (qi / vdr));
+
+#pragma unroll
+    for (int j = 0; j < ncols_dst; ++j) {
+#pragma unroll
+      for (int i = 0; i < rows_per_cuda_block; ++i) {
+        const int row = row0 + i;
+        if (row >= nrows_x) {
+          continue;
+        }
+        const int weight_kbx = row * blocks_per_row_x + kbx;
+        tmp[j][i] +=
+            vec_dot_q_cuda(vx, &y[j * stride_col_y + kby], weight_kbx, kqs);
+      }
+    }
+  }
+
+  __shared__ float tmp_shared[nwarps - 1 > 0 ? nwarps - 1 : 1][ncols_dst]
+                             [rows_per_cuda_block][WARP_SIZE];
+
+  if (threadIdx.y > 0) {
+#pragma unroll
+    for (int j = 0; j < ncols_dst; ++j) {
+#pragma unroll
+      for (int i = 0; i < rows_per_cuda_block; ++i) {
+        tmp_shared[threadIdx.y - 1][j][i][threadIdx.x] = tmp[j][i];
+      }
+    }
+  }
+  __syncthreads();
+  if (threadIdx.y > 0) {
+    return;
+  }
+
+#pragma unroll
+  for (int j = 0; j < ncols_dst; ++j) {
+#pragma unroll
+    for (int i = 0; i < rows_per_cuda_block; ++i) {
+#pragma unroll
+      for (int l = 0; l < nwarps - 1; ++l) {
+        tmp[j][i] += tmp_shared[l][j][i][threadIdx.x];
+      }
+      tmp[j][i] = warp_reduce_sum_f32(tmp[j][i]);
+    }
+    if (threadIdx.x < rows_per_cuda_block &&
+        (rows_per_cuda_block == 1 ||
+         uint32_t(row0 + threadIdx.x) < (uint32_t)nrows_x)) {
+      dst[j * nrows_x + row0 + threadIdx.x] = (dst_t)tmp[j][threadIdx.x];
+    }
+  }
+}
+
 // ---------------------------------------------------------------------------
 // Extern-C kernel entry points
 //
@@ -872,6 +968,23 @@ static __device__ void mmvq_core_fused_glu_impl(
                              vec_dot, ncols>(                                  \
         vx_gate, vx_up, (const block_q8_1 *)vy, dst, ncols_x, nrows_x,          \
         stride_col_y, stride_col_dst, activation);                              \
+  }
+
+#define MMVQ_FUSED_QKV_ENTRY(tag, block_q_t, qk_val, qi_val, vdr_val, vec_dot, \
+                             dst_tag, dst_c_type, ncols)                       \
+  extern "C" __global__ void __launch_bounds__(                                \
+      mmvq_nwarps_for(ncols) * WARP_SIZE, 1)                                    \
+      mmvq_gguf_##tag##_##dst_tag##_fused_qkv_cuda##ncols(                     \
+          const void *__restrict__ vx_q, const void *__restrict__ vx_k,         \
+          const void *__restrict__ vx_v, const void *__restrict__ vy,           \
+          dst_c_type *__restrict__ q_dst, dst_c_type *__restrict__ k_dst,       \
+          dst_c_type *__restrict__ v_dst, const int ncols_x,                   \
+          const int nrows_q, const int nrows_k, const int nrows_v,             \
+          const int stride_col_y) {                                             \
+    mmvq_core_fused_qkv_impl<dst_c_type, qk_val, qi_val, block_q_t, vdr_val,    \
+                             vec_dot, ncols>(                                  \
+        vx_q, vx_k, vx_v, (const block_q8_1 *)vy, q_dst, k_dst, v_dst,          \
+        ncols_x, nrows_q, nrows_k, nrows_v, stride_col_y);                      \
   }
 
 // -- plain entries for all 10 supported quant types, batch sizes 1..8, bf16 +
@@ -925,6 +1038,25 @@ static __device__ void mmvq_core_fused_glu_impl(
                    float, 7)                                                   \
   MMVQ_PLAIN_ENTRY(tag, block_q_t, qk_val, qi_val, vdr_val, vec_dot, f32,      \
                    float, 8)
+
+#define MMVQ_FUSED_QKV_BATCH_SET(tag, block_q_t, qk_val, qi_val, vdr_val,      \
+                                 vec_dot, dst_tag, dst_c_type)                 \
+  MMVQ_FUSED_QKV_ENTRY(tag, block_q_t, qk_val, qi_val, vdr_val, vec_dot,       \
+                       dst_tag, dst_c_type, 1)                                 \
+  MMVQ_FUSED_QKV_ENTRY(tag, block_q_t, qk_val, qi_val, vdr_val, vec_dot,       \
+                       dst_tag, dst_c_type, 2)                                 \
+  MMVQ_FUSED_QKV_ENTRY(tag, block_q_t, qk_val, qi_val, vdr_val, vec_dot,       \
+                       dst_tag, dst_c_type, 3)                                 \
+  MMVQ_FUSED_QKV_ENTRY(tag, block_q_t, qk_val, qi_val, vdr_val, vec_dot,       \
+                       dst_tag, dst_c_type, 4)                                 \
+  MMVQ_FUSED_QKV_ENTRY(tag, block_q_t, qk_val, qi_val, vdr_val, vec_dot,       \
+                       dst_tag, dst_c_type, 5)                                 \
+  MMVQ_FUSED_QKV_ENTRY(tag, block_q_t, qk_val, qi_val, vdr_val, vec_dot,       \
+                       dst_tag, dst_c_type, 6)                                 \
+  MMVQ_FUSED_QKV_ENTRY(tag, block_q_t, qk_val, qi_val, vdr_val, vec_dot,       \
+                       dst_tag, dst_c_type, 7)                                 \
+  MMVQ_FUSED_QKV_ENTRY(tag, block_q_t, qk_val, qi_val, vdr_val, vec_dot,       \
+                       dst_tag, dst_c_type, 8)
 
 MMVQ_PLAIN_BATCH_SET(q4_0, block_q4_0, QK4_0, QI4_0, VDR_Q4_0_Q8_1_MMVQ,
                      vec_dot_q4_0_q8_1)
@@ -1005,6 +1137,36 @@ MMVQ_FUSED_GLU_ENTRY(q8_0, block_q8_0, QK8_0, QI8_0,
                      VDR_Q8_0_Q8_1_MMVQ, vec_dot_q8_0_q8_1, f32, float, 7)
 MMVQ_FUSED_GLU_ENTRY(q8_0, block_q8_0, QK8_0, QI8_0,
                      VDR_Q8_0_Q8_1_MMVQ, vec_dot_q8_0_q8_1, f32, float, 8)
+
+#define MMVQ_FUSED_QKV_TYPE_SET(tag, block_q_t, qk_val, qi_val, vdr_val,      \
+                                vec_dot)                                       \
+  MMVQ_FUSED_QKV_BATCH_SET(tag, block_q_t, qk_val, qi_val, vdr_val, vec_dot,  \
+                           bf16, __nv_bfloat16)                               \
+  MMVQ_FUSED_QKV_BATCH_SET(tag, block_q_t, qk_val, qi_val, vdr_val, vec_dot,  \
+                           f16, half)                                          \
+  MMVQ_FUSED_QKV_BATCH_SET(tag, block_q_t, qk_val, qi_val, vdr_val, vec_dot,  \
+                           f32, float)
+
+MMVQ_FUSED_QKV_TYPE_SET(q4_0, block_q4_0, QK4_0, QI4_0,
+                        VDR_Q4_0_Q8_1_MMVQ, vec_dot_q4_0_q8_1)
+MMVQ_FUSED_QKV_TYPE_SET(q4_1, block_q4_1, QK4_1, QI4_1,
+                        VDR_Q4_1_Q8_1_MMVQ, vec_dot_q4_1_q8_1)
+MMVQ_FUSED_QKV_TYPE_SET(q5_0, block_q5_0, QK5_0, QI5_0,
+                        VDR_Q5_0_Q8_1_MMVQ, vec_dot_q5_0_q8_1)
+MMVQ_FUSED_QKV_TYPE_SET(q5_1, block_q5_1, QK5_1, QI5_1,
+                        VDR_Q5_1_Q8_1_MMVQ, vec_dot_q5_1_q8_1)
+MMVQ_FUSED_QKV_TYPE_SET(q8_0, block_q8_0, QK8_0, QI8_0,
+                        VDR_Q8_0_Q8_1_MMVQ, vec_dot_q8_0_q8_1)
+MMVQ_FUSED_QKV_TYPE_SET(q2_k, block_q2_K, QK_K, QI2_K,
+                        VDR_Q2_K_Q8_1_MMVQ, vec_dot_q2_K_q8_1)
+MMVQ_FUSED_QKV_TYPE_SET(q3_k, block_q3_K, QK_K, QI3_K,
+                        VDR_Q3_K_Q8_1_MMVQ, vec_dot_q3_K_q8_1)
+MMVQ_FUSED_QKV_TYPE_SET(q4_k, block_q4_K, QK_K, QI4_K,
+                        VDR_Q4_K_Q8_1_MMVQ, vec_dot_q4_K_q8_1)
+MMVQ_FUSED_QKV_TYPE_SET(q5_k, block_q5_K, QK_K, QI5_K,
+                        VDR_Q5_K_Q8_1_MMVQ, vec_dot_q5_K_q8_1)
+MMVQ_FUSED_QKV_TYPE_SET(q6_k, block_q6_K, QK_K, QI6_K,
+                        VDR_Q6_K_Q8_1_MMVQ, vec_dot_q6_K_q8_1)
 
 // Padding-aware BF16/F16/F32 -> Q8_1 quantize kernels.
 
@@ -1239,6 +1401,81 @@ mmvq_gguf_quantize_q8_1_f32(const float *__restrict__ x, void *__restrict__ vy,
     }                                                                          \
   }
 
+#define MMVQ_LAUNCHER_FUSED_QKV(tag, dst_tag, dst_c_type)                      \
+  extern "C" void launch_mmvq_gguf_##tag##_##dst_tag##_fused_qkv(              \
+      const void *vx_q, const void *vx_k, const void *vx_v, const void *vy,    \
+      void *q_dst, void *k_dst, void *v_dst, int ncols_x, int nrows_q,         \
+      int nrows_k, int nrows_v, int stride_col_y, int b_size, void *stream) {  \
+    const unsigned int rows_per_block = (b_size <= 1) ? 1 : 2;                 \
+    int max_nrows = nrows_q > nrows_k ? nrows_q : nrows_k;                     \
+    max_nrows = max_nrows > nrows_v ? max_nrows : nrows_v;                    \
+    const unsigned int nblocks =                                               \
+        (unsigned int)((max_nrows + rows_per_block - 1) / rows_per_block);     \
+    unsigned int nwarps;                                                       \
+    if (b_size == 1) {                                                         \
+      nwarps = 8;                                                              \
+    } else if (b_size <= 4) {                                                  \
+      nwarps = 4;                                                              \
+    } else {                                                                   \
+      nwarps = 2;                                                              \
+    }                                                                          \
+    dim3 grid(nblocks, 3, 1);                                                  \
+    dim3 block(WARP_SIZE, nwarps, 1);                                          \
+    cudaStream_t s = static_cast<cudaStream_t>(stream);                        \
+    switch (b_size) {                                                          \
+    case 1:                                                                    \
+      mmvq_gguf_##tag##_##dst_tag##_fused_qkv_cuda1<<<grid, block, 0, s>>>(    \
+          vx_q, vx_k, vx_v, vy, (dst_c_type *)q_dst, (dst_c_type *)k_dst,      \
+          (dst_c_type *)v_dst, ncols_x, nrows_q, nrows_k, nrows_v,             \
+          stride_col_y);                                                       \
+      break;                                                                   \
+    case 2:                                                                    \
+      mmvq_gguf_##tag##_##dst_tag##_fused_qkv_cuda2<<<grid, block, 0, s>>>(    \
+          vx_q, vx_k, vx_v, vy, (dst_c_type *)q_dst, (dst_c_type *)k_dst,      \
+          (dst_c_type *)v_dst, ncols_x, nrows_q, nrows_k, nrows_v,             \
+          stride_col_y);                                                       \
+      break;                                                                   \
+    case 3:                                                                    \
+      mmvq_gguf_##tag##_##dst_tag##_fused_qkv_cuda3<<<grid, block, 0, s>>>(    \
+          vx_q, vx_k, vx_v, vy, (dst_c_type *)q_dst, (dst_c_type *)k_dst,      \
+          (dst_c_type *)v_dst, ncols_x, nrows_q, nrows_k, nrows_v,             \
+          stride_col_y);                                                       \
+      break;                                                                   \
+    case 4:                                                                    \
+      mmvq_gguf_##tag##_##dst_tag##_fused_qkv_cuda4<<<grid, block, 0, s>>>(    \
+          vx_q, vx_k, vx_v, vy, (dst_c_type *)q_dst, (dst_c_type *)k_dst,      \
+          (dst_c_type *)v_dst, ncols_x, nrows_q, nrows_k, nrows_v,             \
+          stride_col_y);                                                       \
+      break;                                                                   \
+    case 5:                                                                    \
+      mmvq_gguf_##tag##_##dst_tag##_fused_qkv_cuda5<<<grid, block, 0, s>>>(    \
+          vx_q, vx_k, vx_v, vy, (dst_c_type *)q_dst, (dst_c_type *)k_dst,      \
+          (dst_c_type *)v_dst, ncols_x, nrows_q, nrows_k, nrows_v,             \
+          stride_col_y);                                                       \
+      break;                                                                   \
+    case 6:                                                                    \
+      mmvq_gguf_##tag##_##dst_tag##_fused_qkv_cuda6<<<grid, block, 0, s>>>(    \
+          vx_q, vx_k, vx_v, vy, (dst_c_type *)q_dst, (dst_c_type *)k_dst,      \
+          (dst_c_type *)v_dst, ncols_x, nrows_q, nrows_k, nrows_v,             \
+          stride_col_y);                                                       \
+      break;                                                                   \
+    case 7:                                                                    \
+      mmvq_gguf_##tag##_##dst_tag##_fused_qkv_cuda7<<<grid, block, 0, s>>>(    \
+          vx_q, vx_k, vx_v, vy, (dst_c_type *)q_dst, (dst_c_type *)k_dst,      \
+          (dst_c_type *)v_dst, ncols_x, nrows_q, nrows_k, nrows_v,             \
+          stride_col_y);                                                       \
+      break;                                                                   \
+    case 8:                                                                    \
+      mmvq_gguf_##tag##_##dst_tag##_fused_qkv_cuda8<<<grid, block, 0, s>>>(    \
+          vx_q, vx_k, vx_v, vy, (dst_c_type *)q_dst, (dst_c_type *)k_dst,      \
+          (dst_c_type *)v_dst, ncols_x, nrows_q, nrows_k, nrows_v,             \
+          stride_col_y);                                                       \
+      break;                                                                   \
+    default:                                                                   \
+      break;                                                                   \
+    }                                                                          \
+  }
+
 MMVQ_LAUNCHER_PLAIN(q4_0, bf16, __nv_bfloat16)
 MMVQ_LAUNCHER_PLAIN(q4_1, bf16, __nv_bfloat16)
 MMVQ_LAUNCHER_PLAIN(q5_0, bf16, __nv_bfloat16)
@@ -1275,6 +1512,22 @@ MMVQ_LAUNCHER_PLAIN(q6_k, f32, float)
 MMVQ_LAUNCHER_FUSED_GLU(q8_0, bf16, __nv_bfloat16)
 MMVQ_LAUNCHER_FUSED_GLU(q8_0, f16, half)
 MMVQ_LAUNCHER_FUSED_GLU(q8_0, f32, float)
+
+#define MMVQ_LAUNCHER_FUSED_QKV_TYPE_SET(tag)                                  \
+  MMVQ_LAUNCHER_FUSED_QKV(tag, bf16, __nv_bfloat16)                            \
+  MMVQ_LAUNCHER_FUSED_QKV(tag, f16, half)                                       \
+  MMVQ_LAUNCHER_FUSED_QKV(tag, f32, float)
+
+MMVQ_LAUNCHER_FUSED_QKV_TYPE_SET(q4_0)
+MMVQ_LAUNCHER_FUSED_QKV_TYPE_SET(q4_1)
+MMVQ_LAUNCHER_FUSED_QKV_TYPE_SET(q5_0)
+MMVQ_LAUNCHER_FUSED_QKV_TYPE_SET(q5_1)
+MMVQ_LAUNCHER_FUSED_QKV_TYPE_SET(q8_0)
+MMVQ_LAUNCHER_FUSED_QKV_TYPE_SET(q2_k)
+MMVQ_LAUNCHER_FUSED_QKV_TYPE_SET(q3_k)
+MMVQ_LAUNCHER_FUSED_QKV_TYPE_SET(q4_k)
+MMVQ_LAUNCHER_FUSED_QKV_TYPE_SET(q5_k)
+MMVQ_LAUNCHER_FUSED_QKV_TYPE_SET(q6_k)
 
 // Quantize launchers.
 

--- a/mistralrs-quant/kernels/mmvq_gguf/mmvq_gguf.cu
+++ b/mistralrs-quant/kernels/mmvq_gguf/mmvq_gguf.cu
@@ -34,6 +34,48 @@ static __device__ __forceinline__ float warp_reduce_max_f32(float x) {
   return x;
 }
 
+enum GluActivation {
+  GLU_SILU = 0,
+  GLU_GELU = 1,
+  GLU_RELU = 2,
+  GLU_GELU_ERF = 3
+};
+
+static __device__ __forceinline__ float glu_silu(float x) {
+  return x / (1.0f + expf(-x));
+}
+
+static __device__ __forceinline__ float glu_gelu(float x) {
+  const float kSqrt2OverPi = 0.7978845608f;
+  const float kCoeff = 0.044715f;
+  const float x3 = x * x * x;
+  const float inner = kSqrt2OverPi * (x + kCoeff * x3);
+  return 0.5f * x * (1.0f + tanhf(inner));
+}
+
+static __device__ __forceinline__ float glu_relu(float x) {
+  return fmaxf(x, 0.0f);
+}
+
+static __device__ __forceinline__ float glu_gelu_erf(float x) {
+  return x * normcdff(x);
+}
+
+static __device__ __forceinline__ float apply_glu_activation(float x, int act) {
+  switch (act) {
+  case GLU_SILU:
+    return glu_silu(x);
+  case GLU_GELU:
+    return glu_gelu(x);
+  case GLU_RELU:
+    return glu_relu(x);
+  case GLU_GELU_ERF:
+    return glu_gelu_erf(x);
+  default:
+    return glu_silu(x);
+  }
+}
+
 static __device__ __forceinline__ int get_int_from_int8(const int8_t *x8,
                                                         const int &i32) {
   const uint16_t *x16 = (const uint16_t *)(x8 + sizeof(int) * i32);
@@ -634,6 +676,9 @@ vec_dot_q6_K_q8_1(const void *__restrict__ vbq,
 // Core mat-vec-q template.
 
 static constexpr __device__ int mmvq_nwarps_for(int ncols_dst) {
+  if (ncols_dst == 1) {
+    return 8;
+  }
   return (ncols_dst <= 4) ? 4 : 2;
 }
 
@@ -711,6 +756,88 @@ mmvq_core_impl(const void *__restrict__ vx, const block_q8_1 *__restrict__ y,
   }
 }
 
+template <typename dst_t, int qk, int qi, typename block_q_t, int vdr,
+          vec_dot_q_cuda_t vec_dot_q_cuda, int ncols_dst>
+static __device__ void mmvq_core_fused_glu_impl(
+    const void *__restrict__ vx_gate, const void *__restrict__ vx_up,
+    const block_q8_1 *__restrict__ y, dst_t *__restrict__ dst,
+    const int ncols_x, const int nrows_x, const int stride_col_y,
+    const int stride_col_dst, const int activation) {
+
+  constexpr int nwarps = mmvq_nwarps_for(ncols_dst);
+  constexpr int rows_per_cuda_block = mmvq_rows_per_cuda_block_for(ncols_dst);
+
+  const int tid = WARP_SIZE * threadIdx.y + threadIdx.x;
+  const int row0 = rows_per_cuda_block * blockIdx.x;
+  const int blocks_per_row_x = ncols_x / qk;
+  constexpr int blocks_per_iter = vdr * nwarps * WARP_SIZE / qi;
+
+  float tmp_gate[ncols_dst][rows_per_cuda_block] = {{0.0f}};
+  float tmp_up[ncols_dst][rows_per_cuda_block] = {{0.0f}};
+
+  for (int kbx = tid / (qi / vdr); kbx < blocks_per_row_x;
+       kbx += blocks_per_iter) {
+    const int kby = kbx * (qk / QK8_1);
+    const int kqs = vdr * (tid % (qi / vdr));
+
+#pragma unroll
+    for (int j = 0; j < ncols_dst; ++j) {
+#pragma unroll
+      for (int i = 0; i < rows_per_cuda_block; ++i) {
+        const int row = row0 + i;
+        const int weight_kbx = row * blocks_per_row_x + kbx;
+        const block_q8_1 *yj = &y[j * stride_col_y + kby];
+        tmp_gate[j][i] += vec_dot_q_cuda(vx_gate, yj, weight_kbx, kqs);
+        tmp_up[j][i] += vec_dot_q_cuda(vx_up, yj, weight_kbx, kqs);
+      }
+    }
+  }
+
+  __shared__ float tmp_shared_gate[nwarps - 1 > 0 ? nwarps - 1 : 1]
+                                 [ncols_dst][rows_per_cuda_block][WARP_SIZE];
+  __shared__ float tmp_shared_up[nwarps - 1 > 0 ? nwarps - 1 : 1]
+                               [ncols_dst][rows_per_cuda_block][WARP_SIZE];
+
+  if (threadIdx.y > 0) {
+#pragma unroll
+    for (int j = 0; j < ncols_dst; ++j) {
+#pragma unroll
+      for (int i = 0; i < rows_per_cuda_block; ++i) {
+        tmp_shared_gate[threadIdx.y - 1][j][i][threadIdx.x] =
+            tmp_gate[j][i];
+        tmp_shared_up[threadIdx.y - 1][j][i][threadIdx.x] = tmp_up[j][i];
+      }
+    }
+  }
+  __syncthreads();
+  if (threadIdx.y > 0) {
+    return;
+  }
+
+#pragma unroll
+  for (int j = 0; j < ncols_dst; ++j) {
+#pragma unroll
+    for (int i = 0; i < rows_per_cuda_block; ++i) {
+#pragma unroll
+      for (int l = 0; l < nwarps - 1; ++l) {
+        tmp_gate[j][i] += tmp_shared_gate[l][j][i][threadIdx.x];
+        tmp_up[j][i] += tmp_shared_up[l][j][i][threadIdx.x];
+      }
+      tmp_gate[j][i] = warp_reduce_sum_f32(tmp_gate[j][i]);
+      tmp_up[j][i] = warp_reduce_sum_f32(tmp_up[j][i]);
+    }
+    if (threadIdx.x < rows_per_cuda_block &&
+        (rows_per_cuda_block == 1 ||
+         uint32_t(row0 + threadIdx.x) < (uint32_t)nrows_x)) {
+      const dst_t gate_val = (dst_t)tmp_gate[j][threadIdx.x];
+      const dst_t up_val = (dst_t)tmp_up[j][threadIdx.x];
+      const dst_t activated =
+          (dst_t)apply_glu_activation((float)gate_val, activation);
+      dst[j * stride_col_dst + row0 + threadIdx.x] = activated * up_val;
+    }
+  }
+}
+
 // ---------------------------------------------------------------------------
 // Extern-C kernel entry points
 //
@@ -721,13 +848,30 @@ mmvq_core_impl(const void *__restrict__ vx, const block_q8_1 *__restrict__ y,
 
 #define MMVQ_PLAIN_ENTRY(tag, block_q_t, qk_val, qi_val, vdr_val, vec_dot,     \
                          dst_tag, dst_c_type, ncols)                           \
-  extern "C" __global__ void mmvq_gguf_##tag##_##dst_tag##_plain_cuda##ncols(  \
+  extern "C" __global__ void __launch_bounds__(                                \
+      mmvq_nwarps_for(ncols) * WARP_SIZE, 1)                                    \
+      mmvq_gguf_##tag##_##dst_tag##_plain_cuda##ncols(                          \
       const void *__restrict__ vx, const void *__restrict__ vy,                \
       dst_c_type *__restrict__ dst, const int ncols_x, const int nrows_x,      \
       const int stride_col_y, const int stride_col_dst) {                      \
     mmvq_core_impl<dst_c_type, qk_val, qi_val, block_q_t, vdr_val, vec_dot,    \
                    ncols>(vx, (const block_q8_1 *)vy, dst, ncols_x, nrows_x,   \
                           stride_col_y, stride_col_dst);                       \
+  }
+
+#define MMVQ_FUSED_GLU_ENTRY(tag, block_q_t, qk_val, qi_val, vdr_val, vec_dot, \
+                             dst_tag, dst_c_type, ncols)                       \
+  extern "C" __global__ void __launch_bounds__(                                \
+      mmvq_nwarps_for(ncols) * WARP_SIZE, 1)                                    \
+      mmvq_gguf_##tag##_##dst_tag##_fused_glu_cuda##ncols(                     \
+          const void *__restrict__ vx_gate, const void *__restrict__ vx_up,     \
+          const void *__restrict__ vy, dst_c_type *__restrict__ dst,            \
+          const int ncols_x, const int nrows_x, const int stride_col_y,         \
+          const int stride_col_dst, const int activation) {                     \
+    mmvq_core_fused_glu_impl<dst_c_type, qk_val, qi_val, block_q_t, vdr_val,    \
+                             vec_dot, ncols>(                                  \
+        vx_gate, vx_up, (const block_q8_1 *)vy, dst, ncols_x, nrows_x,          \
+        stride_col_y, stride_col_dst, activation);                              \
   }
 
 // -- plain entries for all 10 supported quant types, batch sizes 1..8, bf16 +
@@ -802,6 +946,65 @@ MMVQ_PLAIN_BATCH_SET(q5_k, block_q5_K, QK_K, QI5_K, VDR_Q5_K_Q8_1_MMVQ,
                      vec_dot_q5_K_q8_1)
 MMVQ_PLAIN_BATCH_SET(q6_k, block_q6_K, QK_K, QI6_K, VDR_Q6_K_Q8_1_MMVQ,
                      vec_dot_q6_K_q8_1)
+
+MMVQ_FUSED_GLU_ENTRY(q8_0, block_q8_0, QK8_0, QI8_0,
+                     VDR_Q8_0_Q8_1_MMVQ, vec_dot_q8_0_q8_1, bf16,
+                     __nv_bfloat16, 1)
+MMVQ_FUSED_GLU_ENTRY(q8_0, block_q8_0, QK8_0, QI8_0,
+                     VDR_Q8_0_Q8_1_MMVQ, vec_dot_q8_0_q8_1, bf16,
+                     __nv_bfloat16, 2)
+MMVQ_FUSED_GLU_ENTRY(q8_0, block_q8_0, QK8_0, QI8_0,
+                     VDR_Q8_0_Q8_1_MMVQ, vec_dot_q8_0_q8_1, bf16,
+                     __nv_bfloat16, 3)
+MMVQ_FUSED_GLU_ENTRY(q8_0, block_q8_0, QK8_0, QI8_0,
+                     VDR_Q8_0_Q8_1_MMVQ, vec_dot_q8_0_q8_1, bf16,
+                     __nv_bfloat16, 4)
+MMVQ_FUSED_GLU_ENTRY(q8_0, block_q8_0, QK8_0, QI8_0,
+                     VDR_Q8_0_Q8_1_MMVQ, vec_dot_q8_0_q8_1, bf16,
+                     __nv_bfloat16, 5)
+MMVQ_FUSED_GLU_ENTRY(q8_0, block_q8_0, QK8_0, QI8_0,
+                     VDR_Q8_0_Q8_1_MMVQ, vec_dot_q8_0_q8_1, bf16,
+                     __nv_bfloat16, 6)
+MMVQ_FUSED_GLU_ENTRY(q8_0, block_q8_0, QK8_0, QI8_0,
+                     VDR_Q8_0_Q8_1_MMVQ, vec_dot_q8_0_q8_1, bf16,
+                     __nv_bfloat16, 7)
+MMVQ_FUSED_GLU_ENTRY(q8_0, block_q8_0, QK8_0, QI8_0,
+                     VDR_Q8_0_Q8_1_MMVQ, vec_dot_q8_0_q8_1, bf16,
+                     __nv_bfloat16, 8)
+
+MMVQ_FUSED_GLU_ENTRY(q8_0, block_q8_0, QK8_0, QI8_0,
+                     VDR_Q8_0_Q8_1_MMVQ, vec_dot_q8_0_q8_1, f16, half, 1)
+MMVQ_FUSED_GLU_ENTRY(q8_0, block_q8_0, QK8_0, QI8_0,
+                     VDR_Q8_0_Q8_1_MMVQ, vec_dot_q8_0_q8_1, f16, half, 2)
+MMVQ_FUSED_GLU_ENTRY(q8_0, block_q8_0, QK8_0, QI8_0,
+                     VDR_Q8_0_Q8_1_MMVQ, vec_dot_q8_0_q8_1, f16, half, 3)
+MMVQ_FUSED_GLU_ENTRY(q8_0, block_q8_0, QK8_0, QI8_0,
+                     VDR_Q8_0_Q8_1_MMVQ, vec_dot_q8_0_q8_1, f16, half, 4)
+MMVQ_FUSED_GLU_ENTRY(q8_0, block_q8_0, QK8_0, QI8_0,
+                     VDR_Q8_0_Q8_1_MMVQ, vec_dot_q8_0_q8_1, f16, half, 5)
+MMVQ_FUSED_GLU_ENTRY(q8_0, block_q8_0, QK8_0, QI8_0,
+                     VDR_Q8_0_Q8_1_MMVQ, vec_dot_q8_0_q8_1, f16, half, 6)
+MMVQ_FUSED_GLU_ENTRY(q8_0, block_q8_0, QK8_0, QI8_0,
+                     VDR_Q8_0_Q8_1_MMVQ, vec_dot_q8_0_q8_1, f16, half, 7)
+MMVQ_FUSED_GLU_ENTRY(q8_0, block_q8_0, QK8_0, QI8_0,
+                     VDR_Q8_0_Q8_1_MMVQ, vec_dot_q8_0_q8_1, f16, half, 8)
+
+MMVQ_FUSED_GLU_ENTRY(q8_0, block_q8_0, QK8_0, QI8_0,
+                     VDR_Q8_0_Q8_1_MMVQ, vec_dot_q8_0_q8_1, f32, float, 1)
+MMVQ_FUSED_GLU_ENTRY(q8_0, block_q8_0, QK8_0, QI8_0,
+                     VDR_Q8_0_Q8_1_MMVQ, vec_dot_q8_0_q8_1, f32, float, 2)
+MMVQ_FUSED_GLU_ENTRY(q8_0, block_q8_0, QK8_0, QI8_0,
+                     VDR_Q8_0_Q8_1_MMVQ, vec_dot_q8_0_q8_1, f32, float, 3)
+MMVQ_FUSED_GLU_ENTRY(q8_0, block_q8_0, QK8_0, QI8_0,
+                     VDR_Q8_0_Q8_1_MMVQ, vec_dot_q8_0_q8_1, f32, float, 4)
+MMVQ_FUSED_GLU_ENTRY(q8_0, block_q8_0, QK8_0, QI8_0,
+                     VDR_Q8_0_Q8_1_MMVQ, vec_dot_q8_0_q8_1, f32, float, 5)
+MMVQ_FUSED_GLU_ENTRY(q8_0, block_q8_0, QK8_0, QI8_0,
+                     VDR_Q8_0_Q8_1_MMVQ, vec_dot_q8_0_q8_1, f32, float, 6)
+MMVQ_FUSED_GLU_ENTRY(q8_0, block_q8_0, QK8_0, QI8_0,
+                     VDR_Q8_0_Q8_1_MMVQ, vec_dot_q8_0_q8_1, f32, float, 7)
+MMVQ_FUSED_GLU_ENTRY(q8_0, block_q8_0, QK8_0, QI8_0,
+                     VDR_Q8_0_Q8_1_MMVQ, vec_dot_q8_0_q8_1, f32, float, 8)
 
 // Padding-aware BF16/F16/F32 -> Q8_1 quantize kernels.
 
@@ -915,7 +1118,9 @@ mmvq_gguf_quantize_q8_1_f32(const float *__restrict__ x, void *__restrict__ vy,
     const unsigned int nblocks =                                               \
         (unsigned int)((nrows_x + rows_per_block - 1) / rows_per_block);       \
     unsigned int nwarps;                                                       \
-    if (b_size <= 4) {                                                         \
+    if (b_size == 1) {                                                         \
+      nwarps = 8;                                                              \
+    } else if (b_size <= 4) {                                                  \
       nwarps = 4;                                                              \
     } else {                                                                   \
       nwarps = 2;                                                              \
@@ -969,6 +1174,71 @@ mmvq_gguf_quantize_q8_1_f32(const float *__restrict__ x, void *__restrict__ vy,
     }                                                                          \
   }
 
+#define MMVQ_LAUNCHER_FUSED_GLU(tag, dst_tag, dst_c_type)                      \
+  extern "C" void launch_mmvq_gguf_##tag##_##dst_tag##_fused_glu(              \
+      const void *vx_gate, const void *vx_up, const void *vy, void *dst,       \
+      int ncols_x, int nrows_x, int stride_col_y, int stride_col_dst,          \
+      int b_size, int activation, void *stream) {                              \
+    const unsigned int rows_per_block = (b_size <= 1) ? 1 : 2;                 \
+    const unsigned int nblocks =                                               \
+        (unsigned int)((nrows_x + rows_per_block - 1) / rows_per_block);       \
+    unsigned int nwarps;                                                       \
+    if (b_size == 1) {                                                         \
+      nwarps = 8;                                                              \
+    } else if (b_size <= 4) {                                                  \
+      nwarps = 4;                                                              \
+    } else {                                                                   \
+      nwarps = 2;                                                              \
+    }                                                                          \
+    dim3 grid(nblocks, 1, 1);                                                  \
+    dim3 block(WARP_SIZE, nwarps, 1);                                          \
+    cudaStream_t s = static_cast<cudaStream_t>(stream);                        \
+    switch (b_size) {                                                          \
+    case 1:                                                                    \
+      mmvq_gguf_##tag##_##dst_tag##_fused_glu_cuda1<<<grid, block, 0, s>>>(    \
+          vx_gate, vx_up, vy, (dst_c_type *)dst, ncols_x, nrows_x,             \
+          stride_col_y, stride_col_dst, activation);                           \
+      break;                                                                   \
+    case 2:                                                                    \
+      mmvq_gguf_##tag##_##dst_tag##_fused_glu_cuda2<<<grid, block, 0, s>>>(    \
+          vx_gate, vx_up, vy, (dst_c_type *)dst, ncols_x, nrows_x,             \
+          stride_col_y, stride_col_dst, activation);                           \
+      break;                                                                   \
+    case 3:                                                                    \
+      mmvq_gguf_##tag##_##dst_tag##_fused_glu_cuda3<<<grid, block, 0, s>>>(    \
+          vx_gate, vx_up, vy, (dst_c_type *)dst, ncols_x, nrows_x,             \
+          stride_col_y, stride_col_dst, activation);                           \
+      break;                                                                   \
+    case 4:                                                                    \
+      mmvq_gguf_##tag##_##dst_tag##_fused_glu_cuda4<<<grid, block, 0, s>>>(    \
+          vx_gate, vx_up, vy, (dst_c_type *)dst, ncols_x, nrows_x,             \
+          stride_col_y, stride_col_dst, activation);                           \
+      break;                                                                   \
+    case 5:                                                                    \
+      mmvq_gguf_##tag##_##dst_tag##_fused_glu_cuda5<<<grid, block, 0, s>>>(    \
+          vx_gate, vx_up, vy, (dst_c_type *)dst, ncols_x, nrows_x,             \
+          stride_col_y, stride_col_dst, activation);                           \
+      break;                                                                   \
+    case 6:                                                                    \
+      mmvq_gguf_##tag##_##dst_tag##_fused_glu_cuda6<<<grid, block, 0, s>>>(    \
+          vx_gate, vx_up, vy, (dst_c_type *)dst, ncols_x, nrows_x,             \
+          stride_col_y, stride_col_dst, activation);                           \
+      break;                                                                   \
+    case 7:                                                                    \
+      mmvq_gguf_##tag##_##dst_tag##_fused_glu_cuda7<<<grid, block, 0, s>>>(    \
+          vx_gate, vx_up, vy, (dst_c_type *)dst, ncols_x, nrows_x,             \
+          stride_col_y, stride_col_dst, activation);                           \
+      break;                                                                   \
+    case 8:                                                                    \
+      mmvq_gguf_##tag##_##dst_tag##_fused_glu_cuda8<<<grid, block, 0, s>>>(    \
+          vx_gate, vx_up, vy, (dst_c_type *)dst, ncols_x, nrows_x,             \
+          stride_col_y, stride_col_dst, activation);                           \
+      break;                                                                   \
+    default:                                                                   \
+      break;                                                                   \
+    }                                                                          \
+  }
+
 MMVQ_LAUNCHER_PLAIN(q4_0, bf16, __nv_bfloat16)
 MMVQ_LAUNCHER_PLAIN(q4_1, bf16, __nv_bfloat16)
 MMVQ_LAUNCHER_PLAIN(q5_0, bf16, __nv_bfloat16)
@@ -1001,6 +1271,10 @@ MMVQ_LAUNCHER_PLAIN(q3_k, f32, float)
 MMVQ_LAUNCHER_PLAIN(q4_k, f32, float)
 MMVQ_LAUNCHER_PLAIN(q5_k, f32, float)
 MMVQ_LAUNCHER_PLAIN(q6_k, f32, float)
+
+MMVQ_LAUNCHER_FUSED_GLU(q8_0, bf16, __nv_bfloat16)
+MMVQ_LAUNCHER_FUSED_GLU(q8_0, f16, half)
+MMVQ_LAUNCHER_FUSED_GLU(q8_0, f32, float)
 
 // Quantize launchers.
 

--- a/mistralrs-quant/src/distributed/layers.rs
+++ b/mistralrs-quant/src/distributed/layers.rs
@@ -253,6 +253,10 @@ impl QuantMethod for RowParallelLayer {
         self.weight.unquant_weight_bias()
     }
 
+    fn has_bias(&self) -> bool {
+        self.bias.is_some() || self.weight.has_bias()
+    }
+
     #[cfg(feature = "cuda")]
     fn get_qtensor(&self) -> Option<&candle_core::quantized::QTensor> {
         self.weight.get_qtensor()
@@ -584,6 +588,10 @@ impl QuantMethod for ColumnParallelLayer {
 
     fn unquant_weight_bias(&self) -> Option<(Tensor, Option<Tensor>)> {
         self.weight.unquant_weight_bias()
+    }
+
+    fn has_bias(&self) -> bool {
+        self.bias.is_some() || self.weight.has_bias()
     }
 
     #[cfg(feature = "cuda")]
@@ -924,6 +932,10 @@ impl QuantMethod for ReplicatedLayer {
 
     fn unquant_weight_bias(&self) -> Option<(Tensor, Option<Tensor>)> {
         self.0.unquant_weight_bias()
+    }
+
+    fn has_bias(&self) -> bool {
+        self.0.has_bias()
     }
 
     #[cfg(feature = "cuda")]

--- a/mistralrs-quant/src/gguf/fast_mmq.rs
+++ b/mistralrs-quant/src/gguf/fast_mmq.rs
@@ -282,18 +282,18 @@ pub fn plain(w: &QTensor, xs: &Tensor) -> Result<Tensor> {
         candle_core::bail!("fast_mmq: input dtype must be BF16, F16, or F32, got {input_ty:?}");
     }
 
-    // Convert to f32 if needed (MMQ quantize expects f32 input)
-    let xs_f32 = if input_ty == DType::F32 {
-        xs.contiguous()?
-    } else {
-        xs.to_dtype(DType::F32)?.contiguous()?
-    };
-
-    let (xs_storage, xs_layout) = xs_f32.storage_and_layout();
+    let xs = xs.contiguous()?;
+    let (xs_storage, xs_layout) = xs.storage_and_layout();
     let Storage::Cuda(xs_cuda) = &*xs_storage else {
         candle_core::bail!("fast_mmq: input must live on CUDA");
     };
     let xs_offset = xs_layout.start_offset();
+    let type_x = match input_ty {
+        DType::F32 => 0,
+        DType::F16 => 1,
+        DType::BF16 => 30,
+        _ => unreachable!(),
+    };
 
     let stream_ptr = dev.cuda_stream().cu_stream() as *mut std::ffi::c_void;
 
@@ -331,51 +331,135 @@ pub fn plain(w: &QTensor, xs: &Tensor) -> Result<Tensor> {
     let out = unsafe { dev.alloc::<f32>(nrows * b_size)? };
     let stride_col_dst = nrows as i64;
 
-    {
-        let slice = xs_cuda.as_cuda_slice::<f32>()?;
-        let (xs_ptr, _xs_guard) = slice_ptr(slice, xs_offset);
-        let (out_ptr, _out_guard) = slice_ptr(&out, 0);
+    let quantize = quantize_launcher(ds_layout_for(dtype));
+    let launcher = mmq_launcher(dtype).expect("supports() checked");
 
-        unsafe {
-            let quantize = quantize_launcher(ds_layout_for(dtype));
-            quantize(
-                xs_ptr as *const std::ffi::c_void,
-                std::ptr::null(),
-                scratch_ptr,
-                0,
-                k as i64,
-                k as i64,
-                0,
-                0,
-                k_padded as i64,
-                b_size as i64,
-                1,
-                1,
-                stream_ptr,
-            );
+    match input_ty {
+        DType::BF16 => {
+            let slice = xs_cuda.as_cuda_slice::<half::bf16>()?;
+            let (xs_ptr, _xs_guard) = slice_ptr(slice, xs_offset);
+            let (out_ptr, _out_guard) = slice_ptr(&out, 0);
 
-            let launcher = mmq_launcher(dtype).expect("supports() checked");
-            launcher(
-                fixup_ptr,
-                weight_ptr,
-                scratch_ptr as *const std::ffi::c_void,
-                out_ptr as *mut std::ffi::c_void,
-                k as i64,
-                nrows as i64,
-                b_size as i64,
-                stride_row_x,
-                stride_col_dst,
-                di.cc,
-                di.nsm,
-                di.smpbo,
-                di.warp_size,
-                stream_ptr,
-            );
+            unsafe {
+                quantize(
+                    xs_ptr as *const std::ffi::c_void,
+                    std::ptr::null(),
+                    scratch_ptr,
+                    type_x,
+                    k as i64,
+                    k as i64,
+                    0,
+                    0,
+                    k_padded as i64,
+                    b_size as i64,
+                    1,
+                    1,
+                    stream_ptr,
+                );
+
+                launcher(
+                    fixup_ptr,
+                    weight_ptr,
+                    scratch_ptr as *const std::ffi::c_void,
+                    out_ptr as *mut std::ffi::c_void,
+                    k as i64,
+                    nrows as i64,
+                    b_size as i64,
+                    stride_row_x,
+                    stride_col_dst,
+                    di.cc,
+                    di.nsm,
+                    di.smpbo,
+                    di.warp_size,
+                    stream_ptr,
+                );
+            }
         }
+        DType::F16 => {
+            let slice = xs_cuda.as_cuda_slice::<half::f16>()?;
+            let (xs_ptr, _xs_guard) = slice_ptr(slice, xs_offset);
+            let (out_ptr, _out_guard) = slice_ptr(&out, 0);
+
+            unsafe {
+                quantize(
+                    xs_ptr as *const std::ffi::c_void,
+                    std::ptr::null(),
+                    scratch_ptr,
+                    type_x,
+                    k as i64,
+                    k as i64,
+                    0,
+                    0,
+                    k_padded as i64,
+                    b_size as i64,
+                    1,
+                    1,
+                    stream_ptr,
+                );
+
+                launcher(
+                    fixup_ptr,
+                    weight_ptr,
+                    scratch_ptr as *const std::ffi::c_void,
+                    out_ptr as *mut std::ffi::c_void,
+                    k as i64,
+                    nrows as i64,
+                    b_size as i64,
+                    stride_row_x,
+                    stride_col_dst,
+                    di.cc,
+                    di.nsm,
+                    di.smpbo,
+                    di.warp_size,
+                    stream_ptr,
+                );
+            }
+        }
+        DType::F32 => {
+            let slice = xs_cuda.as_cuda_slice::<f32>()?;
+            let (xs_ptr, _xs_guard) = slice_ptr(slice, xs_offset);
+            let (out_ptr, _out_guard) = slice_ptr(&out, 0);
+
+            unsafe {
+                quantize(
+                    xs_ptr as *const std::ffi::c_void,
+                    std::ptr::null(),
+                    scratch_ptr,
+                    type_x,
+                    k as i64,
+                    k as i64,
+                    0,
+                    0,
+                    k_padded as i64,
+                    b_size as i64,
+                    1,
+                    1,
+                    stream_ptr,
+                );
+
+                launcher(
+                    fixup_ptr,
+                    weight_ptr,
+                    scratch_ptr as *const std::ffi::c_void,
+                    out_ptr as *mut std::ffi::c_void,
+                    k as i64,
+                    nrows as i64,
+                    b_size as i64,
+                    stride_row_x,
+                    stride_col_dst,
+                    di.cc,
+                    di.nsm,
+                    di.smpbo,
+                    di.warp_size,
+                    stream_ptr,
+                );
+            }
+        }
+        _ => unreachable!(),
     }
 
     let out_storage = CudaStorage::wrap_cuda_slice(out, dev.clone());
-    let out_tensor = Tensor::from((Storage::Cuda(out_storage), output_shape(&xs_f32, nrows)));
+    let out_tensor = Tensor::from((Storage::Cuda(out_storage), output_shape(&xs, nrows)));
 
     if input_ty == DType::F32 {
         Ok(out_tensor)

--- a/mistralrs-quant/src/gguf/fast_mmvq.rs
+++ b/mistralrs-quant/src/gguf/fast_mmvq.rs
@@ -115,6 +115,23 @@ type FusedGluLauncher = unsafe extern "C" fn(
     stream: *mut std::ffi::c_void,
 );
 
+type FusedQkvLauncher = unsafe extern "C" fn(
+    vx_q: *const std::ffi::c_void,
+    vx_k: *const std::ffi::c_void,
+    vx_v: *const std::ffi::c_void,
+    vy: *const std::ffi::c_void,
+    q_dst: *mut std::ffi::c_void,
+    k_dst: *mut std::ffi::c_void,
+    v_dst: *mut std::ffi::c_void,
+    ncols_x: i32,
+    nrows_q: i32,
+    nrows_k: i32,
+    nrows_v: i32,
+    stride_col_y: i32,
+    b_size: i32,
+    stream: *mut std::ffi::c_void,
+);
+
 fn plain_launcher_bf16(dtype: GgmlDType) -> Option<PlainLauncher> {
     let f: PlainLauncher = match dtype {
         GgmlDType::Q4_0 => ffi::launch_mmvq_gguf_q4_0_bf16_plain,
@@ -171,6 +188,44 @@ fn fused_glu_launcher(input_ty: DType, dtype: GgmlDType) -> Option<FusedGluLaunc
         (DType::BF16, GgmlDType::Q8_0) => Some(ffi::launch_mmvq_gguf_q8_0_bf16_fused_glu),
         (DType::F16, GgmlDType::Q8_0) => Some(ffi::launch_mmvq_gguf_q8_0_f16_fused_glu),
         (DType::F32, GgmlDType::Q8_0) => Some(ffi::launch_mmvq_gguf_q8_0_f32_fused_glu),
+        _ => None,
+    }
+}
+
+fn fused_qkv_launcher(input_ty: DType, dtype: GgmlDType) -> Option<FusedQkvLauncher> {
+    match (input_ty, dtype) {
+        (DType::BF16, GgmlDType::Q4_0) => Some(ffi::launch_mmvq_gguf_q4_0_bf16_fused_qkv),
+        (DType::BF16, GgmlDType::Q4_1) => Some(ffi::launch_mmvq_gguf_q4_1_bf16_fused_qkv),
+        (DType::BF16, GgmlDType::Q5_0) => Some(ffi::launch_mmvq_gguf_q5_0_bf16_fused_qkv),
+        (DType::BF16, GgmlDType::Q5_1) => Some(ffi::launch_mmvq_gguf_q5_1_bf16_fused_qkv),
+        (DType::BF16, GgmlDType::Q8_0) => Some(ffi::launch_mmvq_gguf_q8_0_bf16_fused_qkv),
+        (DType::BF16, GgmlDType::Q2K) => Some(ffi::launch_mmvq_gguf_q2_k_bf16_fused_qkv),
+        (DType::BF16, GgmlDType::Q3K) => Some(ffi::launch_mmvq_gguf_q3_k_bf16_fused_qkv),
+        (DType::BF16, GgmlDType::Q4K) => Some(ffi::launch_mmvq_gguf_q4_k_bf16_fused_qkv),
+        (DType::BF16, GgmlDType::Q5K) => Some(ffi::launch_mmvq_gguf_q5_k_bf16_fused_qkv),
+        (DType::BF16, GgmlDType::Q6K) => Some(ffi::launch_mmvq_gguf_q6_k_bf16_fused_qkv),
+
+        (DType::F16, GgmlDType::Q4_0) => Some(ffi::launch_mmvq_gguf_q4_0_f16_fused_qkv),
+        (DType::F16, GgmlDType::Q4_1) => Some(ffi::launch_mmvq_gguf_q4_1_f16_fused_qkv),
+        (DType::F16, GgmlDType::Q5_0) => Some(ffi::launch_mmvq_gguf_q5_0_f16_fused_qkv),
+        (DType::F16, GgmlDType::Q5_1) => Some(ffi::launch_mmvq_gguf_q5_1_f16_fused_qkv),
+        (DType::F16, GgmlDType::Q8_0) => Some(ffi::launch_mmvq_gguf_q8_0_f16_fused_qkv),
+        (DType::F16, GgmlDType::Q2K) => Some(ffi::launch_mmvq_gguf_q2_k_f16_fused_qkv),
+        (DType::F16, GgmlDType::Q3K) => Some(ffi::launch_mmvq_gguf_q3_k_f16_fused_qkv),
+        (DType::F16, GgmlDType::Q4K) => Some(ffi::launch_mmvq_gguf_q4_k_f16_fused_qkv),
+        (DType::F16, GgmlDType::Q5K) => Some(ffi::launch_mmvq_gguf_q5_k_f16_fused_qkv),
+        (DType::F16, GgmlDType::Q6K) => Some(ffi::launch_mmvq_gguf_q6_k_f16_fused_qkv),
+
+        (DType::F32, GgmlDType::Q4_0) => Some(ffi::launch_mmvq_gguf_q4_0_f32_fused_qkv),
+        (DType::F32, GgmlDType::Q4_1) => Some(ffi::launch_mmvq_gguf_q4_1_f32_fused_qkv),
+        (DType::F32, GgmlDType::Q5_0) => Some(ffi::launch_mmvq_gguf_q5_0_f32_fused_qkv),
+        (DType::F32, GgmlDType::Q5_1) => Some(ffi::launch_mmvq_gguf_q5_1_f32_fused_qkv),
+        (DType::F32, GgmlDType::Q8_0) => Some(ffi::launch_mmvq_gguf_q8_0_f32_fused_qkv),
+        (DType::F32, GgmlDType::Q2K) => Some(ffi::launch_mmvq_gguf_q2_k_f32_fused_qkv),
+        (DType::F32, GgmlDType::Q3K) => Some(ffi::launch_mmvq_gguf_q3_k_f32_fused_qkv),
+        (DType::F32, GgmlDType::Q4K) => Some(ffi::launch_mmvq_gguf_q4_k_f32_fused_qkv),
+        (DType::F32, GgmlDType::Q5K) => Some(ffi::launch_mmvq_gguf_q5_k_f32_fused_qkv),
+        (DType::F32, GgmlDType::Q6K) => Some(ffi::launch_mmvq_gguf_q6_k_f32_fused_qkv),
         _ => None,
     }
 }
@@ -557,6 +612,262 @@ pub fn fused_glu(
                 Storage::Cuda(out_storage),
                 output_shape(&xs, nrows),
             )))
+        }
+        _ => unreachable!(),
+    }
+}
+
+/// Compute Q, K, and V matvecs with one input quantization pass and one MMVQ
+/// kernel. The result tensors match the unfused `plain` outputs for each
+/// projection and preserve the input dtype.
+pub fn fused_qkv(
+    q_w: &QTensor,
+    k_w: &QTensor,
+    v_w: &QTensor,
+    xs: &Tensor,
+) -> Result<(Tensor, Tensor, Tensor)> {
+    let dtype = q_w.dtype();
+    if dtype != k_w.dtype() || dtype != v_w.dtype() {
+        candle_core::bail!(
+            "fast_mmvq fused_qkv: q/k/v dtype mismatch {:?}, {:?}, {:?}",
+            dtype,
+            k_w.dtype(),
+            v_w.dtype()
+        );
+    }
+    let Some(launcher) = fused_qkv_launcher(xs.dtype(), dtype) else {
+        candle_core::bail!("fast_mmvq fused_qkv: unsupported dtype combination");
+    };
+
+    let Device::Cuda(dev) = q_w.device() else {
+        candle_core::bail!("fast_mmvq fused_qkv: q weight must live on CUDA");
+    };
+    let Device::Cuda(k_dev) = k_w.device() else {
+        candle_core::bail!("fast_mmvq fused_qkv: k weight must live on CUDA");
+    };
+    let Device::Cuda(v_dev) = v_w.device() else {
+        candle_core::bail!("fast_mmvq fused_qkv: v weight must live on CUDA");
+    };
+    if dev.id() != k_dev.id() || dev.id() != v_dev.id() {
+        candle_core::bail!("fast_mmvq fused_qkv: q/k/v weights are on different CUDA devices");
+    }
+
+    let (q_nrows, ncols) = q_w.shape().dims2()?;
+    let (k_nrows, k_ncols) = k_w.shape().dims2()?;
+    let (v_nrows, v_ncols) = v_w.shape().dims2()?;
+    if ncols != k_ncols || ncols != v_ncols {
+        candle_core::bail!(
+            "fast_mmvq fused_qkv: q/k/v ncols mismatch {ncols}, {k_ncols}, {v_ncols}"
+        );
+    }
+
+    let (b_size, k) = match xs.dims() {
+        [b, k] => (*b, *k),
+        [b, m, k] => (*b * *m, *k),
+        other => candle_core::bail!("fast_mmvq fused_qkv: unexpected input rank {other:?}"),
+    };
+    if k != ncols {
+        candle_core::bail!(
+            "fast_mmvq fused_qkv: shape mismatch — weight ncols {ncols} vs input tail {k}"
+        );
+    }
+    if b_size == 0 || b_size > MMVQ_MAX_BATCH {
+        candle_core::bail!(
+            "fast_mmvq fused_qkv: batch size {b_size} out of supported range 1..={MMVQ_MAX_BATCH}"
+        );
+    }
+    let input_ty = xs.dtype();
+    if !matches!(input_ty, DType::BF16 | DType::F16 | DType::F32) {
+        candle_core::bail!(
+            "fast_mmvq fused_qkv: input dtype must be BF16, F16, or F32, got {input_ty:?}"
+        );
+    }
+
+    let xs = xs.contiguous()?;
+    let (xs_storage, xs_layout) = xs.storage_and_layout();
+    let Storage::Cuda(xs_cuda) = &*xs_storage else {
+        candle_core::bail!("fast_mmvq fused_qkv: input must live on CUDA");
+    };
+    let xs_offset = xs_layout.start_offset();
+
+    let stream_ptr = dev.cuda_stream().cu_stream() as *mut std::ffi::c_void;
+    let k_padded = pad(k, MATRIX_ROW_PADDING);
+    let num_blocks_per_row = k_padded / Q8_1_BLOCK_SIZE;
+    let dst_row_bytes = num_blocks_per_row * Q8_1_TYPE_SIZE;
+    let scratch_bytes = b_size * dst_row_bytes;
+
+    let (scratch_ptr, _workspace_guard) = workspace_ensure(&dev, scratch_bytes)?;
+    let scratch_ptr = scratch_ptr as *mut std::ffi::c_void;
+    let stride_col_y = (k_padded / Q8_1_BLOCK_SIZE) as i32;
+    let q_ptr = q_w.device_ptr()? as *const std::ffi::c_void;
+    let k_ptr = k_w.device_ptr()? as *const std::ffi::c_void;
+    let v_ptr = v_w.device_ptr()? as *const std::ffi::c_void;
+
+    match input_ty {
+        DType::BF16 => {
+            let slice = xs_cuda.as_cuda_slice::<half::bf16>()?;
+            let q_out = unsafe { dev.alloc::<half::bf16>(q_nrows * b_size)? };
+            let k_out = unsafe { dev.alloc::<half::bf16>(k_nrows * b_size)? };
+            let v_out = unsafe { dev.alloc::<half::bf16>(v_nrows * b_size)? };
+
+            {
+                let (xs_ptr, _xs_guard) = slice_ptr(slice, xs_offset);
+                let (q_out_ptr, _q_out_guard) = slice_ptr(&q_out, 0);
+                let (k_out_ptr, _k_out_guard) = slice_ptr(&k_out, 0);
+                let (v_out_ptr, _v_out_guard) = slice_ptr(&v_out, 0);
+
+                unsafe {
+                    ffi::launch_mmvq_gguf_quantize_q8_1_bf16(
+                        xs_ptr as *const std::ffi::c_void,
+                        scratch_ptr,
+                        k as i32,
+                        k_padded as i32,
+                        b_size as i32,
+                        stream_ptr,
+                    );
+                    launcher(
+                        q_ptr,
+                        k_ptr,
+                        v_ptr,
+                        scratch_ptr as *const std::ffi::c_void,
+                        q_out_ptr as *mut std::ffi::c_void,
+                        k_out_ptr as *mut std::ffi::c_void,
+                        v_out_ptr as *mut std::ffi::c_void,
+                        k as i32,
+                        q_nrows as i32,
+                        k_nrows as i32,
+                        v_nrows as i32,
+                        stride_col_y,
+                        b_size as i32,
+                        stream_ptr,
+                    );
+                }
+            }
+
+            Ok((
+                Tensor::from((
+                    Storage::Cuda(CudaStorage::wrap_cuda_slice(q_out, dev.clone())),
+                    output_shape(&xs, q_nrows),
+                )),
+                Tensor::from((
+                    Storage::Cuda(CudaStorage::wrap_cuda_slice(k_out, dev.clone())),
+                    output_shape(&xs, k_nrows),
+                )),
+                Tensor::from((
+                    Storage::Cuda(CudaStorage::wrap_cuda_slice(v_out, dev.clone())),
+                    output_shape(&xs, v_nrows),
+                )),
+            ))
+        }
+        DType::F16 => {
+            let slice = xs_cuda.as_cuda_slice::<half::f16>()?;
+            let q_out = unsafe { dev.alloc::<half::f16>(q_nrows * b_size)? };
+            let k_out = unsafe { dev.alloc::<half::f16>(k_nrows * b_size)? };
+            let v_out = unsafe { dev.alloc::<half::f16>(v_nrows * b_size)? };
+
+            {
+                let (xs_ptr, _xs_guard) = slice_ptr(slice, xs_offset);
+                let (q_out_ptr, _q_out_guard) = slice_ptr(&q_out, 0);
+                let (k_out_ptr, _k_out_guard) = slice_ptr(&k_out, 0);
+                let (v_out_ptr, _v_out_guard) = slice_ptr(&v_out, 0);
+
+                unsafe {
+                    ffi::launch_mmvq_gguf_quantize_q8_1_f16(
+                        xs_ptr as *const std::ffi::c_void,
+                        scratch_ptr,
+                        k as i32,
+                        k_padded as i32,
+                        b_size as i32,
+                        stream_ptr,
+                    );
+                    launcher(
+                        q_ptr,
+                        k_ptr,
+                        v_ptr,
+                        scratch_ptr as *const std::ffi::c_void,
+                        q_out_ptr as *mut std::ffi::c_void,
+                        k_out_ptr as *mut std::ffi::c_void,
+                        v_out_ptr as *mut std::ffi::c_void,
+                        k as i32,
+                        q_nrows as i32,
+                        k_nrows as i32,
+                        v_nrows as i32,
+                        stride_col_y,
+                        b_size as i32,
+                        stream_ptr,
+                    );
+                }
+            }
+
+            Ok((
+                Tensor::from((
+                    Storage::Cuda(CudaStorage::wrap_cuda_slice(q_out, dev.clone())),
+                    output_shape(&xs, q_nrows),
+                )),
+                Tensor::from((
+                    Storage::Cuda(CudaStorage::wrap_cuda_slice(k_out, dev.clone())),
+                    output_shape(&xs, k_nrows),
+                )),
+                Tensor::from((
+                    Storage::Cuda(CudaStorage::wrap_cuda_slice(v_out, dev.clone())),
+                    output_shape(&xs, v_nrows),
+                )),
+            ))
+        }
+        DType::F32 => {
+            let slice = xs_cuda.as_cuda_slice::<f32>()?;
+            let q_out = unsafe { dev.alloc::<f32>(q_nrows * b_size)? };
+            let k_out = unsafe { dev.alloc::<f32>(k_nrows * b_size)? };
+            let v_out = unsafe { dev.alloc::<f32>(v_nrows * b_size)? };
+
+            {
+                let (xs_ptr, _xs_guard) = slice_ptr(slice, xs_offset);
+                let (q_out_ptr, _q_out_guard) = slice_ptr(&q_out, 0);
+                let (k_out_ptr, _k_out_guard) = slice_ptr(&k_out, 0);
+                let (v_out_ptr, _v_out_guard) = slice_ptr(&v_out, 0);
+
+                unsafe {
+                    ffi::launch_mmvq_gguf_quantize_q8_1_f32(
+                        xs_ptr as *const std::ffi::c_void,
+                        scratch_ptr,
+                        k as i32,
+                        k_padded as i32,
+                        b_size as i32,
+                        stream_ptr,
+                    );
+                    launcher(
+                        q_ptr,
+                        k_ptr,
+                        v_ptr,
+                        scratch_ptr as *const std::ffi::c_void,
+                        q_out_ptr as *mut std::ffi::c_void,
+                        k_out_ptr as *mut std::ffi::c_void,
+                        v_out_ptr as *mut std::ffi::c_void,
+                        k as i32,
+                        q_nrows as i32,
+                        k_nrows as i32,
+                        v_nrows as i32,
+                        stride_col_y,
+                        b_size as i32,
+                        stream_ptr,
+                    );
+                }
+            }
+
+            Ok((
+                Tensor::from((
+                    Storage::Cuda(CudaStorage::wrap_cuda_slice(q_out, dev.clone())),
+                    output_shape(&xs, q_nrows),
+                )),
+                Tensor::from((
+                    Storage::Cuda(CudaStorage::wrap_cuda_slice(k_out, dev.clone())),
+                    output_shape(&xs, k_nrows),
+                )),
+                Tensor::from((
+                    Storage::Cuda(CudaStorage::wrap_cuda_slice(v_out, dev.clone())),
+                    output_shape(&xs, v_nrows),
+                )),
+            ))
         }
         _ => unreachable!(),
     }

--- a/mistralrs-quant/src/gguf/fast_mmvq.rs
+++ b/mistralrs-quant/src/gguf/fast_mmvq.rs
@@ -10,7 +10,7 @@ use candle_core::{
 };
 
 use super::ffi;
-use crate::utils::slice_ptr;
+use crate::{utils::slice_ptr, GluActivationType};
 
 const Q8_1_BLOCK_SIZE: usize = 32;
 const Q8_1_TYPE_SIZE: usize = 36; // 2 halves (4 bytes) + QK8_1 int8 = 4 + 32 = 36
@@ -101,6 +101,20 @@ type PlainLauncher = unsafe extern "C" fn(
     stream: *mut std::ffi::c_void,
 );
 
+type FusedGluLauncher = unsafe extern "C" fn(
+    vx_gate: *const std::ffi::c_void,
+    vx_up: *const std::ffi::c_void,
+    vy: *const std::ffi::c_void,
+    dst: *mut std::ffi::c_void,
+    ncols_x: i32,
+    nrows_x: i32,
+    stride_col_y: i32,
+    stride_col_dst: i32,
+    b_size: i32,
+    activation: i32,
+    stream: *mut std::ffi::c_void,
+);
+
 fn plain_launcher_bf16(dtype: GgmlDType) -> Option<PlainLauncher> {
     let f: PlainLauncher = match dtype {
         GgmlDType::Q4_0 => ffi::launch_mmvq_gguf_q4_0_bf16_plain,
@@ -150,6 +164,15 @@ fn plain_launcher_f32(dtype: GgmlDType) -> Option<PlainLauncher> {
         _ => return None,
     };
     Some(f)
+}
+
+fn fused_glu_launcher(input_ty: DType, dtype: GgmlDType) -> Option<FusedGluLauncher> {
+    match (input_ty, dtype) {
+        (DType::BF16, GgmlDType::Q8_0) => Some(ffi::launch_mmvq_gguf_q8_0_bf16_fused_glu),
+        (DType::F16, GgmlDType::Q8_0) => Some(ffi::launch_mmvq_gguf_q8_0_f16_fused_glu),
+        (DType::F32, GgmlDType::Q8_0) => Some(ffi::launch_mmvq_gguf_q8_0_f32_fused_glu),
+        _ => None,
+    }
 }
 
 /// Compute `w @ xs^T` where `w` is a Q8_1-quantizable GGUF weight tensor and
@@ -317,6 +340,213 @@ pub fn plain(w: &QTensor, xs: &Tensor) -> Result<Tensor> {
                         stride_col_y,
                         stride_col_dst,
                         b_size as i32,
+                        stream_ptr,
+                    );
+                }
+            }
+
+            let out_storage = CudaStorage::wrap_cuda_slice(out, dev.clone());
+            Ok(Tensor::from((
+                Storage::Cuda(out_storage),
+                output_shape(&xs, nrows),
+            )))
+        }
+        _ => unreachable!(),
+    }
+}
+
+/// Decode-only fused gate/up path for Q8_0 GGUF weights.
+///
+/// This computes `activation(gate @ xs) * (up @ xs)` with a single input
+/// quantization pass and a single MMVQ kernel. The result dtype and rounding
+/// match the unfused path: each matvec result is rounded to the input dtype
+/// before applying the GLU activation and multiply.
+pub fn fused_glu(
+    gate_w: &QTensor,
+    up_w: &QTensor,
+    xs: &Tensor,
+    activation: GluActivationType,
+) -> Result<Tensor> {
+    let dtype = gate_w.dtype();
+    if dtype != up_w.dtype() {
+        candle_core::bail!(
+            "fast_mmvq fused_glu: gate/up dtype mismatch {:?} vs {:?}",
+            dtype,
+            up_w.dtype()
+        );
+    }
+    let Some(launcher) = fused_glu_launcher(xs.dtype(), dtype) else {
+        candle_core::bail!("fast_mmvq fused_glu: unsupported dtype combination");
+    };
+
+    let Device::Cuda(dev) = gate_w.device() else {
+        candle_core::bail!("fast_mmvq fused_glu: gate weight must live on CUDA");
+    };
+    let Device::Cuda(up_dev) = up_w.device() else {
+        candle_core::bail!("fast_mmvq fused_glu: up weight must live on CUDA");
+    };
+    if dev.id() != up_dev.id() {
+        candle_core::bail!("fast_mmvq fused_glu: gate/up weights are on different CUDA devices");
+    }
+
+    let (nrows, ncols) = gate_w.shape().dims2()?;
+    let (up_nrows, up_ncols) = up_w.shape().dims2()?;
+    if (nrows, ncols) != (up_nrows, up_ncols) {
+        candle_core::bail!(
+            "fast_mmvq fused_glu: gate/up shape mismatch [{nrows}, {ncols}] vs [{up_nrows}, {up_ncols}]"
+        );
+    }
+
+    let (b_size, k) = match xs.dims() {
+        [b, k] => (*b, *k),
+        [b, m, k] => (*b * *m, *k),
+        other => candle_core::bail!("fast_mmvq fused_glu: unexpected input rank {other:?}"),
+    };
+    if k != ncols {
+        candle_core::bail!(
+            "fast_mmvq fused_glu: shape mismatch — weight [{nrows}, {ncols}] vs input tail {k}"
+        );
+    }
+    if b_size == 0 || b_size > MMVQ_MAX_BATCH {
+        candle_core::bail!(
+            "fast_mmvq fused_glu: batch size {b_size} out of supported range 1..={MMVQ_MAX_BATCH}"
+        );
+    }
+    let input_ty = xs.dtype();
+    if !matches!(input_ty, DType::BF16 | DType::F16 | DType::F32) {
+        candle_core::bail!(
+            "fast_mmvq fused_glu: input dtype must be BF16, F16, or F32, got {input_ty:?}"
+        );
+    }
+
+    let xs = xs.contiguous()?;
+    let (xs_storage, xs_layout) = xs.storage_and_layout();
+    let Storage::Cuda(xs_cuda) = &*xs_storage else {
+        candle_core::bail!("fast_mmvq fused_glu: input must live on CUDA");
+    };
+    let xs_offset = xs_layout.start_offset();
+
+    let stream_ptr = dev.cuda_stream().cu_stream() as *mut std::ffi::c_void;
+    let k_padded = pad(k, MATRIX_ROW_PADDING);
+    let num_blocks_per_row = k_padded / Q8_1_BLOCK_SIZE;
+    let dst_row_bytes = num_blocks_per_row * Q8_1_TYPE_SIZE;
+    let scratch_bytes = b_size * dst_row_bytes;
+
+    let (scratch_ptr, _workspace_guard) = workspace_ensure(&dev, scratch_bytes)?;
+    let scratch_ptr = scratch_ptr as *mut std::ffi::c_void;
+    let stride_col_y = (k_padded / Q8_1_BLOCK_SIZE) as i32;
+    let stride_col_dst = nrows as i32;
+    let gate_ptr = gate_w.device_ptr()? as *const std::ffi::c_void;
+    let up_ptr = up_w.device_ptr()? as *const std::ffi::c_void;
+    let activation = activation as i32;
+
+    match input_ty {
+        DType::BF16 => {
+            let slice = xs_cuda.as_cuda_slice::<half::bf16>()?;
+            let out = unsafe { dev.alloc::<half::bf16>(nrows * b_size)? };
+
+            {
+                let (xs_ptr, _xs_guard) = slice_ptr(slice, xs_offset);
+                let (out_ptr, _out_guard) = slice_ptr(&out, 0);
+
+                unsafe {
+                    ffi::launch_mmvq_gguf_quantize_q8_1_bf16(
+                        xs_ptr as *const std::ffi::c_void,
+                        scratch_ptr,
+                        k as i32,
+                        k_padded as i32,
+                        b_size as i32,
+                        stream_ptr,
+                    );
+                    launcher(
+                        gate_ptr,
+                        up_ptr,
+                        scratch_ptr as *const std::ffi::c_void,
+                        out_ptr as *mut std::ffi::c_void,
+                        k as i32,
+                        nrows as i32,
+                        stride_col_y,
+                        stride_col_dst,
+                        b_size as i32,
+                        activation,
+                        stream_ptr,
+                    );
+                }
+            }
+
+            let out_storage = CudaStorage::wrap_cuda_slice(out, dev.clone());
+            Ok(Tensor::from((
+                Storage::Cuda(out_storage),
+                output_shape(&xs, nrows),
+            )))
+        }
+        DType::F16 => {
+            let slice = xs_cuda.as_cuda_slice::<half::f16>()?;
+            let out = unsafe { dev.alloc::<half::f16>(nrows * b_size)? };
+
+            {
+                let (xs_ptr, _xs_guard) = slice_ptr(slice, xs_offset);
+                let (out_ptr, _out_guard) = slice_ptr(&out, 0);
+
+                unsafe {
+                    ffi::launch_mmvq_gguf_quantize_q8_1_f16(
+                        xs_ptr as *const std::ffi::c_void,
+                        scratch_ptr,
+                        k as i32,
+                        k_padded as i32,
+                        b_size as i32,
+                        stream_ptr,
+                    );
+                    launcher(
+                        gate_ptr,
+                        up_ptr,
+                        scratch_ptr as *const std::ffi::c_void,
+                        out_ptr as *mut std::ffi::c_void,
+                        k as i32,
+                        nrows as i32,
+                        stride_col_y,
+                        stride_col_dst,
+                        b_size as i32,
+                        activation,
+                        stream_ptr,
+                    );
+                }
+            }
+
+            let out_storage = CudaStorage::wrap_cuda_slice(out, dev.clone());
+            Ok(Tensor::from((
+                Storage::Cuda(out_storage),
+                output_shape(&xs, nrows),
+            )))
+        }
+        DType::F32 => {
+            let slice = xs_cuda.as_cuda_slice::<f32>()?;
+            let out = unsafe { dev.alloc::<f32>(nrows * b_size)? };
+
+            {
+                let (xs_ptr, _xs_guard) = slice_ptr(slice, xs_offset);
+                let (out_ptr, _out_guard) = slice_ptr(&out, 0);
+
+                unsafe {
+                    ffi::launch_mmvq_gguf_quantize_q8_1_f32(
+                        xs_ptr as *const std::ffi::c_void,
+                        scratch_ptr,
+                        k as i32,
+                        k_padded as i32,
+                        b_size as i32,
+                        stream_ptr,
+                    );
+                    launcher(
+                        gate_ptr,
+                        up_ptr,
+                        scratch_ptr as *const std::ffi::c_void,
+                        out_ptr as *mut std::ffi::c_void,
+                        k as i32,
+                        nrows as i32,
+                        stride_col_y,
+                        stride_col_dst,
+                        b_size as i32,
+                        activation,
                         stream_ptr,
                     );
                 }

--- a/mistralrs-quant/src/gguf/ffi.rs
+++ b/mistralrs-quant/src/gguf/ffi.rs
@@ -8,6 +8,27 @@
 
 use std::ffi::c_void;
 
+macro_rules! declare_mmvq_fused_qkv {
+    ($fn_name:ident) => {
+        pub fn $fn_name(
+            vx_q: *const c_void,
+            vx_k: *const c_void,
+            vx_v: *const c_void,
+            vy: *const c_void,
+            q_dst: *mut c_void,
+            k_dst: *mut c_void,
+            v_dst: *mut c_void,
+            ncols_x: i32,
+            nrows_q: i32,
+            nrows_k: i32,
+            nrows_v: i32,
+            stride_col_y: i32,
+            b_size: i32,
+            stream: *mut c_void,
+        );
+    };
+}
+
 extern "C" {
     /// Launch Q8_1 quantization kernel
     /// Quantizes f32 input to Q8_1 format for use with quantized matmul kernels.
@@ -1088,6 +1109,39 @@ extern "C" {
         activation: i32,
         stream: *mut c_void,
     );
+
+    declare_mmvq_fused_qkv!(launch_mmvq_gguf_q4_0_bf16_fused_qkv);
+    declare_mmvq_fused_qkv!(launch_mmvq_gguf_q4_1_bf16_fused_qkv);
+    declare_mmvq_fused_qkv!(launch_mmvq_gguf_q5_0_bf16_fused_qkv);
+    declare_mmvq_fused_qkv!(launch_mmvq_gguf_q5_1_bf16_fused_qkv);
+    declare_mmvq_fused_qkv!(launch_mmvq_gguf_q8_0_bf16_fused_qkv);
+    declare_mmvq_fused_qkv!(launch_mmvq_gguf_q2_k_bf16_fused_qkv);
+    declare_mmvq_fused_qkv!(launch_mmvq_gguf_q3_k_bf16_fused_qkv);
+    declare_mmvq_fused_qkv!(launch_mmvq_gguf_q4_k_bf16_fused_qkv);
+    declare_mmvq_fused_qkv!(launch_mmvq_gguf_q5_k_bf16_fused_qkv);
+    declare_mmvq_fused_qkv!(launch_mmvq_gguf_q6_k_bf16_fused_qkv);
+
+    declare_mmvq_fused_qkv!(launch_mmvq_gguf_q4_0_f16_fused_qkv);
+    declare_mmvq_fused_qkv!(launch_mmvq_gguf_q4_1_f16_fused_qkv);
+    declare_mmvq_fused_qkv!(launch_mmvq_gguf_q5_0_f16_fused_qkv);
+    declare_mmvq_fused_qkv!(launch_mmvq_gguf_q5_1_f16_fused_qkv);
+    declare_mmvq_fused_qkv!(launch_mmvq_gguf_q8_0_f16_fused_qkv);
+    declare_mmvq_fused_qkv!(launch_mmvq_gguf_q2_k_f16_fused_qkv);
+    declare_mmvq_fused_qkv!(launch_mmvq_gguf_q3_k_f16_fused_qkv);
+    declare_mmvq_fused_qkv!(launch_mmvq_gguf_q4_k_f16_fused_qkv);
+    declare_mmvq_fused_qkv!(launch_mmvq_gguf_q5_k_f16_fused_qkv);
+    declare_mmvq_fused_qkv!(launch_mmvq_gguf_q6_k_f16_fused_qkv);
+
+    declare_mmvq_fused_qkv!(launch_mmvq_gguf_q4_0_f32_fused_qkv);
+    declare_mmvq_fused_qkv!(launch_mmvq_gguf_q4_1_f32_fused_qkv);
+    declare_mmvq_fused_qkv!(launch_mmvq_gguf_q5_0_f32_fused_qkv);
+    declare_mmvq_fused_qkv!(launch_mmvq_gguf_q5_1_f32_fused_qkv);
+    declare_mmvq_fused_qkv!(launch_mmvq_gguf_q8_0_f32_fused_qkv);
+    declare_mmvq_fused_qkv!(launch_mmvq_gguf_q2_k_f32_fused_qkv);
+    declare_mmvq_fused_qkv!(launch_mmvq_gguf_q3_k_f32_fused_qkv);
+    declare_mmvq_fused_qkv!(launch_mmvq_gguf_q4_k_f32_fused_qkv);
+    declare_mmvq_fused_qkv!(launch_mmvq_gguf_q5_k_f32_fused_qkv);
+    declare_mmvq_fused_qkv!(launch_mmvq_gguf_q6_k_f32_fused_qkv);
 
     /// BF16 -> Q8_1 quantize
     pub fn launch_mmvq_gguf_quantize_q8_1_bf16(

--- a/mistralrs-quant/src/gguf/ffi.rs
+++ b/mistralrs-quant/src/gguf/ffi.rs
@@ -1049,6 +1049,46 @@ extern "C" {
         stream: *mut c_void,
     );
 
+    pub fn launch_mmvq_gguf_q8_0_bf16_fused_glu(
+        vx_gate: *const c_void,
+        vx_up: *const c_void,
+        vy: *const c_void,
+        dst: *mut c_void,
+        ncols_x: i32,
+        nrows_x: i32,
+        stride_col_y: i32,
+        stride_col_dst: i32,
+        b_size: i32,
+        activation: i32,
+        stream: *mut c_void,
+    );
+    pub fn launch_mmvq_gguf_q8_0_f16_fused_glu(
+        vx_gate: *const c_void,
+        vx_up: *const c_void,
+        vy: *const c_void,
+        dst: *mut c_void,
+        ncols_x: i32,
+        nrows_x: i32,
+        stride_col_y: i32,
+        stride_col_dst: i32,
+        b_size: i32,
+        activation: i32,
+        stream: *mut c_void,
+    );
+    pub fn launch_mmvq_gguf_q8_0_f32_fused_glu(
+        vx_gate: *const c_void,
+        vx_up: *const c_void,
+        vy: *const c_void,
+        dst: *mut c_void,
+        ncols_x: i32,
+        nrows_x: i32,
+        stride_col_y: i32,
+        stride_col_dst: i32,
+        b_size: i32,
+        activation: i32,
+        stream: *mut c_void,
+    );
+
     /// BF16 -> Q8_1 quantize
     pub fn launch_mmvq_gguf_quantize_q8_1_bf16(
         x: *const c_void,

--- a/mistralrs-quant/src/gguf/mod.rs
+++ b/mistralrs-quant/src/gguf/mod.rs
@@ -172,6 +172,10 @@ impl QuantMethod for GgufMatMul {
         Some(DType::F32)
     }
 
+    fn has_bias(&self) -> bool {
+        self.b.is_some()
+    }
+
     fn add_delta_w(&self, delta: &Tensor) -> Result<Arc<dyn QuantMethod>> {
         match self {
             Self {

--- a/mistralrs-quant/src/lib.rs
+++ b/mistralrs-quant/src/lib.rs
@@ -1112,6 +1112,51 @@ pub fn try_fused_quantized_gate_up(
     )?))
 }
 
+#[cfg(feature = "cuda")]
+pub fn try_fused_quantized_qkv(
+    xs: &Tensor,
+    q: &dyn QuantMethod,
+    k: &dyn QuantMethod,
+    v: &dyn QuantMethod,
+) -> Result<Option<(Tensor, Tensor, Tensor)>> {
+    if q.has_bias() || k.has_bias() || v.has_bias() {
+        return Ok(None);
+    }
+    if !matches!(xs.dtype(), DType::BF16 | DType::F16 | DType::F32) {
+        return Ok(None);
+    }
+
+    let Some(q_q) = q.get_qtensor() else {
+        return Ok(None);
+    };
+    let Some(k_q) = k.get_qtensor() else {
+        return Ok(None);
+    };
+    let Some(v_q) = v.get_qtensor() else {
+        return Ok(None);
+    };
+    let dtype = q_q.dtype();
+    if dtype != k_q.dtype() || dtype != v_q.dtype() || !gguf::fast_mmvq::supports(dtype) {
+        return Ok(None);
+    }
+
+    let Some((&input_cols, batch_dims)) = xs.dims().split_last() else {
+        return Ok(None);
+    };
+    let flat_batch = batch_dims.iter().product::<usize>();
+    if flat_batch == 0 || flat_batch > gguf::fast_mmvq::MMVQ_MAX_BATCH {
+        return Ok(None);
+    }
+    let (_, q_cols) = q_q.shape().dims2()?;
+    let (_, k_cols) = k_q.shape().dims2()?;
+    let (_, v_cols) = v_q.shape().dims2()?;
+    if input_cols != q_cols || input_cols != k_cols || input_cols != v_cols {
+        return Ok(None);
+    }
+
+    Ok(Some(gguf::fast_mmvq::fused_qkv(q_q, k_q, v_q, xs)?))
+}
+
 fn tensor_prefix(vb: &ShardedVarBuilder) -> String {
     let prefix = vb.prefix();
     if prefix.is_empty() {

--- a/mistralrs-quant/src/lib.rs
+++ b/mistralrs-quant/src/lib.rs
@@ -1039,6 +1039,10 @@ pub trait QuantMethod: Send + Sync + Debug + QuantizedSerde {
         None
     }
 
+    fn has_bias(&self) -> bool {
+        false
+    }
+
     /// Begin tracking stats into an ImatrixLayerStats
     fn begin_track_stats(&mut self) -> Result<()> {
         candle_core::bail!("`{}` does not support tracking stats.", self.name())
@@ -1062,6 +1066,50 @@ impl Module for dyn QuantMethod {
     fn forward(&self, xs: &Tensor) -> Result<Tensor> {
         QuantMethod::forward(self, xs)
     }
+}
+
+#[cfg(feature = "cuda")]
+pub fn try_fused_quantized_gate_up(
+    xs: &Tensor,
+    gate: &dyn QuantMethod,
+    up: &dyn QuantMethod,
+    activation: GluActivationType,
+) -> Result<Option<Tensor>> {
+    if gate.has_bias() || up.has_bias() {
+        return Ok(None);
+    }
+    if !matches!(xs.dtype(), DType::BF16 | DType::F16 | DType::F32) {
+        return Ok(None);
+    }
+
+    let Some(gate_q) = gate.get_qtensor() else {
+        return Ok(None);
+    };
+    let Some(up_q) = up.get_qtensor() else {
+        return Ok(None);
+    };
+    if gate_q.dtype() != GgmlDType::Q8_0 || up_q.dtype() != GgmlDType::Q8_0 {
+        return Ok(None);
+    }
+    if gate_q.shape() != up_q.shape() {
+        return Ok(None);
+    }
+
+    let Some((&k, batch_dims)) = xs.dims().split_last() else {
+        return Ok(None);
+    };
+    let flat_batch = batch_dims.iter().product::<usize>();
+    if flat_batch == 0 || flat_batch > gguf::fast_mmvq::MMVQ_MAX_BATCH {
+        return Ok(None);
+    }
+    let (_, ncols) = gate_q.shape().dims2()?;
+    if k != ncols {
+        return Ok(None);
+    }
+
+    Ok(Some(gguf::fast_mmvq::fused_glu(
+        gate_q, up_q, xs, activation,
+    )?))
 }
 
 fn tensor_prefix(vb: &ShardedVarBuilder) -> String {


### PR DESCRIPTION
This PR improves CUDA performance for Gemma4 and related quantized model paths, with a focus on both prompt/prefill and decode throughput.

- Add CUDA fast paths for fused GGUF/UQFF QKV projection.
- Add a generalized qkv_projections abstraction for models with same-input Q/K/V projections.
- Wire qkv_projections into applicable text and vision self-attention implementations.
- Add fused QKV dispatch support across GGUF fast MMVQ quant types.
- Add CUDA kernel support for fused multi-output MMVQ projection.
- Keep unsupported/inapplicable paths on the existing safe fallback:
    - packed QKV modules
    - cross-attention with different Q and K/V inputs
    - Gemma shared-KV fallback cases
    - QLinear / ClippableLinear paths
- Add generalized CUDA fast paths for fused residual RMSNorm-style operations.
- Add generalized CUDA fast paths for mul_and_act / split activation-multiply patterns.
- Improve decode-side small-shape performance for quantized CUDA execution.
- Improve prompt/prefill throughput by reducing projection/kernel overhead.

## Setup

- Hardware: NVIDIA GB10
- `mistral.rs`: `target/debug/mistralrs bench -m google/gemma-4-E4B-it --quant 8`
- `llama.cpp`: `./build/bin/llama-bench -m gemma-4-E4B-it-Q8_0.gguf -ngl 999 -fa 1`
- Repetitions: 3 measured iterations
- Prompt sweep: prompt length varied, `gen-len=1`
- Decode sweep: context length varied, `gen-len=128`

<img width="1601" height="918" alt="gemma4_q8_prompt_prefill" src="https://github.com/user-attachments/assets/6e1e5e95-f65b-43d6-ba94-e18ee8f5e88c" />
<img width="1602" height="918" alt="gemma4_q8_decode" src="https://github.com/user-attachments/assets/f58fba51-a8b0-4846-981d-c8a4f1511fa9" />

## Prompt / Prefill

| Prompt tokens | `mistral.rs` T/s | `llama.cpp` T/s |
|---:|---:|---:|
| 128 | 2996.8 | 2566.9 |
| 512 | 5583.8 | 4375.2 |
| 1024 | 6165.4 | 4430.2 |
| 2048 | 6932.3 | 4431.0 |
| 4096 | 6608.9 | 4382.7 |

## Decode

128 generated tokens after the listed context length.

| Context tokens | `mistral.rs` T/s | `llama.cpp` T/s |
|---:|---:|---:|
| 128 | 39.4 | 40.26 |
| 512 | 39.3 | 39.20 |
| 1024 | 39.4 | 39.59 |
| 2048 | 39.2 | 39.32 |
| 4096 | 39.3 | 38.82 |
￼
