### PR TITLE
feat(metal): paged chunked prefill, env-tunable with a safe chunk-size floor

### DIFF
--- a/mistralrs-core/src/pipeline/mod.rs
+++ b/mistralrs-core/src/pipeline/mod.rs
@@ -125,6 +125,13 @@ use self::text_models_inputs_processor::{
 
 const DEFAULT_PAGED_PREFILL_CHUNK_SIZE: usize = 4096;
 
+/// Smallest usable prefill chunk. Below this the hybrid GatedDeltaNet conv-state path
+/// overruns its accumulated buffer once the cumulative prefill nears its ~1024 window
+/// (panics with a `narrow` out-of-range; sub-block sizes also drop prompt tokens). 512
+/// is the smallest size verified correct (faithful + deterministic); smaller chunks buy
+/// only marginal activation-peak savings for many more kernel launches, so we floor here.
+const MIN_PAGED_PREFILL_CHUNK_SIZE: usize = 512;
+
 /// Paged prompt-prefill chunk size, env-overridable via `MISTRALRS_PREFILL_CHUNK`. Chunking
 /// bounds the activation peak to the chunk size instead of the prompt length (llama.cpp's
 /// `n_ubatch`). `0` disables it.
@@ -1277,7 +1284,12 @@ pub trait Pipeline:
                     && (self.device().is_cuda() || self.device().is_metal())
                 {
                     let chunk = paged_prefill_chunk_size();
-                    (chunk > 0).then_some(chunk)
+                    // Chunked prefill writes KV per paged block, so the chunk must be a whole
+                    // number of blocks (sub-block chunks land mid-block and corrupt the KV);
+                    // it must also clear MIN_PAGED_PREFILL_CHUNK_SIZE or the hybrid conv state
+                    // overruns. Promote too-small/unaligned values rather than corrupt/crash.
+                    (chunk > 0)
+                        .then(|| chunk.next_multiple_of(block_size).max(MIN_PAGED_PREFILL_CHUNK_SIZE))
                 } else {
                     None
                 };

--- a/mistralrs-core/src/pipeline/mod.rs
+++ b/mistralrs-core/src/pipeline/mod.rs
@@ -124,6 +124,20 @@ use self::text_models_inputs_processor::{
 };
 
 const DEFAULT_PAGED_PREFILL_CHUNK_SIZE: usize = 4096;
+
+/// Paged prompt-prefill chunk size, env-overridable via `MISTRALRS_PREFILL_CHUNK`. Chunking
+/// bounds the activation peak to the chunk size instead of the prompt length (llama.cpp's
+/// `n_ubatch`). `0` disables it.
+fn paged_prefill_chunk_size() -> usize {
+    use std::sync::OnceLock;
+    static CHUNK: OnceLock<usize> = OnceLock::new();
+    *CHUNK.get_or_init(|| {
+        std::env::var("MISTRALRS_PREFILL_CHUNK")
+            .ok()
+            .and_then(|v| v.parse::<usize>().ok())
+            .unwrap_or(DEFAULT_PAGED_PREFILL_CHUNK_SIZE)
+    })
+}
 pub use crate::kv_cache::{
     Cache, CacheManager, EitherCache, HybridLayerCache, KvCache, LayerCaches, NormalCache,
     NormalCacheType,
@@ -1260,9 +1274,10 @@ pub trait Pipeline:
                 let chunk_size = if is_prompt
                     && !return_raw_logits
                     && !self.get_metadata().is_xlora
-                    && self.device().is_cuda()
+                    && (self.device().is_cuda() || self.device().is_metal())
                 {
-                    Some(DEFAULT_PAGED_PREFILL_CHUNK_SIZE)
+                    let chunk = paged_prefill_chunk_size();
+                    (chunk > 0).then_some(chunk)
                 } else {
                     None
                 };


### PR DESCRIPTION
## What

Enable paged prompt-prefill chunking on **Metal**. The chunking loop already exists in
`Pipeline::step` (`build_prompt_chunk_plan` + `set_prefix_cache_len` /
`set_prefill_toks`) but was gated to `self.device().is_cuda()`, so Metal always
prefilled the whole prompt in one shot. This:

- relaxes the gate to `is_cuda() || is_metal()`;
- makes the chunk size env-tunable via `MISTRALRS_PREFILL_CHUNK` (default 4096, `0`
  disables) - the analogue of llama.cpp's `n_ubatch`;
- floors the effective chunk to `next_multiple_of(block_size).max(512)`.

## Why

On Apple Silicon the prefill activation peak scales with prompt length, so a long
prompt (e.g. a coding-assistant context of ~20k tokens) drives the box into swap and
thrashes. Chunking bounds the peak to the chunk size. Measured on a 36 GB Mac with
Qwen3.6: a ~20k-token prefill's peak swap drops from ~5.9 GB to ~1.3 GB for ~13%
slower prefill, and the request completes instead of stalling.

## The floor (important)

Sub-block / very small chunks are not just slow, they are **wrong** on hybrid models:
the GatedDeltaNet conv-state path overruns its buffer once the cumulative prefill
nears its ~1024 window (a `narrow` out-of-range panic on a ~2.5k-token prompt), and
sub-block chunks land mid paged-block and drop prompt tokens. `MISTRALRS_PREFILL_CHUNK=8`
reliably reproduced both. Flooring to a block-aligned `>= 512` sidesteps it; 512 is the
smallest size verified faithful and deterministic, and sub-512 buys only marginal
activation-peak savings for many more kernel launches. The CUDA path only ever used
4096, so this regime was never exercised upstream.

## Scope

`mistralrs-core/src/pipeline/mod.rs`, +29/-2 (two commits). Independent of the other
PRs in code; the floor's motivation is the hybrid (Qwen3.6) path, so this pairs well
landing after #2201.


---
Part of splitting the Qwen3.6 work into focused, reviewable PRs:
- #2206 - zero-element KV cache buffer (Metal prerequisite for #2201)
- #2207 - reap disconnected sequences before prefill (independent)
- #2201 - Qwen3.6 (qwen3_5 / qwen3_5_moe) model support
- #2208 - Metal paged chunked prefill

Suggested merge order: #2206 + #2207 -> #2201 -> #2208.