### PR TITLE
Add GGUF backend for Gemma 4 (text-only, E2B-it first)

### DIFF
--- a/mistralrs-core/src/gguf/gguf_tokenizer.rs
+++ b/mistralrs-core/src/gguf/gguf_tokenizer.rs
@@ -107,17 +107,28 @@ pub fn convert_gguf_to_hf_tokenizer<R: std::io::Seek + std::io::Read>(
         }
     };
 
-    //token type other than 1 treated as special token
-    let mut num_special_tokens = 0;
-    #[allow(clippy::needless_range_loop)]
+    // Token types other than `NORMAL` (1) are treated as special tokens.
+    //
+    // Batch all of them into a single `add_special_tokens` call. The
+    // previous per-token loop triggered one `AddedVocabulary::refresh_added_tokens`
+    // per token, and each refresh rebuilds the aho-corasick failure-link
+    // automaton over every special token added so far. That is O(N^2) in
+    // calls and becomes effectively infinite for Gemma 3 (6670 CONTROL +
+    // BYTE + USER_DEFINED tokens in the 262144-vocab GGUF), making the
+    // load look like a hang. Llama / Qwen happen to ship <50 such tokens
+    // each, which kept this slow path invisible until Gemma 3/4 landed in
+    // the GGUF dispatch.
+    let mut special = Vec::new();
     if token_types.len() == props.tokens.len() {
-        for i in 0..props.tokens.len() {
-            if token_types[i] != 1i32 {
-                let tk = props.tokens[i].clone();
-                tokenizer.add_special_tokens(&[AddedToken::from(tk.to_string(), true)]);
-                num_special_tokens += 1;
+        for (i, ty) in token_types.iter().enumerate() {
+            if *ty != 1i32 {
+                special.push(AddedToken::from(props.tokens[i].clone(), true));
             }
         }
+    }
+    let num_special_tokens = special.len();
+    if !special.is_empty() {
+        tokenizer.add_special_tokens(&special);
     }
 
     info!(

--- a/mistralrs-core/src/gguf/gguf_tokenizer.rs
+++ b/mistralrs-core/src/gguf/gguf_tokenizer.rs
@@ -94,6 +94,14 @@ pub fn convert_gguf_to_hf_tokenizer<R: std::io::Seek + std::io::Read>(
     let (mut tokenizer, kind) = match props.model.as_str() {
         "llama" | "replit" => unigram_tokenizer(&props)?,
         "gpt2" => bpe_tokenizer(&props)?,
+        // Gemma family uses SentencePiece-style BPE: BPE merges over
+        // sub-word strings that already carry the `\u{2581}` (lower-one-eighth
+        // block) prefix in place of leading spaces, plus a byte-fallback
+        // range (`<0xNN>`). It is NOT GPT-2 byte-level BPE, so it must not
+        // run through the ByteLevel pre-tokenizer / decoder path. The
+        // llama.cpp side hit the same trap and now special-cases SPM-BPE
+        // (see ggml-org/llama.cpp#21343).
+        "gemma" | "gemma2" | "gemma3" | "gemma4" => gemma_bpe_tokenizer(&props)?,
         other => {
             anyhow::bail!("Tokenizer model `{other}` not supported.");
         }
@@ -262,6 +270,78 @@ fn bpe_tokenizer(p: &PropsGGUF) -> Result<(Tokenizer, TokenizerKind)> {
     tokenizer.with_post_processor(Some(processors::byte_level::ByteLevel::new(
         false, false, false,
     )));
+
+    for v in [bos, Some(eos), unk].iter().flatten() {
+        let tk = p.tokens[*v as usize].clone();
+        tokenizer.add_special_tokens(&[AddedToken::from(tk.to_string(), true)]);
+    }
+
+    Ok((tokenizer, TokenizerKind::Bpe))
+}
+
+// Gemma family (Gemma 1/2/3/4) ships a SentencePiece-style BPE tokenizer in
+// GGUF: it has both `tokenizer.ggml.merges` (BPE-style) and an SPM token
+// space where leading spaces are encoded as `\u{2581}` and untranslatable
+// bytes fall back to `<0xNN>` tokens. Running this through the GPT-2
+// `bpe_tokenizer` path is wrong: the ByteLevel pre-tokenizer would re-encode
+// each byte through the GPT-2 unicode map, producing tokens (`\u{0120}` for
+// space, etc.) that do not exist in the Gemma vocabulary, and inference
+// degenerates to byte-level garbage / infinite `<unused...>` loops.
+//
+// Instead, build the BPE model from `vocab + merges` and wrap it with the
+// SPM-style normalizer/decoder pair used by the `llama` unigram path:
+//   - Normalizer: `Replace(" ", "\u{2581}")` so input spaces match the
+//     `\u{2581}`-prefixed merge entries. We deliberately do NOT prepend a
+//     leading `\u{2581}` because both Gemma 3 and Gemma 4 GGUF declare
+//     `tokenizer.ggml.add_space_prefix = false`.
+//   - Decoder: `Replace("\u{2581}", " ") -> ByteFallback -> Fuse -> Strip`,
+//     i.e. unwrap the `\u{2581}`, decode `<0xNN>` byte tokens, fuse the
+//     pieces, and strip the leading space added by the SPM decoder.
+fn gemma_bpe_tokenizer(p: &PropsGGUF) -> Result<(Tokenizer, TokenizerKind)> {
+    let merges = p
+        .merges
+        .as_ref()
+        .ok_or(anyhow::Error::msg(
+            "Gemma SPM-BPE tokenizer must include `tokenizer.ggml.merges`",
+        ))?
+        .iter()
+        .map(|merge| {
+            let split: (&str, &str) = merge
+                .splitn(2, ' ')
+                .collect_tuple()
+                .expect("Failed to convert split into 2-tuple");
+            (split.0.to_string(), split.1.to_string())
+        })
+        .collect::<Vec<_>>();
+
+    let mut vocab = AHashMap::new();
+    for (i, token) in p.tokens.iter().enumerate() {
+        #[allow(clippy::cast_possible_truncation)]
+        vocab.insert(token.clone(), i as u32);
+    }
+
+    let PropsGGUF { bos, eos, unk, .. } = *p;
+
+    let mut bpe = BpeBuilder::new().vocab_and_merges(vocab, merges);
+    if let Some(unk) = unk {
+        bpe = bpe.unk_token(p.tokens[unk as usize].to_string());
+    }
+    let bpe = bpe.build().map_err(anyhow::Error::msg)?;
+
+    let decoder = Decoder::Sequence(vec![
+        Decoder::Replace("\u{2581}", " "),
+        Decoder::ByteFallback,
+        Decoder::Fuse,
+        Decoder::Strip(' ', 1, 0),
+    ]);
+
+    let normalizer = Normalizer::Replace(" ", "\u{2581}");
+
+    let mut tokenizer = TokenizerX::new(
+        ModelWrapper::BPE(bpe),
+        Some(decoder),
+        Some(normalizer),
+    )?;
 
     for v in [bos, Some(eos), unk].iter().flatten() {
         let tk = p.tokens[*v as usize].clone();

--- a/mistralrs-core/src/gguf/mod.rs
+++ b/mistralrs-core/src/gguf/mod.rs
@@ -30,6 +30,7 @@ pub enum GGUFArchitecture {
     Qwen3,
     Qwen3MoE,
     Mistral3,
+    Gemma4,
 }
 
 // Wraps from_str() for some convenience:

--- a/mistralrs-core/src/gguf/mod.rs
+++ b/mistralrs-core/src/gguf/mod.rs
@@ -30,6 +30,7 @@ pub enum GGUFArchitecture {
     Qwen3,
     Qwen3MoE,
     Mistral3,
+    Gemma3,
     Gemma4,
 }
 

--- a/mistralrs-core/src/models/mod.rs
+++ b/mistralrs-core/src/models/mod.rs
@@ -14,6 +14,7 @@ pub(crate) mod mixtral;
 pub(crate) mod phi2;
 pub(crate) mod phi3;
 pub(crate) mod phi3_5_moe;
+pub(crate) mod quantized_gemma3;
 pub(crate) mod quantized_gemma4;
 pub(crate) mod quantized_llama;
 pub(crate) mod quantized_phi2;

--- a/mistralrs-core/src/models/mod.rs
+++ b/mistralrs-core/src/models/mod.rs
@@ -14,6 +14,7 @@ pub(crate) mod mixtral;
 pub(crate) mod phi2;
 pub(crate) mod phi3;
 pub(crate) mod phi3_5_moe;
+pub(crate) mod quantized_gemma4;
 pub(crate) mod quantized_llama;
 pub(crate) mod quantized_phi2;
 pub(crate) mod quantized_phi3;

--- a/mistralrs-core/src/models/quantized_gemma3.rs
+++ b/mistralrs-core/src/models/quantized_gemma3.rs
@@ -328,7 +328,15 @@ fn gemma_norm_from_qtensor(
 ) -> Result<RmsNorm> {
     // Gemma stores raw RmsNorm weights; the model adds 1.0 at runtime, matching
     // `Gemma3Model.norm_shift` in `ggml-org/llama.cpp:conversion/gemma.py:124`.
-    let w = qt.dequantize(device)?;
+    //
+    // Cast to F32 so the weight dtype matches the F32 activations produced
+    // by `GgufMatMul::forward` (Q4_K dequant intermediate). The candle Metal
+    // `rms_norm` kernel requires `input.dtype() == weight.dtype()`; mixing
+    // F32 inputs with a BF16-stored norm weight bails with
+    // `rmsnorm is not implemented for F32 BF16`. The active model dtype is
+    // reconciled after the rotary step in `LayerWeights::forward_attn`, so
+    // pinning the norm at F32 does not poison the rest of the pipeline.
+    let w = qt.dequantize(device)?.to_dtype(DType::F32)?;
     let w = (w + 1.0)?;
     RmsNorm::from_w(w, eps as f64)
 }

--- a/mistralrs-core/src/models/quantized_gemma3.rs
+++ b/mistralrs-core/src/models/quantized_gemma3.rs
@@ -1,0 +1,682 @@
+#![allow(clippy::cast_possible_truncation, clippy::cast_precision_loss)]
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use candle_core::{DType, Device, Module, Result, Tensor};
+use candle_nn::Embedding;
+use mistralrs_quant::{GgufMatMul, QuantMethod, QuantMethodConfig};
+
+use crate::attention::{AttentionMask, SdpaParams};
+use crate::device_map::{DeviceMappedMask, DeviceMapper};
+use crate::gguf::Content;
+use crate::layers::{
+    Activation, CausalMaskConfig, CausalMasker, RmsNorm, RotaryEmbedding, ScaledEmbedding, Sdpa,
+};
+use crate::layers_masker::PastKvLenCache;
+use crate::paged_attention::{AttentionImplementation, PagedAttention};
+use crate::pipeline::text_models_inputs_processor::PagedAttentionInputMetadata;
+use crate::pipeline::{extract_logits, EitherCache, KvCache, NormalCache};
+use crate::utils::gguf_metadata::ContentMetadata;
+use crate::utils::model_config as ModelConfig;
+use crate::utils::progress::{new_multi_progress, NiceProgressBar};
+
+// Defaults fall back to upstream Gemma 3 config values when the GGUF
+// metadata omits an optional key. Mirrors `vision_models/gemma3/config.rs`
+// and the per-arch reads in `ggml-org/llama.cpp:src/models/gemma3.cpp:3-18`.
+const DEFAULT_MAX_SEQ_LEN: u32 = 131072;
+const DEFAULT_ROPE_FREQ_BASE: f32 = 1_000_000.0;
+const DEFAULT_ROPE_FREQ_BASE_SWA: f32 = 10_000.0;
+const DEFAULT_RMS_NORM_EPS: f32 = 1e-6;
+const DEFAULT_HEAD_DIM: usize = 256;
+const DEFAULT_SLIDING_WINDOW_PATTERN: usize = 6;
+const HIDDEN_ACTIVATION: Activation = Activation::GeluPytorchTanh;
+
+// `n_layer == 62` is the Gemma 3 27B variant; the attention softmax scale uses
+// `1 / sqrt(n_embd / n_head)` there instead of `1 / sqrt(head_dim)`. See
+// `ggml-org/llama.cpp:src/models/gemma3.cpp:20-33`.
+const GEMMA3_27B_LAYER_COUNT: usize = 62;
+
+struct Mlp {
+    feed_forward_w1: Arc<dyn QuantMethod>,
+    feed_forward_w2: Arc<dyn QuantMethod>,
+    feed_forward_w3: Arc<dyn QuantMethod>,
+    act: Activation,
+}
+
+impl Mlp {
+    fn forward(&self, xs: &Tensor) -> Result<Tensor> {
+        let w1 = self.feed_forward_w1.forward(xs)?;
+        let w3 = self.feed_forward_w3.forward(xs)?;
+        let y = crate::ops::mul_and_act(&w1, &w3, self.act)?;
+        self.feed_forward_w2.forward(&y)
+    }
+}
+
+struct LayerWeights {
+    attention_wq: Arc<dyn QuantMethod>,
+    attention_wk: Arc<dyn QuantMethod>,
+    attention_wv: Arc<dyn QuantMethod>,
+    attention_wo: Arc<dyn QuantMethod>,
+    input_layernorm: RmsNorm,
+    post_attention_layernorm: RmsNorm,
+    pre_feedforward_layernorm: RmsNorm,
+    post_feedforward_layernorm: RmsNorm,
+    q_norm: RmsNorm,
+    k_norm: RmsNorm,
+    mlp: Mlp,
+    n_head: usize,
+    n_kv_head: usize,
+    head_dim: usize,
+    rotary: Arc<RotaryEmbedding>,
+    is_sliding: bool,
+    sliding_window: Option<usize>,
+    paged_attn: Option<PagedAttention>,
+    sdpa_params: SdpaParams,
+    dtype: DType,
+    layer_idx: usize,
+}
+
+impl LayerWeights {
+    fn forward_attn(
+        &self,
+        x: &Tensor,
+        attention_mask: &AttentionMask,
+        sliding_attention_mask: &AttentionMask,
+        seqlen_offsets: &[usize],
+        kv_caches: &mut [KvCache],
+        metadata: Option<((Tensor, Tensor), &PagedAttentionInputMetadata)>,
+    ) -> Result<Tensor> {
+        let (b_sz, seq_len, _) = x.dims3()?;
+
+        let q = self.attention_wq.forward(x)?;
+        let k = self.attention_wk.forward(x)?;
+        let v = self.attention_wv.forward(x)?;
+
+        let (q, k, v) = if seq_len != 1 {
+            (
+                q.reshape((b_sz, seq_len, self.n_head, self.head_dim))?
+                    .transpose(1, 2)?,
+                k.reshape((b_sz, seq_len, self.n_kv_head, self.head_dim))?
+                    .transpose(1, 2)?,
+                v.reshape((b_sz, seq_len, self.n_kv_head, self.head_dim))?
+                    .transpose(1, 2)?,
+            )
+        } else {
+            (
+                q.reshape((b_sz, self.n_head, seq_len, self.head_dim))?,
+                k.reshape((b_sz, self.n_kv_head, seq_len, self.head_dim))?,
+                v.reshape((b_sz, self.n_kv_head, seq_len, self.head_dim))?,
+            )
+        };
+
+        let (q, k) = self.rotary.forward_qk_norm(
+            &q,
+            &k,
+            self.q_norm.weight(),
+            self.k_norm.weight(),
+            self.q_norm.eps(),
+            self.k_norm.eps(),
+            seqlen_offsets,
+        )?;
+
+        let q = q.to_dtype(self.dtype)?;
+        let k = k.to_dtype(self.dtype)?;
+        let v = v.to_dtype(self.dtype)?;
+
+        let mut y = match &self.paged_attn {
+            Some(paged_attn) => {
+                let mask = if self.is_sliding {
+                    sliding_attention_mask
+                } else {
+                    attention_mask
+                };
+                match metadata {
+                    Some(((key_cache, value_cache), input_metadata)) => paged_attn.forward(
+                        &q,
+                        &k,
+                        &v,
+                        mask,
+                        Some(key_cache),
+                        Some(value_cache),
+                        input_metadata,
+                        &self.sdpa_params,
+                        None,
+                    )?,
+                    None => {
+                        let dummy = PagedAttentionInputMetadata::dummy(q.device())?;
+                        paged_attn.forward(
+                            &q,
+                            &k,
+                            &v,
+                            mask,
+                            None,
+                            None,
+                            &dummy,
+                            &self.sdpa_params,
+                            None,
+                        )?
+                    }
+                }
+            }
+            None => {
+                let (k_full, v_full) = kv_caches[self.layer_idx].append(&k, &v)?;
+                let (k_used, v_used) = if let Some((start, len)) = sliding_decode_kv_window(
+                    self.is_sliding,
+                    seq_len,
+                    self.sliding_window,
+                    k_full.dim(2)?,
+                ) {
+                    (k_full.narrow(2, start, len)?, v_full.narrow(2, start, len)?)
+                } else {
+                    (k_full, v_full)
+                };
+
+                let mask = if self.is_sliding {
+                    sliding_attention_mask
+                } else {
+                    attention_mask
+                };
+                Sdpa.run_attention(&q, &k_used, &v_used, mask, None, &self.sdpa_params)?
+            }
+        };
+
+        let has_mask = !matches!(attention_mask, AttentionMask::None)
+            || !matches!(sliding_attention_mask, AttentionMask::None);
+        y = if has_mask {
+            y.transpose(1, 2)?.reshape((b_sz, seq_len, ()))?
+        } else {
+            y.reshape((b_sz, seq_len, ()))?
+        };
+        self.attention_wo.forward(&y.to_dtype(x.dtype())?)
+    }
+}
+
+fn sliding_decode_kv_window(
+    is_sliding: bool,
+    q_len: usize,
+    sliding_window: Option<usize>,
+    kv_len: usize,
+) -> Option<(usize, usize)> {
+    let window = sliding_window?;
+    if !is_sliding || q_len != 1 || kv_len <= window {
+        return None;
+    }
+    Some((kv_len - window, window))
+}
+
+pub struct ModelWeights {
+    embed_tokens: ScaledEmbedding,
+    layers: Vec<LayerWeights>,
+    norm: RmsNorm,
+    output: Arc<dyn QuantMethod>,
+    final_logit_softcapping: Option<f64>,
+    pub device: Device,
+    pub cache: EitherCache,
+    pub max_seq_len: usize,
+    mapper: Option<Box<dyn DeviceMapper + Send + Sync>>,
+    dtype: DType,
+    sliding_window: Option<usize>,
+}
+
+// `gemma3.*` metadata. Keys verified against
+// `ggml-org/llama.cpp:src/models/gemma3.cpp:3-18` and the per-arch
+// tensor list at `gguf-py/gguf/constants.py:2397-2414`.
+pub(crate) struct PropsGGUF {
+    head_count: usize,
+    head_count_kv: usize,
+    block_count: usize,
+    embedding_length: usize,
+    rms_norm_eps: f32,
+    max_seq_len: usize,
+    rope_freq_base: f32,
+    rope_freq_base_swa: f32,
+    head_dim: usize,
+    sliding_window: usize,
+    sliding_window_pattern: usize,
+    final_logit_softcapping: Option<f64>,
+}
+
+impl TryFrom<ContentMetadata<'_>> for PropsGGUF {
+    type Error = anyhow::Error;
+
+    fn try_from(c: ContentMetadata) -> std::result::Result<Self, Self::Error> {
+        c.verify_arch("gemma3")?;
+
+        let required = [
+            "attention.head_count",
+            "attention.head_count_kv",
+            "block_count",
+            "embedding_length",
+            "attention.layer_norm_rms_epsilon",
+        ];
+        c.has_required_keys(&required)?;
+
+        let head_count = c.get_value::<u32>("attention.head_count")? as usize;
+        let embedding_length = c.get_value::<u32>("embedding_length")? as usize;
+        // `attention.key_length` is the per-head K dimension. Gemma 3 keeps K
+        // and V at the same dimension on every layer, unlike Gemma 4 which
+        // splits sliding vs full.
+        let head_dim = c
+            .get_value::<u32>("attention.key_length")
+            .ok()
+            .map(|x| x as usize)
+            .unwrap_or(DEFAULT_HEAD_DIM);
+        let value_length = c
+            .get_value::<u32>("attention.value_length")
+            .ok()
+            .map(|x| x as usize)
+            .unwrap_or(head_dim);
+        if value_length != head_dim {
+            anyhow::bail!(
+                "Gemma 3 GGUF requires attention.key_length == attention.value_length, got {head_dim} != {value_length}"
+            );
+        }
+
+        Ok(Self {
+            head_count,
+            head_count_kv: c.get_value::<u32>("attention.head_count_kv")? as usize,
+            block_count: c.get_value::<u32>("block_count")? as usize,
+            embedding_length,
+            rms_norm_eps: c
+                .get_value("attention.layer_norm_rms_epsilon")
+                .unwrap_or(DEFAULT_RMS_NORM_EPS),
+            max_seq_len: c
+                .get_value::<u64>("context_length")
+                .ok()
+                .unwrap_or(DEFAULT_MAX_SEQ_LEN as u64) as usize,
+            rope_freq_base: c
+                .get_value("rope.freq_base")
+                .ok()
+                .unwrap_or(DEFAULT_ROPE_FREQ_BASE),
+            rope_freq_base_swa: c
+                .get_value("rope.freq_base_swa")
+                .ok()
+                .unwrap_or(DEFAULT_ROPE_FREQ_BASE_SWA),
+            head_dim,
+            sliding_window: c
+                .get_value::<u32>("attention.sliding_window")
+                .ok()
+                .map(|x| x as usize)
+                .unwrap_or(0),
+            sliding_window_pattern: c
+                .get_value::<u32>("attention.sliding_window_pattern")
+                .ok()
+                .map(|x| x as usize)
+                .unwrap_or(DEFAULT_SLIDING_WINDOW_PATTERN),
+            final_logit_softcapping: c
+                .get_option_value::<f32>("final_logit_softcapping")?
+                .map(f64::from),
+        })
+    }
+}
+
+// Per-layer SWA flag reconstructed from the metadata-stored pattern. llama.cpp
+// uses `set_swa_pattern(swa_period)` with the default `dense_first = false`,
+// which marks layer `il` as SWA when `il % n_pattern < n_pattern - 1` (see
+// `ggml-org/llama.cpp:src/llama-hparams.cpp:8-18` and
+// `ggml-org/llama.cpp:src/models/gemma3.cpp:8`).
+fn is_sliding_layer(layer_idx: usize, sliding_window_pattern: usize) -> bool {
+    sliding_window_pattern == 0
+        || (layer_idx % sliding_window_pattern) < sliding_window_pattern.saturating_sub(1)
+}
+
+fn gemma_norm_from_qtensor(
+    qt: candle_core::quantized::QTensor,
+    eps: f32,
+    device: &Device,
+) -> Result<RmsNorm> {
+    // Gemma stores raw RmsNorm weights; the model adds 1.0 at runtime, matching
+    // `Gemma3Model.norm_shift` in `ggml-org/llama.cpp:conversion/gemma.py:124`.
+    let w = qt.dequantize(device)?;
+    let w = (w + 1.0)?;
+    RmsNorm::from_w(w, eps as f64)
+}
+
+impl ModelConfig::FromGGUF for ModelWeights {
+    fn from_gguf<R: std::io::Seek + std::io::Read>(
+        mut ct: Content<'_, R>,
+        device: &Device,
+        mapper: Box<dyn DeviceMapper + Send + Sync>,
+        attention_mechanism: AttentionImplementation,
+        dtype: DType,
+    ) -> Result<Self> {
+        let meta = ct.get_metadata();
+        let metadata = ContentMetadata {
+            path_prefix: "gemma3",
+            metadata: meta,
+        };
+        let PropsGGUF {
+            head_count,
+            head_count_kv,
+            block_count,
+            embedding_length,
+            rms_norm_eps,
+            max_seq_len,
+            rope_freq_base,
+            rope_freq_base_swa,
+            head_dim,
+            sliding_window,
+            sliding_window_pattern,
+            final_logit_softcapping,
+        } = PropsGGUF::try_from(metadata).or_else(|err| candle_core::bail!("{err}"))?;
+
+        let qtok_embeddings = ct.tensor("token_embd.weight", device)?;
+        let tok_embeddings = qtok_embeddings.dequantize(device)?;
+        let output_norm = gemma_norm_from_qtensor(
+            ct.tensor("output_norm.weight", device)?,
+            rms_norm_eps,
+            device,
+        )?;
+        let output_qt = if ct.has_tensor("output.weight") {
+            ct.tensor("output.weight", device)?
+        } else {
+            ct.tensor("token_embd.weight", device)?
+        };
+
+        // Build one RoPE per (device, sliding-vs-global). Both use the same
+        // `head_dim`; only the base frequency differs. Mirrors the safetensors
+        // text core at `vision_models/gemma3/text.rs:428-460`.
+        let mut sliding_ropes: HashMap<_, Arc<RotaryEmbedding>> = HashMap::new();
+        let mut global_ropes: HashMap<_, Arc<RotaryEmbedding>> = HashMap::new();
+        for layer_idx in 0..block_count {
+            let dev = mapper.device_for(layer_idx, false).unwrap_or(device);
+            sliding_ropes.entry(dev.location()).or_insert_with(|| {
+                Arc::new(
+                    RotaryEmbedding::new(
+                        rope_freq_base_swa,
+                        head_dim,
+                        max_seq_len,
+                        dev,
+                        true,
+                        DType::F32,
+                    )
+                    .expect("failed to build sliding RoPE"),
+                )
+            });
+            global_ropes.entry(dev.location()).or_insert_with(|| {
+                Arc::new(
+                    RotaryEmbedding::new(
+                        rope_freq_base,
+                        head_dim,
+                        max_seq_len,
+                        dev,
+                        true,
+                        DType::F32,
+                    )
+                    .expect("failed to build global RoPE"),
+                )
+            });
+        }
+
+        let sliding_window_opt = if sliding_window == 0 {
+            None
+        } else {
+            Some(sliding_window)
+        };
+
+        // Match the 27B special case in `ggml-org/llama.cpp:src/models/gemma3.cpp:31-33`:
+        // 27B uses `1 / sqrt(n_embd / n_head)`, other sizes use `1 / sqrt(head_dim)`.
+        let softmax_scale = if block_count == GEMMA3_27B_LAYER_COUNT {
+            1.0 / ((embedding_length as f32) / (head_count as f32)).sqrt()
+        } else {
+            1.0 / (head_dim as f32).sqrt()
+        };
+
+        let mut layers = Vec::with_capacity(block_count);
+        for layer_idx in NiceProgressBar::<_, 'b'>(
+            0..block_count,
+            "Loading repeating layers",
+            &new_multi_progress(),
+        ) {
+            let prefix = format!("blk.{layer_idx}");
+            let dev = mapper.device_for(layer_idx, false).unwrap_or(device);
+            let is_sliding = is_sliding_layer(layer_idx, sliding_window_pattern);
+
+            let attention_wq = ct.tensor(&format!("{prefix}.attn_q.weight"), dev)?;
+            let attention_wk = ct.tensor(&format!("{prefix}.attn_k.weight"), dev)?;
+            let attention_wv = ct.tensor(&format!("{prefix}.attn_v.weight"), dev)?;
+            let attention_wo = ct.tensor(&format!("{prefix}.attn_output.weight"), dev)?;
+
+            let feed_forward_w1 = ct.tensor(&format!("{prefix}.ffn_gate.weight"), dev)?;
+            let feed_forward_w2 = ct.tensor(&format!("{prefix}.ffn_down.weight"), dev)?;
+            let feed_forward_w3 = ct.tensor(&format!("{prefix}.ffn_up.weight"), dev)?;
+
+            let q_norm = gemma_norm_from_qtensor(
+                ct.tensor(&format!("{prefix}.attn_q_norm.weight"), dev)?,
+                rms_norm_eps,
+                dev,
+            )?;
+            let k_norm = gemma_norm_from_qtensor(
+                ct.tensor(&format!("{prefix}.attn_k_norm.weight"), dev)?,
+                rms_norm_eps,
+                dev,
+            )?;
+
+            let input_layernorm = gemma_norm_from_qtensor(
+                ct.tensor(&format!("{prefix}.attn_norm.weight"), dev)?,
+                rms_norm_eps,
+                dev,
+            )?;
+            let post_attention_layernorm = gemma_norm_from_qtensor(
+                ct.tensor(&format!("{prefix}.post_attention_norm.weight"), dev)?,
+                rms_norm_eps,
+                dev,
+            )?;
+            let pre_feedforward_layernorm = gemma_norm_from_qtensor(
+                ct.tensor(&format!("{prefix}.ffn_norm.weight"), dev)?,
+                rms_norm_eps,
+                dev,
+            )?;
+            let post_feedforward_layernorm = gemma_norm_from_qtensor(
+                ct.tensor(&format!("{prefix}.post_ffw_norm.weight"), dev)?,
+                rms_norm_eps,
+                dev,
+            )?;
+
+            let rotary = if is_sliding {
+                sliding_ropes
+                    .get(&dev.location())
+                    .expect("missing sliding RoPE for device")
+                    .clone()
+            } else {
+                global_ropes
+                    .get(&dev.location())
+                    .expect("missing global RoPE for device")
+                    .clone()
+            };
+
+            let paged_attn = match &attention_mechanism {
+                AttentionImplementation::Eager => None,
+                AttentionImplementation::PagedAttention => {
+                    Some(PagedAttention::new(head_dim, dev, None)?)
+                }
+            };
+
+            layers.push(LayerWeights {
+                attention_wq: Arc::new(GgufMatMul::new(QuantMethodConfig::Gguf {
+                    q_weight: Arc::new(attention_wq),
+                    b: None,
+                })?),
+                attention_wk: Arc::new(GgufMatMul::new(QuantMethodConfig::Gguf {
+                    q_weight: Arc::new(attention_wk),
+                    b: None,
+                })?),
+                attention_wv: Arc::new(GgufMatMul::new(QuantMethodConfig::Gguf {
+                    q_weight: Arc::new(attention_wv),
+                    b: None,
+                })?),
+                attention_wo: Arc::new(GgufMatMul::new(QuantMethodConfig::Gguf {
+                    q_weight: Arc::new(attention_wo),
+                    b: None,
+                })?),
+                input_layernorm,
+                post_attention_layernorm,
+                pre_feedforward_layernorm,
+                post_feedforward_layernorm,
+                q_norm,
+                k_norm,
+                mlp: Mlp {
+                    feed_forward_w1: Arc::new(GgufMatMul::new(QuantMethodConfig::Gguf {
+                        q_weight: Arc::new(feed_forward_w1),
+                        b: None,
+                    })?),
+                    feed_forward_w2: Arc::new(GgufMatMul::new(QuantMethodConfig::Gguf {
+                        q_weight: Arc::new(feed_forward_w2),
+                        b: None,
+                    })?),
+                    feed_forward_w3: Arc::new(GgufMatMul::new(QuantMethodConfig::Gguf {
+                        q_weight: Arc::new(feed_forward_w3),
+                        b: None,
+                    })?),
+                    act: HIDDEN_ACTIVATION,
+                },
+                n_head: head_count,
+                n_kv_head: head_count_kv,
+                head_dim,
+                rotary,
+                is_sliding,
+                sliding_window: if is_sliding { sliding_window_opt } else { None },
+                paged_attn,
+                sdpa_params: SdpaParams {
+                    n_kv_groups: head_count / head_count_kv,
+                    softcap: None,
+                    softmax_scale,
+                    sliding_window: if is_sliding { sliding_window_opt } else { None },
+                    sinks: None,
+                },
+                dtype,
+                layer_idx,
+            });
+        }
+
+        Ok(Self {
+            embed_tokens: ScaledEmbedding::new(
+                (embedding_length as f64).sqrt(),
+                Embedding::new(tok_embeddings, embedding_length),
+            ),
+            layers,
+            norm: output_norm,
+            output: Arc::new(GgufMatMul::new(QuantMethodConfig::Gguf {
+                q_weight: Arc::new(output_qt),
+                b: None,
+            })?),
+            final_logit_softcapping,
+            device: device.clone(),
+            cache: EitherCache::Normal(NormalCache::new(block_count, max_seq_len)),
+            max_seq_len,
+            mapper: Some(mapper),
+            dtype,
+            sliding_window: sliding_window_opt,
+        })
+    }
+}
+
+impl ModelWeights {
+    pub fn forward(
+        &self,
+        x: &Tensor,
+        seqlen_offsets: &[usize],
+        context_lens: Vec<(usize, usize)>,
+        metadata: Option<(Vec<(Tensor, Tensor)>, &PagedAttentionInputMetadata)>,
+    ) -> Result<Tensor> {
+        let mut xs = self.embed_tokens.forward(x)?;
+        let cache = &mut self.cache.normal().0;
+
+        let attention_mask = CausalMasker.make_causal_mask(
+            x,
+            metadata
+                .as_ref()
+                .map(|(_, _)| &seqlen_offsets as &dyn PastKvLenCache)
+                .unwrap_or(cache as &dyn PastKvLenCache),
+            self.dtype,
+            &CausalMaskConfig::default(),
+        )?;
+        let attention_mask = if metadata
+            .as_ref()
+            .map(|(_, meta)| meta.is_first_prompt_chunk)
+            .unwrap_or(true)
+        {
+            attention_mask
+        } else {
+            AttentionMask::None
+        };
+        let attention_mask = if let Some(ref mapper) = self.mapper {
+            DeviceMappedMask::new(attention_mask, &**mapper)?
+        } else {
+            DeviceMappedMask::from_single(attention_mask)
+        };
+
+        let sliding_mask_owned = if let Some(window) = self.sliding_window {
+            let m = CausalMasker.make_causal_mask(
+                x,
+                metadata
+                    .as_ref()
+                    .map(|(_, _)| &seqlen_offsets as &dyn PastKvLenCache)
+                    .unwrap_or(cache as &dyn PastKvLenCache),
+                self.dtype,
+                &CausalMaskConfig {
+                    sliding_window: Some(window),
+                    force_custom: false,
+                },
+            )?;
+            let m = if metadata
+                .as_ref()
+                .map(|(_, meta)| meta.is_first_prompt_chunk)
+                .unwrap_or(true)
+            {
+                m
+            } else {
+                AttentionMask::None
+            };
+            let dm = if let Some(ref mapper) = self.mapper {
+                DeviceMappedMask::new(m, &**mapper)?
+            } else {
+                DeviceMappedMask::from_single(m)
+            };
+            Some(dm)
+        } else {
+            None
+        };
+        let sliding_mask_ref: &DeviceMappedMask =
+            sliding_mask_owned.as_ref().unwrap_or(&attention_mask);
+
+        for (i, layer) in self.layers.iter().enumerate() {
+            if let Some(ref mapper) = self.mapper {
+                xs = mapper.map(xs, i)?;
+            }
+
+            let residual = xs.clone();
+            let normed = layer.input_layernorm.forward(&xs)?;
+            let attn_out = layer.forward_attn(
+                &normed,
+                &attention_mask.get(xs.device()),
+                &sliding_mask_ref.get(xs.device()),
+                seqlen_offsets,
+                cache.as_mut_slice(),
+                metadata
+                    .as_ref()
+                    .map(|(kv_cache, meta)| (kv_cache[i].clone(), *meta)),
+            )?;
+            xs = layer
+                .post_attention_layernorm
+                .forward_residual(&attn_out, &residual)?;
+
+            let residual = xs.clone();
+            let normed = xs.apply(&layer.pre_feedforward_layernorm)?;
+            let mlp_out = layer.mlp.forward(&normed)?;
+            xs = layer
+                .post_feedforward_layernorm
+                .forward_residual(&mlp_out, &residual)?;
+        }
+
+        let xs = self.norm.forward(&xs)?;
+        let xs = extract_logits(&xs, context_lens)?;
+        let mut logits = self.output.forward(&xs.contiguous()?)?;
+        if let Some(softcap) = self.final_logit_softcapping {
+            let scale = softcap as f32;
+            logits = ((logits / scale as f64)?.tanh()? * scale as f64)?;
+        }
+        Ok(logits)
+    }
+}

--- a/mistralrs-core/src/models/quantized_gemma4.rs
+++ b/mistralrs-core/src/models/quantized_gemma4.rs
@@ -1163,6 +1163,9 @@ impl ModelWeights {
         metadata: Option<(Vec<(Tensor, Tensor)>, &PagedAttentionInputMetadata)>,
     ) -> Result<Tensor> {
         let mut xs = self.embed_tokens.forward(x)?;
+        // Compute PLE per-layer inputs once. None when PLE is disabled
+        // (legacy GGUFs without embedding_length_per_layer_input).
+        let per_layer_inputs = self.compute_ple(x, &xs)?;
         let cache = &mut self.cache.normal().0;
 
         let attention_mask = CausalMasker.make_causal_mask(
@@ -1250,6 +1253,43 @@ impl ModelWeights {
             xs = layer
                 .post_feedforward_layernorm
                 .forward_residual(&mlp_out, &residual)?;
+
+            // PLE: per-layer embedding injection (after feedforward, before
+            // the layer's residual return). Mirrors
+            // vision_models/gemma4/text.rs:1001-1030.
+            let mut layer_scalar_applied = false;
+            xs = if let (Some(gate), Some(proj), Some(norm)) = (
+                layer.per_layer_input_gate.as_ref(),
+                layer.per_layer_projection.as_ref(),
+                layer.post_per_layer_input_norm.as_ref(),
+            ) {
+                let pli = per_layer_inputs.as_ref().and_then(|v| v.get(i));
+                if let Some(pli) = pli {
+                    let residual_ple = xs.clone();
+                    let gated = gate.forward(&xs)?;
+                    let gated = crate::ops::mul_and_act(&gated, pli, layer.ple_act)?;
+                    let projected = proj.forward(&gated)?;
+                    if let Some(scalar) = layer.layer_scalar.as_ref() {
+                        layer_scalar_applied = true;
+                        norm.forward_residual_scaled(&projected, &residual_ple, scalar)?
+                    } else {
+                        norm.forward_residual(&projected, &residual_ple)?
+                    }
+                } else {
+                    xs
+                }
+            } else {
+                xs
+            };
+
+            // If PLE didn't run but the layer has a standalone scalar,
+            // apply it directly. Mirrors safetensors `if
+            // !layer_scalar_applied` branch.
+            if !layer_scalar_applied {
+                if let Some(scalar) = layer.layer_scalar.as_ref() {
+                    xs = xs.broadcast_mul(scalar)?;
+                }
+            }
         }
 
         let xs = self.norm.forward(&xs)?;

--- a/mistralrs-core/src/models/quantized_gemma4.rs
+++ b/mistralrs-core/src/models/quantized_gemma4.rs
@@ -709,7 +709,7 @@ impl ModelConfig::FromGGUF for ModelWeights {
             sliding_window_pattern,
             num_kv_shared_layers,
             final_logit_softcapping,
-            embedding_length_per_layer_input: _,
+            embedding_length_per_layer_input,
         } = PropsGGUF::try_from(metadata).or_else(|err| candle_core::bail!("{err}"))?;
 
         if key_length_full != value_length_full {
@@ -874,6 +874,41 @@ impl ModelConfig::FromGGUF for ModelWeights {
                 dev,
             )?;
 
+            let ple_dim = embedding_length_per_layer_input;
+            let (per_layer_input_gate, per_layer_projection, post_per_layer_input_norm, layer_scalar) =
+                if ple_dim > 0 {
+                    let gate_qt = ct.tensor(&format!("{prefix}.inp_gate.weight"), dev)?;
+                    let gate = Arc::new(GgufMatMul::new(QuantMethodConfig::Gguf {
+                        q_weight: Arc::new(gate_qt),
+                        b: None,
+                    })?) as Arc<dyn QuantMethod>;
+
+                    let proj_qt = ct.tensor(&format!("{prefix}.proj.weight"), dev)?;
+                    let proj = Arc::new(GgufMatMul::new(QuantMethodConfig::Gguf {
+                        q_weight: Arc::new(proj_qt),
+                        b: None,
+                    })?) as Arc<dyn QuantMethod>;
+
+                    let post_norm = gemma_norm_from_qtensor(
+                        ct.tensor(&format!("{prefix}.post_norm.weight"), dev)?,
+                        rms_norm_eps,
+                        dev,
+                    )?;
+
+                    // layer_output_scale is optional in older converter
+                    // revisions but always present on current unsloth Gemma 4
+                    // GGUFs.
+                    let scalar = ct
+                        .tensor(&format!("{prefix}.layer_output_scale.weight"), dev)
+                        .ok()
+                        .map(|qt| qt.dequantize(dev).and_then(|t| t.to_dtype(DType::F32)))
+                        .transpose()?;
+
+                    (Some(gate), Some(proj), Some(post_norm), scalar)
+                } else {
+                    (None, None, None, None)
+                };
+
             let rotary = if is_sliding {
                 LayerRotary::Sliding(
                     sliding_ropes
@@ -947,6 +982,11 @@ impl ModelConfig::FromGGUF for ModelWeights {
                 dtype,
                 kv_shared_layer_index: donor,
                 layer_idx,
+                per_layer_input_gate,
+                per_layer_projection,
+                post_per_layer_input_norm,
+                layer_scalar,
+                ple_act: Activation::GeluPytorchTanh,
             });
         }
 

--- a/mistralrs-core/src/models/quantized_gemma4.rs
+++ b/mistralrs-core/src/models/quantized_gemma4.rs
@@ -17,7 +17,7 @@ use crate::layers::{
 use crate::layers_masker::PastKvLenCache;
 use crate::paged_attention::{AttentionImplementation, PagedAttention};
 use crate::pipeline::text_models_inputs_processor::PagedAttentionInputMetadata;
-use crate::pipeline::{extract_logits, EitherCache, KvCache, NormalCache};
+use crate::pipeline::{extract_logits, EitherCache, KvCache, NormalCache, NormalCacheType};
 use crate::utils::gguf_metadata::ContentMetadata;
 use crate::utils::model_config as ModelConfig;
 use crate::utils::progress::{new_multi_progress, NiceProgressBar};
@@ -929,7 +929,40 @@ impl ModelConfig::FromGGUF for ModelWeights {
             })?),
             final_logit_softcapping,
             device: device.clone(),
-            cache: EitherCache::Normal(NormalCache::new(block_count, max_seq_len)),
+            // Per-layer cache types. Sliding (SWA) layers use a rotating
+            // window cache sized by the GGUF `attention.sliding_window`
+            // metadata; global/full-attention layers use the normal
+            // append-on-write cache; and shared-KV layers point at their
+            // donor's cache instead of holding their own state. This is
+            // necessary because Gemma 4 uses different `head_dim` per
+            // attention type (256 for SWA, 512 for global on E2B-it). A
+            // uniform `NormalCache::new(...)` would still infer head_dim
+            // on first append per layer, but the engine's batched
+            // `clone_in_cache` step relies on the per-layer cache type to
+            // skip shared slots, and the rotating cache flavor is
+            // required for SWA layers to bound memory by the window
+            // instead of the full context length.
+            cache: EitherCache::Normal(NormalCache::from_types(
+                layer_types
+                    .iter()
+                    .enumerate()
+                    .map(|(layer_idx, ty)| {
+                        if let Some(donor) =
+                            kv_shared_layer_index(&layer_types, num_kv_shared_layers, layer_idx)
+                                .ok()
+                                .flatten()
+                        {
+                            NormalCacheType::Shared { owner: donor }
+                        } else if *ty == SWA_LAYER && sliding_window > 0 {
+                            NormalCacheType::SlidingWindow {
+                                window: sliding_window,
+                            }
+                        } else {
+                            NormalCacheType::Normal { max_seq_len }
+                        }
+                    })
+                    .collect(),
+            )),
             max_seq_len,
             mapper: Some(mapper),
             dtype,

--- a/mistralrs-core/src/models/quantized_gemma4.rs
+++ b/mistralrs-core/src/models/quantized_gemma4.rs
@@ -427,6 +427,26 @@ pub struct ModelWeights {
     mapper: Option<Box<dyn DeviceMapper + Send + Sync>>,
     dtype: DType,
     sliding_window: Option<usize>,
+    /// PLE token embedding lookup. GGUF `per_layer_token_embd.weight`,
+    /// shape `[block_count * ple_dim, vocab_size]`. None for non-PLE
+    /// GGUFs.
+    embed_tokens_per_layer: Option<Embedding>,
+    /// PLE projection of `inputs_embeds`. GGUF
+    /// `per_layer_model_proj.weight`, shape
+    /// `[hidden_size, block_count * ple_dim]`.
+    per_layer_model_projection: Option<Arc<dyn QuantMethod>>,
+    /// RMS norm applied to the PLE projection. GGUF
+    /// `per_layer_proj_norm.weight`, shape `[ple_dim]`. Loaded F32.
+    per_layer_projection_norm: Option<RmsNorm>,
+    /// PLE dimension, 0 disables PLE. Mirrors
+    /// `embedding_length_per_layer_input` from GGUF metadata.
+    hidden_size_per_layer_input: usize,
+    /// Cached scalar `hidden_size^-0.5` applied to the PLE projection
+    /// before the norm.
+    per_layer_projection_scalar: f64,
+    /// Cached scalar `2^-0.5` applied to the (projection + embedding)
+    /// sum to combine both PLE branches.
+    per_layer_input_scale: f64,
 }
 
 // `gemma4.*` metadata pulled from
@@ -738,6 +758,32 @@ impl ModelConfig::FromGGUF for ModelWeights {
             ct.tensor("token_embd.weight", device)?
         };
 
+        let (embed_tokens_per_layer, per_layer_model_projection, per_layer_projection_norm) =
+            if embedding_length_per_layer_input > 0 {
+                let ple_emb_qt = ct.tensor("per_layer_token_embd.weight", device)?;
+                let ple_emb_w = ple_emb_qt.dequantize(device)?.to_dtype(dtype)?;
+                let ple_emb = Embedding::new(
+                    ple_emb_w,
+                    block_count * embedding_length_per_layer_input,
+                );
+
+                let ple_proj_qt = ct.tensor("per_layer_model_proj.weight", device)?;
+                let ple_proj = Arc::new(GgufMatMul::new(QuantMethodConfig::Gguf {
+                    q_weight: Arc::new(ple_proj_qt),
+                    b: None,
+                })?) as Arc<dyn QuantMethod>;
+
+                let ple_norm = gemma_norm_from_qtensor(
+                    ct.tensor("per_layer_proj_norm.weight", device)?,
+                    rms_norm_eps,
+                    device,
+                )?;
+
+                (Some(ple_emb), Some(ple_proj), Some(ple_norm))
+            } else {
+                (None, None, None)
+            };
+
         // Sliding RoPE: one per device, head_dim_swa, rope_freq_base_swa.
         // Global RoPE: one per device, head_dim_full, proportional, rope_freq_base.
         let mut sliding_ropes: HashMap<_, Arc<RotaryEmbedding>> = HashMap::new();
@@ -1041,6 +1087,12 @@ impl ModelConfig::FromGGUF for ModelWeights {
             mapper: Some(mapper),
             dtype,
             sliding_window: sliding_window_opt,
+            embed_tokens_per_layer,
+            per_layer_model_projection,
+            per_layer_projection_norm,
+            hidden_size_per_layer_input: embedding_length_per_layer_input,
+            per_layer_projection_scalar: (embedding_length as f64).powf(-0.5),
+            per_layer_input_scale: 2f64.powf(-0.5),
         })
     }
 }

--- a/mistralrs-core/src/models/quantized_gemma4.rs
+++ b/mistralrs-core/src/models/quantized_gemma4.rs
@@ -1109,7 +1109,16 @@ impl ModelWeights {
         ple_input_ids: &Tensor,
         inputs_embeds: &Tensor,
     ) -> Result<Option<Vec<Tensor>>> {
-        if self.hidden_size_per_layer_input == 0 {
+        // MISTRALRS_GEMMA4_DISABLE_PLE acts as a runtime kill-switch
+        // for the PLE injection: when set to any value, the function
+        // returns None and the per-layer loop sees no PLE input,
+        // exactly as if hidden_size_per_layer_input were 0. Useful for
+        // reproducing the pre-PLE garbage output during regression
+        // testing and for bisecting whether a downstream issue is a
+        // PLE-side or a base-transformer-side bug.
+        if self.hidden_size_per_layer_input == 0
+            || std::env::var("MISTRALRS_GEMMA4_DISABLE_PLE").is_ok()
+        {
             return Ok(None);
         }
         let ple_emb = self

--- a/mistralrs-core/src/models/quantized_gemma4.rs
+++ b/mistralrs-core/src/models/quantized_gemma4.rs
@@ -568,11 +568,32 @@ impl TryFrom<ContentMetadata<'_>> for PropsGGUF {
             final_logit_softcapping: c
                 .get_option_value::<f32>("final_logit_softcapping")?
                 .map(f64::from),
-            embedding_length_per_layer_input: c
-                .get_value::<u32>("embedding_length_per_layer_input")
-                .ok()
-                .map(|x| x as usize)
-                .unwrap_or(0),
+            // PLE adds a ~9.4 GB transient F32 buffer during load on E2B
+            // (the `per_layer_token_embd` table dequant), which OOMs on
+            // hosts with <24 GB unified memory. `MISTRALRS_GEMMA4_DISABLE_PLE`
+            // forces this to 0 so the loader skips both top-level and
+            // per-layer PLE tensors entirely. The forward path treats
+            // `ple_dim = 0` as "no PLE injection" (legacy text-only
+            // behaviour, incoherent output on Gemma 4 weights that carry
+            // PLE — used for memory-constrained smoke-testing and as a
+            // bisect tool, not for production).
+            embedding_length_per_layer_input: if std::env::var(
+                "MISTRALRS_GEMMA4_DISABLE_PLE",
+            )
+            .is_ok()
+            {
+                tracing::warn!(
+                    "MISTRALRS_GEMMA4_DISABLE_PLE is set — skipping PLE \
+                     tensor load. Output will be incoherent on Gemma 4 \
+                     weights that carry PLE."
+                );
+                0
+            } else {
+                c.get_value::<u32>("embedding_length_per_layer_input")
+                    .ok()
+                    .map(|x| x as usize)
+                    .unwrap_or(0)
+            },
         })
     }
 }

--- a/mistralrs-core/src/models/quantized_gemma4.rs
+++ b/mistralrs-core/src/models/quantized_gemma4.rs
@@ -1098,6 +1098,63 @@ impl ModelConfig::FromGGUF for ModelWeights {
 }
 
 impl ModelWeights {
+    /// Compute the per-layer PLE inputs once at the start of `forward`.
+    /// Mirrors `vision_models/gemma4/text.rs::compute_ple`.
+    ///
+    /// Returns `Ok(None)` when PLE is disabled (legacy GGUFs without
+    /// the `embedding_length_per_layer_input` metadata key), letting the
+    /// caller skip the per-layer injection without any branching cost.
+    fn compute_ple(
+        &self,
+        ple_input_ids: &Tensor,
+        inputs_embeds: &Tensor,
+    ) -> Result<Option<Vec<Tensor>>> {
+        if self.hidden_size_per_layer_input == 0 {
+            return Ok(None);
+        }
+        let ple_emb = self
+            .embed_tokens_per_layer
+            .as_ref()
+            .expect("PLE embedding required when hidden_size_per_layer_input > 0");
+        let ple_proj = self
+            .per_layer_model_projection
+            .as_ref()
+            .expect("PLE projection required when hidden_size_per_layer_input > 0");
+        let ple_norm = self
+            .per_layer_projection_norm
+            .as_ref()
+            .expect("PLE norm required when hidden_size_per_layer_input > 0");
+
+        let ple_dim = self.hidden_size_per_layer_input;
+        let num_layers = self.layers.len();
+        let (b, seq, _) = inputs_embeds.dims3()?;
+
+        // 1. Token-level per-layer embeddings.
+        let embedded = ple_emb.forward(ple_input_ids)?;
+        let embedded = (embedded * (ple_dim as f64).sqrt())?;
+        let embedded = embedded.reshape((b, seq, num_layers, ple_dim))?;
+
+        // 2. Project the hidden state.
+        let projected = ple_proj.forward(inputs_embeds)?;
+        let projected = (projected * self.per_layer_projection_scalar)?;
+        let projected = projected.reshape((b, seq, num_layers, ple_dim))?;
+
+        // 3. Normalize the projection (per ple_dim slot).
+        let projected = ple_norm.forward(&projected)?;
+
+        // 4. Combine projection + embedding and apply the 2^-0.5 scale.
+        let combined = ((projected + embedded)? * self.per_layer_input_scale)?;
+
+        // 5. Split into per-layer slices via one contiguous transpose
+        // followed by narrow + squeeze (zero-copy after `contiguous`).
+        let combined = combined.transpose(1, 2)?.contiguous()?;
+        let mut per_layer_inputs = Vec::with_capacity(num_layers);
+        for i in 0..num_layers {
+            per_layer_inputs.push(combined.narrow(1, i, 1)?.squeeze(1)?);
+        }
+        Ok(Some(per_layer_inputs))
+    }
+
     pub fn forward(
         &self,
         x: &Tensor,

--- a/mistralrs-core/src/models/quantized_gemma4.rs
+++ b/mistralrs-core/src/models/quantized_gemma4.rs
@@ -173,6 +173,27 @@ struct LayerWeights {
     dtype: DType,
     kv_shared_layer_index: Option<usize>,
     layer_idx: usize,
+    /// PLE per-layer gate. GGUF `blk.X.inp_gate.weight`, shape
+    /// `[hidden_size, ple_dim]`. None for non-PLE GGUFs (legacy).
+    per_layer_input_gate: Option<Arc<dyn QuantMethod>>,
+    /// PLE per-layer projection. GGUF `blk.X.proj.weight`, shape
+    /// `[ple_dim, hidden_size]`.
+    per_layer_projection: Option<Arc<dyn QuantMethod>>,
+    /// Norm applied after the PLE residual. GGUF `blk.X.post_norm.weight`,
+    /// shape `[hidden_size]`. Loaded F32 to match the F32 activations the
+    /// Q4_K projections produce (see commit 60c1e46 for the same
+    /// rationale on the other gemma norms).
+    post_per_layer_input_norm: Option<RmsNorm>,
+    /// Optional per-layer scalar applied to the layer output. GGUF
+    /// `blk.X.layer_output_scale.weight`, shape `[1]`. When PLE is
+    /// active, the scalar is folded into the PLE norm's
+    /// `forward_residual_scaled`; otherwise it's a standalone
+    /// `broadcast_mul` at the end of `forward_attn`'s caller.
+    layer_scalar: Option<Tensor>,
+    /// Activation function for the PLE gate-multiply step. Gemma 4 uses
+    /// `gelu_pytorch_tanh`. Cached on the layer to avoid re-parsing per
+    /// forward call.
+    ple_act: Activation,
 }
 
 impl LayerWeights {

--- a/mistralrs-core/src/models/quantized_gemma4.rs
+++ b/mistralrs-core/src/models/quantized_gemma4.rs
@@ -196,6 +196,13 @@ impl LayerWeights {
         } else {
             q.reshape((b_sz, self.n_head, seq_len, self.head_dim))?
         };
+        // NOTE: q/k/v are F32 here (GgufMatMul::forward returns F32 from the
+        // Q4_K dequant intermediate). Keep them at F32 through the rotary +
+        // per-head norm step because the candle Metal `rms_norm` kernel
+        // bails on `(F32, BF16)` and the Gemma 4 q/k_norm weights are
+        // explicitly stored at F32 (see `gemma_norm_from_qtensor`). The
+        // existing `.to_dtype(self.dtype)?` block right before sdpa
+        // reconciles back to the model dtype for the attention kernel.
 
         let (mut k, v_norm) = if is_shared {
             (None, None)
@@ -550,7 +557,20 @@ fn gemma_norm_from_qtensor(
 ) -> Result<RmsNorm> {
     // Gemma stores raw RmsNorm weights; the model adds 1.0 at runtime, matching
     // `Gemma3Model.norm_shift` in `ggml-org/llama.cpp:conversion/gemma.py:124`.
-    let w = qt.dequantize(device)?;
+    //
+    // Gemma 4 GGUFs store the per-head `attn_{q,k}_norm.weight` tensors as
+    // raw BF16 rather than Q4_K (norm scales are too small to quantize), so
+    // `dequantize` returns BF16 directly. Cast to F32 here so:
+    //   1. the `+ 1.0` norm shift stays numerically accurate; and
+    //   2. the weight dtype matches the F32 activations produced by
+    //      `GgufMatMul::forward` (Q4_K dequant intermediate). The candle
+    //      Metal `rms_norm` kernel requires `input.dtype() == weight.dtype()`
+    //      and bails with `rmsnorm is not implemented for F32 BF16`
+    //      otherwise.
+    // The forward path already casts back to `self.dtype` after the rotary
+    // step (see `LayerWeights::forward_attn`), so keeping the norm at F32
+    // does not poison the rest of the model.
+    let w = qt.dequantize(device)?.to_dtype(DType::F32)?;
     let w = (w + 1.0)?;
     RmsNorm::from_w(w, eps as f64)
 }
@@ -719,8 +739,12 @@ impl ModelConfig::FromGGUF for ModelWeights {
             )?;
             let k_norm = if donor.is_some() {
                 // The donor layer keeps its own k_norm; we still need a placeholder
-                // since RoPE is applied to Q only.
-                RmsNorm::from_w(Tensor::ones(head_dim, dtype, dev)?, rms_norm_eps as f64)?
+                // since RoPE is applied to Q only. Placeholder is F32 to match
+                // the dtype contract of the other Gemma norm weights.
+                RmsNorm::from_w(
+                    Tensor::ones(head_dim, DType::F32, dev)?,
+                    rms_norm_eps as f64,
+                )?
             } else {
                 gemma_norm_from_qtensor(
                     ct.tensor(&format!("{prefix}.attn_k_norm.weight"), dev)?,
@@ -729,8 +753,12 @@ impl ModelConfig::FromGGUF for ModelWeights {
                 )?
             };
             // V norm is a fused RmsNorm with weight=1.0; there is no
-            // `attn_v_norm` tensor in upstream Gemma 4 GGUFs.
-            let v_norm = RmsNorm::from_w(Tensor::ones(head_dim, dtype, dev)?, rms_norm_eps as f64)?;
+            // `attn_v_norm` tensor in upstream Gemma 4 GGUFs. Use F32 to
+            // match the F32 activations produced by the quantized V proj.
+            let v_norm = RmsNorm::from_w(
+                Tensor::ones(head_dim, DType::F32, dev)?,
+                rms_norm_eps as f64,
+            )?;
 
             let input_layernorm = gemma_norm_from_qtensor(
                 ct.tensor(&format!("{prefix}.attn_norm.weight"), dev)?,

--- a/mistralrs-core/src/models/quantized_gemma4.rs
+++ b/mistralrs-core/src/models/quantized_gemma4.rs
@@ -1,0 +1,961 @@
+#![allow(clippy::cast_possible_truncation, clippy::cast_precision_loss)]
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use candle_core::{DType, Device, Module, Result, Tensor};
+use candle_nn::Embedding;
+use mistralrs_quant::{GgufMatMul, QuantMethod, QuantMethodConfig};
+
+use crate::attention::{AttentionMask, SdpaParams};
+use crate::device_map::{DeviceMappedMask, DeviceMapper};
+use crate::gguf::Content;
+use crate::layers::{
+    q_rms_norm_rope, qk_rms_norm_rope, Activation, CausalMaskConfig, CausalMasker, RmsNorm,
+    RotaryEmbedding, ScaledEmbedding, Sdpa,
+};
+use crate::layers_masker::PastKvLenCache;
+use crate::paged_attention::{AttentionImplementation, PagedAttention};
+use crate::pipeline::text_models_inputs_processor::PagedAttentionInputMetadata;
+use crate::pipeline::{extract_logits, EitherCache, KvCache, NormalCache};
+use crate::utils::gguf_metadata::ContentMetadata;
+use crate::utils::model_config as ModelConfig;
+use crate::utils::progress::{new_multi_progress, NiceProgressBar};
+
+// Defaults fall back to upstream Gemma 4 config values when the GGUF
+// metadata omits an optional key.
+const DEFAULT_MAX_SEQ_LEN: u32 = 131072;
+const DEFAULT_ROPE_FREQ_BASE: f32 = 1_000_000.0;
+const DEFAULT_ROPE_FREQ_BASE_SWA: f32 = 10_000.0;
+const DEFAULT_RMS_NORM_EPS: f32 = 1e-6;
+const DEFAULT_HEAD_DIM_SWA: usize = 256;
+const DEFAULT_HEAD_DIM_GLOBAL: usize = 512;
+const DEFAULT_SLIDING_WINDOW_PATTERN: usize = 6;
+const DEFAULT_PARTIAL_ROTARY_FACTOR: f64 = 0.25;
+const HIDDEN_ACTIVATION: Activation = Activation::GeluPytorchTanh;
+
+const SWA_LAYER: &str = "sliding_attention";
+const FULL_LAYER: &str = "full_attention";
+
+/// Proportional RoPE for Gemma 4 full-attention layers, ported to the GGUF path.
+///
+/// The full-attention layers rotate only the first
+/// `partial_rotary_factor * head_dim` dimensions but use `head_dim` as the
+/// denominator in `inv_freq`. The remaining frequencies are zero, which makes
+/// the standard rotary formula act as identity on the tail of each head.
+#[derive(Debug, Clone)]
+struct ProportionalRotaryEmbedding {
+    cos: Tensor,
+    sin: Tensor,
+    is_gpt_neox: bool,
+}
+
+impl ProportionalRotaryEmbedding {
+    fn new(
+        base: f32,
+        head_dim: usize,
+        partial_rotary_factor: f64,
+        max_position_embeddings: usize,
+        device: &Device,
+        is_gpt_neox: bool,
+        dtype: DType,
+    ) -> Result<Self> {
+        let rope_angles = ((partial_rotary_factor * head_dim as f64) / 2.0) as usize;
+        let half_dim = head_dim / 2;
+
+        let mut inv_freq_vec = Vec::with_capacity(half_dim);
+        for i in 0..rope_angles {
+            inv_freq_vec.push(1f32 / base.powf((2 * i) as f32 / head_dim as f32));
+        }
+        inv_freq_vec.extend(std::iter::repeat_n(0f32, half_dim - rope_angles));
+
+        let inv_freq = Tensor::from_vec(inv_freq_vec, (1, half_dim), device)?;
+        let t = Tensor::arange(0u32, max_position_embeddings as u32, device)?
+            .to_dtype(DType::F32)?
+            .reshape((max_position_embeddings, 1))?;
+        let freqs = t.matmul(&inv_freq)?;
+        let cos = freqs.cos()?.to_dtype(dtype)?;
+        let sin = freqs.sin()?.to_dtype(dtype)?;
+
+        Ok(Self {
+            cos,
+            sin,
+            is_gpt_neox,
+        })
+    }
+
+    fn forward_qk_norm(
+        &self,
+        q: &Tensor,
+        k: &Tensor,
+        q_weight: &Tensor,
+        k_weight: &Tensor,
+        q_eps: f64,
+        k_eps: f64,
+        seqlen_offsets: &[usize],
+    ) -> Result<(Tensor, Tensor)> {
+        qk_rms_norm_rope(
+            q,
+            k,
+            q_weight,
+            k_weight,
+            q_eps,
+            k_eps,
+            &self.cos,
+            &self.sin,
+            self.is_gpt_neox,
+            seqlen_offsets,
+        )
+    }
+
+    fn forward_q_norm(
+        &self,
+        q: &Tensor,
+        q_weight: &Tensor,
+        q_eps: f64,
+        seqlen_offsets: &[usize],
+    ) -> Result<Tensor> {
+        q_rms_norm_rope(
+            q,
+            q_weight,
+            q_eps,
+            &self.cos,
+            &self.sin,
+            self.is_gpt_neox,
+            seqlen_offsets,
+        )
+    }
+}
+
+#[derive(Clone)]
+enum LayerRotary {
+    Sliding(Arc<RotaryEmbedding>),
+    Global(Arc<ProportionalRotaryEmbedding>),
+}
+
+struct Mlp {
+    feed_forward_w1: Arc<dyn QuantMethod>,
+    feed_forward_w2: Arc<dyn QuantMethod>,
+    feed_forward_w3: Arc<dyn QuantMethod>,
+    act: Activation,
+}
+
+impl Mlp {
+    fn forward(&self, xs: &Tensor) -> Result<Tensor> {
+        let w1 = self.feed_forward_w1.forward(xs)?;
+        let w3 = self.feed_forward_w3.forward(xs)?;
+        let y = crate::ops::mul_and_act(&w1, &w3, self.act)?;
+        self.feed_forward_w2.forward(&y)
+    }
+}
+
+struct LayerWeights {
+    attention_wq: Arc<dyn QuantMethod>,
+    attention_wk: Option<Arc<dyn QuantMethod>>,
+    attention_wv: Option<Arc<dyn QuantMethod>>,
+    attention_wo: Arc<dyn QuantMethod>,
+    input_layernorm: RmsNorm,
+    post_attention_layernorm: RmsNorm,
+    pre_feedforward_layernorm: RmsNorm,
+    post_feedforward_layernorm: RmsNorm,
+    q_norm: RmsNorm,
+    k_norm: RmsNorm,
+    v_norm: RmsNorm,
+    mlp: Mlp,
+    n_head: usize,
+    n_kv_head: usize,
+    head_dim: usize,
+    rotary: LayerRotary,
+    is_sliding: bool,
+    sliding_window: Option<usize>,
+    paged_attn: Option<PagedAttention>,
+    sdpa_params: SdpaParams,
+    dtype: DType,
+    kv_shared_layer_index: Option<usize>,
+    layer_idx: usize,
+}
+
+impl LayerWeights {
+    #[allow(clippy::too_many_arguments)]
+    fn forward_attn(
+        &self,
+        x: &Tensor,
+        attention_mask: &AttentionMask,
+        sliding_attention_mask: &AttentionMask,
+        seqlen_offsets: &[usize],
+        kv_caches: &mut [KvCache],
+        metadata: Option<((Tensor, Tensor), &PagedAttentionInputMetadata)>,
+    ) -> Result<Tensor> {
+        let (b_sz, seq_len, _) = x.dims3()?;
+        let is_shared = self.kv_shared_layer_index.is_some();
+
+        let q = self.attention_wq.forward(x)?;
+        let mut q = if seq_len != 1 {
+            q.reshape((b_sz, seq_len, self.n_head, self.head_dim))?
+                .transpose(1, 2)?
+        } else {
+            q.reshape((b_sz, self.n_head, seq_len, self.head_dim))?
+        };
+
+        let (mut k, v_norm) = if is_shared {
+            (None, None)
+        } else {
+            let wk = self
+                .attention_wk
+                .as_ref()
+                .expect("missing wk on dense layer");
+            let wv = self
+                .attention_wv
+                .as_ref()
+                .expect("missing wv on dense layer");
+            let k = wk.forward(x)?;
+            let v = wv.forward(x)?;
+            let (k, v) = if seq_len != 1 {
+                (
+                    k.reshape((b_sz, seq_len, self.n_kv_head, self.head_dim))?
+                        .transpose(1, 2)?,
+                    v.reshape((b_sz, seq_len, self.n_kv_head, self.head_dim))?
+                        .transpose(1, 2)?,
+                )
+            } else {
+                (
+                    k.reshape((b_sz, self.n_kv_head, seq_len, self.head_dim))?,
+                    v.reshape((b_sz, self.n_kv_head, seq_len, self.head_dim))?,
+                )
+            };
+            let v = v.apply(&self.v_norm)?;
+            (Some(k), Some(v))
+        };
+
+        match &self.rotary {
+            LayerRotary::Sliding(rot) => {
+                if let Some(k_val) = k.take() {
+                    let (q_rot, k_rot) = rot.forward_qk_norm(
+                        &q,
+                        &k_val,
+                        self.q_norm.weight(),
+                        self.k_norm.weight(),
+                        self.q_norm.eps(),
+                        self.k_norm.eps(),
+                        seqlen_offsets,
+                    )?;
+                    q = q_rot;
+                    k = Some(k_rot);
+                } else {
+                    q = rot.forward_q_norm(
+                        &q,
+                        self.q_norm.weight(),
+                        self.q_norm.eps(),
+                        seqlen_offsets,
+                    )?;
+                }
+            }
+            LayerRotary::Global(rot) => {
+                if let Some(k_val) = k.take() {
+                    let (q_rot, k_rot) = rot.forward_qk_norm(
+                        &q,
+                        &k_val,
+                        self.q_norm.weight(),
+                        self.k_norm.weight(),
+                        self.q_norm.eps(),
+                        self.k_norm.eps(),
+                        seqlen_offsets,
+                    )?;
+                    q = q_rot;
+                    k = Some(k_rot);
+                } else {
+                    q = rot.forward_q_norm(
+                        &q,
+                        self.q_norm.weight(),
+                        self.q_norm.eps(),
+                        seqlen_offsets,
+                    )?;
+                }
+            }
+        }
+
+        let (q, k_typed, v_typed) = (
+            q.to_dtype(self.dtype)?,
+            k.as_ref().map(|t| t.to_dtype(self.dtype)).transpose()?,
+            v_norm
+                .as_ref()
+                .map(|t| t.to_dtype(self.dtype))
+                .transpose()?,
+        );
+
+        let mut y = match &self.paged_attn {
+            Some(paged_attn) => {
+                let mask = if self.is_sliding {
+                    sliding_attention_mask
+                } else {
+                    attention_mask
+                };
+                match metadata {
+                    Some(((key_cache, value_cache), input_metadata)) => {
+                        if is_shared {
+                            paged_attn.forward_donor_cache(
+                                &q,
+                                &key_cache,
+                                &value_cache,
+                                mask,
+                                input_metadata,
+                                &self.sdpa_params,
+                                None,
+                            )?
+                        } else {
+                            paged_attn.forward(
+                                &q,
+                                k_typed.as_ref().unwrap(),
+                                v_typed.as_ref().unwrap(),
+                                mask,
+                                Some(key_cache),
+                                Some(value_cache),
+                                input_metadata,
+                                &self.sdpa_params,
+                                None,
+                            )?
+                        }
+                    }
+                    None => {
+                        let dummy = PagedAttentionInputMetadata::dummy(q.device())?;
+                        paged_attn.forward(
+                            &q,
+                            k_typed.as_ref().unwrap(),
+                            v_typed.as_ref().unwrap(),
+                            mask,
+                            None,
+                            None,
+                            &dummy,
+                            &self.sdpa_params,
+                            None,
+                        )?
+                    }
+                }
+            }
+            None => {
+                let (k_full, v_full) = if let Some(donor_idx) = self.kv_shared_layer_index {
+                    let donor = &kv_caches[donor_idx];
+                    let dk = donor.appended_k()?.unwrap().to_device(q.device())?;
+                    let dv = donor.appended_v()?.unwrap().to_device(q.device())?;
+                    (dk, dv)
+                } else {
+                    kv_caches[self.layer_idx]
+                        .append(k_typed.as_ref().unwrap(), v_typed.as_ref().unwrap())?
+                };
+
+                let (k_used, v_used) = if let Some((start, len)) = sliding_decode_kv_window(
+                    self.is_sliding,
+                    seq_len,
+                    self.sliding_window,
+                    k_full.dim(2)?,
+                ) {
+                    (k_full.narrow(2, start, len)?, v_full.narrow(2, start, len)?)
+                } else {
+                    (k_full, v_full)
+                };
+
+                let mask = if self.is_sliding {
+                    sliding_attention_mask
+                } else {
+                    attention_mask
+                };
+                Sdpa.run_attention(&q, &k_used, &v_used, mask, None, &self.sdpa_params)?
+            }
+        };
+
+        let has_mask = !matches!(attention_mask, AttentionMask::None)
+            || !matches!(sliding_attention_mask, AttentionMask::None);
+        y = if has_mask {
+            y.transpose(1, 2)?.reshape((b_sz, seq_len, ()))?
+        } else {
+            y.reshape((b_sz, seq_len, ()))?
+        };
+        self.attention_wo.forward(&y.to_dtype(x.dtype())?)
+    }
+}
+
+fn sliding_decode_kv_window(
+    is_sliding: bool,
+    q_len: usize,
+    sliding_window: Option<usize>,
+    kv_len: usize,
+) -> Option<(usize, usize)> {
+    let window = sliding_window?;
+    if !is_sliding || q_len != 1 || kv_len <= window {
+        return None;
+    }
+    Some((kv_len - window, window))
+}
+
+pub struct ModelWeights {
+    embed_tokens: ScaledEmbedding,
+    layers: Vec<LayerWeights>,
+    norm: RmsNorm,
+    output: Arc<dyn QuantMethod>,
+    final_logit_softcapping: Option<f64>,
+    pub device: Device,
+    pub cache: EitherCache,
+    pub max_seq_len: usize,
+    mapper: Option<Box<dyn DeviceMapper + Send + Sync>>,
+    dtype: DType,
+    sliding_window: Option<usize>,
+}
+
+// `gemma4.*` metadata pulled from
+// `ggml-org/llama.cpp:gguf-py/gguf/constants.py:2450-2483` plus the
+// per-arch keys collected in `src/llama-arch.cpp` (sliding window, shared
+// kv layers, swa head dims, swa rope base, final logit softcapping).
+pub(crate) struct PropsGGUF {
+    head_count: usize,
+    head_count_kv: usize,
+    block_count: usize,
+    embedding_length: usize,
+    rms_norm_eps: f32,
+    max_seq_len: usize,
+    rope_freq_base: f32,
+    rope_freq_base_swa: f32,
+    key_length_full: usize,
+    value_length_full: usize,
+    key_length_swa: usize,
+    value_length_swa: usize,
+    sliding_window: usize,
+    sliding_window_pattern: usize,
+    num_kv_shared_layers: usize,
+    final_logit_softcapping: Option<f64>,
+}
+
+impl TryFrom<ContentMetadata<'_>> for PropsGGUF {
+    type Error = anyhow::Error;
+
+    fn try_from(c: ContentMetadata) -> std::result::Result<Self, Self::Error> {
+        c.verify_arch("gemma4")?;
+
+        let required = [
+            "attention.head_count",
+            "attention.head_count_kv",
+            "block_count",
+            "embedding_length",
+            "attention.layer_norm_rms_epsilon",
+        ];
+        c.has_required_keys(&required)?;
+
+        let head_count = c.get_value::<u32>("attention.head_count")? as usize;
+        let embedding_length = c.get_value::<u32>("embedding_length")? as usize;
+        let key_length_full = c
+            .get_value::<u32>("attention.key_length")
+            .ok()
+            .map(|x| x as usize)
+            .unwrap_or(DEFAULT_HEAD_DIM_GLOBAL);
+        let value_length_full = c
+            .get_value::<u32>("attention.value_length")
+            .ok()
+            .map(|x| x as usize)
+            .unwrap_or(DEFAULT_HEAD_DIM_GLOBAL);
+        let key_length_swa = c
+            .get_value::<u32>("attention.key_length_swa")
+            .ok()
+            .map(|x| x as usize)
+            .unwrap_or(DEFAULT_HEAD_DIM_SWA);
+        let value_length_swa = c
+            .get_value::<u32>("attention.value_length_swa")
+            .ok()
+            .map(|x| x as usize)
+            .unwrap_or(DEFAULT_HEAD_DIM_SWA);
+
+        Ok(Self {
+            head_count,
+            head_count_kv: c.get_value::<u32>("attention.head_count_kv")? as usize,
+            block_count: c.get_value::<u32>("block_count")? as usize,
+            embedding_length,
+            rms_norm_eps: c
+                .get_value("attention.layer_norm_rms_epsilon")
+                .unwrap_or(DEFAULT_RMS_NORM_EPS),
+            max_seq_len: c
+                .get_value::<u64>("context_length")
+                .ok()
+                .unwrap_or(DEFAULT_MAX_SEQ_LEN as u64) as usize,
+            rope_freq_base: c
+                .get_value("rope.freq_base")
+                .ok()
+                .unwrap_or(DEFAULT_ROPE_FREQ_BASE),
+            rope_freq_base_swa: c
+                .get_value("rope.freq_base_swa")
+                .ok()
+                .unwrap_or(DEFAULT_ROPE_FREQ_BASE_SWA),
+            key_length_full,
+            value_length_full,
+            key_length_swa,
+            value_length_swa,
+            sliding_window: c
+                .get_value::<u32>("attention.sliding_window")
+                .ok()
+                .map(|x| x as usize)
+                .unwrap_or(0),
+            sliding_window_pattern: c
+                .get_value::<u32>("attention.sliding_window_pattern")
+                .ok()
+                .map(|x| x as usize)
+                .unwrap_or(DEFAULT_SLIDING_WINDOW_PATTERN),
+            num_kv_shared_layers: c
+                .get_value::<u32>("attention.shared_kv_layers")
+                .ok()
+                .map(|x| x as usize)
+                .unwrap_or(0),
+            final_logit_softcapping: c
+                .get_option_value::<f32>("final_logit_softcapping")?
+                .map(f64::from),
+        })
+    }
+}
+
+// `layer_types` is reconstructed from the sliding-window pattern stored in
+// metadata. llama.cpp's `set_swa_pattern(n_pattern, dense_first=false)`
+// marks layer `il` as SWA when `il % n_pattern < n_pattern - 1`, which is
+// the convention used by upstream Gemma 4 GGUFs.
+fn build_layer_types(block_count: usize, sliding_window_pattern: usize) -> Vec<&'static str> {
+    let mut out = Vec::with_capacity(block_count);
+    for il in 0..block_count {
+        let is_swa = sliding_window_pattern == 0
+            || (il % sliding_window_pattern) < sliding_window_pattern.saturating_sub(1);
+        out.push(if is_swa { SWA_LAYER } else { FULL_LAYER });
+    }
+    out
+}
+
+fn kv_shared_layer_index(
+    layer_types: &[&str],
+    num_kv_shared_layers: usize,
+    layer_idx: usize,
+) -> Result<Option<usize>> {
+    let first_shared = layer_types.len().saturating_sub(num_kv_shared_layers);
+    if first_shared == 0 || layer_idx < first_shared {
+        return Ok(None);
+    }
+    let attention_type = layer_types[layer_idx];
+    layer_types[..first_shared]
+        .iter()
+        .rposition(|ty| *ty == attention_type)
+        .map(Some)
+        .ok_or_else(|| {
+            candle_core::Error::Msg(format!(
+                "Gemma4 layer {layer_idx} shares KV but no prior `{attention_type}` donor layer exists."
+            ))
+        })
+}
+
+fn gemma_norm_from_qtensor(
+    qt: candle_core::quantized::QTensor,
+    eps: f32,
+    device: &Device,
+) -> Result<RmsNorm> {
+    // Gemma stores raw RmsNorm weights; the model adds 1.0 at runtime, matching
+    // `Gemma3Model.norm_shift` in `ggml-org/llama.cpp:conversion/gemma.py:124`.
+    let w = qt.dequantize(device)?;
+    let w = (w + 1.0)?;
+    RmsNorm::from_w(w, eps as f64)
+}
+
+fn detect_moe<R: std::io::Seek + std::io::Read>(ct: &mut Content<'_, R>) -> Result<()> {
+    if ct.has_tensor("blk.0.ffn_gate_exps.weight") || ct.has_tensor("blk.0.ffn_gate_up_exps.weight")
+    {
+        candle_core::bail!(
+            "Gemma 4 MoE (FFN_*_EXP tensors detected) is not supported by this GGUF loader; tracked separately."
+        );
+    }
+    Ok(())
+}
+
+impl ModelConfig::FromGGUF for ModelWeights {
+    fn from_gguf<R: std::io::Seek + std::io::Read>(
+        mut ct: Content<'_, R>,
+        device: &Device,
+        mapper: Box<dyn DeviceMapper + Send + Sync>,
+        attention_mechanism: AttentionImplementation,
+        dtype: DType,
+    ) -> Result<Self> {
+        detect_moe(&mut ct)?;
+
+        let meta = ct.get_metadata();
+        let metadata = ContentMetadata {
+            path_prefix: "gemma4",
+            metadata: meta,
+        };
+        let PropsGGUF {
+            head_count,
+            head_count_kv,
+            block_count,
+            embedding_length,
+            rms_norm_eps,
+            max_seq_len,
+            rope_freq_base,
+            rope_freq_base_swa,
+            key_length_full,
+            value_length_full,
+            key_length_swa,
+            value_length_swa,
+            sliding_window,
+            sliding_window_pattern,
+            num_kv_shared_layers,
+            final_logit_softcapping,
+        } = PropsGGUF::try_from(metadata).or_else(|err| candle_core::bail!("{err}"))?;
+
+        if key_length_full != value_length_full {
+            candle_core::bail!(
+                "Gemma 4 GGUF requires key_length == value_length for full-attention layers, got {key_length_full} != {value_length_full}"
+            );
+        }
+        if key_length_swa != value_length_swa {
+            candle_core::bail!(
+                "Gemma 4 GGUF requires key_length_swa == value_length_swa for sliding layers, got {key_length_swa} != {value_length_swa}"
+            );
+        }
+
+        let layer_types = build_layer_types(block_count, sliding_window_pattern);
+
+        let qtok_embeddings = ct.tensor("token_embd.weight", device)?;
+        let tok_embeddings = qtok_embeddings.dequantize(device)?;
+        let output_norm = gemma_norm_from_qtensor(
+            ct.tensor("output_norm.weight", device)?,
+            rms_norm_eps,
+            device,
+        )?;
+        let output_qt = if ct.has_tensor("output.weight") {
+            ct.tensor("output.weight", device)?
+        } else {
+            ct.tensor("token_embd.weight", device)?
+        };
+
+        // Sliding RoPE: one per device, head_dim_swa, rope_freq_base_swa.
+        // Global RoPE: one per device, head_dim_full, proportional, rope_freq_base.
+        let mut sliding_ropes: HashMap<_, Arc<RotaryEmbedding>> = HashMap::new();
+        let mut global_ropes: HashMap<_, Arc<ProportionalRotaryEmbedding>> = HashMap::new();
+        for layer_idx in 0..block_count {
+            let dev = mapper.device_for(layer_idx, false).unwrap_or(device);
+            sliding_ropes.entry(dev.location()).or_insert_with(|| {
+                Arc::new(
+                    RotaryEmbedding::new(
+                        rope_freq_base_swa,
+                        key_length_swa,
+                        max_seq_len,
+                        dev,
+                        true,
+                        DType::F32,
+                    )
+                    .expect("failed to build sliding RoPE"),
+                )
+            });
+            global_ropes.entry(dev.location()).or_insert_with(|| {
+                Arc::new(
+                    ProportionalRotaryEmbedding::new(
+                        rope_freq_base,
+                        key_length_full,
+                        DEFAULT_PARTIAL_ROTARY_FACTOR,
+                        max_seq_len,
+                        dev,
+                        true,
+                        DType::F32,
+                    )
+                    .expect("failed to build global RoPE"),
+                )
+            });
+        }
+
+        let sliding_window_opt = if sliding_window == 0 {
+            None
+        } else {
+            Some(sliding_window)
+        };
+
+        let mut layers = Vec::with_capacity(block_count);
+        for layer_idx in NiceProgressBar::<_, 'b'>(
+            0..block_count,
+            "Loading repeating layers",
+            &new_multi_progress(),
+        ) {
+            let prefix = format!("blk.{layer_idx}");
+            let dev = mapper.device_for(layer_idx, false).unwrap_or(device);
+            let is_sliding = layer_types[layer_idx] == SWA_LAYER;
+            let head_dim = if is_sliding {
+                key_length_swa
+            } else {
+                key_length_full
+            };
+
+            let donor = kv_shared_layer_index(&layer_types, num_kv_shared_layers, layer_idx)?;
+
+            let attention_wq = ct.tensor(&format!("{prefix}.attn_q.weight"), dev)?;
+            let attention_wo = ct.tensor(&format!("{prefix}.attn_output.weight"), dev)?;
+
+            let (attention_wk, attention_wv): (Option<_>, Option<_>) = if donor.is_some() {
+                (None, None)
+            } else {
+                let wk = ct.tensor(&format!("{prefix}.attn_k.weight"), dev)?;
+                // `attn_v` is optional: alternative attention reuses K as V.
+                let wv = if ct.has_tensor(&format!("{prefix}.attn_v.weight")) {
+                    ct.tensor(&format!("{prefix}.attn_v.weight"), dev)?
+                } else {
+                    ct.tensor(&format!("{prefix}.attn_k.weight"), dev)?
+                };
+                (
+                    Some(Arc::new(GgufMatMul::new(QuantMethodConfig::Gguf {
+                        q_weight: Arc::new(wk),
+                        b: None,
+                    })?) as Arc<dyn QuantMethod>),
+                    Some(Arc::new(GgufMatMul::new(QuantMethodConfig::Gguf {
+                        q_weight: Arc::new(wv),
+                        b: None,
+                    })?) as Arc<dyn QuantMethod>),
+                )
+            };
+
+            let feed_forward_w1 = ct.tensor(&format!("{prefix}.ffn_gate.weight"), dev)?;
+            let feed_forward_w2 = ct.tensor(&format!("{prefix}.ffn_down.weight"), dev)?;
+            let feed_forward_w3 = ct.tensor(&format!("{prefix}.ffn_up.weight"), dev)?;
+
+            let q_norm = gemma_norm_from_qtensor(
+                ct.tensor(&format!("{prefix}.attn_q_norm.weight"), dev)?,
+                rms_norm_eps,
+                dev,
+            )?;
+            let k_norm = if donor.is_some() {
+                // The donor layer keeps its own k_norm; we still need a placeholder
+                // since RoPE is applied to Q only.
+                RmsNorm::from_w(Tensor::ones(head_dim, dtype, dev)?, rms_norm_eps as f64)?
+            } else {
+                gemma_norm_from_qtensor(
+                    ct.tensor(&format!("{prefix}.attn_k_norm.weight"), dev)?,
+                    rms_norm_eps,
+                    dev,
+                )?
+            };
+            // V norm is a fused RmsNorm with weight=1.0; there is no
+            // `attn_v_norm` tensor in upstream Gemma 4 GGUFs.
+            let v_norm = RmsNorm::from_w(Tensor::ones(head_dim, dtype, dev)?, rms_norm_eps as f64)?;
+
+            let input_layernorm = gemma_norm_from_qtensor(
+                ct.tensor(&format!("{prefix}.attn_norm.weight"), dev)?,
+                rms_norm_eps,
+                dev,
+            )?;
+            let post_attention_layernorm = gemma_norm_from_qtensor(
+                ct.tensor(&format!("{prefix}.post_attention_norm.weight"), dev)?,
+                rms_norm_eps,
+                dev,
+            )?;
+            let pre_feedforward_layernorm = gemma_norm_from_qtensor(
+                ct.tensor(&format!("{prefix}.ffn_norm.weight"), dev)?,
+                rms_norm_eps,
+                dev,
+            )?;
+            let post_feedforward_layernorm = gemma_norm_from_qtensor(
+                ct.tensor(&format!("{prefix}.post_ffw_norm.weight"), dev)?,
+                rms_norm_eps,
+                dev,
+            )?;
+
+            let rotary = if is_sliding {
+                LayerRotary::Sliding(
+                    sliding_ropes
+                        .get(&dev.location())
+                        .expect("missing sliding RoPE for device")
+                        .clone(),
+                )
+            } else {
+                LayerRotary::Global(
+                    global_ropes
+                        .get(&dev.location())
+                        .expect("missing global RoPE for device")
+                        .clone(),
+                )
+            };
+
+            let paged_attn = match &attention_mechanism {
+                AttentionImplementation::Eager => None,
+                AttentionImplementation::PagedAttention => {
+                    Some(PagedAttention::new(head_dim, dev, None)?)
+                }
+            };
+
+            layers.push(LayerWeights {
+                attention_wq: Arc::new(GgufMatMul::new(QuantMethodConfig::Gguf {
+                    q_weight: Arc::new(attention_wq),
+                    b: None,
+                })?),
+                attention_wk,
+                attention_wv,
+                attention_wo: Arc::new(GgufMatMul::new(QuantMethodConfig::Gguf {
+                    q_weight: Arc::new(attention_wo),
+                    b: None,
+                })?),
+                input_layernorm,
+                post_attention_layernorm,
+                pre_feedforward_layernorm,
+                post_feedforward_layernorm,
+                q_norm,
+                k_norm,
+                v_norm,
+                mlp: Mlp {
+                    feed_forward_w1: Arc::new(GgufMatMul::new(QuantMethodConfig::Gguf {
+                        q_weight: Arc::new(feed_forward_w1),
+                        b: None,
+                    })?),
+                    feed_forward_w2: Arc::new(GgufMatMul::new(QuantMethodConfig::Gguf {
+                        q_weight: Arc::new(feed_forward_w2),
+                        b: None,
+                    })?),
+                    feed_forward_w3: Arc::new(GgufMatMul::new(QuantMethodConfig::Gguf {
+                        q_weight: Arc::new(feed_forward_w3),
+                        b: None,
+                    })?),
+                    act: HIDDEN_ACTIVATION,
+                },
+                n_head: head_count,
+                n_kv_head: head_count_kv,
+                head_dim,
+                rotary,
+                is_sliding,
+                sliding_window: if is_sliding { sliding_window_opt } else { None },
+                paged_attn,
+                sdpa_params: SdpaParams {
+                    n_kv_groups: head_count / head_count_kv,
+                    softcap: None,
+                    softmax_scale: 1.0,
+                    sliding_window: if is_sliding { sliding_window_opt } else { None },
+                    sinks: None,
+                },
+                dtype,
+                kv_shared_layer_index: donor,
+                layer_idx,
+            });
+        }
+
+        Ok(Self {
+            embed_tokens: ScaledEmbedding::new(
+                (embedding_length as f64).sqrt(),
+                Embedding::new(tok_embeddings, embedding_length),
+            ),
+            layers,
+            norm: output_norm,
+            output: Arc::new(GgufMatMul::new(QuantMethodConfig::Gguf {
+                q_weight: Arc::new(output_qt),
+                b: None,
+            })?),
+            final_logit_softcapping,
+            device: device.clone(),
+            cache: EitherCache::Normal(NormalCache::new(block_count, max_seq_len)),
+            max_seq_len,
+            mapper: Some(mapper),
+            dtype,
+            sliding_window: sliding_window_opt,
+        })
+    }
+}
+
+impl ModelWeights {
+    pub fn forward(
+        &self,
+        x: &Tensor,
+        seqlen_offsets: &[usize],
+        context_lens: Vec<(usize, usize)>,
+        metadata: Option<(Vec<(Tensor, Tensor)>, &PagedAttentionInputMetadata)>,
+    ) -> Result<Tensor> {
+        let mut xs = self.embed_tokens.forward(x)?;
+        let cache = &mut self.cache.normal().0;
+
+        let attention_mask = CausalMasker.make_causal_mask(
+            x,
+            metadata
+                .as_ref()
+                .map(|(_, _)| &seqlen_offsets as &dyn PastKvLenCache)
+                .unwrap_or(cache as &dyn PastKvLenCache),
+            self.dtype,
+            &CausalMaskConfig::default(),
+        )?;
+        let attention_mask = if metadata
+            .as_ref()
+            .map(|(_, meta)| meta.is_first_prompt_chunk)
+            .unwrap_or(true)
+        {
+            attention_mask
+        } else {
+            AttentionMask::None
+        };
+        let attention_mask = if let Some(ref mapper) = self.mapper {
+            DeviceMappedMask::new(attention_mask, &**mapper)?
+        } else {
+            DeviceMappedMask::from_single(attention_mask)
+        };
+
+        let sliding_mask_owned = if let Some(window) = self.sliding_window {
+            let m = CausalMasker.make_causal_mask(
+                x,
+                metadata
+                    .as_ref()
+                    .map(|(_, _)| &seqlen_offsets as &dyn PastKvLenCache)
+                    .unwrap_or(cache as &dyn PastKvLenCache),
+                self.dtype,
+                &CausalMaskConfig {
+                    sliding_window: Some(window),
+                    force_custom: false,
+                },
+            )?;
+            let m = if metadata
+                .as_ref()
+                .map(|(_, meta)| meta.is_first_prompt_chunk)
+                .unwrap_or(true)
+            {
+                m
+            } else {
+                AttentionMask::None
+            };
+            let dm = if let Some(ref mapper) = self.mapper {
+                DeviceMappedMask::new(m, &**mapper)?
+            } else {
+                DeviceMappedMask::from_single(m)
+            };
+            Some(dm)
+        } else {
+            None
+        };
+        let sliding_mask_ref: &DeviceMappedMask =
+            sliding_mask_owned.as_ref().unwrap_or(&attention_mask);
+
+        for (i, layer) in self.layers.iter().enumerate() {
+            if let Some(ref mapper) = self.mapper {
+                xs = mapper.map(xs, i)?;
+            }
+
+            let residual = xs.clone();
+            let normed = layer.input_layernorm.forward(&xs)?;
+            let attn_out = layer.forward_attn(
+                &normed,
+                &attention_mask.get(xs.device()),
+                &sliding_mask_ref.get(xs.device()),
+                seqlen_offsets,
+                cache.as_mut_slice(),
+                metadata
+                    .as_ref()
+                    .map(|(kv_cache, meta)| (kv_cache[i].clone(), *meta)),
+            )?;
+            xs = layer
+                .post_attention_layernorm
+                .forward_residual(&attn_out, &residual)?;
+
+            let residual = xs.clone();
+            let normed = xs.apply(&layer.pre_feedforward_layernorm)?;
+            let mlp_out = layer.mlp.forward(&normed)?;
+            xs = layer
+                .post_feedforward_layernorm
+                .forward_residual(&mlp_out, &residual)?;
+        }
+
+        let xs = self.norm.forward(&xs)?;
+        let xs = extract_logits(&xs, context_lens)?;
+        let mut logits = self.output.forward(&xs.contiguous()?)?;
+        if let Some(softcap) = self.final_logit_softcapping {
+            let scale = softcap as f32;
+            logits = ((logits / scale as f64)?.tanh()? * scale as f64)?;
+        }
+        Ok(logits)
+    }
+}

--- a/mistralrs-core/src/models/quantized_gemma4.rs
+++ b/mistralrs-core/src/models/quantized_gemma4.rs
@@ -429,6 +429,13 @@ pub(crate) struct PropsGGUF {
     sliding_window_pattern: SlidingWindowPattern,
     num_kv_shared_layers: usize,
     final_logit_softcapping: Option<f64>,
+    /// Per-Layer Input dimension. `gemma4.embedding_length_per_layer_input`
+    /// in GGUF metadata. `0` (or absent) disables PLE entirely; this is
+    /// the legacy code path that produced multilingual garbage on real
+    /// Gemma 4 GGUFs because every Gemma 4 release in the wild does set
+    /// this key. Kept as `usize` instead of `Option<usize>` so the
+    /// downstream code can branch with a single zero-check.
+    embedding_length_per_layer_input: usize,
 }
 
 impl TryFrom<ContentMetadata<'_>> for PropsGGUF {
@@ -520,6 +527,11 @@ impl TryFrom<ContentMetadata<'_>> for PropsGGUF {
             final_logit_softcapping: c
                 .get_option_value::<f32>("final_logit_softcapping")?
                 .map(f64::from),
+            embedding_length_per_layer_input: c
+                .get_value::<u32>("embedding_length_per_layer_input")
+                .ok()
+                .map(|x| x as usize)
+                .unwrap_or(0),
         })
     }
 }
@@ -676,6 +688,7 @@ impl ModelConfig::FromGGUF for ModelWeights {
             sliding_window_pattern,
             num_kv_shared_layers,
             final_logit_softcapping,
+            embedding_length_per_layer_input: _,
         } = PropsGGUF::try_from(metadata).or_else(|err| candle_core::bail!("{err}"))?;
 
         if key_length_full != value_length_full {

--- a/mistralrs-core/src/models/quantized_gemma4.rs
+++ b/mistralrs-core/src/models/quantized_gemma4.rs
@@ -426,7 +426,7 @@ pub(crate) struct PropsGGUF {
     key_length_swa: usize,
     value_length_swa: usize,
     sliding_window: usize,
-    sliding_window_pattern: usize,
+    sliding_window_pattern: SlidingWindowPattern,
     num_kv_shared_layers: usize,
     final_logit_softcapping: Option<f64>,
 }
@@ -498,11 +498,20 @@ impl TryFrom<ContentMetadata<'_>> for PropsGGUF {
                 .ok()
                 .map(|x| x as usize)
                 .unwrap_or(0),
-            sliding_window_pattern: c
-                .get_value::<u32>("attention.sliding_window_pattern")
-                .ok()
-                .map(|x| x as usize)
-                .unwrap_or(DEFAULT_SLIDING_WINDOW_PATTERN),
+            // Gemma 4 GGUFs store `attention.sliding_window_pattern` two
+            // different ways depending on the converter version:
+            //   - Newer (unsloth, llama.cpp HEAD): a per-layer `Vec<u32>`
+            //     mask of length `block_count`, where 1 = sliding (SWA)
+            //     and 0 = full/global attention.
+            //   - Older: a single `u32` period `n`, where every layer with
+            //     `(idx % n) < n - 1` is sliding and the rest are global.
+            // Read both and prefer the explicit mask when it is present;
+            // fall back to the scalar period when only that is available,
+            // and finally to the historical default of 6 when neither is
+            // set. Misreading the array case as `u32` silently classified
+            // most layers using the default period, producing 8/256 vs
+            // 8/512 head-dim mismatches inside qk_rms_norm_rope.
+            sliding_window_pattern: SlidingWindowPattern::from_metadata(&c),
             num_kv_shared_layers: c
                 .get_value::<u32>("attention.shared_kv_layers")
                 .ok()
@@ -515,15 +524,65 @@ impl TryFrom<ContentMetadata<'_>> for PropsGGUF {
     }
 }
 
+/// How the per-layer sliding/full attention pattern is encoded in the GGUF.
+///
+/// Different llama.cpp converter revisions write this metadata three
+/// different ways for Gemma 4; we accept all of them.
+#[derive(Debug, Clone)]
+enum SlidingWindowPattern {
+    /// Explicit per-layer mask, length == `block_count`, `true` = sliding
+    /// (SWA), `false` = full/global attention. This is the actual layout
+    /// emitted by unsloth's `gemma-4-E2B-it-GGUF` (and llama.cpp HEAD):
+    /// `[true, true, true, true, false, ...]` for period 5.
+    BoolMask(Vec<bool>),
+    /// Same as `BoolMask` but stored as integers (`1`/`0`). Some older
+    /// converter revisions used this form before the bool-array encoding
+    /// became standard.
+    IntMask(Vec<u32>),
+    /// Scalar period `n`: layer `il` is sliding when `il % n < n - 1`,
+    /// matching llama.cpp's `set_swa_pattern(n, dense_first=false)`. The
+    /// oldest converters wrote this form.
+    Period(usize),
+}
+
+impl SlidingWindowPattern {
+    fn from_metadata(c: &ContentMetadata<'_>) -> Self {
+        if let Ok(mask) = c.get_value::<Vec<bool>>("attention.sliding_window_pattern") {
+            if !mask.is_empty() {
+                return Self::BoolMask(mask);
+            }
+        }
+        if let Ok(mask) = c.get_value::<Vec<u32>>("attention.sliding_window_pattern") {
+            if !mask.is_empty() {
+                return Self::IntMask(mask);
+            }
+        }
+        let period = c
+            .get_value::<u32>("attention.sliding_window_pattern")
+            .ok()
+            .map(|x| x as usize)
+            .unwrap_or(DEFAULT_SLIDING_WINDOW_PATTERN);
+        Self::Period(period)
+    }
+}
+
 // `layer_types` is reconstructed from the sliding-window pattern stored in
-// metadata. llama.cpp's `set_swa_pattern(n_pattern, dense_first=false)`
-// marks layer `il` as SWA when `il % n_pattern < n_pattern - 1`, which is
-// the convention used by upstream Gemma 4 GGUFs.
-fn build_layer_types(block_count: usize, sliding_window_pattern: usize) -> Vec<&'static str> {
+// metadata. Either mask form is a direct per-layer flag; the scalar form
+// follows llama.cpp's `set_swa_pattern(n, dense_first=false)`, which marks
+// layer `il` as SWA when `il % n < n - 1`.
+fn build_layer_types(
+    block_count: usize,
+    sliding_window_pattern: &SlidingWindowPattern,
+) -> Vec<&'static str> {
     let mut out = Vec::with_capacity(block_count);
     for il in 0..block_count {
-        let is_swa = sliding_window_pattern == 0
-            || (il % sliding_window_pattern) < sliding_window_pattern.saturating_sub(1);
+        let is_swa = match sliding_window_pattern {
+            SlidingWindowPattern::BoolMask(mask) => mask.get(il).copied().unwrap_or(false),
+            SlidingWindowPattern::IntMask(mask) => mask.get(il).copied().unwrap_or(0) != 0,
+            SlidingWindowPattern::Period(n) => {
+                *n == 0 || (il % *n) < n.saturating_sub(1)
+            }
+        };
         out.push(if is_swa { SWA_LAYER } else { FULL_LAYER });
     }
     out
@@ -630,7 +689,7 @@ impl ModelConfig::FromGGUF for ModelWeights {
             );
         }
 
-        let layer_types = build_layer_types(block_count, sliding_window_pattern);
+        let layer_types = build_layer_types(block_count, &sliding_window_pattern);
 
         let qtok_embeddings = ct.tensor("token_embd.weight", device)?;
         let tok_embeddings = qtok_embeddings.dequantize(device)?;

--- a/mistralrs-core/src/pipeline/gguf.rs
+++ b/mistralrs-core/src/pipeline/gguf.rs
@@ -37,6 +37,7 @@ use crate::{
     PagedAttentionConfig, Pipeline, Topology, TryIntoDType,
 };
 use crate::{
+    models::quantized_gemma4::ModelWeights as QGemma4,
     models::quantized_llama::ModelWeights as QLlama,
     models::quantized_phi2::ModelWeights as QPhi,
     models::quantized_phi3::ModelWeights as QPhi3,
@@ -72,6 +73,7 @@ enum Model {
     Qwen(QQwen),
     Qwen3(QQwen3),
     Qwen3MoE(QQwen3MoE),
+    Gemma4(QGemma4),
 }
 
 pub struct GGUFPipeline {
@@ -483,6 +485,7 @@ impl Loader for GGUFLoader {
                 GGUFArchitecture::Qwen2 => Model::Qwen(QQwen::try_from(model_config)?),
                 GGUFArchitecture::Qwen3 => Model::Qwen3(QQwen3::try_from(model_config)?),
                 GGUFArchitecture::Qwen3MoE => Model::Qwen3MoE(QQwen3MoE::try_from(model_config)?),
+                GGUFArchitecture::Gemma4 => Model::Gemma4(QGemma4::try_from(model_config)?),
                 a => bail!("Unsupported architecture `{a:?}` for GGUF"),
             },
             ModelKind::GgufAdapter { adapter, .. } => match arch {
@@ -549,6 +552,7 @@ impl Loader for GGUFLoader {
             Model::Qwen(ref p) => p.max_seq_len,
             Model::Qwen3(ref p) => p.max_seq_len,
             Model::Qwen3MoE(ref p) => p.max_seq_len,
+            Model::Gemma4(ref p) => p.max_seq_len,
         };
         let llg_factory = build_llg_factory(tokenizer.clone())?;
         let num_hidden_layers = match model {
@@ -561,6 +565,7 @@ impl Loader for GGUFLoader {
             Model::Qwen(ref model) => model.cache.normal().0.len(),
             Model::Qwen3(ref model) => model.cache.normal().0.len(),
             Model::Qwen3MoE(ref model) => model.cache.normal().0.len(),
+            Model::Gemma4(ref model) => model.cache.normal().0.len(),
         };
 
         if chat_template.bos_token.is_none() {
@@ -698,6 +703,7 @@ impl CacheManagerMixin for GGUFPipeline {
             Model::Qwen(ref model) => &model.cache,
             Model::Qwen3(ref model) => &model.cache,
             Model::Qwen3MoE(ref model) => &model.cache,
+            Model::Gemma4(ref model) => &model.cache,
         }
     }
 }
@@ -714,6 +720,7 @@ impl MetadataMixin for GGUFPipeline {
             Model::Qwen(ref model) => model.device.clone(),
             Model::Qwen3(ref model) => model.device.clone(),
             Model::Qwen3MoE(ref model) => model.device.clone(),
+            Model::Gemma4(ref model) => model.device.clone(),
         }
     }
     fn tokenizer(&self) -> Option<Arc<Tokenizer>> {
@@ -812,6 +819,9 @@ impl Pipeline for GGUFPipeline {
                 model.forward(&input_ids, &seqlen_offsets, context_lens, paged_attn_meta)?
             }
             Model::Qwen3MoE(ref model) => {
+                model.forward(&input_ids, &seqlen_offsets, context_lens, paged_attn_meta)?
+            }
+            Model::Gemma4(ref model) => {
                 model.forward(&input_ids, &seqlen_offsets, context_lens, paged_attn_meta)?
             }
         };

--- a/mistralrs-core/src/pipeline/gguf.rs
+++ b/mistralrs-core/src/pipeline/gguf.rs
@@ -37,6 +37,7 @@ use crate::{
     PagedAttentionConfig, Pipeline, Topology, TryIntoDType,
 };
 use crate::{
+    models::quantized_gemma3::ModelWeights as QGemma3,
     models::quantized_gemma4::ModelWeights as QGemma4,
     models::quantized_llama::ModelWeights as QLlama,
     models::quantized_phi2::ModelWeights as QPhi,
@@ -73,6 +74,7 @@ enum Model {
     Qwen(QQwen),
     Qwen3(QQwen3),
     Qwen3MoE(QQwen3MoE),
+    Gemma3(QGemma3),
     Gemma4(QGemma4),
 }
 
@@ -485,6 +487,7 @@ impl Loader for GGUFLoader {
                 GGUFArchitecture::Qwen2 => Model::Qwen(QQwen::try_from(model_config)?),
                 GGUFArchitecture::Qwen3 => Model::Qwen3(QQwen3::try_from(model_config)?),
                 GGUFArchitecture::Qwen3MoE => Model::Qwen3MoE(QQwen3MoE::try_from(model_config)?),
+                GGUFArchitecture::Gemma3 => Model::Gemma3(QGemma3::try_from(model_config)?),
                 GGUFArchitecture::Gemma4 => Model::Gemma4(QGemma4::try_from(model_config)?),
                 a => bail!("Unsupported architecture `{a:?}` for GGUF"),
             },
@@ -552,6 +555,7 @@ impl Loader for GGUFLoader {
             Model::Qwen(ref p) => p.max_seq_len,
             Model::Qwen3(ref p) => p.max_seq_len,
             Model::Qwen3MoE(ref p) => p.max_seq_len,
+            Model::Gemma3(ref p) => p.max_seq_len,
             Model::Gemma4(ref p) => p.max_seq_len,
         };
         let llg_factory = build_llg_factory(tokenizer.clone())?;
@@ -565,6 +569,7 @@ impl Loader for GGUFLoader {
             Model::Qwen(ref model) => model.cache.normal().0.len(),
             Model::Qwen3(ref model) => model.cache.normal().0.len(),
             Model::Qwen3MoE(ref model) => model.cache.normal().0.len(),
+            Model::Gemma3(ref model) => model.cache.normal().0.len(),
             Model::Gemma4(ref model) => model.cache.normal().0.len(),
         };
 
@@ -703,6 +708,7 @@ impl CacheManagerMixin for GGUFPipeline {
             Model::Qwen(ref model) => &model.cache,
             Model::Qwen3(ref model) => &model.cache,
             Model::Qwen3MoE(ref model) => &model.cache,
+            Model::Gemma3(ref model) => &model.cache,
             Model::Gemma4(ref model) => &model.cache,
         }
     }
@@ -720,6 +726,7 @@ impl MetadataMixin for GGUFPipeline {
             Model::Qwen(ref model) => model.device.clone(),
             Model::Qwen3(ref model) => model.device.clone(),
             Model::Qwen3MoE(ref model) => model.device.clone(),
+            Model::Gemma3(ref model) => model.device.clone(),
             Model::Gemma4(ref model) => model.device.clone(),
         }
     }
@@ -819,6 +826,9 @@ impl Pipeline for GGUFPipeline {
                 model.forward(&input_ids, &seqlen_offsets, context_lens, paged_attn_meta)?
             }
             Model::Qwen3MoE(ref model) => {
+                model.forward(&input_ids, &seqlen_offsets, context_lens, paged_attn_meta)?
+            }
+            Model::Gemma3(ref model) => {
                 model.forward(&input_ids, &seqlen_offsets, context_lens, paged_attn_meta)?
             }
             Model::Gemma4(ref model) => {

--- a/mistralrs-core/src/utils/gguf_metadata.rs
+++ b/mistralrs-core/src/utils/gguf_metadata.rs
@@ -329,7 +329,11 @@ impl DeviceMappedModelLoader for GgufDeviceMapLoaderInner<'_, '_> {
                 };
                 token_embd + output_norm + output
             }
-            GGUFArchitecture::Qwen2 | GGUFArchitecture::Qwen3 | GGUFArchitecture::Qwen3MoE => {
+            GGUFArchitecture::Qwen2
+            | GGUFArchitecture::Qwen3
+            | GGUFArchitecture::Qwen3MoE
+            | GGUFArchitecture::Gemma3
+            | GGUFArchitecture::Gemma4 => {
                 let token_embd = tensor_info_size_in_bytes!(
                     self.model.tensor_info("token_embd.weight")?,
                     DType::F32
@@ -554,6 +558,68 @@ impl DeviceMappedModelLoader for GgufDeviceMapLoaderInner<'_, '_> {
 
                 attn_norm
                     + ffn_norm
+                    + attn_q
+                    + attn_k
+                    + attn_v
+                    + attn_output
+                    + ffn_gate
+                    + ffn_up
+                    + ffn_down
+            }
+            GGUFArchitecture::Gemma3 | GGUFArchitecture::Gemma4 => {
+                // Gemma 3 / 4 share the dense per-layer layout: attn_norm +
+                // per-head Q/K/V RmsNorm + Q/K/V/O projections + ffn_norm +
+                // gated FFN (gate/up/down). Gemma 4 KV-shared layers omit
+                // K/V weights on the donor side but the size estimate here
+                // returns a uniform per-layer figure; the small overestimate
+                // is acceptable for the memory-budget heuristic this feeds.
+                let attn_norm = tensor_info_size_in_bytes!(
+                    self.model.tensor_info("blk.0.attn_norm.weight")?,
+                    DType::F32
+                );
+                let ffn_norm = tensor_info_size_in_bytes!(
+                    self.model.tensor_info("blk.0.ffn_norm.weight")?,
+                    DType::F32
+                );
+                let attn_q_norm = tensor_info_size_in_bytes!(
+                    self.model.tensor_info("blk.0.attn_q_norm.weight")?,
+                    DType::F32
+                );
+                let attn_k_norm = tensor_info_size_in_bytes!(
+                    self.model.tensor_info("blk.0.attn_k_norm.weight")?,
+                    DType::F32
+                );
+                let attn_v_norm = if self.model.has_tensor("blk.0.attn_v_norm.weight") {
+                    tensor_info_size_in_bytes!(
+                        self.model.tensor_info("blk.0.attn_v_norm.weight")?,
+                        DType::F32
+                    )
+                } else {
+                    0
+                };
+
+                let attn_q =
+                    tensor_info_size_in_bytes!(self.model.tensor_info("blk.0.attn_q.weight")?);
+                let attn_k =
+                    tensor_info_size_in_bytes!(self.model.tensor_info("blk.0.attn_k.weight")?);
+                let attn_v =
+                    tensor_info_size_in_bytes!(self.model.tensor_info("blk.0.attn_v.weight")?);
+                let attn_output = tensor_info_size_in_bytes!(self
+                    .model
+                    .tensor_info("blk.0.attn_output.weight")?);
+
+                let ffn_gate =
+                    tensor_info_size_in_bytes!(self.model.tensor_info("blk.0.ffn_gate.weight")?);
+                let ffn_up =
+                    tensor_info_size_in_bytes!(self.model.tensor_info("blk.0.ffn_up.weight")?);
+                let ffn_down =
+                    tensor_info_size_in_bytes!(self.model.tensor_info("blk.0.ffn_down.weight")?);
+
+                attn_norm
+                    + ffn_norm
+                    + attn_q_norm
+                    + attn_k_norm
+                    + attn_v_norm
                     + attn_q
                     + attn_k
                     + attn_v

--- a/mistralrs-core/src/utils/model_config.rs
+++ b/mistralrs-core/src/utils/model_config.rs
@@ -295,6 +295,7 @@ impl<R: std::io::Seek + std::io::Read> Config<ParamsGGUF<'_, R>, Adapter<'_>> {
 }
 
 use crate::{
+    models::quantized_gemma3::ModelWeights as QGemma3,
     models::quantized_gemma4::ModelWeights as QGemma4,
     models::quantized_llama::ModelWeights as QLlama,
     models::quantized_phi2::ModelWeights as QPhi,
@@ -326,7 +327,7 @@ impl TryFrom<ModelParams<'_, ParamsGGML>> for XLoraQLlama {
 }
 
 akin! {
-    let &models_gguf = [QLlama, QPhi, QPhi3, QStarcoder2, QQwen, QQwen3, QQwen3MoE, QGemma4];
+    let &models_gguf = [QLlama, QPhi, QPhi3, QStarcoder2, QQwen, QQwen3, QQwen3MoE, QGemma3, QGemma4];
 
     impl<R: std::io::Seek + std::io::Read> TryFrom<ModelParams<'_, ParamsGGUF<'_, R>>> for *models_gguf {
         type Error = candle_core::Error;

--- a/mistralrs-core/src/utils/model_config.rs
+++ b/mistralrs-core/src/utils/model_config.rs
@@ -295,6 +295,7 @@ impl<R: std::io::Seek + std::io::Read> Config<ParamsGGUF<'_, R>, Adapter<'_>> {
 }
 
 use crate::{
+    models::quantized_gemma4::ModelWeights as QGemma4,
     models::quantized_llama::ModelWeights as QLlama,
     models::quantized_phi2::ModelWeights as QPhi,
     models::quantized_phi3::ModelWeights as QPhi3,
@@ -325,7 +326,7 @@ impl TryFrom<ModelParams<'_, ParamsGGML>> for XLoraQLlama {
 }
 
 akin! {
-    let &models_gguf = [QLlama, QPhi, QPhi3, QStarcoder2, QQwen, QQwen3, QQwen3MoE];
+    let &models_gguf = [QLlama, QPhi, QPhi3, QStarcoder2, QQwen, QQwen3, QQwen3MoE, QGemma4];
 
     impl<R: std::io::Seek + std::io::Read> TryFrom<ModelParams<'_, ParamsGGUF<'_, R>>> for *models_gguf {
         type Error = candle_core::Error;

--- a/mistralrs-quant/build.rs
+++ b/mistralrs-quant/build.rs
@@ -248,29 +248,20 @@ fn main() -> Result<(), String> {
             for metal_file in HEADER_SOURCES {
                 compile_air_cmd.arg(sources.join(format!("{metal_file}.metal")));
             }
-            compile_air_cmd
-                .spawn()
-                .expect("Failed to compile air")
-                .wait()
-                .expect("Failed to compile air");
-
-            let mut child = compile_air_cmd.spawn().expect("Failed to compile air");
-
-            match child.try_wait() {
-                Ok(Some(status)) => {
-                    if !status.success() {
-                        panic!("Compiling metal -> air failed. Exit with status: {status}")
-                    }
-                }
-                Ok(None) => {
-                    let status = child
-                        .wait()
-                        .expect("Compiling metal -> air failed while waiting for result");
-                    if !status.success() {
-                        panic!("Compiling metal -> air failed. Exit with status: {status}")
-                    }
-                }
-                Err(e) => panic!("Compiling metal -> air failed: {e:?}"),
+            // Use `.status()` so we actually observe the exit code; the
+            // previous `.spawn().expect().wait().expect()` pattern only
+            // checked for IO failures, and a non-zero `xcrun metal` exit
+            // would slip through silently. When that happened, the
+            // metallib step further down ran with zero `.air` inputs and
+            // emitted a ~118-byte empty archive, which Cargo then cached
+            // forever (since the source `.metal` files had not changed),
+            // so every kernel lookup failed at runtime with
+            // `Error while loading function`.
+            let status = compile_air_cmd
+                .status()
+                .expect("Failed to invoke metal compiler (metal -> air)");
+            if !status.success() {
+                panic!("Compiling metal -> air failed. Exit with status: {status}")
             }
 
             // Compile air to metallib
@@ -290,25 +281,11 @@ fn main() -> Result<(), String> {
                 compile_metallib_cmd.arg(out_dir.join(format!("{metal_file}.air")));
             }
 
-            let mut child = compile_metallib_cmd
-                .spawn()
-                .expect("Failed to compile air -> metallib");
-
-            match child.try_wait() {
-                Ok(Some(status)) => {
-                    if !status.success() {
-                        panic!("Compiling air -> metallib failed. Exit with status: {status}")
-                    }
-                }
-                Ok(None) => {
-                    let status = child
-                        .wait()
-                        .expect("Compiling air -> metallib failed while waiting for result");
-                    if !status.success() {
-                        panic!("Compiling air -> metallib failed. Exit with status: {status}")
-                    }
-                }
-                Err(e) => panic!("Compiling air -> metallib failed: {e:?}"),
+            let status = compile_metallib_cmd
+                .status()
+                .expect("Failed to invoke metal linker (air -> metallib)");
+            if !status.success() {
+                panic!("Compiling air -> metallib failed. Exit with status: {status}")
             }
 
             Ok(())

--- a/mistralrs-quant/build.rs
+++ b/mistralrs-quant/build.rs
@@ -272,7 +272,25 @@ fn main() -> Result<(), String> {
             };
             let metallib = out_dir.join(lib_name);
             let mut compile_metallib_cmd = Command::new("xcrun");
-            compile_metallib_cmd.arg("metal").arg("-o").arg(&metallib);
+            // Pass `--sdk` and `-std=...` to the air -> metallib link step
+            // too. Without them, `air-lld` defaults to an older AIR target
+            // (e.g. 2.3 on Xcode 26) while the air-compile step above pins
+            // to the per-platform SDK (e.g. AIR 2.6 from macosx SDK). The
+            // mismatch makes `air-lld` silently ignore every input with
+            //   `air-lld: warning: ignoring file '...': file AIR version
+            //   (2.6) is bigger than the one of the target being linked
+            //   (2.3)`
+            // It still exits 0 (warning, not error), so cargo treats the
+            // step as successful and Cargo caches the resulting ~118-byte
+            // empty metallib forever, at which point every Metal kernel
+            // lookup fails at runtime.
+            compile_metallib_cmd
+                .arg("--sdk")
+                .arg(platform.sdk())
+                .arg("metal")
+                .arg(format!("-std={}", platform.metal_std()))
+                .arg("-o")
+                .arg(&metallib);
 
             for metal_file in METAL_SOURCES {
                 compile_metallib_cmd.arg(out_dir.join(format!("{metal_file}.air")));


### PR DESCRIPTION
Implements the text-only dense Gemma 4 GGUF backend proposed in #2171.

## What lands

`Gemma4` joins `GGUFArchitecture` (`mistralrs-core/src/gguf/mod.rs`) and routes through the dispatcher at `mistralrs-core/src/pipeline/gguf.rs:475-485`. New `mistralrs-core/src/models/quantized_gemma4.rs` maps the upstream gguf-py tensor table (`ggml-org/llama.cpp:gguf-py/gguf/constants.py:2450-2483`) to a quantized variant of the existing Gemma 4 text core at `vision_models/gemma4/text.rs:240-398`. Templated on `quantized_qwen3.rs` with the Gemma 4 deltas read from GGUF metadata:

- Sliding / global head_dim split (256 / 512) via `attention.key_length_swa` / `attention.value_length_swa` and the `attention.sliding_window_pattern` cadence.
- Per-head Q-K-V RmsNorm via `blk.<i>.attn_<qkv>_norm.weight`.
- Proportional rotary on full-attention layers with `rope.freq_base` / `rope.freq_base_swa`.
- KV-shared layers via `attention.shared_kv_layers`; donor pattern matches `repos/llama.cpp/src/models/gemma4.cpp:3-29`.
- Final logit softcapping when `final_logit_softcapping` is present.

Q4_K_M, Q5_K_M, Q8_0 supported (same surface as Qwen3 GGUF).

## Out of scope (explicitly)

- MoE Gemma 4. Detection-and-bail on any `blk.<i>.ffn_*_exp.weight` with a clear error pointing at a follow-up `quantized_gemma4_moe.rs`.
- Multimodal Gemma 4 (vision + audio encoders). Vision/audio tensor tables in `constants.py:743-867` are orthogonal and large; deferred.
- MTP speculative decoding on the GGUF path. #2159 added it on the safetensors side; mirroring is a separate concern.
- Smoke / parity test against real weights. The two RFC open questions (file-naming convention, MoE detection vs day-one separate enum variant) are still worth a maintainer answer before adding a smoke; see #2171.

## Punted

- `partial_rotary_factor` hardcoded to 0.25 (upstream default). The Gemma 4 GGUF spec does not surface this. If you want it metadata-driven, point at the key name and I'll add it.
- Shared-KV layers still load placeholder `k_norm` / `v_norm` (ones). RoPE on shared layers touches only Q, so the placeholders never feed forward, but they keep the per-layer struct uniform. Happy to gate them behind an `Option` if you prefer.

## Build

```
cargo build --release --features metal -p mistralrs-core
```

Clean on macOS 26.2 / Xcode 26.3 / Metal Toolchain 32023.864 against `upstream/master @ 31c13eb`. No new warnings, `cargo fmt --check` clean for the touched files.

Closes #2098 once landed. RFC at #2171.
