### PR TITLE
fix(metal): back zero-element KV cache buffers with a shared placeholder

### DIFF
--- a/mistralrs-core/src/paged_attention/cache_engine.rs
+++ b/mistralrs-core/src/paged_attention/cache_engine.rs
@@ -87,6 +87,23 @@ impl CacheEngine {
     ) -> Result<Vec<KVCache>> {
         let mut gpu_cache = Vec::new();
 
+        // No-KV (linear-attention) layers in hybrid models produce a 0-element KV cache
+        // tensor. Metal rejects newBufferWithLength:0 and these buffers are never read, so
+        // back them all with a single shared 1-element placeholder instead of allocating one
+        // per such layer.
+        let mut kv_placeholder = None;
+        let mut kv_block_buffer =
+            |dev: &candle_core::MetalDevice, elem_count: usize, name: &'static str| {
+                if elem_count == 0 {
+                    if kv_placeholder.is_none() {
+                        kv_placeholder = Some(dev.new_private_buffer(1, dtype, "kv_placeholder")?);
+                    }
+                    Ok(kv_placeholder.clone().unwrap())
+                } else {
+                    dev.new_private_buffer(elem_count, dtype, name)
+                }
+            };
+
         for (layer_idx, device) in layer_devices
             .iter()
             .take(model_config.num_layers())
@@ -126,7 +143,7 @@ impl CacheEngine {
                                 * key_block_shape.1
                                 * key_block_shape.2
                                 * key_block_shape.3;
-                            let buffer = dev.new_private_buffer(elem_count, dtype, "k_cache")?;
+                            let buffer = kv_block_buffer(dev, elem_count, "k_cache")?;
                             let storage = Storage::Metal(MetalStorage::new(
                                 buffer,
                                 dev.clone(),
@@ -174,7 +191,7 @@ impl CacheEngine {
                                 * value_block_shape.0
                                 * value_block_shape.1
                                 * value_block_shape.2;
-                            let buffer = dev.new_private_buffer(elem_count, dtype, "v_cache")?;
+                            let buffer = kv_block_buffer(dev, elem_count, "v_cache")?;
                             let storage = Storage::Metal(MetalStorage::new(
                                 buffer,
                                 dev.clone(),
@@ -228,7 +245,7 @@ impl CacheEngine {
                                 * key_block_shape.0
                                 * key_block_shape.1
                                 * key_block_shape.2;
-                            let buffer = dev.new_private_buffer(elem_count, dtype, "k_cache")?;
+                            let buffer = kv_block_buffer(dev, elem_count, "k_cache")?;
                             let storage = Storage::Metal(MetalStorage::new(
                                 buffer,
                                 dev.clone(),
@@ -291,7 +308,7 @@ impl CacheEngine {
                             let elem_count = cache_config.num_gpu_blocks
                                 * cache_config.block_size
                                 * kv_lora_rank;
-                            let buffer = dev.new_private_buffer(elem_count, dtype, "k_cache")?;
+                            let buffer = kv_block_buffer(dev, elem_count, "k_cache")?;
                             let storage = Storage::Metal(MetalStorage::new(
                                 buffer,
                                 dev.clone(),
@@ -334,7 +351,7 @@ impl CacheEngine {
                             let elem_count = cache_config.num_gpu_blocks
                                 * cache_config.block_size
                                 * kpe_head_dim;
-                            let buffer = dev.new_private_buffer(elem_count, dtype, "v_cache")?;
+                            let buffer = kv_block_buffer(dev, elem_count, "v_cache")?;
                             let storage = Storage::Metal(MetalStorage::new(
                                 buffer,
                                 dev.clone(),


### PR DESCRIPTION
## What

PagedAttention allocates a per-layer KV cache block buffer sized to the layer's
KV. Hybrid models have layers with **no** KV (the linear-attention / GatedDeltaNet
layers carry a recurrent state instead), so that size is `0`. On Metal,
`new_private_buffer(0)` produces a zero-length buffer that later indexing treats as
invalid. Back those zero-element buffers with a shared 1-element placeholder
(`elem_count.max(1)`) so the no-KV layers allocate something valid and are simply
never read as KV.

## Why

Without this, any hybrid model (e.g. Qwen3.6 `qwen3_5_moe`) crashes on Metal as soon
as the cache engine sets up the no-KV layers. The change is a harmless general
hardening for the dense path (a layer with KV is unaffected; `max(1)` is a no-op
there).

## Scope

`mistralrs-core/src/paged_attention/cache_engine.rs`, +22/-5. Self-contained.

This is a prerequisite for #2201 (Qwen3.6 on Metal). It is split out as its own small
PR for reviewability; suggested merge order: this + the engine-reap fix, then #2201,
then the chunked-prefill PR.


---
Part of splitting the Qwen3.6 work into focused, reviewable PRs:
- #2206 - zero-element KV cache buffer (Metal prerequisite for #2201)
- #2207 - reap disconnected sequences before prefill (independent)
- #2201 - Qwen3.6 (qwen3_5 / qwen3_5_moe) model support
- #2208 - Metal paged chunked prefill

Suggested merge order: #2206 + #2207 -> #2201 -> #2208.