### PR TITLE
fix(metal): register PR #2166 kernels in runtime-compile path

### DIFF
--- a/mistralrs-core/src/metal/kernels/gdn.metal
+++ b/mistralrs-core/src/metal/kernels/gdn.metal
@@ -4,6 +4,18 @@
 #include <metal_stdlib>
 using namespace metal;
 
+// The kernel instantiations below use `bfloat16_t` — the ggml/llama.cpp
+// convention this file inherited from the CUDA port. Apple Metal exposes
+// its IEEE bfloat16 as `bfloat` (Metal 3.1+, macOS 14+). The other name,
+// `bfloat16`, is the *internal* Apple struct `__Reserved_Name__Do_not_use_bfloat16`
+// which is only forward-declared in metal_extended_vector — usable in
+// typedefs but NOT for pointer arithmetic / subscripting, so aliasing to
+// it explodes with "incomplete type" errors at kernel instantiation.
+// Alias to the public `bfloat` so the runtime Metal compiler (used when
+// MISTRALRS_METAL_PRECOMPILE=0) gets a fully-defined type. The
+// precompiled metallib path is unaffected either way.
+typedef bfloat bfloat16_t;
+
 // ============================================================================
 // Kernel 1: gated_delta_rule_recurrence
 //

--- a/mistralrs-quant/src/metal_kernels/mod.rs
+++ b/mistralrs-quant/src/metal_kernels/mod.rs
@@ -139,6 +139,12 @@ impl Kernels {
             "softmax_with_sinks.metal",
             include_str!("softmax_with_sinks.metal"),
         );
