### PR TITLE
Fix Qwen3.6 (qwen3_5 / qwen3_5_moe) on Metal: RMSNorm, AFQ, lm_head, hybrid KV cache

### DIFF
--- a/mistralrs-core/src/gdn/layer.rs
+++ b/mistralrs-core/src/gdn/layer.rs
@@ -10,10 +10,10 @@ use super::cache::GdnLayerCache;
 use super::config::{GdnConfig, GdnDims};
 use super::norm::RmsNormGated;
 use super::projection::GdnProjection;
-use super::weights::{GdnWeightLoadCtx, GdnWeightMode, GdnWeights};
+use super::weights::{GdnInProj, GdnWeightLoadCtx, GdnWeightMode, GdnWeights};
 
 pub struct GatedDeltaNet {
-    pub in_proj: Arc<dyn QuantMethod>,
+    pub in_proj: GdnInProj,
     pub conv1d_weight: Tensor,
     pub dt_bias: Tensor,
     pub a_log: Tensor,
@@ -91,22 +91,14 @@ impl GatedDeltaNet {
     }
 
     fn project(&self, x: &Tensor, batch_size: usize, seq_len: usize) -> Result<GdnProjection> {
-        let mixed = self.in_proj.forward(x)?;
+        let mixed = self.in_proj.forward(x, &self.dims)?;
         GdnProjection::from_packed(mixed, &self.dims, batch_size, seq_len)
     }
 
     pub fn residual_input_projection_tensors(&self) -> (Tensor, Tensor) {
-        let weight = self
-            .in_proj
-            .dequantize_w()
-            .expect("failed to dequantize GDN input projection");
-        let qkvz = weight
-            .narrow(0, 0, self.dims.qkvz_out_dim())
-            .expect("failed to split GDN qkvz projection");
-        let ba = weight
-            .narrow(0, self.dims.qkvz_out_dim(), self.dims.ba_out_dim())
-            .expect("failed to split GDN ba projection");
-        (qkvz, ba)
+        self.in_proj
+            .dequantize_concat(&self.dims)
+            .expect("failed to dequantize GDN input projection")
     }
 
     fn finish_forward(

--- a/mistralrs-core/src/gdn/mod.rs
+++ b/mistralrs-core/src/gdn/mod.rs
@@ -11,6 +11,6 @@ mod projection;
 mod weights;
 
 pub use cache::GdnLayerCache;
-pub use config::GdnConfig;
+pub use config::{GdnConfig, GdnDims};
 pub use layer::GatedDeltaNet;
 pub use weights::GdnWeightMode;

--- a/mistralrs-core/src/gdn/weights.rs
+++ b/mistralrs-core/src/gdn/weights.rs
@@ -1,6 +1,9 @@
 use candle_core::{Device, Result, Tensor};
 use candle_nn::Linear;
-use mistralrs_quant::{Comm, QuantMethod, ReplicatedLayer, RowParallelLayer, ShardedVarBuilder};
+use mistralrs_quant::{
+    AfqLayer, Comm, QuantMethod, QuantizedConfig, ReplicatedLayer, RowParallelLayer,
+    ShardedVarBuilder,
+};
 use std::sync::Arc;
 
 use crate::device_map::DeviceMapper;
@@ -13,13 +16,157 @@ pub enum GdnWeightMode {
     MergedWithFallback,
 }
 
+// MLX-AFQ checkpoints (e.g. mlx-community/Qwen3.6-*-4bit) ship the four
+// in_proj_{qkv,z,b,a} weights as separate AFQ-packed tensors with their own
+// scales+biases. We can't dequantise-and-concat at load time (the activated
+// memory cost would be huge), so we keep them split and combine on the
+// activation side in `forward`.
+pub enum GdnInProj {
+    Merged(Arc<dyn QuantMethod>),
+    SplitAfq {
+        qkv: Arc<dyn QuantMethod>,
+        z: Arc<dyn QuantMethod>,
+        b: Arc<dyn QuantMethod>,
+        a: Arc<dyn QuantMethod>,
+    },
+}
+
 pub struct GdnWeights {
-    pub in_proj: Arc<dyn QuantMethod>,
+    pub in_proj: GdnInProj,
     pub conv1d_weight: Tensor,
     pub dt_bias: Tensor,
     pub a_log: Tensor,
     pub norm: RmsNormGated,
     pub out_proj: Arc<dyn QuantMethod>,
+}
+
+fn is_afq(cfg: &Option<QuantizedConfig>) -> bool {
+    matches!(cfg, Some(QuantizedConfig::Afq { .. }))
+}
+
+impl GdnInProj {
+    // Activation-side projection. Merged path delegates to the single combined
+    // matmul. SplitAfq runs four separate AFQ matmuls and re-creates the same
+    // per-head interleaved layout that the merged-weight path would have
+    // produced, so `GdnProjection::from_packed` downstream can unpack it
+    // unchanged.
+    pub fn forward(
+        &self,
+        x: &candle_core::Tensor,
+        dims: &GdnDims,
+    ) -> candle_core::Result<candle_core::Tensor> {
+        use candle_core::D;
+        match self {
+            GdnInProj::Merged(inner) => inner.forward(x),
+            GdnInProj::SplitAfq { qkv, z, b, a } => {
+                // MLX-style activation path: each AfqLayer matmul produces
+                // a flat per-type output, then we split / per-head reshape /
+                // concat on the activation side. Mathematically matches the
+                // Python `mlx_lm/models/qwen3_5.py` GatedDeltaNet code:
+                //
+                //   qkv = self.in_proj_qkv(x)         # (B, S, key_dim*2 + value_dim) flat
+                //   z   = self.in_proj_z(x)           # (B, S, value_dim) flat
+                //   ...
+                //   q, k, v = split(qkv, [key_dim, 2*key_dim])
+                //            each then reshape(B, S, num_*_heads, *_head_dim)
+                //
+                // After concat-along-last we re-flatten to the per-head
+                // interleaved layout `GdnProjection::from_packed` expects.
+                let qkv_out = qkv.forward(x)?; // (..., key_dim*2 + value_dim)
+                let z_out = z.forward(x)?; // (..., value_dim)
+                let b_out = b.forward(x)?; // (..., num_v_heads)
+                let a_out = a.forward(x)?; // (..., num_v_heads)
+
+                let last = qkv_out.dims().len() - 1;
+                let q_flat = qkv_out.narrow(last, 0, dims.key_dim)?;
+                let k_flat = qkv_out.narrow(last, dims.key_dim, dims.key_dim)?;
+                let v_flat = qkv_out.narrow(last, 2 * dims.key_dim, dims.value_dim)?;
+
+                let lead: Vec<usize> = x.dims().iter().take(x.dims().len() - 1).copied().collect();
+                let q_shape: Vec<usize> = lead
+                    .iter()
+                    .copied()
+                    .chain([dims.num_k_heads, dims.head_k_dim])
+                    .collect();
+                let v_shape: Vec<usize> = lead
+                    .iter()
+                    .copied()
+                    .chain([dims.num_k_heads, dims.v_per_group * dims.head_v_dim])
+                    .collect();
+                let ba_shape: Vec<usize> = lead
+                    .iter()
+                    .copied()
+                    .chain([dims.num_k_heads, dims.v_per_group])
+                    .collect();
+
+                let q_g = q_flat.reshape(q_shape.as_slice())?;
+                let k_g = k_flat.reshape(q_shape.as_slice())?;
+                let v_g = v_flat.reshape(v_shape.as_slice())?;
+                let z_g = z_out.reshape(v_shape.as_slice())?;
+                let b_g = b_out.reshape(ba_shape.as_slice())?;
+                let a_g = a_out.reshape(ba_shape.as_slice())?;
+
+                let qkvz = candle_core::Tensor::cat(&[q_g, k_g, v_g, z_g], D::Minus1)?;
+                let ba = candle_core::Tensor::cat(&[b_g, a_g], D::Minus1)?;
+
+                let qkvz_flat_shape: Vec<usize> =
+                    lead.iter().copied().chain([dims.qkvz_out_dim()]).collect();
+                let ba_flat_shape: Vec<usize> =
+                    lead.iter().copied().chain([dims.ba_out_dim()]).collect();
+                let qkvz = qkvz.contiguous()?.reshape(qkvz_flat_shape)?;
+                let ba = ba.contiguous()?.reshape(ba_flat_shape)?;
+                candle_core::Tensor::cat(&[qkvz, ba], D::Minus1)
+            }
+        }
+    }
+
+    // Dequantised weights for the rare callers that need them
+    // (currently `GatedDeltaNet::residual_input_projection_tensors`). For the
+    // SplitAfq path this is best-effort: callers should usually use `forward`.
+    pub fn dequantize_concat(
+        &self,
+        dims: &GdnDims,
+    ) -> candle_core::Result<(candle_core::Tensor, candle_core::Tensor)> {
+        match self {
+            GdnInProj::Merged(inner) => {
+                let w = inner.dequantize_w()?;
+                let qkvz = w.narrow(0, 0, dims.qkvz_out_dim())?;
+                let ba = w.narrow(0, dims.qkvz_out_dim(), dims.ba_out_dim())?;
+                Ok((qkvz, ba))
+            }
+            GdnInProj::SplitAfq { qkv, z, b, a } => {
+                // Mirror exactly what load_split_qkvz does: split the flat
+                // [q | k | v] qkv weight into q, k, v slices first, THEN
+                // per-head reshape each piece. Same for b/a.
+                let qkv_w = qkv.dequantize_w()?; // (key_dim*2 + value_dim, hidden_size)
+                let z_w = z.dequantize_w()?; // (value_dim, hidden_size)
+                let b_w = b.dequantize_w()?; // (num_v_heads, hidden_size)
+                let a_w = a.dequantize_w()?; // (num_v_heads, hidden_size)
+                let q_w = qkv_w.narrow(0, 0, dims.key_dim)?;
+                let k_w = qkv_w.narrow(0, dims.key_dim, dims.key_dim)?;
+                let v_w = qkv_w.narrow(0, dims.key_dim * 2, dims.value_dim)?;
+                let q_g = q_w.reshape((dims.num_k_heads, dims.head_k_dim, dims.hidden_size))?;
+                let k_g = k_w.reshape((dims.num_k_heads, dims.head_k_dim, dims.hidden_size))?;
+                let v_g = v_w.reshape((
+                    dims.num_k_heads,
+                    dims.v_per_group * dims.head_v_dim,
+                    dims.hidden_size,
+                ))?;
+                let z_g = z_w.reshape((
+                    dims.num_k_heads,
+                    dims.v_per_group * dims.head_v_dim,
+                    dims.hidden_size,
+                ))?;
+                let b_g = b_w.reshape((dims.num_k_heads, dims.v_per_group, dims.hidden_size))?;
+                let a_g = a_w.reshape((dims.num_k_heads, dims.v_per_group, dims.hidden_size))?;
+                let qkvz = candle_core::Tensor::cat(&[q_g, k_g, v_g, z_g], 1)?
+                    .reshape((dims.qkvz_out_dim(), dims.hidden_size))?;
+                let ba = candle_core::Tensor::cat(&[b_g, a_g], 1)?
+                    .reshape((dims.ba_out_dim(), dims.hidden_size))?;
+                Ok((qkvz, ba))
+            }
+        }
+    }
 }
 
 pub struct GdnWeightLoadCtx<'a> {
@@ -50,21 +197,69 @@ impl GdnWeights {
         };
         let vb_la = mapper.set_device(layer_idx, vb.pp("linear_attn"), loading_isq);
 
-        let qkvz_w = move_to_target(
-            load_qkvz(&vb_la, dims, &weight_mode)?,
-            isq_target_device.as_ref(),
-        )?;
-        let ba_w = move_to_target(
-            load_ba(&vb_la, dims, &weight_mode)?,
-            isq_target_device.as_ref(),
-        )?;
-        let in_proj_w = Tensor::cat(&[qkvz_w, ba_w], 0)?;
-        let in_proj =
-            ReplicatedLayer::from_linear(Linear::new(in_proj_w, None), vb_la.pp("in_proj"))?;
-        let conv1d_weight = move_to_target(
-            vb_la.get((dims.conv_dim, 1, dims.conv_kernel_size), "conv1d.weight")?,
-            isq_target_device.as_ref(),
-        )?;
+        let qc = cfg.quantization_config();
+        let in_proj = if is_afq(qc) {
+            // MLX AFQ split layout: four separate AfqLayer's. Activation-side
+            // combine happens in GdnInProj::forward.
+            let qkv = AfqLayer::afq_linear_b(
+                dims.hidden_size,
+                dims.key_dim * 2 + dims.value_dim,
+                qc.as_ref().unwrap(),
+                false,
+                vb_la.pp("in_proj_qkv"),
+            )?;
+            let z = AfqLayer::afq_linear_b(
+                dims.hidden_size,
+                dims.value_dim,
+                qc.as_ref().unwrap(),
+                false,
+                vb_la.pp("in_proj_z"),
+            )?;
+            let b = AfqLayer::afq_linear_b(
+                dims.hidden_size,
+                dims.num_v_heads,
+                qc.as_ref().unwrap(),
+                false,
+                vb_la.pp("in_proj_b"),
+            )?;
+            let a = AfqLayer::afq_linear_b(
+                dims.hidden_size,
+                dims.num_v_heads,
+                qc.as_ref().unwrap(),
+                false,
+                vb_la.pp("in_proj_a"),
+            )?;
+            GdnInProj::SplitAfq { qkv, z, b, a }
+        } else {
+            let qkvz_w = move_to_target(
+                load_qkvz(&vb_la, dims, &weight_mode)?,
+                isq_target_device.as_ref(),
+            )?;
+            let ba_w = move_to_target(
+                load_ba(&vb_la, dims, &weight_mode)?,
+                isq_target_device.as_ref(),
+            )?;
+            let in_proj_w = Tensor::cat(&[qkvz_w, ba_w], 0)?;
+            GdnInProj::Merged(ReplicatedLayer::from_linear(
+                Linear::new(in_proj_w, None),
+                vb_la.pp("in_proj"),
+            )?)
+        };
+        // MLX-AFQ ships conv1d.weight transposed: (out, kernel, in=1) instead
+        // of candle's (out, in=1, kernel). Try the native layout first; fall
+        // back to a permuted load for MLX checkpoints.
+        let conv1d_weight = match vb_la
+            .get((dims.conv_dim, 1, dims.conv_kernel_size), "conv1d.weight")
+        {
+            Ok(t) => move_to_target(t, isq_target_device.as_ref())?,
+            Err(_) => {
+                let raw = vb_la.get((dims.conv_dim, dims.conv_kernel_size, 1), "conv1d.weight")?;
+                move_to_target(
+                    raw.permute((0, 2, 1))?.contiguous()?,
+                    isq_target_device.as_ref(),
+                )?
+            }
+        };
         let dt_bias = move_to_target(
             vb_la.get(dims.num_v_heads, "dt_bias")?,
             isq_target_device.as_ref(),

--- a/mistralrs-core/src/layers.rs
+++ b/mistralrs-core/src/layers.rs
@@ -428,6 +428,18 @@ impl GemmaRmsNorm {
         })
     }
 
+    // RMSNorm using the on-disk weight verbatim (no Gemma `+1` shift). mlx_lm
+    // pre-shifts norm weights only for unsanitized checkpoints; sanitized MLX
+    // exports ship raw weights, so `+1` here would over-scale every norm.
+    pub fn new_unshifted(size: usize, eps: f64, vb: ShardedVarBuilder) -> Result<Self> {
+        let original_weight = vb.get(size, "weight")?;
+        Ok(Self {
+            eps,
+            weight: original_weight.clone(),
+            original_weight,
+        })
+    }
+
     pub fn weight(&self) -> &Tensor {
         &self.weight
     }

--- a/mistralrs-core/src/paged_attention/config.rs
+++ b/mistralrs-core/src/paged_attention/config.rs
@@ -132,6 +132,12 @@ fn select_kv_cache_layout_for_layer<M: ModelConfigLike + ?Sized>(
 pub trait ModelConfigLike {
     fn max_seq_len(&self) -> usize;
     fn num_layers(&self) -> usize;
+    // Layers that actually hold a context-sized KV cache. Defaults to all
+    // layers; hybrid models (e.g. Qwen3.6) override it so the 48 linear-attention
+    // layers don't get an unused KV cache allocated (a 4x waste at 64 vs 16).
+    fn num_kv_cache_layers(&self) -> usize {
+        self.num_layers()
+    }
     fn hidden_size(&self) -> usize;
     fn num_kv_heads(&self) -> usize;
     fn num_attn_heads(&self) -> usize;
@@ -266,6 +272,79 @@ impl ModelConfigLike for ModelConfigMetadata {
                 kpe_head_dim,
             } => kv_lora_rank + kpe_head_dim,
         }
+    }
+}
+
+/// Wraps a [`ModelConfigMetadata`] for hybrid models (e.g. Qwen3.6) where only
+/// some layers hold a context-sized KV cache. Linear-attention layers report 0
+/// KV heads so PagedAttention allocates them no cache, and `num_kv_cache_layers`
+/// counts only the KV-bearing layers so the pool is sized to them, not all layers.
+#[derive(Clone)]
+pub struct HybridKvCacheConfig {
+    inner: ModelConfigMetadata,
+    layer_has_kv_cache: Vec<bool>,
+}
+
+impl HybridKvCacheConfig {
+    pub fn new(inner: ModelConfigMetadata, layer_has_kv_cache: Vec<bool>) -> Self {
+        Self {
+            inner,
+            layer_has_kv_cache,
+        }
+    }
+}
+
+impl ModelConfigLike for HybridKvCacheConfig {
+    fn max_seq_len(&self) -> usize {
+        self.inner.max_seq_len()
+    }
+    fn num_layers(&self) -> usize {
+        self.inner.num_layers()
+    }
+    fn num_kv_cache_layers(&self) -> usize {
+        self.layer_has_kv_cache.iter().filter(|&&b| b).count()
+    }
+    fn hidden_size(&self) -> usize {
+        self.inner.hidden_size()
+    }
+    fn num_kv_heads(&self) -> usize {
+        self.inner.num_kv_heads()
+    }
+    fn num_attn_heads(&self) -> usize {
+        self.inner.num_attn_heads()
+    }
+    fn k_head_dim(&self) -> usize {
+        self.inner.k_head_dim()
+    }
+    fn v_head_dim(&self) -> usize {
+        self.inner.v_head_dim()
+    }
+    fn num_kv_heads_for_layer(&self, layer_idx: usize) -> usize {
+        if self
+            .layer_has_kv_cache
+            .get(layer_idx)
+            .copied()
+            .unwrap_or(true)
+        {
+            self.inner.num_kv_heads()
+        } else {
+            0
+        }
+    }
+    fn kv_cache_layout(&self) -> KvCacheLayout {
+        self.inner.kv_cache_layout()
+    }
+    fn kv_cache_layout_for_layer(&self, layer_idx: usize) -> KvCacheLayout {
+        self.inner.kv_cache_layout_for_layer(layer_idx)
+    }
+    fn attention_backend_kind(&self) -> AttentionBackendKind {
+        self.inner.attention_backend_kind()
+    }
+    fn attention_backend_kind_for_layer(&self, layer_idx: usize) -> AttentionBackendKind {
+        self.inner.attention_backend_kind_for_layer(layer_idx)
+    }
+    fn kv_cache_elements_per_token(&self) -> usize {
+        self.inner.kv_cache_elements_per_token()
     }
 }
 

