### PR TITLE
feat: add Prometheus /metrics endpoint

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -141,7 +141,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -152,7 +152,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1733,7 +1733,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users 0.5.2",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1933,7 +1933,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1947,6 +1947,17 @@ name = "esaxx-rs"
 version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d817e038c30374a4bcb22f94d0a8a0e216958d4c3dcde369b1439fec4bdda6e6"
+
+[[package]]
+name = "evmap"
+version = "11.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b8874945f036109c72242964c1174cf99434e30cfa45bf45fedc983f50046f8"
+dependencies = [
+ "hashbag",
+ "left-right",
+ "smallvec 1.15.1",
+]
 
 [[package]]
 name = "exr"
@@ -2524,6 +2535,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "generator"
+version = "0.8.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52f04ae4152da20c76fe800fa48659201d5cf627c5149ca0b707b69d7eef6cf9"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "libc",
+ "log",
+ "rustversion",
+ "windows-link 0.2.1",
+ "windows-result 0.4.1",
+]
+
+[[package]]
 name = "generic-array"
 version = "0.14.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2636,6 +2662,12 @@ dependencies = [
  "rand_distr 0.5.1",
  "zerocopy",
 ]
+
+[[package]]
+name = "hashbag"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7040a10f52cba493ddb09926e15d10a9d8a28043708a405931fe4c6f19fac064"
 
 [[package]]
 name = "hashbrown"