+        file_system.insert("flash_attn.metal", include_str!("flash_attn.metal"));
+        file_system.insert(
+            "rmsnorm_residual.metal",
+            include_str!("rmsnorm_residual.metal"),
+        );
+        file_system.insert("topk_logits.metal", include_str!("topk_logits.metal"));
 
         // Recursive include preprocessor
         fn preprocess_includes(
@@ -264,6 +270,9 @@ impl Kernels {
             "copy.metal", // Copy operations (includes utils.metal, copy_impl.metal)
             "scan.metal", // Scan operations (includes utils.metal, scan_impl.metal)
             "sort.metal", // Sort operations (includes utils.metal, sort_impl.metal)
+            "flash_attn.metal", // Flash attention DK=512 variants
+            "rmsnorm_residual.metal", // Fused RMSNorm + residual
+            "topk_logits.metal", // Two-stage top-k + softmax stats
         ];
 
         for file in main_files {

--- a/mistralrs-quant/src/metal_kernels/mod.rs
+++ b/mistralrs-quant/src/metal_kernels/mod.rs
@@ -137,6 +137,16 @@ impl Kernels {
             "softmax_with_sinks.metal",
             include_str!("softmax_with_sinks.metal"),
         );
+        // Kernels added by upstream PR #2166 (Gemma 4 Metal optimization).
+        // These must be registered here so MISTRALRS_METAL_PRECOMPILE=0 builds
+        // can compile them at runtime; build.rs already lists them in
+        // METAL_SOURCES for the precompiled path.
+        file_system.insert("flash_attn.metal", include_str!("flash_attn.metal"));
+        file_system.insert(
+            "rmsnorm_residual.metal",
+            include_str!("rmsnorm_residual.metal"),
+        );
+        file_system.insert("topk_logits.metal", include_str!("topk_logits.metal"));
 
         // Recursive include preprocessor
         fn preprocess_includes(
@@ -250,16 +260,19 @@ impl Kernels {
         // Note: bf16.metal is excluded as it only contains type definitions that
         // are already in utils.metal, which would cause duplicate definitions
         let main_files = vec![
-            "bitwise.metal",        // Bitwise operations
-            "blockwise_fp8.metal",  // FP8 blockwise operations (includes float8.metal, utils.metal)
+            "bitwise.metal",          // Bitwise operations
+            "blockwise_fp8.metal", // FP8 blockwise operations (includes float8.metal, utils.metal)
             "bnb_dequantize.metal", // BitsAndBytes dequantization (includes utils.metal)
-            "fused_glu.metal",      // Fused GLU operations (activation(a) * b)
+            "fused_glu.metal",     // Fused GLU operations (activation(a) * b)
             "hqq_dequantize.metal", // HQQ dequantization
-            "mxfp4.metal",          // MXFP4 kernels
-            "quantized.metal",      // Quantization operations (includes utils.metal)
-            "copy.metal",           // Copy operations (includes utils.metal, copy_impl.metal)
-            "scan.metal",           // Scan operations (includes utils.metal, scan_impl.metal)
-            "sort.metal",           // Sort operations (includes utils.metal, sort_impl.metal)
+            "mxfp4.metal",         // MXFP4 kernels
+            "quantized.metal",     // Quantization operations (includes utils.metal)
+            "copy.metal",          // Copy operations (includes utils.metal, copy_impl.metal)
+            "scan.metal",          // Scan operations (includes utils.metal, scan_impl.metal)
+            "sort.metal",          // Sort operations (includes utils.metal, sort_impl.metal)
+            "flash_attn.metal",    // Flash attention DK=512 variants (PR #2166)
+            "rmsnorm_residual.metal", // Fused RMSNorm + residual (PR #2166)
+            "topk_logits.metal",   // Two-stage top-k + softmax stats (PR #2166)
         ];
 
         for file in main_files {


### PR DESCRIPTION
Fixes #2168 — `MISTRALRS_METAL_PRECOMPILE=0` builds (introduced by #1518) regressed in two places after recent kernel work.

## Commit 1: register PR #2166's new kernels in the runtime-compile path

PR #2166 added three new top-level kernel files (`rmsnorm_residual.metal`, `topk_logits.metal`, `flash_attn.metal`) and registered them in `mistralrs-quant/build.rs`'s `METAL_SOURCES` for the precompiled metallib path, but did not register them in the runtime-compile path's `file_system` map and `main_files` list in `mistralrs-quant/src/metal_kernels/mod.rs`.

When precompile is disabled (e.g. on Apple Silicon with Metal 4 where the precompiled metallib lacks function variants for the current GPU), runtime falls back to `MTLDevice.newLibraryWithSource` via `Kernels::compile_kernels_at_runtime`. Without the new files in both lists, the runtime library is built without those kernels and `library.get_function("rmsnorm_residual_bf16", ...)` fails on first inference:

```
Error while loading function: rmsnorm_residual_bf16
```

13 lines: 3 entries each to `file_system` and `main_files`. Each file has clean header dependencies (only `<metal_stdlib>` and `<metal_simdgroup*>`, which `main_source`'s preamble already provides).

## Commit 2: typedef `bfloat16_t` for runtime-compiled GDN kernels

`mistralrs-core/src/metal/kernels/gdn.metal` instantiates templates with `bfloat16_t`, the ggml/llama.cpp type-name convention inherited from the CUDA port. Apple Metal's stdlib doesn't expose `bfloat16_t`: it has `bfloat` (Metal 3.1+, macOS 14+) as the public type, and `bfloat16` as a forward-only struct (`__Reserved_Name__Do_not_use_bfloat16`) in `metal_extended_vector`.

The precompiled path resolves `bfloat16_t` via build-time headers, but the runtime-compiled path bails with:

```
error: unknown type name 'bfloat16_t'; did you mean 'bfloat16'?
instantiate_conv1d_update(bfloat16_t);
```

Aliasing to the forward-only `bfloat16` fails differently (incomplete-type errors at template instantiation). The fix is a one-line `typedef bfloat bfloat16_t;` at the top of `gdn.metal` so both compile paths see a fully-defined type. This unblocks Qwen 3.5 / 3.6 hybrid models on Apple Silicon under precompile=0; Gemma 4 and other non-hybrid models were unaffected.

This fix overlaps with #2047 (`fix(metal): GDN bfloat16, PA scheduler, error handling, MLX SDPA fixes`) which has been open since 2026-04-02 and contains the same typedef plus several unrelated improvements. Happy to drop this commit if #2047 is prioritized.

## Validation

- `cargo check --features metal` on `mistralrs-quant` with `MISTRALRS_METAL_PRECOMPILE=0` — clean.
- End-to-end: Qwen 3.6 27B AFQ4 ISQ inference on Apple Silicon / macOS 26 — both commits required for the model to load and produce tokens. Before commit 1: `rmsnorm_residual_bf16` missing on first inference. After commit 1, before commit 2: GDN kernel compile fails with `bfloat16_t` unknown. After both: clean inference, PR #2166's decode perf wins intact.

## Out of scope (separate work)

- `f8q8.metal` (#1883) and `hqq_bitpack.metal` (#1586) are also in `METAL_SOURCES` but missing from the runtime path. They predate the regression; leaving them out to keep this PR surgical.
- Three hand-maintained mirrors of the same kernel-file list (`METAL_SOURCES` in `build.rs` + `file_system` + `main_files` in `mod.rs`) is the design smell that made this regression possible. Single-sourcing (e.g. `build.rs` emits a generated `kernels.rs` that `mod.rs` `include!`s) is a worthwhile follow-up refactor.

## Suggestion

Adding `MISTRALRS_METAL_PRECOMPILE=0` to the CI matrix would catch this class of regression before it ships. Three precompile=0 incompatibilities have surfaced in the last six weeks (the two in this PR plus an `f8q8`/`hqq_bitpack` gap that affects pre-existing kernels).