### PR TITLE
fix(cuda): build top-k kernels on sm_75 (Turing)

### DIFF
--- a/mistralrs-core/src/cuda/sort.cu
+++ b/mistralrs-core/src/cuda/sort.cu
@@ -432,7 +432,7 @@ __global__ void topk_kernel(const T *__restrict__ input, // [nrows, ncols]
       if (tid == 0) {
         if (final_idx < 0) {
           final_idx = 0;
-          final_max = (T)0;
+          final_max = (T)0.0f;
         }
         row_values[ki] = final_max;
         row_indices[ki] = (uint32_t)final_idx;
@@ -593,7 +593,7 @@ __global__ void topk_softmax_kernel(
       if (tid == 0) {
         if (final_idx < 0) {
           final_idx = 0;
-          final_max = (T)0;
+          final_max = (T)0.0f;
         }
         s_topk_vals[ki] = final_max;
         s_topk_idx[ki] = final_idx;


### PR DESCRIPTION
CUDA 12.0's cuda_bf16.hpp gates the __nv_bfloat16(int) constructor behind __CUDA_ARCH__ >= 800. At sm_75 only the float and double ctors are visible, so (T)0 with T = __nv_bfloat16 is ambiguous and nvcc rejects the topk_kernel<__nv_bfloat16> and topk_softmax_kernel<__nv_bfloat16> instantiations. Switch the two literals to 0.0f so the unambiguous __nv_bfloat16(const float) ctor matches; behaviour is unchanged for float/double/__half. Verified building on a Quadro RTX 8000 (sm_75) with CUDA 12.0.