--- a/mistralrs-core/src/paged_attention/mod.rs
+++ b/mistralrs-core/src/paged_attention/mod.rs
@@ -22,7 +22,9 @@ pub const _PAD_SLOT_ID: i64 = -1;
 pub use attention_backend::AttentionBackendKind;
 pub use cache_engine::{CacheConfig, CacheEngine, PagedCacheType};
 use candle_core::{DType, Device};
-pub use config::{KvCacheLayout, KvCacheTopology, ModelConfigLike, ModelConfigMetadata};
+pub use config::{
+    HybridKvCacheConfig, KvCacheLayout, KvCacheTopology, ModelConfigLike, ModelConfigMetadata,
+};
 pub use kv_cache_manager::KVCacheManager;
 pub use layers::PagedAttention;
 pub use scheduler::{
@@ -80,14 +82,17 @@ macro_rules! mb_to_blocks {
         $mb_size
             / $dtype_size
             / $block_size
-            / $config.num_layers()
+            / $config.num_kv_cache_layers()
             / $config.kv_cache_elements_per_token()
     };
 }
 
 macro_rules! ctxt_to_blocks {
     ($context_len:expr, $dtype_size:expr, $block_size:expr, $config:expr) => {
-        $context_len * $dtype_size * $config.num_layers() * $config.kv_cache_elements_per_token()
+        $context_len
+            * $dtype_size
+            * $config.num_kv_cache_layers()
+            * $config.kv_cache_elements_per_token()
     };
 }
 

