### PR TITLE
fix(engine): drop disconnected sequences before the prefill pass

### DIFF
--- a/mistralrs-core/src/engine/mod.rs
+++ b/mistralrs-core/src/engine/mod.rs
@@ -600,6 +600,18 @@ impl Engine {
                     }
                 }
                 SchedulerOutput::PagedAttention { mut output } => {
+                    // See DefaultScheduler arm: cancel sequences whose receiver is gone
+                    // before they consume a (prefill) forward pass and block the queue.
+                    output.scheduled.retain(|seq| {
+                        let seq = seq.lock().unwrap();
+                        if seq.responder().is_closed() {
+                            seq.set_state(SequenceState::Done(StopReason::Canceled));
+                            false
+                        } else {
+                            true
+                        }
+                    });
+
                     if !output.scheduled.is_empty() {
                         let is_prompt = get_mut_arcmutex!(output.scheduled[0]).is_prompt();
 


### PR DESCRIPTION
## What

Reap sequences whose client has disconnected **before** running the prefill pass,
not after. A prompt prefill is the expensive step; if the client is already gone, the
sequence should be dropped before it consumes a forward.

## Why

With `max_num_seqs = 1` (serialized scheduling, common on memory-constrained Metal),
a large-prompt prefill from a client that has already disconnected would still run to
completion and block the single slot, stalling every subsequent request. Dropping
disconnected sequences up front frees the queue immediately.

## Scope

`mistralrs-core/src/engine/mod.rs`, +12. Self-contained and general (not tied to any
model or backend). Independent of the other PRs in this series.


---
Part of splitting the Qwen3.6 work into focused, reviewable PRs:
- #2206 - zero-element KV cache buffer (Metal prerequisite for #2201)
- #2207 - reap disconnected sequences before prefill (independent)
- #2201 - Qwen3.6 (qwen3_5 / qwen3_5_moe) model support
- #2208 - Metal paged chunked prefill

Suggested merge order: #2206 + #2207 -> #2201 -> #2208.