### PR TITLE
fix(engine): handle SendError when client disconnects during error reporting

### DIFF
--- a/mistralrs-core/src/utils/mod.rs
+++ b/mistralrs-core/src/utils/mod.rs
@@ -177,13 +177,19 @@ macro_rules! handle_pipeline_forward_error {
                             session_id: None,
                         };
 
-                        seq.responder()
+                        if let Err(send_err) = seq.responder()
                             .send(Response::ModelError(
                                 e.to_string(),
-                                partial_completion_response
+                                partial_completion_response,
                             ))
                             .await
-                            .unwrap();
+                        {
+                            tracing::warn!(
+                                "Failed to send chat model error to client for seq {}: {} (client likely disconnected)",
+                                seq.id(),
+                                send_err
+                            );
+                        }
                     } else {
                         let partial_completion_response = CompletionResponse {
                             id: seq.id().to_string(),
@@ -195,13 +201,19 @@ macro_rules! handle_pipeline_forward_error {
                             usage: group.get_usage(),
                         };
 
-                        seq.responder()
+                        if let Err(send_err) = seq.responder()
                             .send(Response::CompletionModelError(
                                 e.to_string(),
-                                partial_completion_response
+                                partial_completion_response,
                             ))
                             .await
-                            .unwrap();
+                        {
+                            tracing::warn!(
+                                "Failed to send completion model error to client for seq {}: {} (client likely disconnected)",
+                                seq.id(),
+                                send_err
+                            );
+                        }
                     }
                 }
                 for seq in $seq_slice.iter_mut() {


### PR DESCRIPTION
Fixes #2147

## Problem

When a client cancels an in-flight inference request (drops the receiver), and the engine then hits an error processing the same sequence, the engine panics:

    thread '<unnamed>' panicked at .../engine/mod.rs:473:48:
    called `Result::unwrap()` on an `Err` value: SendError { .. }

The supervisor catches the panic and reboots the engine, but the restart flushes the prefix cache and disrupts other in-flight sequences.

## Root cause

The stack trace points to engine/mod.rs because that's the macro invocation site. The actual buggy code is in the `handle_pipeline_forward_error!` macro body in `mistralrs-core/src/utils/mod.rs`, which calls `.send(...).await.unwrap()` to notify the client of an error. If the client has already disconnected, the unwrap panics.

The notification is best-effort anyway. The sequence is marked `SequenceState::Error` immediately after, so a failed send has no correctness impact on engine state.

## Fix

Replace the two `.unwrap()` calls (chat and completion branches of the macro) with logged best-effort sends using `tracing::warn!`. The engine now survives client cancellation without restart.

## Out of scope

`mistralrs-core/src/distributed.rs` has 4 similar `.send().await.unwrap()` patterns (lines 170, 180, 191, 208). Different failure mode (inter-process distributed path), so leaving those for a follow-up PR if useful.

## Testing

- `cargo check -p mistralrs-core` ✓
- `cargo clippy -p mistralrs-core --no-deps -- -D warnings` ✓ (no new warnings)
- `cargo fmt --check` ✓