--- a/mistralrs-core/src/vision_models/qwen3_5/text.rs
+++ b/mistralrs-core/src/vision_models/qwen3_5/text.rs
@@ -16,7 +16,7 @@ use super::config::{LayerType, TextConfig};
 use crate::{
     attention::{AttentionMask, SdpaParams},
     device_map::{DeviceMappedMask, DeviceMapper},
-    gdn::{GatedDeltaNet, GdnConfig, GdnLayerCache, GdnWeightMode},
+    gdn::{GatedDeltaNet, GdnConfig, GdnDims, GdnLayerCache, GdnWeightMode},
     kv_cache::{
         HybridCache, HybridCacheConfig, HybridLayerCache, HybridLayerType, RecurrentLayerConfig,
     },
@@ -75,6 +75,41 @@ struct FullAttention {
     sdpa_params: SdpaParams,
 }
 
+// mlx_lm qwen3_5.py shifts RMSNorm weights by +1 only for unsanitized (HF)
+// checkpoints; sanitized MLX checkpoints keep raw weights.
+fn gemma_rms_norm(
+    shift: bool,
+    size: usize,
+    eps: f64,
+    vb: ShardedVarBuilder,
+) -> Result<GemmaRmsNorm> {
+    if shift {
+        GemmaRmsNorm::new(size, eps, vb)
+    } else {
+        GemmaRmsNorm::new_unshifted(size, eps, vb)
+    }
+}
+
+// Unsanitized checkpoints store conv1d as (out, 1, kernel) (last dim != 1) and
+// carry MTP weights; mlx_lm shifts their norm weights by +1. The sanitized MLX
+// layout is (out, kernel, 1). conv1d layout discriminates the two and co-occurs
+// with MTP, so probing the first linear layer's conv1d shape is sufficient.
+fn checkpoint_shifts_norm_weights(vb_m: &ShardedVarBuilder, cfg: &TextConfig) -> bool {
+    let Some(idx) = cfg
+        .layer_types()
+        .iter()
+        .position(|t| matches!(t, LayerType::LinearAttention))
+    else {
+        return false;
+    };
+    let dims = GdnDims::new(cfg as &dyn GdnConfig);
+    vb_m.pp("layers")
+        .pp(idx)
+        .pp("linear_attn")
+        .get((dims.conv_dim, 1, dims.conv_kernel_size), "conv1d.weight")
+        .is_ok()
+}
+
 impl FullAttention {
     #[allow(clippy::too_many_arguments)]
     fn load(
@@ -86,6 +121,7 @@ impl FullAttention {
         rotary_emb: Arc<Qwen3VLRotaryEmbedding>,
         paged_attn: Option<PagedAttention>,
         comm: &Arc<mistralrs_quant::Comm>,
+        shift_norm: bool,
     ) -> Result<Self> {
         let vb_sa = mapper.set_device(layer_idx, vb.pp("self_attn"), loading_isq);
         let num_heads = cfg.num_attention_heads;
@@ -130,8 +166,18 @@ impl FullAttention {
         )?;
 
         let vb_sa_norms = mapper.set_device(layer_idx, vb.pp("self_attn"), false);
-        let q_norm = GemmaRmsNorm::new(head_dim, cfg.rms_norm_eps, vb_sa_norms.pp("q_norm"))?;
-        let k_norm = GemmaRmsNorm::new(head_dim, cfg.rms_norm_eps, vb_sa_norms.pp("k_norm"))?;
+        let q_norm = gemma_rms_norm(
+            shift_norm,
+            head_dim,
+            cfg.rms_norm_eps,
+            vb_sa_norms.pp("q_norm"),
+        )?;
+        let k_norm = gemma_rms_norm(
+            shift_norm,
+            head_dim,
+            cfg.rms_norm_eps,
+            vb_sa_norms.pp("k_norm"),
+        )?;
 
         Ok(Self {
             q_proj,
@@ -425,6 +471,7 @@ impl Qwen3_5TextModel {
         )?;
 
         let layer_types = cfg.layer_types();
+        let shift_norm = checkpoint_shifts_norm_weights(&vb_m, cfg);
 
         // Create MRoPE embeddings (one per device, using rot_dim not head_dim)
         let rot_dim = cfg.rot_dim();
@@ -482,6 +529,7 @@ impl Qwen3_5TextModel {
                         rotary_emb,
                         paged_attn,
                         &comm,
+                        shift_norm,
                     )?)
                 }
                 LayerType::LinearAttention => LayerImpl::LinearAttention(GatedDeltaNet::load(
@@ -495,12 +543,14 @@ impl Qwen3_5TextModel {
                 )?),
             };
 
-            let input_layernorm = GemmaRmsNorm::new(
+            let input_layernorm = gemma_rms_norm(
+                shift_norm,
                 cfg.hidden_size,
                 cfg.rms_norm_eps,
                 mapper.set_device(layer_idx, vb_l.pp(layer_idx).pp("input_layernorm"), false),
             )?;
-            let post_attention_layernorm = GemmaRmsNorm::new(
+            let post_attention_layernorm = gemma_rms_norm(
+                shift_norm,
                 cfg.hidden_size,
                 cfg.rms_norm_eps,
                 mapper.set_device(
@@ -531,18 +581,26 @@ impl Qwen3_5TextModel {
             })
         })?;
 
-        let norm = GemmaRmsNorm::new(
+        let norm = gemma_rms_norm(
+            shift_norm,
             cfg.hidden_size,
             cfg.rms_norm_eps,
             mapper.set_nm_device(vb_m.pp("norm"), false),
         )?;
         let lm_head = if !tie {
+            // MLX checkpoints nest lm_head under the same wrapper as `model`
+            // (`language_model.lm_head.*`); pick it off the same condition as vb_m.
+            let lm_head_vb = if vb.contains_tensor("language_model.model.embed_tokens.weight") {
+                vb.pp("language_model").pp("lm_head")
+            } else {
+                vb.pp("lm_head")
+            };
             ReplicatedLayer::new(
                 cfg.hidden_size,
                 cfg.vocab_size,
                 &cfg.quantization_config,
                 false,
-                mapper.set_nm_device(vb.pp("lm_head"), normal_loading_metadata.loading_isq),
+                mapper.set_nm_device(lm_head_vb, normal_loading_metadata.loading_isq),
             )?
         } else {
             ReplicatedLayer::from_linear(

--- a/mistralrs-core/src/vision_models/qwen3_5_moe/config.rs
+++ b/mistralrs-core/src/vision_models/qwen3_5_moe/config.rs
@@ -110,7 +110,7 @@ impl TextConfig {
     }
 }
 
-#[derive(Debug, Clone, serde::Deserialize)]
+#[derive(Debug, Clone)]
 pub struct Config {
     pub text_config: TextConfig,
     pub vision_config: VisionConfig,
@@ -121,4 +121,42 @@ pub struct Config {
     pub tie_word_embeddings: bool,
     /// Top-level quantization_config takes precedence
     pub quantization_config: Option<QuantizedConfig>,
+}
+
+// MLX-converted checkpoints (mlx-community, unsloth UD-MLX) put the
+// quantization_config at the top level of the config JSON, not inside
+// text_config. Propagate it down so GdnConfig::quantization_config (read off
+// TextConfig) sees the AFQ settings.
+impl<'de> serde::Deserialize<'de> for Config {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        #[derive(serde::Deserialize)]
+        struct ConfigWire {
+            text_config: TextConfig,
+            vision_config: VisionConfig,
+            image_token_id: u32,
+            video_token_id: u32,
+            vision_start_token_id: u32,
+            vision_end_token_id: u32,
+            tie_word_embeddings: bool,
+            #[serde(default)]
+            quantization_config: Option<QuantizedConfig>,
+        }
+        let mut wire = ConfigWire::deserialize(deserializer)?;
+        if wire.text_config.quantization_config.is_none() {
+            wire.text_config.quantization_config = wire.quantization_config.clone();
+        }
+        Ok(Config {
+            text_config: wire.text_config,
+            vision_config: wire.vision_config,
+            image_token_id: wire.image_token_id,
+            video_token_id: wire.video_token_id,
+            vision_start_token_id: wire.vision_start_token_id,
+            vision_end_token_id: wire.vision_end_token_id,
+            tie_word_embeddings: wire.tie_word_embeddings,
+            quantization_config: wire.quantization_config,
+        })
+    }
 }

--- a/mistralrs-core/src/vision_models/qwen3_5_moe/mod.rs
+++ b/mistralrs-core/src/vision_models/qwen3_5_moe/mod.rs
@@ -17,7 +17,7 @@ use crate::{
     layers_masker::PastKvLenCache,
     paged_attention::{
         encoder_cache::{CacheModality, EncoderCacheManager},
-        AttentionImplementation, ModelConfigMetadata,
+        AttentionImplementation, HybridKvCacheConfig, ModelConfigLike, ModelConfigMetadata,
     },
     pipeline::{
         EitherCache, IsqModel, ModelForwardContext, MultimodalModel, NormalLoadingMetadata,
@@ -520,6 +520,17 @@ impl MultimodalModel for Qwen3_5MoeModel {
     }
     fn config(&self) -> &ModelConfigMetadata {
         &self.text.cfg
+    }
+    fn model_config(&self) -> Arc<dyn ModelConfigLike + Send + Sync> {
+        // Only full-attention layers hold a KV cache; report the per-layer mask
+        // so PagedAttention doesn't allocate cache for the linear-attention layers.
+        let mask = self
+            .text
+            .layer_types
+            .iter()
+            .map(|t| matches!(t, config::LayerType::FullAttention))
+            .collect();
+        Arc::new(HybridKvCacheConfig::new(self.text.cfg.clone(), mask))
     }
     fn default_model_specific_args(&self, input_ids: &Tensor) -> Box<dyn Any> {
         assert_eq!(input_ids.dims()[0], 1);

--- a/mistralrs-core/src/vision_models/qwen3_5_moe/text.rs
+++ b/mistralrs-core/src/vision_models/qwen3_5_moe/text.rs
@@ -16,7 +16,7 @@ use super::config::{LayerType, TextConfig};
 use crate::{
     attention::{AttentionMask, SdpaParams},
     device_map::{DeviceMappedMask, DeviceMapper},
-    gdn::{GatedDeltaNet, GdnConfig, GdnLayerCache, GdnWeightMode},
+    gdn::{GatedDeltaNet, GdnConfig, GdnDims, GdnLayerCache, GdnWeightMode},
     kv_cache::{
         HybridCache, HybridCacheConfig, HybridLayerCache, HybridLayerType, RecurrentLayerConfig,
     },
@@ -76,6 +76,41 @@ struct FullAttention {
     sdpa_params: SdpaParams,
 }
 
+// mlx_lm qwen3_5.py shifts RMSNorm weights by +1 only for unsanitized (HF)
+// checkpoints; sanitized MLX checkpoints keep raw weights.
+fn gemma_rms_norm(
+    shift: bool,
+    size: usize,
+    eps: f64,
+    vb: ShardedVarBuilder,
+) -> Result<GemmaRmsNorm> {
+    if shift {
+        GemmaRmsNorm::new(size, eps, vb)
+    } else {
+        GemmaRmsNorm::new_unshifted(size, eps, vb)
+    }
+}
+
+// Unsanitized checkpoints store conv1d as (out, 1, kernel) (last dim != 1) and
+// carry MTP weights; mlx_lm shifts their norm weights by +1. The sanitized MLX
+// layout is (out, kernel, 1). conv1d layout discriminates the two and co-occurs
+// with MTP, so probing the first linear layer's conv1d shape is sufficient.
+fn checkpoint_shifts_norm_weights(vb_m: &ShardedVarBuilder, cfg: &TextConfig) -> bool {
+    let Some(idx) = cfg
+        .layer_types()
+        .iter()
+        .position(|t| matches!(t, LayerType::LinearAttention))
+    else {
+        return false;
+    };
+    let dims = GdnDims::new(cfg as &dyn GdnConfig);
+    vb_m.pp("layers")
+        .pp(idx)
+        .pp("linear_attn")
+        .get((dims.conv_dim, 1, dims.conv_kernel_size), "conv1d.weight")
+        .is_ok()
+}
+
 impl FullAttention {
     #[allow(clippy::too_many_arguments)]
     fn load(
@@ -87,6 +122,7 @@ impl FullAttention {
         rotary_emb: Arc<Qwen3VLRotaryEmbedding>,
         paged_attn: Option<PagedAttention>,
         comm: &Arc<mistralrs_quant::Comm>,
+        shift_norm: bool,
     ) -> Result<Self> {
         let vb_sa = mapper.set_device(layer_idx, vb.pp("self_attn"), loading_isq);
         let num_heads = cfg.num_attention_heads;
@@ -131,8 +167,18 @@ impl FullAttention {
         )?;
 
         let vb_sa_norms = mapper.set_device(layer_idx, vb.pp("self_attn"), false);
-        let q_norm = GemmaRmsNorm::new(head_dim, cfg.rms_norm_eps, vb_sa_norms.pp("q_norm"))?;
-        let k_norm = GemmaRmsNorm::new(head_dim, cfg.rms_norm_eps, vb_sa_norms.pp("k_norm"))?;
+        let q_norm = gemma_rms_norm(
+            shift_norm,
+            head_dim,
+            cfg.rms_norm_eps,
+            vb_sa_norms.pp("q_norm"),
+        )?;
+        let k_norm = gemma_rms_norm(
+            shift_norm,
+            head_dim,
+            cfg.rms_norm_eps,
+            vb_sa_norms.pp("k_norm"),
+        )?;
 
         Ok(Self {
             q_proj,
@@ -287,11 +333,28 @@ impl SparseMoeBlock {
             .cloned()
             .unwrap_or(real_device);
 
-        let gate = layers::linear_no_bias(
-            cfg.hidden_size,
-            cfg.num_experts,
-            vb.pp("gate").set_device(layer_device.clone()),
-        )?;
+        // MLX-AFQ checkpoints quantise the MoE router (`gate`,
+        // `shared_expert_gate`); if a quantization config is present, load
+        // via ColumnParallelLayer so the per-tensor AFQ override applies.
+        // Otherwise fall back to plain linear (Qwen3-Next style).
+        let gate: candle_nn::Linear = match &cfg.quantization_config {
+            Some(qc) => {
+                let qm = mistralrs_quant::ColumnParallelLayer::new(
+                    cfg.hidden_size,
+                    cfg.num_experts,
+                    &Some(qc.clone()),
+                    false,
+                    comm,
+                    vb.pp("gate").set_device(layer_device.clone()),
+                )?;
+                candle_nn::Linear::new(qm.dequantize_w()?, None)
+            }
+            None => layers::linear_no_bias(
+                cfg.hidden_size,
+                cfg.num_experts,
+                vb.pp("gate").set_device(layer_device.clone()),
+            )?,
+        };
 
         let moe_cfg = MoEExpertsConfig {
             num_experts: cfg.num_experts,
@@ -320,13 +383,28 @@ impl SparseMoeBlock {
             comm,
         )?;
 
-        let mut seg_w = vb
-            .pp("shared_expert_gate")
-            .get((1, cfg.hidden_size), "weight")?;
-        if loading_isq {
-            seg_w = seg_w.to_device(&layer_device)?;
-        }
-        let shared_expert_gate = Linear::new(seg_w, None);
+        let shared_expert_gate = match &cfg.quantization_config {
+            Some(qc) => {
+                let qm = mistralrs_quant::ColumnParallelLayer::new(
+                    cfg.hidden_size,
+                    1,
+                    &Some(qc.clone()),
+                    false,
+                    comm,
+                    vb.pp("shared_expert_gate").set_device(layer_device.clone()),
+                )?;
+                Linear::new(qm.dequantize_w()?, None)
+            }
+            None => {
+                let mut seg_w = vb
+                    .pp("shared_expert_gate")
+                    .get((1, cfg.hidden_size), "weight")?;
+                if loading_isq {
+                    seg_w = seg_w.to_device(&layer_device)?;
+                }
+                Linear::new(seg_w, None)
+            }
+        };
 
         Ok(Self {
             gate,
@@ -447,7 +525,7 @@ pub struct Qwen3_5MoeTextModel {
     embed_tokens: Embedding,
     pub(super) norm: GemmaRmsNorm,
     layers: Vec<DecoderLayer>,
-    layer_types: Vec<LayerType>,
+    pub(super) layer_types: Vec<LayerType>,
     mapper: Box<dyn DeviceMapper + Send + Sync>,
     lm_head: Arc<dyn QuantMethod>,
     pub(super) cache: EitherCache,
@@ -486,6 +564,7 @@ impl Qwen3_5MoeTextModel {
         }
 
         let layer_types = cfg.layer_types();
+        let shift_norm = checkpoint_shifts_norm_weights(&vb_m, cfg);
 
         // Create MRoPE embeddings (one per device, using rot_dim not head_dim)
         let rot_dim = cfg.rot_dim();
@@ -543,6 +622,7 @@ impl Qwen3_5MoeTextModel {
                         rotary_emb,
                         paged_attn,
                         &comm,
+                        shift_norm,
                     )?)
                 }
                 LayerType::LinearAttention => LayerImpl::LinearAttention(GatedDeltaNet::load(
@@ -556,12 +636,14 @@ impl Qwen3_5MoeTextModel {
                 )?),
             };
 
-            let input_layernorm = GemmaRmsNorm::new(
+            let input_layernorm = gemma_rms_norm(
+                shift_norm,
                 cfg.hidden_size,
                 cfg.rms_norm_eps,
                 mapper.set_device(layer_idx, vb_l.pp(layer_idx).pp("input_layernorm"), false),
             )?;
-            let post_attention_layernorm = GemmaRmsNorm::new(
+            let post_attention_layernorm = gemma_rms_norm(
+                shift_norm,
                 cfg.hidden_size,
                 cfg.rms_norm_eps,
                 mapper.set_device(
@@ -593,18 +675,27 @@ impl Qwen3_5MoeTextModel {
             })
         })?;
 
-        let norm = GemmaRmsNorm::new(
+        let norm = gemma_rms_norm(
+            shift_norm,
             cfg.hidden_size,
             cfg.rms_norm_eps,
             mapper.set_nm_device(vb_m.pp("norm"), false),
         )?;
         let lm_head = if !tie {
+            // MLX checkpoints store lm_head as `language_model.lm_head.*`
+            // (a sibling of `language_model.model.*`). Pick the prefix that
+            // actually exists in the checkpoint.
+            let lm_head_vb = if vb.contains_tensor("language_model.lm_head.weight") {
+                vb.pp("language_model").pp("lm_head")
+            } else {
+                vb.pp("lm_head")
+            };
             ReplicatedLayer::new(
                 cfg.hidden_size,
                 cfg.vocab_size,
                 &cfg.quantization_config,
                 false,
-                mapper.set_nm_device(vb.pp("lm_head"), normal_loading_metadata.loading_isq),
+                mapper.set_nm_device(lm_head_vb, normal_loading_metadata.loading_isq),
             )?
         } else {
             ReplicatedLayer::from_linear(
@@ -818,7 +909,8 @@ impl Qwen3_5MoeTextModel {
         let xs = xs.to_device(&self.device)?;
         let xs = xs.apply(&self.norm)?;
         let xs = ctx.logits(&xs)?;
-        self.lm_head.forward(&xs)
+        let logits = self.lm_head.forward(&xs)?;
+        Ok(logits)
     }
 
     fn deepstack_process(

--- a/mistralrs-quant/src/afq/mod.rs
+++ b/mistralrs-quant/src/afq/mod.rs
@@ -296,7 +296,9 @@ impl AfqLayer {
         bias: bool,
         vb: ShardedVarBuilder,
     ) -> Result<Arc<dyn QuantMethod>> {
-        let QuantizedConfig::Afq { bits, group_size } = config else {
+        // MLX checkpoints carry per-tensor overrides (the MoE router runs at
+        // 8-bit while the rest stays at 4-bit); afq_params_for_path applies them.
+        let Some((bits, group_size)) = config.afq_params_for_path(&vb.prefix()) else {
             candle_core::bail!("Unexpected quantization config.")
         };
 
@@ -322,8 +324,8 @@ impl AfqLayer {
             scales,
             bias,
             biases,
-            bits: AfqBits::try_from(*bits)?,
-            group_size: AfqGroupSize::try_from(*group_size)?,
+            bits: AfqBits::try_from(bits)?,
+            group_size: AfqGroupSize::try_from(group_size)?,
         }))
     }
 
@@ -335,7 +337,7 @@ impl AfqLayer {
         bias: bool,
         vb: ShardedVarBuilder,
     ) -> Result<Arc<dyn QuantMethod>> {
-        let QuantizedConfig::Afq { bits, group_size } = config else {
+        let Some((bits, group_size)) = config.afq_params_for_path(&vb.prefix()) else {
             candle_core::bail!("Unexpected quantization config.")
         };
 
@@ -367,8 +369,8 @@ impl AfqLayer {
             scales,
             bias,
             biases,
-            bits: AfqBits::try_from(*bits)?,
-            group_size: AfqGroupSize::try_from(*group_size)?,
+            bits: AfqBits::try_from(bits)?,
+            group_size: AfqGroupSize::try_from(group_size)?,
         }))
     }
 }

--- a/mistralrs-quant/src/lib.rs
+++ b/mistralrs-quant/src/lib.rs
@@ -392,6 +392,13 @@ pub enum QuantizedConfig {
     Afq {
         bits: usize,
         group_size: usize,
+        // MLX AFQ checkpoints carry per-tensor overrides as sibling keys of
+        // the top-level config (e.g. mlx-community/Qwen3.6-* runs the MoE
+        // router at 8-bit while the rest of the model is 4-bit). Maps the
+        // full tensor path (without the trailing field) to (bits, group_size).
+        // Empty for non-MLX or uniformly-quantised checkpoints.
+        #[serde(default, skip)]
+        overrides: std::collections::HashMap<String, (usize, usize)>,
     },
     MXFP4 {},
 }
@@ -407,13 +414,36 @@ struct RawConfig {
     bnb_4bit_quant_type: Option<String>,
 }
 
+// MLX configs put per-tensor AFQ overrides as sibling keys at the same level
+// as `bits`/`group_size`. Scan the raw JSON object for object-valued siblings
+// and pull `(bits, group_size)` out of each.
+fn collect_afq_overrides(
+    value: &serde_json::Value,
+) -> std::collections::HashMap<String, (usize, usize)> {
+    let mut out = std::collections::HashMap::new();
+    let Some(obj) = value.as_object() else {
+        return out;
+    };
+    for (k, v) in obj {
+        let Some(inner) = v.as_object() else { continue };
+        let bits = inner.get("bits").and_then(|x| x.as_u64());
+        let gs = inner.get("group_size").and_then(|x| x.as_u64());
+        if let (Some(b), Some(g)) = (bits, gs) {
+            out.insert(k.clone(), (b as usize, g as usize));
+        }
+    }
+    out
+}
+
 // Custom deserializer implementation
 impl<'de> Deserialize<'de> for QuantizedConfig {
     fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
     where
         D: Deserializer<'de>,
     {
-        let raw = RawConfig::deserialize(deserializer)?;
+        let value = serde_json::Value::deserialize(deserializer)?;
+        let raw: RawConfig =
+            serde_json::from_value(value.clone()).map_err(serde::de::Error::custom)?;
 
         match &raw.quant_method {
             Some(m) if m == "gptq" || m == "awq" => {
@@ -446,7 +476,11 @@ impl<'de> Deserialize<'de> for QuantizedConfig {
                 let group_size = raw
                     .group_size
                     .ok_or_else(|| serde::de::Error::missing_field("group_size"))?;
-                Ok(QuantizedConfig::Afq { bits, group_size })
+                Ok(QuantizedConfig::Afq {
+                    bits,
+                    group_size,
+                    overrides: collect_afq_overrides(&value),
+                })
             }
             Some(m) if m == "mxfp4" => {
                 Ok(QuantizedConfig::MXFP4 {  })
@@ -458,7 +492,11 @@ impl<'de> Deserialize<'de> for QuantizedConfig {
                 let group_size = raw
                     .group_size
                     .ok_or_else(|| serde::de::Error::missing_field("group_size"))?;
-                Ok(QuantizedConfig::Afq { bits, group_size })
+                Ok(QuantizedConfig::Afq {
+                    bits,
+                    group_size,
+                    overrides: collect_afq_overrides(&value),
+                })
             }
             Some(unknown_method) => {
                 Err(serde::de::Error::custom(format!(
@@ -470,6 +508,24 @@ impl<'de> Deserialize<'de> for QuantizedConfig {
 }
 
 impl QuantizedConfig {
+    // Return (bits, group_size) for an AFQ layer at `path`. Looks up the MLX
+    // per-tensor override map first, falling back to the model-wide defaults.
+    // `path` is typically `vb.prefix()` of the AfqLayer being loaded.
+    pub fn afq_params_for_path(&self, path: &str) -> Option<(usize, usize)> {
+        let Self::Afq {
+            bits,
+            group_size,
+            overrides,
+        } = self
+        else {
+            return None;
+        };
+        if let Some(&(b, g)) = overrides.get(path) {
+            return Some((b, g));
+        }
+        Some((*bits, *group_size))
+    }
+
     pub fn name(&self) -> &'static str {
         match self {
             Self::GptqAwq { .. } => "gptq",


### PR DESCRIPTION
Adds support for **Qwen3.6** - both the dense `qwen3_5` and the MoE `qwen3_5_moe`
(35B-A3B) - and makes them numerically correct on Metal.

## Root causes fixed

- **RMSNorm `+1` convention.** `GemmaRmsNorm::new` bakes `weight = on_disk + 1.0`, but
  the sanitized `mlx-community/Qwen3.6-*` checkpoints ship **raw** RMSNorm weights
  (MLX's `should_shift_norm_weights` is false for these: conv1d `(…,4,1)`, no MTP). The
  `+1` over-scaled every norm (~2.1x) and the SiLU MoE compounded it into a ~14x
  experts blow-up and an over-peaked router. Fixed with an unshifted norm at the
  affected sites.
- **AFQ packed loading / lm_head** for the MLX-quantized checkpoints.
- **Hybrid KV cache**: full-attention layers use the paged KV pool; the
  linear-attention (GatedDeltaNet) layers carry a recurrent state. The cache/config
  plumbing wires both per `layer_types`.

The MoE experts ship pre-fused as `switch_mlp.{gate,up,down}_proj`; the existing
`FusedExperts` path loads them via `afq_packed_linear_b` and applies router weights
correctly - no layout change was needed (verified, was a red herring).

## Correctness

`"Hello"` renders identically to `mlx_lm` (embedding byte-for-byte, all layer
last-position norms within bf16 rounding, identical top-1 logit), and greedy
generation begins identically. Verified on `Qwen3.6-27B-4bit` and `Qwen3.6-35B-A3B-4bit`
on Apple Silicon Metal.

## Notes

- Rebased onto current `main` (clean).
- This PR is now scoped to **Qwen3.6 only**. It was split out of a larger branch into
  reviewable pieces; the **zero-element KV buffer** fix is a prerequisite for running
  this on Metal. Suggested merge order: zero-buffer + engine-reap → this → chunked-prefill.

## Scope

`gdn/*`, `vision_models/qwen3_5{,_moe}/*`, `paged_attention/config.rs`, `layers.rs`,
`mistralrs-quant/{afq,lib}` - 12 files, +614/-74.


---
Part of splitting the Qwen3.6 work into focused, reviewable PRs:
- #2206 - zero-element KV cache buffer (Metal prerequisite for #2201)
- #2207 - reap disconnected sequences before prefill (independent)
- #2201 - Qwen3.6 (qwen3_5 / qwen3_5_moe) model support
- #2208 - Metal paged chunked prefill

Suggested merge order: #2206 + #2207 -> #2201 -> #2208.