### PR TITLE
perf(gguf): batch add_special_tokens to drop O(N^2) tokenizer load

### DIFF
--- a/mistralrs-core/src/gguf/gguf_tokenizer.rs
+++ b/mistralrs-core/src/gguf/gguf_tokenizer.rs
@@ -100,16 +100,7 @@ pub fn convert_gguf_to_hf_tokenizer<R: std::io::Seek + std::io::Read>(
     };
 
     // Token types other than `NORMAL` (1) are treated as special tokens.
-    //
-    // Batch all of them into a single `add_special_tokens` call. The
-    // previous per-token loop triggered one `AddedVocabulary::refresh_added_tokens`
-    // per token, and each refresh rebuilds the aho-corasick failure-link
-    // automaton over every special token added so far. That is O(N^2) in
-    // calls and becomes effectively infinite for Gemma 3 (6670 CONTROL +
-    // BYTE + USER_DEFINED tokens in the 262144-vocab GGUF), making the
-    // load look like a hang. Llama / Qwen happen to ship <50 such tokens
-    // each, which kept this slow path invisible until Gemma 3/4 landed in
-    // the GGUF dispatch.
+    // Batch them so `AddedVocabulary` refreshes its matchers once.
     let mut special = Vec::new();
     if token_types.len() == props.tokens.len() {
         for (i, ty) in token_types.iter().enumerate() {

--- a/mistralrs-core/src/gguf/gguf_tokenizer.rs
+++ b/mistralrs-core/src/gguf/gguf_tokenizer.rs
@@ -99,17 +99,28 @@ pub fn convert_gguf_to_hf_tokenizer<R: std::io::Seek + std::io::Read>(
         }
     };
 
-    //token type other than 1 treated as special token
-    let mut num_special_tokens = 0;
-    #[allow(clippy::needless_range_loop)]
+    // Token types other than `NORMAL` (1) are treated as special tokens.
+    //
+    // Batch all of them into a single `add_special_tokens` call. The
+    // previous per-token loop triggered one `AddedVocabulary::refresh_added_tokens`
+    // per token, and each refresh rebuilds the aho-corasick failure-link
+    // automaton over every special token added so far. That is O(N^2) in
+    // calls and becomes effectively infinite for Gemma 3 (6670 CONTROL +
+    // BYTE + USER_DEFINED tokens in the 262144-vocab GGUF), making the
+    // load look like a hang. Llama / Qwen happen to ship <50 such tokens
+    // each, which kept this slow path invisible until Gemma 3/4 landed in
+    // the GGUF dispatch.
+    let mut special = Vec::new();
     if token_types.len() == props.tokens.len() {
-        for i in 0..props.tokens.len() {
-            if token_types[i] != 1i32 {
-                let tk = props.tokens[i].clone();
-                tokenizer.add_special_tokens(&[AddedToken::from(tk.to_string(), true)]);
-                num_special_tokens += 1;
+        for (i, ty) in token_types.iter().enumerate() {
+            if *ty != 1i32 {
+                special.push(AddedToken::from(props.tokens[i].clone(), true));
             }
         }
+    }
+    let num_special_tokens = special.len();
+    if !special.is_empty() {
+        tokenizer.add_special_tokens(&special);
     }
 
     info!(


### PR DESCRIPTION
## Summary

`convert_gguf_to_hf_tokenizer` walked the GGUF token table and called
`tokenizer.add_special_tokens(&[AddedToken::from(tk, true)])` once per
non-NORMAL token. Each of those calls internally runs
`AddedVocabulary::refresh_added_tokens`, which rebuilds the
aho-corasick failure-link automaton over every special token added so
far. For a vocabulary with N non-NORMAL tokens that is O(N²) calls,
where each call also scales with the failure-link automaton size.

Collect all the additions into one `Vec<AddedToken>` and submit them
in a single `add_special_tokens` call so the aho-corasick is rebuilt
once instead of N times. Behaviour is otherwise unchanged.

## Why it surfaced now

Llama and Qwen GGUFs ship <50 non-NORMAL tokens each, which kept this
path imperceptible. Gemma-family GGUFs are a different shape — Gemma 3
1B (`unsloth/gemma-3-1b-it-GGUF`) reports

```
gemma3 vocab: 262144 tokens
  type 1 (NORMAL): 255,474
  type 3 (CONTROL): 6,251
  type 4 (USER_DEFINED): 163
  type 6 (BYTE): 256
```

so the old loop made 6,670 `add_special_tokens` calls and the
aho-corasick rebuild dominated tokenizer load. End-to-end load went
from ~200 ms to >3 minutes on M-series hardware, and looked like a hang
in most embedding hosts. `sample(1)` on the stuck process pointed
straight at `aho_corasick::nfa::noncontiguous::Compiler::build_trie`
under `AddedVocabulary::refresh_added_tokens`, ≈80% of all samples.

## Verification

Before: tokenizer construction for Gemma 3 1B Q4_K_M takes ~3 min on
M-series, with the call graph dominated by aho-corasick rebuilds.

After: ~13 s end-to-end model load including weight download from disk
on the same hardware. Same `num special tokens 6670` reported in
`info!`, same tokens flagged.

Llama / Qwen GGUFs unchanged: the loop body runs in microseconds either
way at their token counts.

## Out of scope

No behaviour change. No new dependencies. Same `info!` line content.