### PR TITLE
feat(gemma4): optimize metal MoE perf

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -141,7 +141,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -152,7 +152,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -1567,7 +1567,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users 0.5.2",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1767,7 +1767,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3988,7 +3988,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -5376,7 +5376,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -5435,7 +5435,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -6386,7 +6386,7 @@ dependencies = [
  "getrandom 0.3.4",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -7495,7 +7495,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/mistralrs-core/src/kv_cache/rotating_cache.rs
+++ b/mistralrs-core/src/kv_cache/rotating_cache.rs
@@ -286,13 +286,16 @@ impl RotatingCache {
             }
         } else {
             let keep_from_old = retained_len.min(self.max_seq_len - seq_len);
+            // Only rotate when keep_start > 0 (the cache has reached the sliding window and we actually need to shift entries left).
             if keep_from_old > 0 {
                 let keep_start = retained_len - keep_from_old;
-                let kept = ad
-                    .narrow(self.dim, keep_start, keep_from_old)?
-                    .copy()?
-                    .contiguous()?;
-                ad.slice_set(&kept, self.dim, 0)?;
+                if keep_start > 0 {
+                    let kept = ad
+                        .narrow(self.dim, keep_start, keep_from_old)?
+                        .copy()?
+                        .contiguous()?;
+                    ad.slice_set(&kept, self.dim, 0)?;
+                }
             }
 
             ad.slice_set(&src.contiguous()?, self.dim, keep_from_old)?;

--- a/mistralrs-core/src/moe/experts.rs
+++ b/mistralrs-core/src/moe/experts.rs
@@ -867,11 +867,7 @@ impl MoEExperts {
         } else {
             #[cfg(feature = "metal")]
             if let Some(ys) = self.try_forward_fast_metal_sorted(
-                &xs_flat,
-                topk_ids,
-                weights,
-                num_tokens,
-                hidden_dim,
+                &xs_flat, topk_ids, weights, num_tokens, hidden_dim,
             )? {
                 return Self::topk_weight_reduce(&ys, topk_weights, original_dtype);
             }
@@ -899,9 +895,7 @@ impl MoEExperts {
         original_dtype: DType,
     ) -> Result<Tensor> {
         #[cfg(feature = "metal")]
-        if ys.device().is_metal()
-            && matches!(ys.dtype(), DType::BF16 | DType::F16 | DType::F32)
-        {
+        if ys.device().is_metal() && matches!(ys.dtype(), DType::BF16 | DType::F16 | DType::F32) {
             let (num_tokens, top_k, hidden) = ys.dims3()?;
             let flat = ys.reshape((num_tokens * top_k, hidden))?;
             return mistralrs_quant::metal_moe_weighted_reduce_flat(
@@ -933,8 +927,8 @@ impl MoEExperts {
         hidden_dim: usize,
     ) -> Result<Option<Tensor>> {
         use mistralrs_quant::{
-            afq_gather_qmm_rhs_sorted, afq_gather_qmm_rhs_sorted_gate_up,
-            metal_arg_sort_u32_1d, AfqBits, AfqGroupSize,
+            afq_gather_qmm_rhs_sorted, afq_gather_qmm_rhs_sorted_gate_up, metal_arg_sort_u32_1d,
+            AfqBits, AfqGroupSize,
         };
 
         const SORTED_MOE_MIN_TOKENS_TOPK: usize = 64;

--- a/mistralrs-core/src/moe/experts.rs
+++ b/mistralrs-core/src/moe/experts.rs
@@ -873,11 +873,7 @@ impl MoEExperts {
                 num_tokens,
                 hidden_dim,
             )? {
-                return ys
-                    .to_dtype(DType::F32)?
-                    .broadcast_mul(&topk_weights.unsqueeze(D::Minus1)?)?
-                    .sum(D::Minus2)?
-                    .to_dtype(original_dtype);
+                return Self::topk_weight_reduce(&ys, topk_weights, original_dtype);
             }
             // Metal fallback: broadcast gather shapes
             let xs = xs.reshape((b_size, seq_len, 1, 1, hidden_dim))?;
@@ -891,6 +887,31 @@ impl MoEExperts {
                 .reshape((num_tokens, self.num_experts_per_tok, hidden_dim))?
         };
 
+        Self::topk_weight_reduce(&ys, topk_weights, original_dtype)
+    }
+
+    /// Collapses `[num_tokens, top_k, hidden]` per-expert outputs into
+    /// `[num_tokens, hidden]` via topk-weighted sum. On Metal with a supported
+    /// dtype this is a single fused kernel; otherwise it's the candle op chain.
+    fn topk_weight_reduce(
+        ys: &Tensor,
+        topk_weights: &Tensor,
+        original_dtype: DType,
+    ) -> Result<Tensor> {
+        #[cfg(feature = "metal")]
+        if ys.device().is_metal()
+            && matches!(ys.dtype(), DType::BF16 | DType::F16 | DType::F32)
+        {
+            let (num_tokens, top_k, hidden) = ys.dims3()?;
+            let flat = ys.reshape((num_tokens * top_k, hidden))?;
+            return mistralrs_quant::metal_moe_weighted_reduce_flat(
+                &flat,
+                topk_weights,
+                num_tokens,
+                top_k,
+            )?
+            .to_dtype(original_dtype);
+        }
         ys.to_dtype(DType::F32)?
             .broadcast_mul(&topk_weights.unsqueeze(D::Minus1)?)?
             .sum(D::Minus2)?

--- a/mistralrs-core/src/moe/experts.rs
+++ b/mistralrs-core/src/moe/experts.rs
@@ -865,7 +865,21 @@ impl MoEExperts {
                 .fused_down_proj
                 .gather_forward(&(up * gate.apply(&self.act)?)?, topk_ids)?
         } else {
-            // Metal path: use broadcast gather shapes
+            #[cfg(feature = "metal")]
+            if let Some(ys) = self.try_forward_fast_metal_sorted(
+                &xs_flat,
+                topk_ids,
+                weights,
+                num_tokens,
+                hidden_dim,
+            )? {
+                return ys
+                    .to_dtype(DType::F32)?
+                    .broadcast_mul(&topk_weights.unsqueeze(D::Minus1)?)?
+                    .sum(D::Minus2)?
+                    .to_dtype(original_dtype);
+            }
+            // Metal fallback: broadcast gather shapes
             let xs = xs.reshape((b_size, seq_len, 1, 1, hidden_dim))?;
             let indices = topk_ids.reshape((b_size, seq_len, self.num_experts_per_tok))?;
             let gate = weights.fused_gate_proj.gather_forward(&xs, &indices)?;
@@ -881,6 +895,104 @@ impl MoEExperts {
             .broadcast_mul(&topk_weights.unsqueeze(D::Minus1)?)?
             .sum(D::Minus2)?
             .to_dtype(original_dtype)
+    }
+
+    /// Metal fast path that mirrors MLX's SwitchGLU: sort tokens by expert id,
+    /// run all three projections as tiled grouped GEMMs that reuse expert
+    /// weights across the sorted tile, then unsort. Returns Ok(Some(out))
+    /// shaped `[num_tokens, top_k, hidden]` when applicable, Ok(None) otherwise
+    /// (e.g. weights are not AFQ, group_size/bits aren't instantiated, etc.).
+    #[cfg(feature = "metal")]
+    fn try_forward_fast_metal_sorted(
+        &self,
+        xs_flat: &Tensor,
+        topk_ids: &Tensor,
+        weights: &FastExpertsWeights,
+        num_tokens: usize,
+        hidden_dim: usize,
+    ) -> Result<Option<Tensor>> {
+        use mistralrs_quant::{
+            afq_gather_qmm_rhs_sorted, afq_gather_qmm_rhs_sorted_gate_up,
+            metal_arg_sort_u32_1d, AfqBits, AfqGroupSize,
+        };
+
+        const SORTED_MOE_MIN_TOKENS_TOPK: usize = 64;
+
+        let top_k = self.num_experts_per_tok;
+        let m = num_tokens * top_k;
+        if m < SORTED_MOE_MIN_TOKENS_TOPK {
+            return Ok(None);
+        }
+
+        let gate_inner = weights.fused_gate_proj.afq_inner();
+        let up_inner = weights.fused_up_proj.afq_inner();
+        let down_inner = weights.fused_down_proj.afq_inner();
+        let (Some(gate_inner), Some(up_inner), Some(down_inner)) =
+            (gate_inner, up_inner, down_inner)
+        else {
+            return Ok(None);
+        };
+
+        if gate_inner.group_size != AfqGroupSize::Med
+            || up_inner.group_size != AfqGroupSize::Med
+            || down_inner.group_size != AfqGroupSize::Med
+        {
+            return Ok(None);
+        }
+        let bits_ok = |b: AfqBits| matches!(b, AfqBits::Eight | AfqBits::Four);
+        if !bits_ok(gate_inner.bits) || !bits_ok(up_inner.bits) || !bits_ok(down_inner.bits) {
+            return Ok(None);
+        }
+        // Fused gate+up needs the same bits on both halves (kernels share the
+        // template instantiation key).
+        if gate_inner.bits != up_inner.bits {
+            return Ok(None);
+        }
+        let act_idx: usize = match self.act {
+            Activation::Silu | Activation::Swish => 0,
+            Activation::Gelu => 2, // mistralrs Activation::Gelu == gelu_erf
+            Activation::GeluPytorchTanh | Activation::NewGelu => 1,
+            Activation::Relu => 3,
+            _ => return Ok(None),
+        };
+
+        let topk_ids_flat = topk_ids.reshape((m,))?.to_dtype(DType::U32)?.contiguous()?;
+        let perm = metal_arg_sort_u32_1d(&topk_ids_flat)?;
+        let sorted_expert_ids = topk_ids_flat.gather(&perm, 0)?;
+
+        let sorted_token_idx = perm
+            .to_dtype(DType::F32)?
+            .affine(1.0 / top_k as f64, 0.0)?
+            .floor()?
+            .to_dtype(DType::U32)?;
+        let x_sorted = xs_flat.index_select(&sorted_token_idx, 0)?;
+
+        let mid = afq_gather_qmm_rhs_sorted_gate_up(
+            &x_sorted,
+            gate_inner.w_q,
+            gate_inner.scales,
+            gate_inner.biases,
+            up_inner.w_q,
+            up_inner.scales,
+            up_inner.biases,
+            &sorted_expert_ids,
+            gate_inner.group_size,
+            gate_inner.bits,
+            act_idx,
+        )?;
+        let down_sorted = afq_gather_qmm_rhs_sorted(
+            &mid,
+            down_inner.w_q,
+            down_inner.scales,
+            down_inner.biases,
+            &sorted_expert_ids,
+            down_inner.group_size,
+            down_inner.bits,
+        )?;
+
+        let inv_perm = metal_arg_sort_u32_1d(&perm)?;
+        let y_unsorted = down_sorted.index_select(&inv_perm, 0)?;
+        Ok(Some(y_unsorted.reshape((num_tokens, top_k, hidden_dim))?))
     }
 
     /// Fused MoE decode path for CUDA.

--- a/mistralrs-quant/build.rs
+++ b/mistralrs-quant/build.rs
@@ -143,7 +143,7 @@ fn main() -> Result<(), String> {
         use std::process::Command;
         use std::{env, str};
 
-        const METAL_SOURCES: [&str; 18] = [
+        const METAL_SOURCES: [&str; 19] = [
             "bitwise",
             "blockwise_fp8",
             "bnb_dequantize",
@@ -152,6 +152,7 @@ fn main() -> Result<(), String> {
             "fused_glu",
             "hqq_dequantize",
             "hqq_bitpack",
+            "moe",
             "mxfp4",
             "quantized",
             "rmsnorm_residual",

--- a/mistralrs-quant/src/afq/mod.rs
+++ b/mistralrs-quant/src/afq/mod.rs
@@ -16,7 +16,7 @@ use crate::{
     QuantizedSerde, QuantizedSerdeType, ShardedVarBuilder,
 };
 
-pub(crate) mod ops;
+pub mod ops;
 
 #[cfg(feature = "cuda")]
 pub(crate) mod ffi;

--- a/mistralrs-quant/src/afq/ops.rs
+++ b/mistralrs-quant/src/afq/ops.rs
@@ -520,6 +520,318 @@ pub(crate) fn afq_mm_op(
     )
 }
 
+/// Stable wrapper around candle's `call_mlx_arg_sort` for u32 keys. Candle's
+/// `Tensor::arg_sort_last_dim` uses a single-threadgroup bitonic sort that
+/// silently returns garbage for n > 1024 on Metal; this routes around it by
+/// calling the multi-block sort directly. Returns u32 perm of shape [n].
+/// `Kernels` is cached process-wide so the metallib only compiles once.
+#[cfg(feature = "metal")]
+pub fn metal_arg_sort_u32_1d(keys: &Tensor) -> Result<Tensor> {
+    use std::sync::OnceLock;
+    static KERNELS: OnceLock<candle_metal_kernels::Kernels> = OnceLock::new();
+
+    if keys.rank() != 1 {
+        candle_core::bail!("metal_arg_sort_u32_1d expects rank 1; got {:?}", keys.dims());
+    }
+    if keys.dtype() != DType::U32 {
+        candle_core::bail!(
+            "metal_arg_sort_u32_1d expects u32; got {:?}",
+            keys.dtype()
+        );
+    }
+    if !keys.is_contiguous() {
+        candle_core::bail!("metal_arg_sort_u32_1d expects contiguous input");
+    }
+
+    let n = keys.dim(0)?;
+    let storage = keys.storage_and_layout().0;
+    let Storage::Metal(s) = &*storage else {
+        candle_core::bail!("expected metal storage");
+    };
+    let device = s.device();
+    let dst = device.new_buffer(n, DType::U32, "argsort-perm")?;
+
+    let cmk_device: &candle_metal_kernels::metal::Device = device.device();
+    let kernels = KERNELS.get_or_init(candle_metal_kernels::Kernels::new);
+    let encoder = device.command_encoder()?;
+    encoder.set_label("mlx-argsort");
+    let src_offset = keys.layout().start_offset() * DType::U32.size_in_bytes();
+    let src = candle_metal_kernels::BufferOffset {
+        buffer: s.buffer(),
+        offset_in_bytes: src_offset,
+    };
+    candle_metal_kernels::call_mlx_arg_sort(
+        cmk_device,
+        &encoder,
+        kernels,
+        candle_metal_kernels::DType::U32,
+        /* nrows */ 1,
+        /* ncols */ n,
+        src,
+        &dst,
+    )
+    .map_err(candle_core::Error::wrap)?;
+
+    Ok(Tensor::from((
+        Storage::Metal(MetalStorage::new(dst, device.clone(), n, DType::U32)),
+        Shape::from(vec![n]),
+    )))
+}
+
+/// Sorted-MoE tiled grouped GEMM via the MLX-ported `affine_gather_qmm_rhs`
+/// kernel. `x_sorted` is `[M, K]` row-contiguous with rows pre-sorted so that
+/// rows mapped to the same expert are contiguous. `sorted_expert_ids` is `[M]`
+/// u32 of expert ids in the same order. `w` is `[E, N, K]` (transpose=true).
+/// Output is `[M, N]` in the sorted row order; caller is responsible for the
+/// inverse permutation back to the natural token-expert order.
+#[cfg(feature = "metal")]
+#[allow(clippy::too_many_arguments)]
+pub fn afq_gather_qmm_rhs_sorted(
+    x_sorted: &Tensor,
+    w: &Tensor,
+    scales: &Tensor,
+    biases: &Tensor,
+    sorted_expert_ids: &Tensor,
+    group_size: AfqGroupSize,
+    bits: AfqBits,
+) -> Result<Tensor> {
+    let group_size = group_size as usize;
+    let bits = bits as usize;
+
+    if w.dtype() != DType::U32 {
+        candle_core::bail!("AFQ weight matrix must be u32");
+    }
+    if scales.dims() != biases.dims() {
+        candle_core::bail!("Scales and biases must share shape");
+    }
+    if x_sorted.rank() != 2 {
+        candle_core::bail!(
+            "afq_gather_qmm_rhs_sorted expects x_sorted rank 2 [M,K]; got {:?}",
+            x_sorted.dims()
+        );
+    }
+    if w.rank() != 3 {
+        candle_core::bail!(
+            "afq_gather_qmm_rhs_sorted expects w rank 3 [E,N,K] (transpose=true); got {:?}",
+            w.dims()
+        );
+    }
+    if sorted_expert_ids.dtype() != DType::U32 || sorted_expert_ids.rank() != 1 {
+        candle_core::bail!(
+            "sorted_expert_ids must be u32 rank-1; got dtype={:?} rank={}",
+            sorted_expert_ids.dtype(),
+            sorted_expert_ids.rank()
+        );
+    }
+
+    let m = x_sorted.dim(0)?;
+    let k = x_sorted.dim(1)?;
+    let n = w.dim(1)?;
+    let k_w = w.dim(2)? * 32 / bits;
+    if k != k_w {
+        candle_core::bail!("x_sorted K ({k}) must match w K ({k_w})");
+    }
+    if sorted_expert_ids.dim(0)? != m {
+        candle_core::bail!(
+            "sorted_expert_ids len ({}) must match M ({m})",
+            sorted_expert_ids.dim(0)?
+        );
+    }
+    assert_eq!(x_sorted.layout().start_offset(), 0);
+    assert_eq!(w.layout().start_offset(), 0);
+    assert_eq!(scales.layout().start_offset(), 0);
+    assert_eq!(biases.layout().start_offset(), 0);
+    assert_eq!(sorted_expert_ids.layout().start_offset(), 0);
+
+    let x_s = x_sorted.storage_and_layout().0;
+    let Storage::Metal(x_s) = &*x_s else {
+        candle_core::bail!("expected metal x_sorted")
+    };
+    let w_s = w.storage_and_layout().0;
+    let Storage::Metal(w_s) = &*w_s else {
+        candle_core::bail!("expected metal w")
+    };
+    let s_s = scales.storage_and_layout().0;
+    let Storage::Metal(s_s) = &*s_s else {
+        candle_core::bail!("expected metal scales")
+    };
+    let b_s = biases.storage_and_layout().0;
+    let Storage::Metal(b_s) = &*b_s else {
+        candle_core::bail!("expected metal biases")
+    };
+    let i_s = sorted_expert_ids.storage_and_layout().0;
+    let Storage::Metal(i_s) = &*i_s else {
+        candle_core::bail!("expected metal sorted_expert_ids")
+    };
+
+    let device = w_s.device();
+    let out_shape = vec![m, n];
+    let output =
+        device.new_buffer(out_shape.iter().product(), scales.dtype(), "afq-gather-rhs")?;
+    let encoder = device.command_encoder()?;
+    encoder.set_label("afq-gather-rhs");
+
+    crate::metal_kernels::call_afq_gather_qmm_rhs(
+        device.device(),
+        &encoder,
+        &crate::metal_kernels::Kernels::new(),
+        scales.dtype(),
+        x_s.buffer(),
+        x_sorted.layout().start_offset() * x_sorted.dtype().size_in_bytes(),
+        w_s.buffer(),
+        s_s.buffer(),
+        b_s.buffer(),
+        i_s.buffer(),
+        &output,
+        m,
+        n,
+        k,
+        bits,
+        group_size,
+    )
+    .map_err(candle_core::Error::wrap)?;
+
+    Ok(Tensor::from((
+        Storage::Metal(MetalStorage::new(
+            output,
+            device.clone(),
+            out_shape.iter().product(),
+            scales.dtype(),
+        )),
+        Shape::from(out_shape),
+    )))
+}
+
+/// Fused gate+up sorted-MoE kernel: computes `y = activation(gate(x)) * up(x)`
+/// in a single launch. Saves one matmul + the intermediate gate buffer + the
+/// extra x global reads. `act_idx` matches the codes used by qmm_t_gate_up:
+/// 0=Silu/Swish, 1=Gelu(tanh approx), 2=Gelu(erf approx), 3=Relu.
+#[cfg(feature = "metal")]
+#[allow(clippy::too_many_arguments)]
+pub fn afq_gather_qmm_rhs_sorted_gate_up(
+    x_sorted: &Tensor,
+    w_gate: &Tensor,
+    scales_gate: &Tensor,
+    biases_gate: &Tensor,
+    w_up: &Tensor,
+    scales_up: &Tensor,
+    biases_up: &Tensor,
+    sorted_expert_ids: &Tensor,
+    group_size: AfqGroupSize,
+    bits: AfqBits,
+    act_idx: usize,
+) -> Result<Tensor> {
+    let group_size = group_size as usize;
+    let bits = bits as usize;
+
+    if x_sorted.rank() != 2 {
+        candle_core::bail!(
+            "expects x_sorted rank 2 [M,K]; got {:?}",
+            x_sorted.dims()
+        );
+    }
+    for (name, w) in [("w_gate", w_gate), ("w_up", w_up)] {
+        if w.dtype() != DType::U32 {
+            candle_core::bail!("{name} must be u32");
+        }
+        if w.rank() != 3 {
+            candle_core::bail!("{name} expects rank 3 [E,N,K]; got {:?}", w.dims());
+        }
+    }
+    if scales_gate.dims() != biases_gate.dims() || scales_up.dims() != biases_up.dims() {
+        candle_core::bail!("Scales/biases shape mismatch");
+    }
+    if w_gate.dims() != w_up.dims() || scales_gate.dims() != scales_up.dims() {
+        candle_core::bail!("Gate and up weight shapes must match");
+    }
+    if sorted_expert_ids.dtype() != DType::U32 || sorted_expert_ids.rank() != 1 {
+        candle_core::bail!("sorted_expert_ids must be u32 rank-1");
+    }
+
+    let m = x_sorted.dim(0)?;
+    let k = x_sorted.dim(1)?;
+    let n = w_gate.dim(1)?;
+    let k_w = w_gate.dim(2)? * 32 / bits;
+    if k != k_w {
+        candle_core::bail!("x K ({k}) must match w K ({k_w})");
+    }
+    if sorted_expert_ids.dim(0)? != m {
+        candle_core::bail!("sorted_expert_ids len must be M");
+    }
+    for t in [
+        x_sorted,
+        w_gate,
+        scales_gate,
+        biases_gate,
+        w_up,
+        scales_up,
+        biases_up,
+        sorted_expert_ids,
+    ] {
+        assert_eq!(t.layout().start_offset(), 0);
+    }
+
+    let extract = |t: &Tensor, lbl: &str| -> Result<_> {
+        let s = t.storage_and_layout().0;
+        let Storage::Metal(s) = &*s else {
+            candle_core::bail!("expected metal {lbl}")
+        };
+        Ok(s.clone())
+    };
+    let x_s = extract(x_sorted, "x_sorted")?;
+    let wg_s = extract(w_gate, "w_gate")?;
+    let sg_s = extract(scales_gate, "scales_gate")?;
+    let bg_s = extract(biases_gate, "biases_gate")?;
+    let wu_s = extract(w_up, "w_up")?;
+    let su_s = extract(scales_up, "scales_up")?;
+    let bu_s = extract(biases_up, "biases_up")?;
+    let i_s = extract(sorted_expert_ids, "sorted_expert_ids")?;
+
+    let device = wg_s.device();
+    let out_shape = vec![m, n];
+    let output = device.new_buffer(
+        out_shape.iter().product(),
+        scales_gate.dtype(),
+        "afq-gather-rhs-gate-up",
+    )?;
+    let encoder = device.command_encoder()?;
+    encoder.set_label("afq-gather-rhs-gate-up");
+
+    crate::metal_kernels::call_afq_gather_qmm_rhs_gate_up(
+        device.device(),
+        &encoder,
+        &crate::metal_kernels::Kernels::new(),
+        scales_gate.dtype(),
+        x_s.buffer(),
+        x_sorted.layout().start_offset() * x_sorted.dtype().size_in_bytes(),
+        wg_s.buffer(),
+        sg_s.buffer(),
+        bg_s.buffer(),
+        wu_s.buffer(),
+        su_s.buffer(),
+        bu_s.buffer(),
+        i_s.buffer(),
+        &output,
+        m,
+        n,
+        k,
+        bits,
+        group_size,
+        act_idx,
+    )
+    .map_err(candle_core::Error::wrap)?;
+
+    Ok(Tensor::from((
+        Storage::Metal(MetalStorage::new(
+            output,
+            device.clone(),
+            out_shape.iter().product(),
+            scales_gate.dtype(),
+        )),
+        Shape::from(out_shape),
+    )))
+}
+
 #[cfg(feature = "metal")]
 #[cfg(test)]
 mod metal_tests {
@@ -647,6 +959,181 @@ mod metal_tests {
     fn test_afq_two() -> Result<()> {
         let rmse = run_afq_roundtrip(AfqBits::Two)?;
         assert!(rmse < 0.40, "{rmse}");
+        Ok(())
+    }
+
+    #[test]
+    fn test_metal_arg_sort_u32_1d() -> Result<()> {
+        use crate::afq::ops::metal_arg_sort_u32_1d;
+        let device = Device::new_metal(0)?;
+        for n in [1024usize, 4096, 8192, 32768] {
+            let data: Vec<u32> = (0..n as u32).rev().collect();
+            let t = Tensor::from_vec(data.clone(), (n,), &device)?;
+            let perm = metal_arg_sort_u32_1d(&t)?;
+            let p = perm.to_vec1::<u32>()?;
+            for i in 0..n {
+                assert_eq!(
+                    p[i],
+                    (n - 1 - i) as u32,
+                    "n={n} idx={i}: perm[{i}]={} expected {}",
+                    p[i],
+                    n - 1 - i
+                );
+            }
+            let sorted_keys = t.gather(&perm, 0)?.to_vec1::<u32>()?;
+            for i in 0..n {
+                assert_eq!(sorted_keys[i], i as u32, "n={n} sorted[{i}]={} expected {i}", sorted_keys[i]);
+            }
+        }
+        Ok(())
+    }
+
+    #[test]
+    fn test_argsort_large() -> Result<()> {
+        let device = Device::new_metal(0)?;
+        for n in [1024usize, 4096, 8192, 16384, 32768] {
+            let data: Vec<u32> = (0..n as u32).rev().collect();
+            let t = Tensor::from_vec(data, (n,), &device)?;
+            let perm = t.arg_sort_last_dim(true)?;
+            let p = perm.to_vec1::<u32>()?;
+            let ok = p[0] == (n - 1) as u32 && p[n - 1] == 0;
+            println!("n={n} perm[0]={} perm[-1]={} ok={ok}", p[0], p[n - 1]);
+        }
+        Ok(())
+    }
+
+    // Cross-check the MLX-ported sorted-MoE kernel against a dequantized
+    // reference. Catches RoPE-style layout / dispatch / unalignment bugs
+    // before they hit the benchmark.
+    #[test]
+    fn test_afq_gather_qmm_rhs_sorted_matches_dequant_ref() -> Result<()> {
+        use crate::afq::ops::{
+            afq_dequantize_op, afq_gather_qmm_rhs_sorted, afq_quantize_op,
+        };
+
+        let device = Device::new_metal(0)?;
+        let group_size = AfqGroupSize::Med;
+        let bits = AfqBits::Eight;
+        let bits_usize = bits as usize;
+        let gs_usize = group_size as usize;
+
+        // Includes M < 128 (BM=16 path), 128 <= M < 512 (BM=32), M >= 512 (BM=64),
+        // and an unaligned-M case for the unaligned branches.
+        let cases: &[(usize, usize, usize, usize)] = &[
+            (4, 64, 64, 64),
+            (4, 17, 64, 64),
+            (4, 64, 96, 64),
+            (4, 64, 64, 128),
+            (8, 128, 704, 2816),
+            (8, 200, 704, 2816),
+            (8, 512, 704, 2816),
+            (8, 600, 704, 2816),
+            (8, 2048, 704, 2816),
+        ];
+        for &(num_experts, m, n, k) in cases {
+            assert!(k % gs_usize == 0);
+            let w = Tensor::randn(0f32, 0.02f32, (num_experts, n, k), &device)?;
+            let (w_q, scales, biases) = afq_quantize_op(&w, group_size, bits)?;
+            let w_dequant = afq_dequantize_op(&w_q, &scales, &biases, group_size, bits)?;
+
+            let x = Tensor::randn(0f32, 1f32, (m, k), &device)?;
+
+            let ids_vec: Vec<u32> = (0..m)
+                .map(|i| ((i * 7 + 13) % num_experts) as u32)
+                .collect();
+            let mut sorted: Vec<u32> = ids_vec.clone();
+            sorted.sort();
+            let sorted_ids = Tensor::from_vec(sorted.clone(), (m,), &device)?;
+
+            let y_new = afq_gather_qmm_rhs_sorted(
+                &x,
+                &w_q,
+                &scales,
+                &biases,
+                &sorted_ids,
+                group_size,
+                bits,
+            )?;
+
+            let w_sel = w_dequant.index_select(&sorted_ids, 0)?;
+            let y_ref = x
+                .unsqueeze(1)?
+                .matmul(&w_sel.transpose(1, 2)?)?
+                .squeeze(1)?;
+            let diff = (y_new - y_ref.clone())?
+                .abs()?
+                .max_all()?
+                .to_scalar::<f32>()?;
+            let scale = y_ref.abs()?.max_all()?.to_scalar::<f32>()?;
+            assert!(
+                diff <= scale * 1e-2,
+                "case e={num_experts} m={m} n={n} k={k}: max diff {diff} exceeds 1e-2 * |ref| ({})",
+                scale * 1e-2
+            );
+            let _ = bits_usize;
+        }
+        Ok(())
+    }
+
+    #[test]
+    fn test_afq_gather_qmm_rhs_sorted_gate_up_matches_dequant_ref() -> Result<()> {
+        use crate::afq::ops::{
+            afq_dequantize_op, afq_gather_qmm_rhs_sorted_gate_up, afq_quantize_op,
+        };
+
+        let device = Device::new_metal(0)?;
+        let group_size = AfqGroupSize::Med;
+        let bits = AfqBits::Eight;
+
+        // Test with act=0 (Silu), since it's simple to reference.
+        let cases: &[(usize, usize, usize, usize)] = &[
+            (4, 64, 64, 64),
+            (8, 128, 704, 2816),
+            (8, 600, 704, 2816),
+        ];
+        for &(num_experts, m, n, k) in cases {
+            let wg = Tensor::randn(0f32, 0.02f32, (num_experts, n, k), &device)?;
+            let wu = Tensor::randn(0f32, 0.02f32, (num_experts, n, k), &device)?;
+            let (wg_q, sg, bg) = afq_quantize_op(&wg, group_size, bits)?;
+            let (wu_q, su, bu) = afq_quantize_op(&wu, group_size, bits)?;
+            let wg_d = afq_dequantize_op(&wg_q, &sg, &bg, group_size, bits)?;
+            let wu_d = afq_dequantize_op(&wu_q, &su, &bu, group_size, bits)?;
+
+            let x = Tensor::randn(0f32, 1f32, (m, k), &device)?;
+
+            let ids_vec: Vec<u32> = (0..m)
+                .map(|i| ((i * 7 + 13) % num_experts) as u32)
+                .collect();
+            let mut sorted: Vec<u32> = ids_vec.clone();
+            sorted.sort();
+            let sorted_ids = Tensor::from_vec(sorted, (m,), &device)?;
+
+            let y_new = afq_gather_qmm_rhs_sorted_gate_up(
+                &x, &wg_q, &sg, &bg, &wu_q, &su, &bu, &sorted_ids,
+                group_size, bits, /* act=Silu */ 0,
+            )?;
+
+            let wg_sel = wg_d.index_select(&sorted_ids, 0)?;
+            let wu_sel = wu_d.index_select(&sorted_ids, 0)?;
+            let gate = x
+                .unsqueeze(1)?
+                .matmul(&wg_sel.transpose(1, 2)?)?
+                .squeeze(1)?;
+            let up = x
+                .unsqueeze(1)?
+                .matmul(&wu_sel.transpose(1, 2)?)?
+                .squeeze(1)?;
+            let y_ref = (gate.silu()? * up)?;
+            let diff = (y_new - y_ref.clone())?
+                .abs()?
+                .max_all()?
+                .to_scalar::<f32>()?;
+            let scale = y_ref.abs()?.max_all()?.to_scalar::<f32>()?.max(1e-6);
+            assert!(
+                diff <= scale * 5e-2,
+                "case e={num_experts} m={m} n={n} k={k}: gate_up diff {diff} > 5e-2 * {scale}"
+            );
+        }
         Ok(())
     }
 }

--- a/mistralrs-quant/src/afq/ops.rs
+++ b/mistralrs-quant/src/afq/ops.rs
@@ -531,13 +531,13 @@ pub fn metal_arg_sort_u32_1d(keys: &Tensor) -> Result<Tensor> {
     static KERNELS: OnceLock<candle_metal_kernels::Kernels> = OnceLock::new();
 
     if keys.rank() != 1 {
-        candle_core::bail!("metal_arg_sort_u32_1d expects rank 1; got {:?}", keys.dims());
+        candle_core::bail!(
+            "metal_arg_sort_u32_1d expects rank 1; got {:?}",
+            keys.dims()
+        );
     }
     if keys.dtype() != DType::U32 {
-        candle_core::bail!(
-            "metal_arg_sort_u32_1d expects u32; got {:?}",
-            keys.dtype()
-        );
+        candle_core::bail!("metal_arg_sort_u32_1d expects u32; got {:?}", keys.dtype());
     }
     if !keys.is_contiguous() {
         candle_core::bail!("metal_arg_sort_u32_1d expects contiguous input");
@@ -616,7 +616,10 @@ pub fn metal_moe_weighted_reduce_flat(
     }
 
     let inputs = inputs.contiguous()?;
-    let topk_weights = topk_weights.flatten_all()?.to_dtype(DType::F32)?.contiguous()?;
+    let topk_weights = topk_weights
+        .flatten_all()?
+        .to_dtype(DType::F32)?
+        .contiguous()?;
     let (in_storage, in_layout) = inputs.storage_and_layout();
     let Storage::Metal(in_s) = &*in_storage else {
         candle_core::bail!("metal_moe_weighted_reduce_flat: inputs must live on Metal");
@@ -743,8 +746,7 @@ pub fn afq_gather_qmm_rhs_sorted(
 
     let device = w_s.device();
     let out_shape = vec![m, n];
-    let output =
-        device.new_buffer(out_shape.iter().product(), scales.dtype(), "afq-gather-rhs")?;
+    let output = device.new_buffer(out_shape.iter().product(), scales.dtype(), "afq-gather-rhs")?;
     let encoder = device.command_encoder()?;
     encoder.set_label("afq-gather-rhs");
 
@@ -802,10 +804,7 @@ pub fn afq_gather_qmm_rhs_sorted_gate_up(
     let bits = bits as usize;
 
     if x_sorted.rank() != 2 {
-        candle_core::bail!(
-            "expects x_sorted rank 2 [M,K]; got {:?}",
-            x_sorted.dims()
-        );
+        candle_core::bail!("expects x_sorted rank 2 [M,K]; got {:?}", x_sorted.dims());
     }
     for (name, w) in [("w_gate", w_gate), ("w_up", w_up)] {
         if w.dtype() != DType::U32 {
@@ -1059,7 +1058,11 @@ mod metal_tests {
             }
             let sorted_keys = t.gather(&perm, 0)?.to_vec1::<u32>()?;
             for i in 0..n {
-                assert_eq!(sorted_keys[i], i as u32, "n={n} sorted[{i}]={} expected {i}", sorted_keys[i]);
+                assert_eq!(
+                    sorted_keys[i], i as u32,
+                    "n={n} sorted[{i}]={} expected {i}",
+                    sorted_keys[i]
+                );
             }
         }
         Ok(())
@@ -1084,9 +1087,7 @@ mod metal_tests {
     // before they hit the benchmark.
     #[test]
     fn test_afq_gather_qmm_rhs_sorted_matches_dequant_ref() -> Result<()> {
-        use crate::afq::ops::{
-            afq_dequantize_op, afq_gather_qmm_rhs_sorted, afq_quantize_op,
-        };
+        use crate::afq::ops::{afq_dequantize_op, afq_gather_qmm_rhs_sorted, afq_quantize_op};
 
         let device = Device::new_metal(0)?;
         let group_size = AfqGroupSize::Med;
@@ -1158,24 +1159,13 @@ mod metal_tests {
         let device = Device::new_metal(0)?;
 
         // Mix of small (cache-friendly) and Gemma-4-26B-A4B-shape cases.
-        let cases: &[(usize, usize, usize)] = &[
-            (2, 2, 8),
-            (4, 8, 64),
-            (4096, 8, 2816),
-        ];
+        let cases: &[(usize, usize, usize)] = &[(2, 2, 8), (4, 8, 64), (4096, 8, 2816)];
         for &(num_tokens, topk, hidden) in cases {
             let m = num_tokens * topk;
-            let inputs = Tensor::randn(0f32, 1f32, (m, hidden), &device)?
-                .to_dtype(DType::BF16)?;
-            let topk_weights =
-                Tensor::randn(0f32, 0.5f32, (num_tokens, topk), &device)?;
+            let inputs = Tensor::randn(0f32, 1f32, (m, hidden), &device)?.to_dtype(DType::BF16)?;
+            let topk_weights = Tensor::randn(0f32, 0.5f32, (num_tokens, topk), &device)?;
 
-            let y_new = metal_moe_weighted_reduce_flat(
-                &inputs,
-                &topk_weights,
-                num_tokens,
-                topk,
-            )?;
+            let y_new = metal_moe_weighted_reduce_flat(&inputs, &topk_weights, num_tokens, topk)?;
 
             let y_ref = inputs
                 .reshape((num_tokens, topk, hidden))?
@@ -1214,11 +1204,8 @@ mod metal_tests {
         let bits = AfqBits::Eight;
 
         // Test with act=0 (Silu), since it's simple to reference.
-        let cases: &[(usize, usize, usize, usize)] = &[
-            (4, 64, 64, 64),
-            (8, 128, 704, 2816),
-            (8, 600, 704, 2816),
-        ];
+        let cases: &[(usize, usize, usize, usize)] =
+            &[(4, 64, 64, 64), (8, 128, 704, 2816), (8, 600, 704, 2816)];
         for &(num_experts, m, n, k) in cases {
             let wg = Tensor::randn(0f32, 0.02f32, (num_experts, n, k), &device)?;
             let wu = Tensor::randn(0f32, 0.02f32, (num_experts, n, k), &device)?;
@@ -1237,8 +1224,17 @@ mod metal_tests {
             let sorted_ids = Tensor::from_vec(sorted, (m,), &device)?;
 
             let y_new = afq_gather_qmm_rhs_sorted_gate_up(
-                &x, &wg_q, &sg, &bg, &wu_q, &su, &bu, &sorted_ids,
-                group_size, bits, /* act=Silu */ 0,
+                &x,
+                &wg_q,
+                &sg,
+                &bg,
+                &wu_q,
+                &su,
+                &bu,
+                &sorted_ids,
+                group_size,
+                bits,
+                /* act=Silu */ 0,
             )?;
 
             let wg_sel = wg_d.index_select(&sorted_ids, 0)?;

--- a/mistralrs-quant/src/afq/ops.rs
+++ b/mistralrs-quant/src/afq/ops.rs
@@ -578,6 +578,83 @@ pub fn metal_arg_sort_u32_1d(keys: &Tensor) -> Result<Tensor> {
     )))
 }
 
+/// Fused topk-weighted reduce: collapses `[num_tokens * topk, hidden]`
+/// per-assignment outputs into `[num_tokens, hidden]` by topk-weighted sum.
+/// One Metal launch replaces the `reshape -> to_dtype(F32) -> broadcast_mul ->
+/// sum -> to_dtype` tail. Accepts BF16/F16/F32 input, f32 weights.
+#[cfg(feature = "metal")]
+pub fn metal_moe_weighted_reduce_flat(
+    inputs: &Tensor,
+    topk_weights: &Tensor,
+    num_tokens: usize,
+    topk: usize,
+) -> Result<Tensor> {
+    if inputs.rank() != 2 {
+        candle_core::bail!(
+            "metal_moe_weighted_reduce_flat: inputs must be rank 2 [M,H], got {:?}",
+            inputs.dims()
+        );
+    }
+    let total_assignments = inputs.dim(0)?;
+    let hidden = inputs.dim(1)?;
+    if total_assignments != num_tokens * topk {
+        candle_core::bail!(
+            "metal_moe_weighted_reduce_flat: input rows {total_assignments} != num_tokens {num_tokens} * topk {topk}"
+        );
+    }
+    if topk_weights.elem_count() != total_assignments {
+        candle_core::bail!(
+            "metal_moe_weighted_reduce_flat: topk_weights must have {total_assignments} elements, got {}",
+            topk_weights.elem_count()
+        );
+    }
+    if !matches!(inputs.dtype(), DType::F32 | DType::F16 | DType::BF16) {
+        candle_core::bail!(
+            "metal_moe_weighted_reduce_flat: unsupported input dtype {:?}",
+            inputs.dtype()
+        );
+    }
+
+    let inputs = inputs.contiguous()?;
+    let topk_weights = topk_weights.flatten_all()?.to_dtype(DType::F32)?.contiguous()?;
+    let (in_storage, in_layout) = inputs.storage_and_layout();
+    let Storage::Metal(in_s) = &*in_storage else {
+        candle_core::bail!("metal_moe_weighted_reduce_flat: inputs must live on Metal");
+    };
+    let (tw_storage, tw_layout) = topk_weights.storage_and_layout();
+    let Storage::Metal(tw_s) = &*tw_storage else {
+        candle_core::bail!("metal_moe_weighted_reduce_flat: topk_weights must live on Metal");
+    };
+
+    let device = in_s.device();
+    let out_elems = num_tokens * hidden;
+    let dtype = inputs.dtype();
+    let output = device.new_buffer(out_elems, dtype, "moe-weighted-reduce")?;
+
+    let encoder = device.command_encoder()?;
+    encoder.set_label("moe-weighted-reduce");
+    crate::metal_kernels::call_moe_weighted_reduce_flat(
+        device.device(),
+        &encoder,
+        &crate::metal_kernels::Kernels::new(),
+        dtype,
+        in_s.buffer(),
+        in_layout.start_offset() * dtype.size_in_bytes(),
+        tw_s.buffer(),
+        tw_layout.start_offset() * DType::F32.size_in_bytes(),
+        &output,
+        num_tokens,
+        hidden,
+        topk,
+    )
+    .map_err(candle_core::Error::wrap)?;
+
+    Ok(Tensor::from((
+        Storage::Metal(MetalStorage::new(output, device.clone(), out_elems, dtype)),
+        Shape::from(vec![num_tokens, hidden]),
+    )))
+}
+
 /// Sorted-MoE tiled grouped GEMM via the MLX-ported `affine_gather_qmm_rhs`
 /// kernel. `x_sorted` is `[M, K]` row-contiguous with rows pre-sorted so that
 /// rows mapped to the same expert are contiguous. `sorted_expert_ids` is `[M]`
@@ -1071,6 +1148,57 @@ mod metal_tests {
                 scale * 1e-2
             );
             let _ = bits_usize;
+        }
+        Ok(())
+    }
+
+    #[test]
+    fn test_metal_moe_weighted_reduce_flat_matches_ref() -> Result<()> {
+        use crate::afq::ops::metal_moe_weighted_reduce_flat;
+        let device = Device::new_metal(0)?;
+
+        // Mix of small (cache-friendly) and Gemma-4-26B-A4B-shape cases.
+        let cases: &[(usize, usize, usize)] = &[
+            (2, 2, 8),
+            (4, 8, 64),
+            (4096, 8, 2816),
+        ];
+        for &(num_tokens, topk, hidden) in cases {
+            let m = num_tokens * topk;
+            let inputs = Tensor::randn(0f32, 1f32, (m, hidden), &device)?
+                .to_dtype(DType::BF16)?;
+            let topk_weights =
+                Tensor::randn(0f32, 0.5f32, (num_tokens, topk), &device)?;
+
+            let y_new = metal_moe_weighted_reduce_flat(
+                &inputs,
+                &topk_weights,
+                num_tokens,
+                topk,
+            )?;
+
+            let y_ref = inputs
+                .reshape((num_tokens, topk, hidden))?
+                .to_dtype(DType::F32)?
+                .broadcast_mul(&topk_weights.unsqueeze(D::Minus1)?)?
+                .sum(D::Minus2)?
+                .to_dtype(DType::BF16)?;
+            let diff = (y_new - y_ref.clone())?
+                .abs()?
+                .max_all()?
+                .to_dtype(DType::F32)?
+                .to_scalar::<f32>()?;
+            let scale = y_ref
+                .abs()?
+                .max_all()?
+                .to_dtype(DType::F32)?
+                .to_scalar::<f32>()?
+                .max(1e-3);
+            assert!(
+                diff <= scale * 5e-2,
+                "num_tokens={num_tokens} topk={topk} hidden={hidden}: diff {diff} > 5e-2 * |ref| ({})",
+                scale * 5e-2
+            );
         }
         Ok(())
     }

--- a/mistralrs-quant/src/lib.rs
+++ b/mistralrs-quant/src/lib.rs
@@ -50,6 +50,7 @@ pub use afq::{AfqBits, AfqGroupSize, AfqInner, AfqLayer};
 #[cfg(feature = "metal")]
 pub use afq::ops::{
     afq_gather_qmm_rhs_sorted, afq_gather_qmm_rhs_sorted_gate_up, metal_arg_sort_u32_1d,
+    metal_moe_weighted_reduce_flat,
 };
 pub use bitsandbytes::{BnbLinear, BnbQuantParams, BnbQuantType};
 pub use blockwise_fp8::{

--- a/mistralrs-quant/src/lib.rs
+++ b/mistralrs-quant/src/lib.rs
@@ -46,12 +46,12 @@ use lora::merge_lora_weights;
 use regex::Regex;
 pub use safetensors::{Shard, ShardedSafeTensors, ShardedVarBuilder};
 
-pub use afq::{AfqBits, AfqGroupSize, AfqInner, AfqLayer};
 #[cfg(feature = "metal")]
 pub use afq::ops::{
     afq_gather_qmm_rhs_sorted, afq_gather_qmm_rhs_sorted_gate_up, metal_arg_sort_u32_1d,
     metal_moe_weighted_reduce_flat,
 };
+pub use afq::{AfqBits, AfqGroupSize, AfqInner, AfqLayer};
 pub use bitsandbytes::{BnbLinear, BnbQuantParams, BnbQuantType};
 pub use blockwise_fp8::{
     blockwise_fp8_moe, fp8_blockwise_dequantize, fp8_blockwise_quantize, BlockwiseFP8Linear,

--- a/mistralrs-quant/src/lib.rs
+++ b/mistralrs-quant/src/lib.rs
@@ -47,6 +47,10 @@ use regex::Regex;
 pub use safetensors::{Shard, ShardedSafeTensors, ShardedVarBuilder};
 
 pub use afq::{AfqBits, AfqGroupSize, AfqInner, AfqLayer};
+#[cfg(feature = "metal")]
+pub use afq::ops::{
+    afq_gather_qmm_rhs_sorted, afq_gather_qmm_rhs_sorted_gate_up, metal_arg_sort_u32_1d,
+};
 pub use bitsandbytes::{BnbLinear, BnbQuantParams, BnbQuantType};
 pub use blockwise_fp8::{
     blockwise_fp8_moe, fp8_blockwise_dequantize, fp8_blockwise_quantize, BlockwiseFP8Linear,

--- a/mistralrs-quant/src/metal_kernels/mod.rs
+++ b/mistralrs-quant/src/metal_kernels/mod.rs
@@ -1519,7 +1519,11 @@ pub fn call_afq_gather_qmm_rhs_gate_up(
 
     // Reuse the same tile picker but only BM=16/32 are instantiated for the
     // fused kernel (BM=64 isn't a win and would double instantiations).
-    let (bm, bn, bk, wm, wn) = if m >= 128 { (32, 32, 32, 1, 2) } else { (16, 32, 32, 1, 2) };
+    let (bm, bn, bk, wm, wn) = if m >= 128 {
+        (32, 32, 32, 1, 2)
+    } else {
+        (16, 32, 32, 1, 2)
+    };
     let align_m = m.is_multiple_of(bm);
     let align_n = n.is_multiple_of(bn);
     let align_k = k.is_multiple_of(bk);

--- a/mistralrs-quant/src/metal_kernels/mod.rs
+++ b/mistralrs-quant/src/metal_kernels/mod.rs
@@ -1386,6 +1386,183 @@ pub fn call_afq_qmm_splitk(
     Ok(())
 }
 
+// Tile presets for the MLX-ported sorted-MoE gather GEMM. Must match the
+// instantiations in quantized.metal: (BM, BN, BK, WM, WN).
+const AFQ_GATHER_RHS_BN: usize = 32;
+const AFQ_GATHER_RHS_BK: usize = 32;
+
+fn pick_afq_gather_rhs_tile(m: usize) -> (usize, usize, usize, usize, usize) {
+    // BM=32 is a sweet spot on M3-class Apple GPUs: BM=64 regresses on
+    // 26B-A4B-class MoE prefill (register pressure / occupancy), BM=16 leaves
+    // arithmetic intensity on the table for large M.
+    if m >= 128 {
+        (32, AFQ_GATHER_RHS_BN, AFQ_GATHER_RHS_BK, 1, 2)
+    } else {
+        (16, AFQ_GATHER_RHS_BN, AFQ_GATHER_RHS_BK, 1, 2)
+    }
+}
+
+/// Sorted-MoE tiled grouped GEMM (ported from MLX `affine_gather_qmm_rhs`).
+/// Caller must pre-sort `x` and `indices` by expert id; rows for the same
+/// expert must be contiguous. Output `y` has the same row order as `x` and
+/// must be unsorted by the caller using the inverse permutation.
+#[allow(clippy::too_many_arguments)]
+pub fn call_afq_gather_qmm_rhs(
+    device: &Device,
+    ep: impl EncoderProvider,
+    kernels: &Kernels,
+    ty: DType,
+    x: &Buffer,
+    x_offset: usize,
+    w: &Buffer,
+    scales: &Buffer,
+    biases: &Buffer,
+    indices: &Buffer,
+    out: &Buffer,
+    m: usize,
+    n: usize,
+    k: usize,
+    bits: usize,
+    group_size: usize,
+) -> Result<(), MetalKernelError> {
+    let type_string = match ty {
+        DType::F32 => "float",
+        DType::BF16 => "bfloat16_t",
+        DType::F16 => "float16_t",
+        other => {
+            return Err(MetalKernelError::DTypeMismatch {
+                expected: vec![DType::F32, DType::F16, DType::BF16],
+                got: other,
+            })
+        }
+    };
+
+    let (bm, bn, bk, wm, wn) = pick_afq_gather_rhs_tile(m);
+    let align_m = m.is_multiple_of(bm);
+    let align_n = n.is_multiple_of(bn);
+    let align_k = k.is_multiple_of(bk);
+    let am = if align_m { "t" } else { "n" };
+    let an = if align_n { "t" } else { "n" };
+    let ak = if align_k { "t" } else { "n" };
+    let name = format!(
+        "affine_gather_qmm_rhs_{type_string}_gs_{group_size}_b_{bits}_bm_{bm}_bn_{bn}_bk_{bk}_wm_{wm}_wn_{wn}_t_true_alM_{am}_alN_{an}_alK_{ak}",
+    );
+
+    let pipeline = kernels.load_pipeline(device, &name)?;
+
+    let encoder = ep.encoder();
+    let encoder: &ComputeCommandEncoderRef = encoder.as_ref();
+    encoder.set_compute_pipeline_state(&pipeline);
+
+    encoder.set_input_buffer(0, Some(x), x_offset);
+    encoder.set_input_buffer(1, Some(w), 0);
+    encoder.set_input_buffer(2, Some(scales), 0);
+    encoder.set_input_buffer(3, Some(biases), 0);
+    encoder.set_input_buffer(4, Some(indices), 0);
+    encoder.set_output_buffer(5, Some(out), 0);
+    <i32 as EncoderParam>::set_param(encoder, 6, m as i32);
+    <i32 as EncoderParam>::set_param(encoder, 7, n as i32);
+    <i32 as EncoderParam>::set_param(encoder, 8, k as i32);
+
+    let group_dims = MTLSize {
+        width: 32,
+        height: wn,
+        depth: wm,
+    };
+    let grid_dims = MTLSize {
+        width: n.div_ceil(bn),
+        height: m.div_ceil(bm),
+        depth: 1,
+    };
+    encoder.dispatch_thread_groups(grid_dims, group_dims);
+    Ok(())
+}
+
+/// Fused gate+up variant of `call_afq_gather_qmm_rhs`. Computes
+/// `y = activation(gate_proj(x)) * up_proj(x)` in one launch. `act_idx` maps
+/// to the same `ACT` codes used by `qmm_t_gate_up`:
+/// 0=Silu/Swish, 1=Gelu(tanh approx), 2=Gelu(erf approx), 3=Relu.
+#[allow(clippy::too_many_arguments)]
+pub fn call_afq_gather_qmm_rhs_gate_up(
+    device: &Device,
+    ep: impl EncoderProvider,
+    kernels: &Kernels,
+    ty: DType,
+    x: &Buffer,
+    x_offset: usize,
+    w_gate: &Buffer,
+    scales_gate: &Buffer,
+    biases_gate: &Buffer,
+    w_up: &Buffer,
+    scales_up: &Buffer,
+    biases_up: &Buffer,
+    indices: &Buffer,
+    out: &Buffer,
+    m: usize,
+    n: usize,
+    k: usize,
+    bits: usize,
+    group_size: usize,
+    act_idx: usize,
+) -> Result<(), MetalKernelError> {
+    let type_string = match ty {
+        DType::F32 => "float",
+        DType::BF16 => "bfloat16_t",
+        DType::F16 => "float16_t",
+        other => {
+            return Err(MetalKernelError::DTypeMismatch {
+                expected: vec![DType::F32, DType::F16, DType::BF16],
+                got: other,
+            })
+        }
+    };
+
+    // Reuse the same tile picker but only BM=16/32 are instantiated for the
+    // fused kernel (BM=64 isn't a win and would double instantiations).
+    let (bm, bn, bk, wm, wn) = if m >= 128 { (32, 32, 32, 1, 2) } else { (16, 32, 32, 1, 2) };
+    let align_m = m.is_multiple_of(bm);
+    let align_n = n.is_multiple_of(bn);
+    let align_k = k.is_multiple_of(bk);
+    let am = if align_m { "t" } else { "n" };
+    let an = if align_n { "t" } else { "n" };
+    let ak = if align_k { "t" } else { "n" };
+    let name = format!(
+        "affine_gather_qmm_rhs_gate_up_{type_string}_gs_{group_size}_b_{bits}_act_{act_idx}_bm_{bm}_bn_{bn}_bk_{bk}_wm_{wm}_wn_{wn}_alM_{am}_alN_{an}_alK_{ak}",
+    );
+
+    let pipeline = kernels.load_pipeline(device, &name)?;
+
+    let encoder = ep.encoder();
+    let encoder: &ComputeCommandEncoderRef = encoder.as_ref();
+    encoder.set_compute_pipeline_state(&pipeline);
+
+    encoder.set_input_buffer(0, Some(x), x_offset);
+    encoder.set_input_buffer(1, Some(w_gate), 0);
+    encoder.set_input_buffer(2, Some(scales_gate), 0);
+    encoder.set_input_buffer(3, Some(biases_gate), 0);
+    encoder.set_input_buffer(4, Some(w_up), 0);
+    encoder.set_input_buffer(5, Some(scales_up), 0);
+    encoder.set_input_buffer(6, Some(biases_up), 0);
+    encoder.set_input_buffer(7, Some(indices), 0);
+    encoder.set_output_buffer(8, Some(out), 0);
+    <i32 as EncoderParam>::set_param(encoder, 9, m as i32);
+    <i32 as EncoderParam>::set_param(encoder, 10, n as i32);
+    <i32 as EncoderParam>::set_param(encoder, 11, k as i32);
+
+    let group_dims = MTLSize {
+        width: 32,
+        height: wn,
+        depth: wm,
+    };
+    let grid_dims = MTLSize {
+        width: n.div_ceil(bn),
+        height: m.div_ceil(bm),
+        depth: 1,
+    };
+    encoder.dispatch_thread_groups(grid_dims, group_dims);
+    Ok(())
+}
+
 #[allow(clippy::too_many_arguments)]
 pub fn call_mxfp4_matmul(
     device: &Device,

--- a/mistralrs-quant/src/metal_kernels/mod.rs
+++ b/mistralrs-quant/src/metal_kernels/mod.rs
@@ -1563,6 +1563,75 @@ pub fn call_afq_gather_qmm_rhs_gate_up(
     Ok(())
 }
 
+/// Fused topk-weighted reduce: collapses
+/// `[num_tokens * topk, hidden]` (per-assignment outputs in row-contiguous
+/// (token, slot) order) into `[num_tokens, hidden]`, with each slot scaled by
+/// `topk_weights[token*topk + slot]`. Accumulation is in fp32. Replaces the
+/// `reshape -> to_dtype(F32) -> broadcast_mul -> sum -> to_dtype` tail.
+#[allow(clippy::too_many_arguments)]
+pub fn call_moe_weighted_reduce_flat(
+    device: &Device,
+    ep: impl EncoderProvider,
+    kernels: &Kernels,
+    ty: DType,
+    inputs: &Buffer,
+    inputs_offset: usize,
+    topk_weights: &Buffer,
+    topk_weights_offset: usize,
+    out: &Buffer,
+    num_tokens: usize,
+    hidden: usize,
+    topk: usize,
+) -> Result<(), MetalKernelError> {
+    let type_string = match ty {
+        DType::F32 => "float",
+        DType::BF16 => "bfloat",
+        DType::F16 => "half",
+        other => {
+            return Err(MetalKernelError::DTypeMismatch {
+                expected: vec![DType::F32, DType::F16, DType::BF16],
+                got: other,
+            })
+        }
+    };
+    let name = format!("moe_weighted_reduce_flat_{type_string}");
+    let pipeline = kernels.load_pipeline(device, &name)?;
+
+    let encoder = ep.encoder();
+    let encoder: &ComputeCommandEncoderRef = encoder.as_ref();
+    encoder.set_compute_pipeline_state(&pipeline);
+    encoder.set_input_buffer(0, Some(inputs), inputs_offset);
+    encoder.set_input_buffer(1, Some(topk_weights), topk_weights_offset);
+    encoder.set_output_buffer(2, Some(out), 0);
+    <i32 as EncoderParam>::set_param(encoder, 3, num_tokens as i32);
+    <i32 as EncoderParam>::set_param(encoder, 4, hidden as i32);
+    <i32 as EncoderParam>::set_param(encoder, 5, topk as i32);
+
+    // 2D grid over (hidden, num_tokens). Each thread handles one output cell.
+    // Threadgroup chosen to keep h-dim wide for coalesced writes.
+    let tg_x: usize = 64;
+    let tg_y: usize = 4;
+    let group_dims = MTLSize {
+        width: tg_x,
+        height: tg_y,
+        depth: 1,
+    };
+    let grid_dims = MTLSize {
+        width: hidden.div_ceil(tg_x) * tg_x,
+        height: num_tokens.div_ceil(tg_y) * tg_y,
+        depth: 1,
+    };
+    encoder.dispatch_thread_groups(
+        MTLSize {
+            width: grid_dims.width / tg_x,
+            height: grid_dims.height / tg_y,
+            depth: 1,
+        },
+        group_dims,
+    );
+    Ok(())
+}
+
 #[allow(clippy::too_many_arguments)]
 pub fn call_mxfp4_matmul(
     device: &Device,

--- a/mistralrs-quant/src/metal_kernels/moe.metal
+++ b/mistralrs-quant/src/metal_kernels/moe.metal
@@ -1,0 +1,46 @@
+#include "utils.metal"
+#include <metal_stdlib>
+using namespace metal;
+
+// Fused topk-weighted reduce across MoE expert assignments.
+// Input rows are in (token, slot)-major order: row `t*topk + s` is token `t`'s
+// `s`-th expert contribution. Output row `t` is the topk-weighted sum across
+// slots. Accumulation happens in fp32 regardless of T to preserve precision.
+template <typename T>
+[[kernel]] void moe_weighted_reduce_flat(
+    const device T *inputs [[buffer(0)]],
+    const device float *topk_weights [[buffer(1)]],
+    device T *outputs [[buffer(2)]],
+    const constant int &num_tokens [[buffer(3)]],
+    const constant int &hidden [[buffer(4)]],
+    const constant int &topk [[buffer(5)]],
+    uint2 gid [[thread_position_in_grid]]) {
+  const int h = int(gid.x);
+  const int t = int(gid.y);
+  if (h >= hidden || t >= num_tokens) {
+    return;
+  }
+  const size_t assignment_base = size_t(t) * size_t(topk);
+  float acc = 0.0f;
+  for (int s = 0; s < topk; ++s) {
+    const size_t assignment = assignment_base + size_t(s);
+    acc += static_cast<float>(inputs[assignment * size_t(hidden) + size_t(h)]) *
+           topk_weights[assignment];
+  }
+  outputs[size_t(t) * size_t(hidden) + size_t(h)] = static_cast<T>(acc);
+}
+
+#define instantiate_moe_weighted_reduce(type)                                  \
+  template [[host_name("moe_weighted_reduce_flat_" #type)]] [[kernel]] void    \
+  moe_weighted_reduce_flat<type>(                                              \
+      const device type *inputs [[buffer(0)]],                                 \
+      const device float *topk_weights [[buffer(1)]],                          \
+      device type *outputs [[buffer(2)]],                                      \
+      const constant int &num_tokens [[buffer(3)]],                            \
+      const constant int &hidden [[buffer(4)]],                                \
+      const constant int &topk [[buffer(5)]],                                  \
+      uint2 gid [[thread_position_in_grid]]);
+
+instantiate_moe_weighted_reduce(float)
+instantiate_moe_weighted_reduce(bfloat)
+instantiate_moe_weighted_reduce(half)

--- a/mistralrs-quant/src/metal_kernels/quantized.metal
+++ b/mistralrs-quant/src/metal_kernels/quantized.metal
@@ -3770,7 +3770,15 @@ template <typename T, const int group_size, const int bits>
   instantiate_affine_gather_qmm_rhs_align(type, group_size, bits, 16, 32, 32,  \
                                           1, 2, true)                          \
       instantiate_affine_gather_qmm_rhs_align(type, group_size, bits, 32, 32,  \
-                                              32, 1, 2, true)
+                                              32, 1, 2, true)                  \
+          instantiate_affine_gather_qmm_rhs_align(type, group_size, bits, 16,  \
+                                                  64, 32, 1, 2, true)          \
+              instantiate_affine_gather_qmm_rhs_align(type, group_size, bits,  \
+                                                      32, 64, 32, 1, 2, true)  \
+                  instantiate_affine_gather_qmm_rhs_align(                     \
+                      type, group_size, bits, 16, 32, 64, 1, 2, true)          \
+                      instantiate_affine_gather_qmm_rhs_align(                 \
+                          type, group_size, bits, 32, 32, 64, 1, 2, true)
 
 #define instantiate_gather_gate_up_one(type, group_size, bits, act, bm, bn,    \
                                        bk, wm, wn, alM, alN, alK, alM_c,       \

--- a/mistralrs-quant/src/metal_kernels/quantized.metal
+++ b/mistralrs-quant/src/metal_kernels/quantized.metal
@@ -267,6 +267,28 @@ template <typename T> struct BaseMMAFrag<T, 8, 8> {
     }
   }
 
+  template <typename DstPtrType, typename StrX, typename StrY, typename StartX,
+            typename StopX, typename StartY, typename StopY, typename OffX,
+            typename OffY>
+  METAL_FUNC static constexpr void
+  store_slice(const thread frag_type &src, DstPtrType dst, StrX str_x,
+              StrY str_y, StartX start_x, StopX stop_x, StartY start_y,
+              StopY stop_y, OffX off_x = Int<0>{}, OffY off_y = Int<0>{}) {
+    using U = pointer_element_t<DstPtrType>;
+
+    STEEL_PRAGMA_UNROLL
+    for (short i = 0; i < kElemRows; i++) {
+      STEEL_PRAGMA_UNROLL
+      for (short j = 0; j < kElemCols; j++) {
+        if ((off_x + i) < stop_x && (off_x + i) >= start_x &&
+            (off_y + j) < stop_y && (off_y + j) >= start_y) {
+          dst[(off_x + i) * str_x + (off_y + j) * str_y.value] =
+              static_cast<U>(src[i * kElemCols + j]);
+        }
+      }
+    }
+  }
+
   METAL_FUNC static constexpr void mma(thread frag_type &D, thread frag_type &A,
                                        thread frag_type &B,
                                        thread frag_type &C) {
@@ -485,6 +507,20 @@ struct MMATile {
       }
     }
   }
+
+  template <typename U, int w_x, int w_y>
+  METAL_FUNC void store_slice(device U *dst, const int ld, const short2 start,
+                              const short2 stop) const {
+    STEEL_PRAGMA_UNROLL
+    for (int i = 0; i < kTileRows; ++i) {
+      STEEL_PRAGMA_UNROLL
+      for (int j = 0; j < kTileCols; ++j) {
+        MMAFrag_t::store_slice(frag_at(i, j), dst, ld, Int<1>{}, start.y,
+                               stop.y, start.x, stop.x,
+                               (i * kFragRows) * w_x, (j * kFragCols) * w_y);
+      }
+    }
+  }
 };
 
 template <typename T, typename U, int M, int N, int K>
@@ -625,6 +661,24 @@ struct BlockMMA {
       return;
 
     Ctile.template store_safe<U, WM, WN>(D, ldd, dst_tile_dims);
+  }
+
+  METAL_FUNC void store_result_slice(device U *D, const int ldd, short2 start,
+                                     short2 stop) {
+    STEEL_PRAGMA_UNROLL
+    for (short i = 0; i < decltype(Ctile)::kElemsPerTile; i++) {
+      Ctile.elems()[i] = Epilogue::apply(Ctile.elems()[i]);
+    }
+
+    D += sm * ldd + sn;
+    start -= short2(sn, sm);
+    stop -= short2(sn, sm);
+
+    if (stop.y <= 0 || stop.x <= 0) {
+      return;
+    }
+
+    Ctile.template store_slice<U, WM, WN>(D, ldd, start, stop);
   }
 
   /* Apply epilogue */
@@ -2980,6 +3034,371 @@ bs_qvm(const device uint32_t *w [[buffer(0)]],
                                 out_vec_size, tid, simd_gid, simd_lid);
 }
 
+// MLX-ported K-loop helpers for tiled GEMM. Shared by the gather_qmm_rhs kernel.
+template <typename T, typename mma_t, typename loader_a_t, typename loader_b_t>
+METAL_FUNC void gemm_loop_aligned(threadgroup T *As, threadgroup T *Bs,
+                                  thread mma_t &mma_op,
+                                  thread loader_a_t &loader_a,
+                                  thread loader_b_t &loader_b,
+                                  const int k_iterations) {
+  for (int k = 0; k < k_iterations; k++) {
+    threadgroup_barrier(mem_flags::mem_threadgroup);
+    loader_a.load_unsafe();
+    loader_b.load_unsafe();
+    threadgroup_barrier(mem_flags::mem_threadgroup);
+    mma_op.mma(As, Bs);
+    loader_a.next();
+    loader_b.next();
+  }
+}
+
+template <bool rows_aligned, bool cols_aligned, bool transpose, typename T,
+          typename mma_t, typename loader_a_t, typename loader_b_t>
+METAL_FUNC void
+gemm_loop_unaligned(threadgroup T *As, threadgroup T *Bs, thread mma_t &mma_op,
+                    thread loader_a_t &loader_a, thread loader_b_t &loader_b,
+                    const int k_iterations, const short tgp_bm,
+                    const short tgp_bn, const short tgp_bk) {
+  for (int k = 0; k < k_iterations; k++) {
+    threadgroup_barrier(mem_flags::mem_threadgroup);
+    if (rows_aligned) {
+      loader_a.load_unsafe();
+    } else {
+      loader_a.load_safe(short2(tgp_bk, tgp_bm));
+    }
+    if (cols_aligned) {
+      loader_b.load_unsafe();
+    } else {
+      loader_b.load_safe(transpose ? short2(tgp_bk, tgp_bn)
+                                   : short2(tgp_bn, tgp_bk));
+    }
+    threadgroup_barrier(mem_flags::mem_threadgroup);
+    mma_op.mma(As, Bs);
+    loader_a.next();
+    loader_b.next();
+  }
+}
+
+template <typename T, typename mma_t, typename loader_a_t, typename loader_b_t>
+METAL_FUNC void gemm_loop_finalize(threadgroup T *As, threadgroup T *Bs,
+                                   thread mma_t &mma_op,
+                                   thread loader_a_t &loader_a,
+                                   thread loader_b_t &loader_b,
+                                   const short2 tile_a, const short2 tile_b) {
+  loader_a.load_safe(tile_a);
+  loader_b.load_safe(tile_b);
+  threadgroup_barrier(mem_flags::mem_threadgroup);
+  mma_op.mma(As, Bs);
+}
+
+// Sorted-MoE tiled grouped GEMM: x rows are pre-sorted by expert id so that
+// each BM-row tile covers at most a handful of expert runs. For each run inside
+// the tile we materialize one BlockMMA against the run's expert weights and
+// store either the full result (run == BM) or a slice. transpose=true means
+// w is laid out as [N, K] (the AFQ matmul `transpose` flag, matching MLX).
+template <typename T, int group_size, int bits, int BM, int BN, int BK, int WM,
+          int WN, bool transpose, bool align_M, bool align_N, bool align_K>
+[[kernel]] void affine_gather_qmm_rhs(
+    const device T *x [[buffer(0)]],
+    const device uint32_t *w [[buffer(1)]],
+    const device T *scales [[buffer(2)]],
+    const device T *biases [[buffer(3)]],
+    const device uint32_t *indices [[buffer(4)]],
+    device T *y [[buffer(5)]], const constant int &M [[buffer(6)]],
+    const constant int &N [[buffer(7)]], const constant int &K [[buffer(8)]],
+    uint3 tid [[threadgroup_position_in_grid]],
+    uint simd_group_id [[simdgroup_index_in_threadgroup]],
+    uint simd_lane_id [[thread_index_in_simdgroup]]) {
+  constexpr int pack_factor = bits == 3    ? 8
+                              : bits == 6  ? 4
+                              : bits == 40 ? 2
+                                           : 8 / bits;
+  constexpr int bytes_per_pack = (bits == 3 || bits == 6) ? 3 : 1;
+  constexpr int BK_padded = (BK + 16 / sizeof(T));
+  constexpr int BN_padded = (BN + 16 / sizeof(T));
+
+  using mma_t =
+      mlx::steel::BlockMMA<T, T, BM, BN, BK, WM, WN, false, transpose,
+                           BK_padded, transpose ? BK_padded : BN_padded>;
+  using loader_x_t =
+      mlx::steel::BlockLoader<T, BM, BK, BK_padded, 1, WM * WN * SIMD_SIZE>;
+  using loader_w_t =
+      QuantizedBlockLoader<T, transpose ? BN : BK, transpose ? BK : BN,
+                           transpose ? BK_padded : BN_padded, transpose,
+                           WM * WN * SIMD_SIZE, group_size, bits>;
+
+  threadgroup T Xs[BM * BK_padded];
+  threadgroup T Ws[transpose ? BN * BK_padded : BK * BN_padded];
+
+  const int K_w = K * bytes_per_pack / pack_factor;
+  const int K_g = K / group_size;
+  const int N_w = N * bytes_per_pack / pack_factor;
+  const int N_g = N / group_size;
+  const int K_it = K / BK;
+  const size_t stride_w = transpose ? size_t(N) * K_w : size_t(K) * N_w;
+  const size_t stride_s = transpose ? size_t(N) * K_g : size_t(K) * N_g;
+  const int y_row = tid.y * BM;
+  const int y_col = tid.x * BN;
+  const size_t y_row_long = size_t(y_row);
+  const size_t y_col_long = size_t(y_col);
+
+  const short tgp_bm = align_M ? BM : short(min(BM, M - y_row));
+  const short tgp_bn = align_N ? BN : short(min(BN, N - y_col));
+
+  const int k_remain = K - K_it * BK;
+  const short2 tile_x = short2(k_remain, tgp_bm);
+  const short2 tile_w =
+      transpose ? short2(k_remain, tgp_bn) : short2(tgp_bn, k_remain);
+
+  auto wl = (const device uint8_t *)w;
+  x += y_row_long * K;
+  y += y_row_long * N + y_col_long;
+  wl += transpose ? y_col_long * K_w : y_col * bytes_per_pack / pack_factor;
+  scales += transpose ? y_col_long * K_g : y_col / group_size;
+  biases += transpose ? y_col_long * K_g : y_col / group_size;
+
+  uint32_t index;
+  short offset;
+  uint32_t index_next = indices[y_row];
+  short offset_next = 0;
+  int n = 0;
+  while (n < tgp_bm) {
+    n++;
+    offset = offset_next;
+    index = index_next;
+    offset_next = tgp_bm;
+    for (; n < tgp_bm; n++) {
+      if (indices[y_row + n] != index) {
+        offset_next = n;
+        index_next = indices[y_row + n];
+        break;
+      }
+    }
+    threadgroup_barrier(mem_flags::mem_none);
+
+    thread mma_t mma_op(simd_group_id, simd_lane_id);
+    thread loader_x_t loader_x(x, K, Xs, simd_group_id, simd_lane_id);
+    thread loader_w_t loader_w(
+        wl + index * stride_w, scales + index * stride_s,
+        biases + index * stride_s, transpose ? K : N, Ws, simd_group_id,
+        simd_lane_id);
+
+    if (align_M && align_N) {
+      gemm_loop_aligned(Xs, Ws, mma_op, loader_x, loader_w, K_it);
+      if (!align_K) {
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+        gemm_loop_finalize(Xs, Ws, mma_op, loader_x, loader_w, tile_x, tile_w);
+      }
+      if (offset_next - offset == BM) {
+        mma_op.store_result(y, N);
+      } else {
+        mma_op.store_result_slice(y, N, short2(0, offset),
+                                  short2(BN, offset_next));
+      }
+    } else {
+      if ((align_M || tgp_bm == BM) && (align_N || tgp_bn == BN)) {
+        gemm_loop_aligned(Xs, Ws, mma_op, loader_x, loader_w, K_it);
+        if (!align_K) {
+          threadgroup_barrier(mem_flags::mem_threadgroup);
+          gemm_loop_finalize(Xs, Ws, mma_op, loader_x, loader_w, tile_x,
+                             tile_w);
+        }
+        if (offset_next - offset == BM) {
+          mma_op.store_result(y, N);
+        } else {
+          mma_op.store_result_slice(y, N, short2(0, offset),
+                                    short2(BN, offset_next));
+        }
+      } else if (align_N || tgp_bn == BN) {
+        gemm_loop_unaligned<false, true, transpose>(
+            Xs, Ws, mma_op, loader_x, loader_w, K_it, tgp_bm, tgp_bn, BK);
+        if (!align_K) {
+          threadgroup_barrier(mem_flags::mem_threadgroup);
+          gemm_loop_finalize(Xs, Ws, mma_op, loader_x, loader_w, tile_x,
+                             tile_w);
+        }
+        mma_op.store_result_slice(y, N, short2(0, offset),
+                                  short2(BN, offset_next));
+      } else if (align_M || tgp_bm == BM) {
+        gemm_loop_unaligned<true, false, transpose>(
+            Xs, Ws, mma_op, loader_x, loader_w, K_it, tgp_bm, tgp_bn, BK);
+        if (!align_K) {
+          threadgroup_barrier(mem_flags::mem_threadgroup);
+          gemm_loop_finalize(Xs, Ws, mma_op, loader_x, loader_w, tile_x,
+                             tile_w);
+        }
+        mma_op.store_result_slice(y, N, short2(0, offset),
+                                  short2(tgp_bn, offset_next));
+      } else {
+        gemm_loop_unaligned<false, false, transpose>(
+            Xs, Ws, mma_op, loader_x, loader_w, K_it, tgp_bm, tgp_bn, BK);
+        if (!align_K) {
+          threadgroup_barrier(mem_flags::mem_threadgroup);
+          gemm_loop_finalize(Xs, Ws, mma_op, loader_x, loader_w, tile_x,
+                             tile_w);
+        }
+        mma_op.store_result_slice(y, N, short2(0, offset),
+                                  short2(tgp_bn, offset_next));
+      }
+    }
+  }
+}
+
+// Fused gate+up variant of `affine_gather_qmm_rhs`. Reads x once, runs two
+// MMAs per K-iter (gate and up sharing Xs in threadgroup mem, Ws reloaded
+// between the two), and writes a single tensor `y = activation(gate) * up`.
+// Saves one matmul launch + the intermediate gate buffer vs running gate and
+// up separately.
+template <typename T, int group_size, int bits, int ACT, int BM, int BN, int BK,
+          int WM, int WN, bool align_M, bool align_N, bool align_K>
+[[kernel]] void affine_gather_qmm_rhs_gate_up(
+    const device T *x [[buffer(0)]],
+    const device uint32_t *w_gate [[buffer(1)]],
+    const device T *scales_gate [[buffer(2)]],
+    const device T *biases_gate [[buffer(3)]],
+    const device uint32_t *w_up [[buffer(4)]],
+    const device T *scales_up [[buffer(5)]],
+    const device T *biases_up [[buffer(6)]],
+    const device uint32_t *indices [[buffer(7)]],
+    device T *y [[buffer(8)]], const constant int &M [[buffer(9)]],
+    const constant int &N [[buffer(10)]], const constant int &K [[buffer(11)]],
+    uint3 tid [[threadgroup_position_in_grid]],
+    uint simd_group_id [[simdgroup_index_in_threadgroup]],
+    uint simd_lane_id [[thread_index_in_simdgroup]]) {
+  constexpr int pack_factor = bits == 3    ? 8
+                              : bits == 6  ? 4
+                              : bits == 40 ? 2
+                                           : 8 / bits;
+  constexpr int bytes_per_pack = (bits == 3 || bits == 6) ? 3 : 1;
+  constexpr int BK_padded = (BK + 16 / sizeof(T));
+
+  using mma_t = mlx::steel::BlockMMA<T, T, BM, BN, BK, WM, WN, false, true,
+                                     BK_padded, BK_padded>;
+  using loader_x_t =
+      mlx::steel::BlockLoader<T, BM, BK, BK_padded, 1, WM * WN * SIMD_SIZE>;
+  using loader_w_t =
+      QuantizedBlockLoader<T, BN, BK, BK_padded, 1, WM * WN * SIMD_SIZE,
+                           group_size, bits>;
+
+  threadgroup T Xs[BM * BK_padded];
+  threadgroup T Ws[BN * BK_padded];
+
+  const int K_w = K * bytes_per_pack / pack_factor;
+  const int K_g = K / group_size;
+  const int K_it = K / BK;
+  const size_t stride_w = size_t(N) * K_w;
+  const size_t stride_s = size_t(N) * K_g;
+  const int y_row = tid.y * BM;
+  const int y_col = tid.x * BN;
+  const size_t y_row_long = size_t(y_row);
+  const size_t y_col_long = size_t(y_col);
+
+  const short tgp_bm = align_M ? BM : short(min(BM, M - y_row));
+  const short tgp_bn = align_N ? BN : short(min(BN, N - y_col));
+
+  const int k_remain = K - K_it * BK;
+  const short2 tile_x = short2(k_remain, tgp_bm);
+  const short2 tile_w = short2(k_remain, tgp_bn);
+
+  auto gwl = (const device uint8_t *)w_gate;
+  auto uwl = (const device uint8_t *)w_up;
+  x += y_row_long * K;
+  y += y_row_long * N + y_col_long;
+  gwl += y_col_long * K_w;
+  uwl += y_col_long * K_w;
+  scales_gate += y_col_long * K_g;
+  biases_gate += y_col_long * K_g;
+  scales_up += y_col_long * K_g;
+  biases_up += y_col_long * K_g;
+
+  uint32_t index;
+  short offset;
+  uint32_t index_next = indices[y_row];
+  short offset_next = 0;
+  int n = 0;
+  while (n < tgp_bm) {
+    n++;
+    offset = offset_next;
+    index = index_next;
+    offset_next = tgp_bm;
+    for (; n < tgp_bm; n++) {
+      if (indices[y_row + n] != index) {
+        offset_next = n;
+        index_next = indices[y_row + n];
+        break;
+      }
+    }
+    threadgroup_barrier(mem_flags::mem_none);
+
+    thread mma_t mma_gate(simd_group_id, simd_lane_id);
+    thread mma_t mma_up(simd_group_id, simd_lane_id);
+
+    thread loader_x_t loader_x(x, K, Xs, simd_group_id, simd_lane_id);
+    thread loader_w_t loader_g(
+        gwl + index * stride_w, scales_gate + index * stride_s,
+        biases_gate + index * stride_s, K, Ws, simd_group_id, simd_lane_id);
+    thread loader_w_t loader_u(
+        uwl + index * stride_w, scales_up + index * stride_s,
+        biases_up + index * stride_s, K, Ws, simd_group_id, simd_lane_id);
+
+    const bool m_full = align_M || tgp_bm == BM;
+    const bool n_full = align_N || tgp_bn == BN;
+    for (int k = 0; k < K_it; ++k) {
+      threadgroup_barrier(mem_flags::mem_threadgroup);
+      if (m_full) {
+        loader_x.load_unsafe();
+      } else {
+        loader_x.load_safe(short2(BK, tgp_bm));
+      }
+      if (n_full) {
+        loader_g.load_unsafe();
+      } else {
+        loader_g.load_safe(short2(BK, tgp_bn));
+      }
+      threadgroup_barrier(mem_flags::mem_threadgroup);
+      mma_gate.mma(Xs, Ws);
+
+      threadgroup_barrier(mem_flags::mem_threadgroup);
+      if (n_full) {
+        loader_u.load_unsafe();
+      } else {
+        loader_u.load_safe(short2(BK, tgp_bn));
+      }
+      threadgroup_barrier(mem_flags::mem_threadgroup);
+      mma_up.mma(Xs, Ws);
+
+      loader_x.next();
+      loader_g.next();
+      loader_u.next();
+    }
+    if (!align_K) {
+      threadgroup_barrier(mem_flags::mem_threadgroup);
+      loader_x.load_safe(tile_x);
+      loader_g.load_safe(tile_w);
+      threadgroup_barrier(mem_flags::mem_threadgroup);
+      mma_gate.mma(Xs, Ws);
+      threadgroup_barrier(mem_flags::mem_threadgroup);
+      loader_u.load_safe(tile_w);
+      threadgroup_barrier(mem_flags::mem_threadgroup);
+      mma_up.mma(Xs, Ws);
+    }
+
+    for (short i = 0; i < decltype(mma_gate.Ctile)::kElemsPerTile; ++i) {
+      float g = static_cast<float>(mma_gate.Ctile.elems()[i]);
+      float u = static_cast<float>(mma_up.Ctile.elems()[i]);
+      mma_gate.Ctile.elems()[i] =
+          static_cast<T>(fused_glu_activation<ACT>(g) * u);
+    }
+
+    if (offset_next - offset == BM && n_full) {
+      mma_gate.store_result(y, N);
+    } else {
+      mma_gate.store_result_slice(y, N, short2(0, offset),
+                                  short2(n_full ? BN : tgp_bn, offset_next));
+    }
+  }
+}
+
 template <typename T, const int group_size, const int bits,
           const bool aligned_N, const int BM = 32, const int BK = 32,
           const int BN = 32>
@@ -3310,6 +3729,96 @@ template <typename T, const int group_size, const int bits>
                          "_act_" #act "_alN_false",                            \
                          qmm_t_gate_up, type, group_size, bits, act, false)
 
+#define instantiate_affine_gather_qmm_rhs_one(                                 \
+    type, group_size, bits, bm, bn, bk, wm, wn, transpose, alM, alN, alK,      \
+    alM_c, alN_c, alK_c)                                                       \
+  instantiate_kernel("affine_gather_qmm_rhs_" #type "_gs_" #group_size         \
+                     "_b_" #bits "_bm_" #bm "_bn_" #bn "_bk_" #bk "_wm_" #wm   \
+                     "_wn_" #wn "_t_" #transpose "_alM_" #alM_c "_alN_" #alN_c \
+                     "_alK_" #alK_c,                                           \
+                     affine_gather_qmm_rhs, type, group_size, bits, bm, bn,    \
+                     bk, wm, wn, transpose, alM, alN, alK)
+
+#define instantiate_affine_gather_qmm_rhs_align(type, group_size, bits, bm,    \
+                                                bn, bk, wm, wn, transpose)     \
+  instantiate_affine_gather_qmm_rhs_one(type, group_size, bits, bm, bn, bk,    \
+                                        wm, wn, transpose, true, true, true,   \
+                                        t, t, t)                               \
+      instantiate_affine_gather_qmm_rhs_one(                                   \
+          type, group_size, bits, bm, bn, bk, wm, wn, transpose, true, true,   \
+          false, t, t, n)                                                      \
+          instantiate_affine_gather_qmm_rhs_one(                               \
+              type, group_size, bits, bm, bn, bk, wm, wn, transpose, true,     \
+              false, true, t, n, t)                                            \
+              instantiate_affine_gather_qmm_rhs_one(                           \
+                  type, group_size, bits, bm, bn, bk, wm, wn, transpose, true, \
+                  false, false, t, n, n)                                       \
+                  instantiate_affine_gather_qmm_rhs_one(                       \
+                      type, group_size, bits, bm, bn, bk, wm, wn, transpose,   \
+                      false, true, true, n, t, t)                              \
+                      instantiate_affine_gather_qmm_rhs_one(                   \
+                          type, group_size, bits, bm, bn, bk, wm, wn,          \
+                          transpose, false, true, false, n, t, n)              \
+                          instantiate_affine_gather_qmm_rhs_one(               \
+                              type, group_size, bits, bm, bn, bk, wm, wn,      \
+                              transpose, false, false, true, n, n, t)          \
+                              instantiate_affine_gather_qmm_rhs_one(           \
+                                  type, group_size, bits, bm, bn, bk, wm, wn,  \
+                                  transpose, false, false, false, n, n, n)
+
+#define instantiate_affine_gather_qmm_rhs(type, group_size, bits)              \
+  instantiate_affine_gather_qmm_rhs_align(type, group_size, bits, 16, 32, 32,  \
+                                          1, 2, true)                          \
+      instantiate_affine_gather_qmm_rhs_align(type, group_size, bits, 32, 32,  \
+                                              32, 1, 2, true)
+
+#define instantiate_gather_gate_up_one(type, group_size, bits, act, bm, bn,    \
+                                       bk, wm, wn, alM, alN, alK, alM_c,       \
+                                       alN_c, alK_c)                           \
+  instantiate_kernel("affine_gather_qmm_rhs_gate_up_" #type "_gs_" #group_size \
+                     "_b_" #bits "_act_" #act "_bm_" #bm "_bn_" #bn "_bk_" #bk \
+                     "_wm_" #wm "_wn_" #wn "_alM_" #alM_c "_alN_" #alN_c       \
+                     "_alK_" #alK_c,                                           \
+                     affine_gather_qmm_rhs_gate_up, type, group_size, bits,    \
+                     act, bm, bn, bk, wm, wn, alM, alN, alK)
+
+#define instantiate_gather_gate_up_align(type, group_size, bits, act, bm, bn,  \
+                                         bk, wm, wn)                           \
+  instantiate_gather_gate_up_one(type, group_size, bits, act, bm, bn, bk, wm,  \
+                                 wn, true, true, true, t, t, t)                \
+      instantiate_gather_gate_up_one(type, group_size, bits, act, bm, bn, bk,  \
+                                     wm, wn, false, true, true, n, t, t)       \
+          instantiate_gather_gate_up_one(type, group_size, bits, act, bm, bn,  \
+                                         bk, wm, wn, true, false, true, t, n,  \
+                                         t)                                    \
+              instantiate_gather_gate_up_one(type, group_size, bits, act, bm,  \
+                                             bn, bk, wm, wn, false, false,    \
+                                             true, n, n, t)                    \
+                  instantiate_gather_gate_up_one(type, group_size, bits, act,  \
+                                                 bm, bn, bk, wm, wn, true,    \
+                                                 true, false, t, t, n)         \
+                      instantiate_gather_gate_up_one(                          \
+                          type, group_size, bits, act, bm, bn, bk, wm, wn,     \
+                          false, true, false, n, t, n)                         \
+                          instantiate_gather_gate_up_one(                      \
+                              type, group_size, bits, act, bm, bn, bk, wm, wn, \
+                              true, false, false, t, n, n)                     \
+                              instantiate_gather_gate_up_one(                  \
+                                  type, group_size, bits, act, bm, bn, bk, wm, \
+                                  wn, false, false, false, n, n, n)
+
+#define instantiate_gather_gate_up_act(type, group_size, bits, act)            \
+  instantiate_gather_gate_up_align(type, group_size, bits, act, 16, 32, 32, 1, \
+                                   2)                                          \
+      instantiate_gather_gate_up_align(type, group_size, bits, act, 32, 32,    \
+                                       32, 1, 2)
+
+#define instantiate_gather_gate_up(type, group_size, bits)                     \
+  instantiate_gather_gate_up_act(type, group_size, bits, 0)                    \
+      instantiate_gather_gate_up_act(type, group_size, bits, 1)                \
+          instantiate_gather_gate_up_act(type, group_size, bits, 2)            \
+              instantiate_gather_gate_up_act(type, group_size, bits, 3)
+
 #define instantiate_qmm_t_qkv(type, group_size, bits)                          \
   instantiate_kernel("qmm_t_qkv_" #type "_gs_" #group_size "_b_" #bits,        \
                      qmm_t_qkv, type, group_size, bits)
@@ -3386,4 +3895,18 @@ template <typename T, const int group_size, const int bits>
           instantiate_quantized_groups(8) instantiate_quantized_types(         \
               32, 40) /* mxfp4 with block size 32 */
 
-instantiate_quantized_all() // clang-format on
+instantiate_quantized_all()
+
+// Targeted instantiations for affine_gather_qmm_rhs.
+// Keeps kernel count small: only the (dtype, bits, group_size) tuples used by
+// real MoE models. Add more as new MoE quants come online.
+#define instantiate_affine_gather_qmm_rhs_for_type(type)                       \
+  instantiate_affine_gather_qmm_rhs(type, 64, 8)                               \
+      instantiate_affine_gather_qmm_rhs(type, 64, 4)                           \
+          instantiate_gather_gate_up(type, 64, 8)                              \
+              instantiate_gather_gate_up(type, 64, 4)
+
+instantiate_affine_gather_qmm_rhs_for_type(bfloat16_t)
+instantiate_affine_gather_qmm_rhs_for_type(float16_t)
+instantiate_affine_gather_qmm_rhs_for_type(float)
+// clang-format on


### PR DESCRIPTION
- Add `affine_gather_qmm_rhs` (and its fused gate+up variant)
- Add `moe_weighted_reduce_flat`, a single-launch fused kernel that collapses `[num_tokens * top_k, hidden]` per-expert outputs into `[num_tokens, hidden]` via topk-weighted sum + dtype cast
- Guard the rotating sliding-window KV cache's `slice_set` against the no-op self-copy at the prefill/decode boundary
- Minor cleanups across `afq/ops.rs` and `moe/experts.rs` to wire the new paths in and avoid unnecessary intermediate allocations.

<img width="1308" height="812" alt="bench_decode" src="https://github.com/user-attachments/assets/aa96036c-5468-468d-996b-99e09a0710bf" />
<img width="1308" height="818" alt="bench_prefill" src="https://github.com/user-attachments/assets/c12377db-0fc6-452c-8904-14bd2f691b7c" />


### Gemma 4 26B-A4B prefill

| Prompt | mistral.rs | llama.cpp -fa | MLX |
|---:|---:|---:|---:|
|  128 |   575.7 T/s |   820.4 T/s |   82.4 T/s* |
|  512 |   903.0 T/s |  1251.0 T/s |  226.3 T/s* |
| 1024 |   931.1 T/s |  1216.7 T/s |  301.5 T/s* |
| 2048 |   880.6 T/s |  1187.7 T/s |  479.6 T/s* |
| 4096 |   819.7 T/s |  1094.1 T/s |  758.6 T/s* |

\* `mlx_lm.generate` wall-clock includes harness overhead.

### Gemma 4 26B-A4B decode

| Depth | mistral.rs | llama.cpp -fa | MLX |
|---:|---:|---:|---:|
|  128 |   43.3 T/s |   62.4 T/s |   58.0 T/s |
|  512 |   32.3 T/s |   63.7 T/s |   61.7 T/s |
| 1024 |   44.7 T/s |   61.5 T/s |   62.9 T/s |
| 2048 |   44.2 T/s |   61.4 T/s |   62.8 T/s |
| 4096 |   43.8 T/s |   59.8 T/s |   63.0 T/s |