@@ -2839,6 +2871,7 @@ dependencies = [
  "hyper",
  "hyper-util",
  "rustls",
+ "rustls-native-certs",
  "rustls-pki-types",
  "tokio",
  "tokio-rustls",
@@ -3292,6 +3325,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a79a3332a6609480d7d0c9eab957bca6b455b91bb84e66d19f5ff66294b85b8"
 
 [[package]]
+name = "left-right"
+version = "0.11.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f0c21e4c8ff95f487fb34e6f9182875f42c84cef966d29216bf115d9bba835a"
+dependencies = [
+ "crossbeam-utils",
+ "loom",
+ "slab",
+]
+
+[[package]]
 name = "libc"
 version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3417,6 +3461,19 @@ name = "log"
 version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+
+[[package]]
+name = "loom"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "419e0dc8046cb947daa77eb95ae174acfbddb7673b4151f56d1eed8e93fbfaca"
+dependencies = [
+ "cfg-if",
+ "generator",
+ "scoped-tls",
+ "tracing",
+ "tracing-subscriber",
+]
 
 [[package]]
 name = "loop9"
@@ -3572,6 +3629,56 @@ dependencies = [
  "log",
  "objc",
  "paste",
+]
+
+[[package]]
+name = "metrics"
+version = "0.24.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89550ee9f79e88fef3119de263694973a8adb26c21d75322164fb8c493039fe2"
+dependencies = [
+ "portable-atomic",
+ "rapidhash",
+]
+
+[[package]]
+name = "metrics-exporter-prometheus"
+version = "0.18.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1db0d8f1fc9e62caebd0319e11eaec5822b0186c171568f0480b46a0137f9108"
+dependencies = [
+ "base64 0.22.1",
+ "evmap",
+ "http-body-util",
+ "hyper",
+ "hyper-rustls",
+ "hyper-util",
+ "indexmap 2.13.0",
+ "ipnet",
+ "metrics",
+ "metrics-util",
+ "quanta",
+ "rustls",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "metrics-util"
+version = "0.20.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96f8722f8562635f92f8ed992f26df0532266eb03d5202607c20c0d7e9745e13"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+ "hashbrown 0.16.1",
+ "metrics",
+ "quanta",
+ "rand 0.9.4",
+ "rand_xoshiro",
+ "rapidhash",
+ "sketches-ddsketch",
 ]
 
 [[package]]
@@ -4026,6 +4133,8 @@ dependencies = [
  "indexmap 2.13.0",
  "intel-mkl-src",
  "itertools 0.14.0",
+ "metrics",
+ "metrics-exporter-prometheus",
  "mistralrs-core",
  "reqwest 0.13.1",
  "serde",
@@ -4211,7 +4320,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4995,6 +5104,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "quanta"
+version = "0.12.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3ab5a9d756f0d97bdc89019bd2e4ea098cf9cde50ee7564dde6b81ccc8f06c7"
+dependencies = [
+ "crossbeam-utils",
+ "libc",
+ "once_cell",
+ "raw-cpuid",
+ "wasi",
+ "web-sys",
+ "winapi",
+]
+
+[[package]]
 name = "quick-error"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5167,6 +5291,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3382fc9f0aad4f2e2a56b53d9133c8c810b4dbf21e7e370e24346161a5b2c7bd"
 dependencies = [
  "rand_core 0.9.5",
+]
+
+[[package]]
+name = "rand_xoshiro"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f703f4665700daf5512dcca5f43afa6af89f09db47fb56be587f80636bda2d41"
+dependencies = [
+ "rand_core 0.9.5",
+]
+
+[[package]]
+name = "rapidhash"
+version = "4.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5e48930979c155e2f33aa36ab3119b5ee81332beb6482199a8ecd6029b80b59"
+dependencies = [
+ "rustversion",
 ]
 
 [[package]]
@@ -5733,7 +5875,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5881,6 +6023,12 @@ dependencies = [
  "serde_derive_internals",
  "syn 2.0.114",
 ]
+
+[[package]]
+name = "scoped-tls"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1cf6437eb19a8f4a6cc0f7dca544973b0b78843adbfeb3683d1a94a0024a294"
 
 [[package]]
 name = "scopeguard"
@@ -6241,6 +6389,12 @@ name = "siphasher"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56199f7ddabf13fe5074ce809e7d3f42b42ae711800501b5b16ea82ad029c39d"
+
+[[package]]
+name = "sketches-ddsketch"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c6f73aeb92d671e0cc4dca167e59b2deb6387c375391bc99ee743f326994a2b"
 
 [[package]]
 name = "slab"
@@ -7818,7 +7972,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,6 +57,8 @@ accelerate-src = { version = "0.3.2" }
 intel-mkl-src = { version = "0.8.1", features = ["mkl-static-lp64-iomp"] }
 tracing = "0.1.44"
 tracing-subscriber = { version = "0.3.22", features = ["env-filter"] }
+metrics = "0.24.6"
+metrics-exporter-prometheus = "0.18.3"
 futures = "0.3"
 clap = { version = "4.5.54", features = ["derive", "wrap_help"] }
 pyo3 = { version = "0.25.1", features = ["full", "extension-module", "either", "abi3-py310"] }

--- a/README.md
+++ b/README.md
@@ -90,6 +90,7 @@ Mean tokens per second across prompt lengths and decode depths from 128 to 16384
 - **True multimodality**: Text, vision, video, and audio, speech generation, image generation, and embeddings in one engine.
 - **Smart quantization**: `--quant` automatically selects the best quantization format at that level: using a prebuilt UQFF if one is published, otherwise applying ISQ. [Docs](https://ericlbuehler.github.io/mistral.rs/tutorials/06-quantize-a-model/)
 - **OpenAI + Anthropic compatible serving**: The same `mistralrs serve` process exposes OpenAI-compatible `/v1` endpoints and Anthropic-compatible Messages endpoints.
+- **Prometheus metrics**: `mistralrs serve` exposes a `/metrics` endpoint in Prometheus format, recording per-request counts and latency labeled by method, route, and status. [Docs](https://ericlbuehler.github.io/mistral.rs/reference/http-api/)
 - **Built-in web UI**: Served at `/ui` by default. Shows reasoning, code execution, plots, and files inline. Edit any message and the new branch runs with its own Python state. Pass `--no-ui` to disable.
 - **Hardware-aware**: `mistralrs tune` benchmarks your system and picks optimal quantization + device mapping.
 - **Flexible SDKs**: Python package and Rust crate to build your projects.

--- a/docs/src/content/docs/reference/http-api.md
+++ b/docs/src/content/docs/reference/http-api.md
@@ -281,6 +281,14 @@ Delete a session. Always returns 200 whether the session existed or not.
 
 Returns 200 when the server is up. Does not verify model load status.
 
+### `GET /metrics`
+
+Exposes server metrics in the Prometheus text exposition format for scraping. Two metrics are recorded per request: `http_requests_total` (counter) and `http_request_duration_seconds` (histogram), each labeled by `method`, `path`, and `status`. The `path` label uses the matched route pattern (e.g. `/v1/responses/{id}`) rather than the concrete URI, so per-request identifiers do not inflate label cardinality; requests that match no route are labeled `<unmatched>`. Returns 503 until the recorder is initialized at startup.
+
+```bash
+curl http://localhost:1234/metrics
+```
+
 ### `GET /v1/system/info`
 
 Returns system information (OS, memory, GPUs, mistralrs version).

--- a/mistralrs-server-core/Cargo.toml
+++ b/mistralrs-server-core/Cargo.toml
@@ -32,6 +32,8 @@ serde_json.workspace = true
 tokio.workspace = true
 tower-http = { workspace = true, features = ["cors"] }
 tracing.workspace = true
+metrics.workspace = true
+metrics-exporter-prometheus.workspace = true
 url.workspace = true
 utoipa = { workspace = true, features = ["axum_extras"] }
 utoipa-swagger-ui = { workspace = true, features = ["axum"], optional = true }

--- a/mistralrs-server-core/src/lib.rs
+++ b/mistralrs-server-core/src/lib.rs
@@ -231,6 +231,7 @@ pub mod files;
 pub mod handler_core;
 mod handlers;
 pub mod image_generation;
+pub mod metrics;
 pub mod mistralrs_for_server_builder;
 pub mod mistralrs_server_router_builder;
 pub mod openai;

--- a/mistralrs-server-core/src/metrics.rs
+++ b/mistralrs-server-core/src/metrics.rs
@@ -1,0 +1,44 @@
+//! Prometheus metrics support for the mistral.rs server.
+//! Installs a process-wide Prometheus recorder and exposes a `/metrics`
+//! endpoint rendering metrics in the Prometheus text exposition format.
+use axum::{extract::Request, middleware::Next, response::Response};
+use axum::{http::StatusCode, response::IntoResponse};
+use metrics_exporter_prometheus::{PrometheusBuilder, PrometheusHandle};
+use std::sync::OnceLock;
+use std::time::Instant;
+static PROMETHEUS_HANDLE: OnceLock<PrometheusHandle> = OnceLock::new();
+/// Install the global Prometheus recorder. Safe to call once at startup.
+pub fn install_prometheus_recorder() {
+    if PROMETHEUS_HANDLE.get().is_some() {
+        return;
+    }
+    let handle = PrometheusBuilder::new()
+        .install_recorder()
+        .expect("failed to install Prometheus recorder");
+    let _ = PROMETHEUS_HANDLE.set(handle);
+}
+/// Axum handler for `GET /metrics`. Renders the Prometheus exposition format.
+pub async fn metrics() -> impl IntoResponse {
+    match PROMETHEUS_HANDLE.get() {
+        Some(handle) => (StatusCode::OK, handle.render()).into_response(),
+        None => (
+            StatusCode::SERVICE_UNAVAILABLE,
+            "metrics recorder not initialized",
+        )
+            .into_response(),
+    }
+}
+/// Axum middleware that records per-request metrics: a request counter and a
+/// latency histogram, both labeled by method, path, and response status.
+pub async fn track_metrics(req: Request, next: Next) -> Response {
+    let method = req.method().to_string();
+    let path = req.uri().path().to_string();
+    let start = Instant::now();
+    let response = next.run(req).await;
+    let latency = start.elapsed().as_secs_f64();
+    let status = response.status().as_u16().to_string();
+    let labels = [("method", method), ("path", path), ("status", status)];
+    metrics::counter!("http_requests_total", &labels).increment(1);
+    metrics::histogram!("http_request_duration_seconds", &labels).record(latency);
+    response
+}

--- a/mistralrs-server-core/src/metrics.rs
+++ b/mistralrs-server-core/src/metrics.rs
@@ -1,7 +1,11 @@
 //! Prometheus metrics support for the mistral.rs server.
 //! Installs a process-wide Prometheus recorder and exposes a `/metrics`
 //! endpoint rendering metrics in the Prometheus text exposition format.
-use axum::{extract::Request, middleware::Next, response::Response};
+use axum::{
+    extract::{MatchedPath, Request},
+    middleware::Next,
+    response::Response,
+};
 use axum::{http::StatusCode, response::IntoResponse};
 use metrics_exporter_prometheus::{PrometheusBuilder, PrometheusHandle};
 use std::sync::OnceLock;
@@ -32,7 +36,14 @@ pub async fn metrics() -> impl IntoResponse {
 /// latency histogram, both labeled by method, path, and response status.
 pub async fn track_metrics(req: Request, next: Next) -> Response {
     let method = req.method().to_string();
-    let path = req.uri().path().to_string();
+    // Use the matched route pattern (e.g. "/v1/files/{id}") rather than the
+    // raw URI path so that high-cardinality segments (ids, session keys) and
+    // arbitrary 404 paths do not each create a separate Prometheus time series.
+    let path = req
+        .extensions()
+        .get::<MatchedPath>()
+        .map(|m| m.as_str().to_string())
+        .unwrap_or_else(|| "<unmatched>".to_string());
     let start = Instant::now();
     let response = next.run(req).await;
     let latency = start.elapsed().as_secs_f64();

--- a/mistralrs-server-core/src/mistralrs_server_router_builder.rs
+++ b/mistralrs-server-core/src/mistralrs_server_router_builder.rs
@@ -4,6 +4,7 @@ use anyhow::Result;
 use axum::{
     extract::DefaultBodyLimit,
     http::{self, header::HeaderName, Method},
+    middleware,
     routing::{get, post},
     Extension, Router,
 };
@@ -25,6 +26,7 @@ use crate::{
         reload_model, system_doctor, system_info, tune_model, unload_model,
     },
     image_generation::image_generation,
+    metrics::{metrics, track_metrics},
     responses::{cancel_response, create_response, delete_response, get_response},
     route_registry::{
         AGENT_APPROVAL_ROUTE, ANTHROPIC_COUNT_TOKENS_ROUTE, ANTHROPIC_MESSAGES_ROUTE,
@@ -232,6 +234,7 @@ impl MistralRsServerRouterBuilder {
     ///     .await?;
     /// ```
     pub async fn build(self) -> Result<Router> {
+        crate::metrics::install_prometheus_recorder();
         let mistralrs = self.mistralrs.ok_or_else(|| {
             anyhow::anyhow!("`mistralrs` instance must be set. Use `with_mistralrs`.")
         })?;
@@ -309,6 +312,7 @@ fn init_router(
         .route(SYSTEM_INFO_ROUTE.path, get(system_info))
         .route(SYSTEM_DOCTOR_ROUTE.path, post(system_doctor))
         .route(HEALTH_ROUTE.path, get(health))
+        .route("/metrics", get(metrics))
         .route(ROOT_ROUTE.path, get(health))
         .route(RE_ISQ_ROUTE.path, post(re_isq))
         .route(IMAGE_GENERATION_ROUTE.path, post(image_generation))
@@ -327,6 +331,7 @@ fn init_router(
             SESSION_ROUTE.path,
             get(get_session).put(put_session).delete(delete_session),
         )
+        .layer(middleware::from_fn(track_metrics))
         .layer(cors_layer)
         .layer(DefaultBodyLimit::max(router_max_body_limit))
         .layer(Extension(agentic_defaults.approval_broker.clone()))


### PR DESCRIPTION
Opening this as discussed in #831. I posted there a couple of days ago to
check the approach before opening a PR; opening it now so there's something
concrete to review, and I'm happy to adjust based on your preferences.

## What this adds
- a `GET /metrics` endpoint exposing the Prometheus text exposition format
- a process-wide Prometheus recorder installed at router build time
- an axum middleware recording `http_requests_total` (counter) and
  `http_request_duration_seconds` (latency), labeled by method, path, status

Footprint is small: one new module (`metrics.rs`) plus a few lines wiring the
route, recorder, and layer into the server router builder. Rebased on current
master.

## Notes / open questions (from #831)
- **Library**: uses `metrics` + `metrics-exporter-prometheus`, the lightest
  companion given the crate already depends on `tracing`. If you'd rather
  align on the `opentelemetry-rust` stack referenced in #830, I can rework it.
- **Histogram vs summary**: the exporter renders latency as a summary with
  quantiles by default; bucketed histograms aggregate better across instances.
  Happy to switch if you prefer.
- **Inference-level metrics** (tokens, in-flight requests, queue depth) would
  be a natural follow-up, kept out of this PR to keep it focused.

Builds clean, `clippy -D warnings` and existing tests pass, and I verified the
`/metrics` endpoint live against a running server.