### PR TITLE
feat(models): integrate DiffusionGemma and integrate block-diffusion models

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ Fast, flexible LLM inference.
 
 ## Latest
 
+- **DiffusionGemma**: block-diffusion text generation. Denoises 256-token blocks in parallel for ~2x autoregressive throughput, fully integrated: paged attention, prefix caching, ISQ, vision, and tool calling. [Guide](https://ericlbuehler.github.io/mistral.rs/guides/models/use-block-diffusion/)
 - **Anthropic Messages API**: `mistralrs serve` now exposes Anthropic-compatible `/v1/messages` and `/v1/messages/count_tokens` endpoints alongside the OpenAI-compatible `/v1` API. [Guide](https://ericlbuehler.github.io/mistral.rs/guides/serve/anthropic-messages-api/)
 - **v0.8.2 CUDA performance**: CUDA graphs, FlashInfer paged kernels, and MoE optimizations deliver strong results on GB10, B200, and H100 SXM. [Benchmarks](#benchmarks)
 - **Agentic runtime**: web search, local Python code execution with model feedback, session management, and custom tool hooks. [Guide](https://ericlbuehler.github.io/mistral.rs/tutorials/05-build-an-agent/)
@@ -221,6 +222,8 @@ mistralrs doctor
 <details>
 <summary><b>Multimodal Models</b></summary>
 
+- DiffusionGemma
+- Gemma 4
 - Qwen 3.5
 - Qwen 3.5 MoE
 - Qwen 3-VL

--- a/docs/src/content/docs/guides/models/use-block-diffusion.md
+++ b/docs/src/content/docs/guides/models/use-block-diffusion.md
@@ -1,0 +1,47 @@
+---
+title: Block-diffusion models
+description: Run diffusion text generation models like DiffusionGemma.
+sidebar:
+  order: 8
+---
+
+Block-diffusion models generate text by iteratively *denoising* whole blocks of tokens in parallel instead of sampling one token at a time. A causal encoder fills the KV cache with the prompt; the model then refines a block (a "canvas") of mask tokens over a handful of bidirectional passes, commits it, and repeats. Because each pass produces many tokens at once, throughput is typically around 2x an equivalent autoregressive model.
+
+Currently supported: 
+- **DiffusionGemma** (`google/diffusiongemma-26B-A4B-it`), a 26B-A4B mixture-of-experts model with vision input, built on the Gemma 4 architecture.
+
+## Quick start
+
+No special flags or APIs, as block-diffusion models are detected automatically and served through the standard endpoints:
+
+```bash
+mistralrs run -m google/diffusiongemma-26B-A4B-it
+```
+
+Or as an OpenAI-compatible server:
+
+```bash
+mistralrs serve -p 1234 -m google/diffusiongemma-26B-A4B-it
+```
+
+```bash
+curl http://localhost:1234/v1/chat/completions \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "default",
+    "messages": [{"role": "user", "content": "Why is the sky blue?"}],
+    "max_tokens": 1024
+  }'
+```
+
+The Rust and Python SDKs work unchanged — see [`mistralrs/examples/models/diffusion_gemma`](https://github.com/EricLBuehler/mistral.rs/tree/master/mistralrs/examples/models/diffusion_gemma) (streaming, shows block-at-a-time output) and [`examples/python/diffusion_gemma.py`](https://github.com/EricLBuehler/mistral.rs/blob/master/examples/python/diffusion_gemma.py) (vision input). Any other chat completion example applies as-is.
+
+## What behaves differently
+
+- **Streaming is bursty.** Output arrives one block (up to 256 tokens) at a time, after that block's denoising loop converges, rather than token by token.
+- **Sampling is the diffusion schedule.** The temperature ramp, entropy-bound acceptance, and stopping thresholds come from the checkpoint's `generation_config.json`. Request-level `temperature`, `top_p`, and penalties are ignored. `max_tokens` still caps output length.
+- **Stats split differently.** Prompt T/s measures the encoder prefill alone; decode T/s is the effective denoising throughput (committed tokens over denoising time).
+- **Thinking is on by default.** DiffusionGemma's channel-tag reasoning is parsed into the reasoning field, like other thinking models.
+- **Tool calling** works through the model's native format, including calls spanning block boundaries. Grammar-constrained generation (`tool_choice: required`/named tools, JSON schema outputs) is not enforced during denoising — parallel token refinement is incompatible with per-token grammars — so the model's trained formatting is relied upon.
+
+See also: [model notes](/mistral.rs/reference/model-notes/) and the [supported models reference](/mistral.rs/reference/supported-models/).

--- a/docs/src/content/docs/reference/model-notes.md
+++ b/docs/src/content/docs/reference/model-notes.md
@@ -7,11 +7,15 @@ sidebar:
 
 ## DiffusionGemma
 
-**Block-diffusion text generation.** DiffusionGemma generates text in 256-token blocks: a causal encoder fills the KV cache, then each block is iteratively denoised with bidirectional attention (up to 48 steps, usually far fewer thanks to adaptive stopping). Output streams one block at a time rather than token by token.
+See the [block-diffusion guide](/mistral.rs/guides/models/use-block-diffusion/) for setup, examples, and performance tuning.
+
+**Block-diffusion text generation.** DiffusionGemma generates text in 256-token blocks: a causal encoder fills the KV cache, then each block is iteratively denoised with bidirectional attention (up to 48 steps, usually far fewer thanks to adaptive stopping). Output streams one block at a time rather than token by token, and reported stats split encoder prefill (prompt) from denoising (decode) time.
 
 **Sampling parameters.** The denoising schedule (temperature ramp, entropy-bound acceptance, stopping thresholds) comes from the checkpoint's `generation_config.json`. Request-level `temperature`/`top_p` are ignored; `max_tokens` caps the number of generated blocks.
 
-**Concurrency.** Concurrent requests batch through the encoder; their canvases denoise sequentially within each engine step.
+**Concurrency.** Concurrent requests with equal context lengths batch together and denoise their blocks in lockstep, amortizing the expert sweep; requests with different prompt lengths run as separate groups.
+
+**Thinking and tools.** Channel-tag reasoning is enabled by default and parsed into the reasoning field. Native/auto tool calling works, including calls spanning block boundaries. Grammar-constrained generation (`tool_choice: required`/named, JSON schema outputs) is not enforced during denoising; the model's native formatting is relied upon.
 
 ## Gemma 4
 

--- a/docs/src/content/docs/reference/model-notes.md
+++ b/docs/src/content/docs/reference/model-notes.md
@@ -5,6 +5,14 @@ sidebar:
   order: 10
 ---
 
+## DiffusionGemma
+
+**Block-diffusion text generation.** DiffusionGemma generates text in 256-token blocks: a causal encoder fills the KV cache, then each block is iteratively denoised with bidirectional attention (up to 48 steps, usually far fewer thanks to adaptive stopping). Output streams one block at a time rather than token by token.
+
+**Sampling parameters.** The denoising schedule (temperature ramp, entropy-bound acceptance, stopping thresholds) comes from the checkpoint's `generation_config.json`. Request-level `temperature`/`top_p` are ignored; `max_tokens` caps the number of generated blocks.
+
+**Concurrency.** Concurrent requests batch through the encoder; their canvases denoise sequentially within each engine step.
+
 ## Gemma 4
 
 **Strict tool grammar.** Gemma 4 enforces tool call format through constrained decoding (llguidance). Enabled by default.

--- a/docs/src/content/docs/reference/supported-models.md
+++ b/docs/src/content/docs/reference/supported-models.md
@@ -66,6 +66,7 @@ Passing `--arch` is only necessary in rare cases.
 | `Qwen3_5Moe` | `Qwen/Qwen3.5-35B-A3B` | Text, image |
 | `Voxtral` | `mistralai/Voxtral-Mini-3B-2507` | Text, audio |
 | `Gemma4` | `google/gemma-4-E4B-it` | Text, image, audio, video |
+| `DiffusionGemma` | `google/diffusiongemma-26B-A4B-it` | Text, image (block-diffusion text generation) |
 
 ## Image generation
 

--- a/examples/python/diffusion_gemma.py
+++ b/examples/python/diffusion_gemma.py
@@ -1,0 +1,38 @@
+from mistralrs import Runner, Which, ChatCompletionRequest, MultimodalArchitecture
+
+# DiffusionGemma is a block-diffusion model: it denoises 256-token blocks in
+# parallel instead of sampling tokens one at a time. The API is unchanged, but
+# sampling parameters (temperature/top_p) are ignored in favor of the
+# checkpoint's denoising schedule, and streamed output arrives block by block.
+runner = Runner(
+    which=Which.MultimodalPlain(
+        model_id="google/diffusiongemma-26B-A4B-it",
+        arch=MultimodalArchitecture.DiffusionGemma,
+    ),
+)
+
+res = runner.send_chat_completion_request(
+    ChatCompletionRequest(
+        model="default",
+        messages=[
+            {
+                "role": "user",
+                "content": [
+                    {
+                        "type": "image_url",
+                        "image_url": {
+                            "url": "https://www.nhmagazine.com/content/uploads/2019/05/mtwashingtonFranconia-2-19-18-108-Edit-Edit.jpg"
+                        },
+                    },
+                    {
+                        "type": "text",
+                        "text": "What is this?",
+                    },
+                ],
+            }
+        ],
+        max_tokens=1024,
+    )
+)
+print(res.choices[0].message.content)
+print(res.usage)

--- a/mistralrs-core/src/block_diffusion.rs
+++ b/mistralrs-core/src/block_diffusion.rs
@@ -1,0 +1,22 @@
+//! Block-diffusion text generation support (e.g. DiffusionGemma): models that commit a
+//! whole denoised block of tokens per engine step instead of sampling one token from logits.
+
+/// Mixin for block-diffusion models. Defaults describe an ordinary autoregressive model;
+/// diffusion models override all three.
+pub trait BlockDiffusionMixin {
+    /// When true, `forward` returns committed block token ids as a u32 tensor
+    /// [bs, block_len] rather than logits.
+    fn is_block_diffusion(&self) -> bool {
+        false
+    }
+
+    /// Hand the model the checkpoint's raw `generation_config.json` (the source of truth
+    /// for denoising parameters). No-op for other models.
+    fn configure_block_diffusion(&self, _generation_config_json: &str) {}
+
+    /// Time the last forward spent in the denoising loop (vs encoding); lets the engine
+    /// book that share as completion time rather than prompt time.
+    fn take_block_denoise_time(&self) -> Option<std::time::Duration> {
+        None
+    }
+}

--- a/mistralrs-core/src/engine/mod.rs
+++ b/mistralrs-core/src/engine/mod.rs
@@ -668,6 +668,7 @@ impl Engine {
                                     prompt_chunk_attention_policy: crate::paged_attention::block_hash::MultimodalAttentionPolicy::Causal,
                                     has_noncausal_mm_context: false,
                                     mm_prefix_ranges_by_seq_id: HashMap::new(),
+                                    is_final_prompt_chunk: true,
                                 };
 
                                 let return_raw_logits = guards_mut[0].return_raw_logits;

--- a/mistralrs-core/src/lib.rs
+++ b/mistralrs-core/src/lib.rs
@@ -59,6 +59,7 @@ pub use toml_selector::{get_toml_selected_model_device_map_params, get_toml_sele
 
 mod amoe;
 mod attention;
+mod block_diffusion;
 mod diagnostics;
 mod diffusion_models;
 pub mod distributed;

--- a/mistralrs-core/src/moe/experts/config.rs
+++ b/mistralrs-core/src/moe/experts/config.rs
@@ -78,6 +78,24 @@ impl BackendChoice {
     }
 }
 
+/// Resolve and log the MoE backend choice up front so the one-time INFO line lands before
+/// any loading progress bar starts instead of splitting it.
+pub fn prelog_moe_backend(
+    device: Device,
+    dtype: DType,
+    loading_isq: bool,
+    quantization_config: &Option<QuantizedConfig>,
+    act: Activation,
+) {
+    let _ = MoEExpertsBackend::resolve(&BackendChoice::new(
+        device,
+        dtype,
+        loading_isq,
+        quantization_config,
+        act,
+    ));
+}
+
 impl MoEExpertsBackend {
     fn from_env() -> Option<Self> {
         let force = std::env::var("MISTRALRS_MOE_BACKEND").ok()?;

--- a/mistralrs-core/src/moe/experts/mod.rs
+++ b/mistralrs-core/src/moe/experts/mod.rs
@@ -15,7 +15,7 @@ use std::sync::Arc;
 
 use crate::layers::Activation;
 
-pub use config::{ExpertProjNames, MoEExpertsConfig};
+pub use config::{prelog_moe_backend, ExpertProjNames, MoEExpertsConfig};
 
 #[cfg(feature = "cutile")]
 use backends::CutileExpertsWeights;

--- a/mistralrs-core/src/moe/mod.rs
+++ b/mistralrs-core/src/moe/mod.rs
@@ -2,7 +2,7 @@ mod experts;
 
 use mistralrs_quant::Shard;
 
-pub use experts::{ExpertProjNames, MoEExperts, MoEExpertsConfig};
+pub use experts::{prelog_moe_backend, ExpertProjNames, MoEExperts, MoEExpertsConfig};
 
 pub fn shard(dim: usize, rank: usize, world_size: usize) -> Shard {
     Shard::Simple {

--- a/mistralrs-core/src/paged_attention/kv_cache_manager.rs
+++ b/mistralrs-core/src/paged_attention/kv_cache_manager.rs
@@ -323,7 +323,9 @@ impl KVCacheManager {
             None => return,
         };
 
-        let num_full_blocks = num_computed_tokens / self.block_size;
+        // Clamp to allocated blocks: callers may pass token counts that run ahead of
+        // allocation (e.g. block generation appends many tokens per step).
+        let num_full_blocks = (num_computed_tokens / self.block_size).min(req.block_ids.len());
         if req.num_cached_blocks >= num_full_blocks {
             return;
         }

--- a/mistralrs-core/src/paged_attention/layers/mod.rs
+++ b/mistralrs-core/src/paged_attention/layers/mod.rs
@@ -41,6 +41,19 @@ pub mod paged_attention {
             candle_core::bail!("Paged attention requires the CUDA or Metal feature flags.");
         }
 
+        #[allow(unused_variables)]
+        pub fn gather_canvas_kv(
+            &self,
+            _key_cache: &Tensor,
+            _value_cache: &Tensor,
+            _input_metadata: &PagedAttentionInputMetadata,
+            _seq_idx: usize,
+            _kv_len: usize,
+            _dtype: candle_core::DType,
+        ) -> Result<(Tensor, Tensor)> {
+            candle_core::bail!("Paged attention requires the CUDA or Metal feature flags.");
+        }
+
         #[allow(clippy::too_many_arguments)]
         #[allow(unused_variables)]
         pub fn forward_donor_cache(

--- a/mistralrs-core/src/paged_attention/layers/paged_attention.rs
+++ b/mistralrs-core/src/paged_attention/layers/paged_attention.rs
@@ -408,6 +408,75 @@ impl PagedAttention {
         })
     }
 
+    /// Gather a batch of sequences' full KV from the paged cache into one contiguous
+    /// `[num_seqs, kv_heads, kv_len, head_size]` pair. All sequences share the same kv_len
+    /// (the block-diffusion scheduler buckets by context length). Block-diffusion canvas
+    /// passes snapshot the frozen encoder cache once per block and reuse it across all
+    /// denoising steps. Metadata block-table rows are per query row; one row per sequence
+    /// is selected by stride.
+    pub fn gather_canvas_kv(
+        &self,
+        key_cache: &Tensor,
+        value_cache: &Tensor,
+        input_metadata: &PagedAttentionInputMetadata,
+        num_seqs: usize,
+        kv_len: usize,
+        dtype: DType,
+    ) -> Result<(Tensor, Tensor)> {
+        let device = key_cache.device();
+        let loc = device.location();
+        let block_tables = input_metadata
+            .full_block_tables
+            .as_ref()
+            .and_then(|m| m.get(&loc))
+            .or_else(|| {
+                input_metadata
+                    .block_tables
+                    .as_ref()
+                    .and_then(|m| m.get(&loc))
+            })
+            .ok_or_else(|| {
+                candle_core::Error::Msg(format!(
+                    "canvas KV gather requires block tables (full: {:?}, windowed: {:?}, want {:?})",
+                    input_metadata
+                        .full_block_tables
+                        .as_ref()
+                        .map(|m| m.keys().collect::<Vec<_>>()),
+                    input_metadata
+                        .block_tables
+                        .as_ref()
+                        .map(|m| m.keys().collect::<Vec<_>>()),
+                    loc,
+                ))
+            })?;
+        let total_rows = block_tables.dim(0)?;
+        let rows_per_seq = total_rows / num_seqs;
+        let table = if rows_per_seq <= 1 {
+            block_tables.narrow(0, 0, num_seqs)?
+        } else {
+            let row_idx: Vec<u32> = (0..num_seqs).map(|i| (i * rows_per_seq) as u32).collect();
+            block_tables.index_select(&Tensor::from_vec(row_idx, (num_seqs,), device)?, 0)?
+        };
+        let cu_kv = cumulative_seqlens_from_lengths(&vec![kv_len; num_seqs], device)?;
+        let (k, v) = gather_kv_cache_for_layout(
+            key_cache,
+            value_cache,
+            self.k_scale.as_ref(),
+            self.v_scale.as_ref(),
+            &table,
+            &cu_kv,
+            dtype,
+        )?;
+        // Packed [num_seqs * kv_len, kv_heads, head_size] -> [num_seqs, kv_heads, kv_len, hd].
+        let unpack = |t: Tensor| -> Result<Tensor> {
+            let (_, kv_heads, head_size) = t.dims3()?;
+            t.reshape((num_seqs, kv_len, kv_heads, head_size))?
+                .transpose(1, 2)?
+                .contiguous()
+        };
+        Ok((unpack(k)?, unpack(v)?))
+    }
+
     fn update_kv_scale_if_needed(
         &self,
         tensors: PagedForwardTensors<'_>,

--- a/mistralrs-core/src/paged_attention/scheduler.rs
+++ b/mistralrs-core/src/paged_attention/scheduler.rs
@@ -33,6 +33,9 @@ type BucketKey = (usize, bool, usize);
 /// Allow sequences to wait for 64 scheduling passes before warning of deprivation.
 const WAITING_TIMEOUT: usize = 64;
 
+/// (seq_id, tokens, mm_features, block_hash_revision, unencoded_tail_len)
+type SeqCacheInfo = (usize, Vec<u32>, Vec<MultiModalFeature>, u64, usize);
+
 pub struct PagedAttentionSchedulerOutput {
     /// Either ALL prompt or ALL completion.
     pub scheduled: Vec<Arc<Mutex<Sequence>>>,
@@ -447,7 +450,7 @@ impl PagedAttentionScheduler {
         // sooner, rather than waiting until finish/preempt. cache_blocks is idempotent.
         if self.prefix_caching_enabled {
             // Collect sequence info first to avoid borrow conflict with self.ensure_block_hashes
-            let seq_infos: Vec<(usize, Vec<u32>, Vec<MultiModalFeature>, u64)> = self
+            let seq_infos: Vec<SeqCacheInfo> = self
                 .running
                 .iter()
                 .map(|seq| {
@@ -456,15 +459,26 @@ impl PagedAttentionScheduler {
                     let tokens = seq_guard.get_toks().to_vec();
                     let mm_features = seq_guard.mm_features().to_vec();
                     let block_hash_revision = seq_guard.block_hash_revision();
-                    (seq_id, tokens, mm_features, block_hash_revision)
+                    let unencoded_tail = seq_guard.unencoded_tail_len();
+                    (
+                        seq_id,
+                        tokens,
+                        mm_features,
+                        block_hash_revision,
+                        unencoded_tail,
+                    )
                 })
                 .collect();
 
-            for (seq_id, tokens, mm_features, block_hash_revision) in &seq_infos {
+            for (seq_id, tokens, mm_features, block_hash_revision, unencoded_tail) in &seq_infos {
                 self.ensure_block_hashes(*seq_id, tokens, mm_features, *block_hash_revision);
                 if let Some(block_hashes) = self.seq_block_hashes.get(seq_id).cloned() {
                     let mut kv_mgr = get_mut_arcmutex!(self.kv_cache_manager);
-                    kv_mgr.cache_blocks(*seq_id, &block_hashes, tokens.len());
+                    kv_mgr.cache_blocks(
+                        *seq_id,
+                        &block_hashes,
+                        tokens.len().saturating_sub(*unencoded_tail),
+                    );
                 }
             }
         }
@@ -480,7 +494,7 @@ impl PagedAttentionScheduler {
 
     pub fn free_finished_sequence_groups(&mut self) {
         // Collect finished sequence info before modifying self.running
-        let mut finished: Vec<(usize, Vec<u32>, Vec<MultiModalFeature>, u64)> = Vec::new();
+        let mut finished: Vec<SeqCacheInfo> = Vec::new();
         for seq in self.running.iter() {
             let seq_guard = get_mut_arcmutex!(seq);
             if seq_guard.is_finished_paged_attn() {
@@ -488,7 +502,8 @@ impl PagedAttentionScheduler {
                 let tokens = seq_guard.get_toks().to_vec();
                 let mm_features = seq_guard.mm_features().to_vec();
                 let block_hash_revision = seq_guard.block_hash_revision();
-                finished.push((id, tokens, mm_features, block_hash_revision));
+                let unencoded_tail = seq_guard.unencoded_tail_len();
+                finished.push((id, tokens, mm_features, block_hash_revision, unencoded_tail));
             }
         }
 
@@ -498,17 +513,21 @@ impl PagedAttentionScheduler {
 
         // Cache and free blocks for finished sequences
         if self.prefix_caching_enabled {
-            for (id, tokens, mm_features, block_hash_revision) in &finished {
+            for (id, tokens, mm_features, block_hash_revision, unencoded_tail) in &finished {
                 self.ensure_block_hashes(*id, tokens, mm_features, *block_hash_revision);
                 let block_hashes = self.seq_block_hashes.get(id).cloned().unwrap_or_default();
                 let mut kv_mgr = get_mut_arcmutex!(self.kv_cache_manager);
-                kv_mgr.cache_blocks(*id, &block_hashes, tokens.len());
+                kv_mgr.cache_blocks(
+                    *id,
+                    &block_hashes,
+                    tokens.len().saturating_sub(*unencoded_tail),
+                );
                 drop(kv_mgr);
             }
         }
 
         let mut kv_mgr = get_mut_arcmutex!(self.kv_cache_manager);
-        for (id, _, _, _) in finished {
+        for (id, _, _, _, _) in finished {
             kv_mgr.free(id);
             self.seq_block_hashes.remove(&id);
             self.seq_block_hash_revisions.remove(&id);
@@ -531,6 +550,7 @@ impl PagedAttentionScheduler {
         let tokens = seq_guard.get_toks().to_vec();
         let mm_features = seq_guard.mm_features().to_vec();
         let block_hash_revision = seq_guard.block_hash_revision();
+        let unencoded_tail = seq_guard.unencoded_tail_len();
         drop(seq_guard);
 
         // Ensure block hashes are up-to-date before freeing
@@ -544,7 +564,11 @@ impl PagedAttentionScheduler {
         // Cache all full blocks and free, blocks stay in cache for LRU reuse
         let mut kv_mgr = get_mut_arcmutex!(self.kv_cache_manager);
         if self.prefix_caching_enabled {
-            kv_mgr.cache_blocks(seq_id, &block_hashes, tokens.len());
+            kv_mgr.cache_blocks(
+                seq_id,
+                &block_hashes,
+                tokens.len().saturating_sub(unencoded_tail),
+            );
         }
         kv_mgr.free(seq_id);
         drop(kv_mgr);

--- a/mistralrs-core/src/pipeline/cuda_graph.rs
+++ b/mistralrs-core/src/pipeline/cuda_graph.rs
@@ -551,6 +551,7 @@ impl CudaDecodeGraphMetadataBuffers {
             full_context_lens: option_tensor_map_from_var_map(&self.full_context_lens),
             full_max_context_len: bucket_context_len_from_vars(&self.full_block_tables, block_size),
             is_first_prompt_chunk: metadata.is_first_prompt_chunk,
+            is_final_prompt_chunk: metadata.is_final_prompt_chunk,
             prompt_chunk_attention_policy: metadata.prompt_chunk_attention_policy,
             has_noncausal_mm_context: metadata.has_noncausal_mm_context,
             mm_prefix_ranges: metadata.mm_prefix_ranges.clone(),

--- a/mistralrs-core/src/pipeline/inputs_processor.rs
+++ b/mistralrs-core/src/pipeline/inputs_processor.rs
@@ -135,6 +135,9 @@ pub mod text_models_inputs_processor {
         pub prompt_chunk_attention_policy: MultimodalAttentionPolicy,
         pub has_noncausal_mm_context: bool,
         pub mm_prefix_ranges_by_seq_id: HashMap<usize, Vec<(usize, usize)>>,
+        /// False only for non-final chunks of a chunked prompt; block-diffusion models skip
+        /// canvas generation until the prompt is fully encoded.
+        pub is_final_prompt_chunk: bool,
     }
 
     impl PagedAttentionMeta {
@@ -170,6 +173,7 @@ pub mod text_models_inputs_processor {
         pub full_context_lens: Option<HashMap<DeviceLocation, Tensor>>,
         pub full_max_context_len: Option<usize>,
         pub is_first_prompt_chunk: bool,
+        pub is_final_prompt_chunk: bool,
         pub prompt_chunk_attention_policy: MultimodalAttentionPolicy,
         pub has_noncausal_mm_context: bool,
         pub mm_prefix_ranges: Option<HashMap<DeviceLocation, Tensor>>,
@@ -209,6 +213,7 @@ pub mod text_models_inputs_processor {
                 full_max_context_len: None,
                 slot_mappings: HashMap::from([(dev.location(), Tensor::new(&[0f32], dev)?)]),
                 is_first_prompt_chunk: true,
+                is_final_prompt_chunk: true,
                 prompt_chunk_attention_policy: MultimodalAttentionPolicy::Causal,
                 has_noncausal_mm_context: false,
                 mm_prefix_ranges: None,
@@ -443,6 +448,7 @@ pub mod text_models_inputs_processor {
                 full_context_lens,
                 full_max_context_len,
                 is_first_prompt_chunk: false,
+                is_final_prompt_chunk: self.is_final_prompt_chunk,
                 prompt_chunk_attention_policy: MultimodalAttentionPolicy::Causal,
                 has_noncausal_mm_context: self.has_noncausal_mm_context,
                 mm_prefix_ranges: self.mm_prefix_ranges.clone(),
@@ -1111,6 +1117,7 @@ pub mod text_models_inputs_processor {
                 },
                 full_max_context_len,
                 is_first_prompt_chunk: chunk_offset_toks == 0 && !has_any_cache_hit,
+                is_final_prompt_chunk: paged_attn_metadata.is_final_prompt_chunk,
                 prompt_chunk_attention_policy,
                 // Per-forward flag: only true when a noncausal range actually reaches this
                 // chunk's query rows. The sticky per-conversation flag lives on
@@ -1189,6 +1196,7 @@ pub mod text_models_inputs_processor {
         mut paged_attn_metadata: Option<&mut PagedAttentionMeta>,
         mapper: Option<&dyn DeviceMapper>,
         sliding_window: Option<usize>,
+        decode_window: usize,
     ) -> Result<InputMetadata> {
         // Pad each sequence by the padding token to the max len.
         let flash_attn = crate::using_flash_attn();
@@ -1217,7 +1225,7 @@ pub mod text_models_inputs_processor {
             } else {
                 &[]
             };
-            let start_pos = ctxt.len().saturating_sub(1);
+            let start_pos = ctxt.len().saturating_sub(decode_window);
             let mut ctxt = ctxt[start_pos..].to_vec();
             ctxt.extend(staged_speculative.iter().copied().map(T::from));
             let query_len = ctxt.len();
@@ -1495,7 +1503,9 @@ pub mod text_models_inputs_processor {
                 paged_kv_chunk_size_map.insert(location, kv_chunk_size_device.clone());
                 paged_kv_block_valid_mask_map.insert(location, block_valid_mask_device.clone());
 
-                if use_standard_metadata {
+                // Block-diffusion decode windows also need the plain tables for the
+                // per-canvas KV gather, regardless of the attention backend layout.
+                if use_standard_metadata || decode_window > 1 {
                     let block_tables_device = block_tables.clone().to_device(&device)?;
                     let context_lens_device = context_lens.clone().to_device(&device)?;
                     block_tables_map.insert(location, block_tables_device.clone());
@@ -1599,16 +1609,19 @@ pub mod text_models_inputs_processor {
 
             Some(PagedAttentionInputMetadata {
                 slot_mappings: slot_mappings_map,
-                block_tables: use_standard_metadata.then_some(block_tables_map),
+                block_tables: (use_standard_metadata || decode_window > 1)
+                    .then_some(block_tables_map),
                 context_lens: use_standard_metadata.then_some(context_lens_map),
                 block_size: Some(block_size),
                 paged_context_lens_cpu: Some(paged_attn_context_lens.clone()),
                 full_paged_context_lens_cpu: Some(full_paged_attn_context_lens.clone()),
                 max_context_len: use_standard_metadata.then_some(*max_context_len),
-                full_block_tables: use_standard_metadata.then_some(full_block_tables_map),
+                full_block_tables: (use_standard_metadata || decode_window > 1)
+                    .then_some(full_block_tables_map),
                 full_context_lens: use_standard_metadata.then_some(full_context_lens_map),
                 full_max_context_len: use_standard_metadata.then_some(full_max_context_len),
                 is_first_prompt_chunk: false,
+                is_final_prompt_chunk: true,
                 prompt_chunk_attention_policy: MultimodalAttentionPolicy::Causal,
                 has_noncausal_mm_context: false,
                 mm_prefix_ranges: None,
@@ -1706,6 +1719,52 @@ pub mod text_models_inputs_processor {
             paged_attn_metadata,
             mapper,
             sliding_window,
+            1,
+        )
+        .map(|inputs| InnerInputProcessorOutput {
+            inputs,
+            seq_indices: (0..input_seqs.len()).collect(),
+        })
+    }
+
+    /// `get_completion_input` for models that consume more than one new token per decode step
+    /// (e.g. block diffusion, where each step feeds the last committed canvas to the encoder).
+    #[allow(clippy::too_many_arguments)]
+    pub(crate) fn get_completion_input_windowed<
+        T: WithDType + std::fmt::Debug + From<u32> + Clone,
+    >(
+        toks: Vec<&[T]>,
+        input_seqs: &[&mut Sequence],
+        device: &Device,
+        no_kv_cache: bool,
+        last_n_context_len: Option<(usize, usize)>,
+        return_raw_logits: bool,
+        paged_attn_metadata: Option<&mut PagedAttentionMeta>,
+        mapper: Option<&dyn DeviceMapper>,
+        sliding_window: Option<usize>,
+        decode_window: usize,
+    ) -> Result<InnerInputProcessorOutput> {
+        if no_kv_cache {
+            return get_prompt_input(
+                toks,
+                input_seqs,
+                device,
+                last_n_context_len,
+                return_raw_logits,
+                paged_attn_metadata,
+                mapper,
+                None,
+            );
+        }
+
+        make_completion_chunk(
+            toks,
+            input_seqs,
+            device,
+            paged_attn_metadata,
+            mapper,
+            sliding_window,
+            decode_window,
         )
         .map(|inputs| InnerInputProcessorOutput {
             inputs,

--- a/mistralrs-core/src/pipeline/loaders/mod.rs
+++ b/mistralrs-core/src/pipeline/loaders/mod.rs
@@ -29,8 +29,8 @@ pub use normal_loaders::{
 };
 
 pub use multimodal_loaders::{
-    AutoMultimodalLoader, Gemma3Loader, Gemma3nLoader, Gemma4Loader, Idefics2Loader,
-    Idefics3Loader, LLaVALoader, LLaVANextLoader, MiniCpmOLoader, Mistral3Loader,
+    AutoMultimodalLoader, DiffusionGemmaLoader, Gemma3Loader, Gemma3nLoader, Gemma4Loader,
+    Idefics2Loader, Idefics3Loader, LLaVALoader, LLaVANextLoader, MiniCpmOLoader, Mistral3Loader,
     MultimodalLoaderType, MultimodalModel, MultimodalModelLoader, Phi3VLoader, Phi4MMLoader,
     Qwen2VLLoader, Qwen2_5VLLoader, Qwen3VLLoader, Qwen3VLMoELoader, Qwen3_5Loader,
     Qwen3_5MoeLoader, VLlama4Loader, VLlamaLoader, VoxtralLoader,

--- a/mistralrs-core/src/pipeline/loaders/multimodal_loaders.rs
+++ b/mistralrs-core/src/pipeline/loaders/multimodal_loaders.rs
@@ -35,6 +35,7 @@ use crate::pipeline::{
 use crate::speculative::SpeculativeTargetMixin;
 use crate::utils::varbuilder_utils::DeviceForLoadTensor;
 use crate::vision_models::clip::ClipConfig;
+use crate::vision_models::diffusion_gemma::{DiffusionGemmaConfig, DiffusionGemmaModel};
 use crate::vision_models::gemma3::config::Gemma3Config;
 use crate::vision_models::gemma3::{Gemma3Model, Gemma3Processor};
 use crate::vision_models::gemma3n::config::{Gemma3nConfig, IntermediateSize};
@@ -106,6 +107,14 @@ pub trait MultimodalModel: IsqModel + AnyMoeBaseModelMixin + SpeculativeTargetMi
     /// Reset model-specific state (e.g. cached audio embeddings) between requests.
     /// Called when the pipeline's non-granular state is reset.
     fn reset_model_specific_state(&self) {}
+    /// Block-diffusion models generate a whole block of tokens per engine step. When true,
+    /// `forward` returns committed block token ids as a u32 tensor [bs, block_len], not logits.
+    fn is_block_diffusion(&self) -> bool {
+        false
+    }
+    /// Hand block-diffusion models the checkpoint's raw `generation_config.json` (the source
+    /// of truth for denoising parameters). No-op for other models.
+    fn configure_block_diffusion(&self, _generation_config_json: &str) {}
 }
 
 pub trait MultimodalModelLoader: IsqModelLoader + Send + Sync + DeviceMappedModelLoader {
@@ -218,6 +227,8 @@ pub enum MultimodalLoaderType {
     Voxtral,
     #[serde(rename = "gemma4")]
     Gemma4,
+    #[serde(rename = "diffusiongemma")]
+    DiffusionGemma,
 }
 
 // https://github.com/huggingface/transformers/blob/cff06aac6fad28019930be03f5d467055bf62177/src/transformers/models/auto/modeling_auto.py#L448
@@ -242,6 +253,7 @@ impl MultimodalLoaderType {
             | "Gemma4ForCausalLM"
             | "Gemma4UnifiedForConditionalGeneration"
             | "Gemma4UnifiedForCausalLM" => Ok(Self::Gemma4),
+            "DiffusionGemmaForBlockDiffusion" => Ok(Self::DiffusionGemma),
             "Qwen3VLForConditionalGeneration" => Ok(Self::Qwen3VL),
             "Qwen3VLMoeForConditionalGeneration" => Ok(Self::Qwen3VLMoE),
             "Qwen3_5ForConditionalGeneration" => Ok(Self::Qwen3_5),
@@ -274,12 +286,13 @@ impl FromStr for MultimodalLoaderType {
             "llama4" => Ok(Self::Llama4),
             "gemma3n" => Ok(Self::Gemma3n),
             "gemma4" => Ok(Self::Gemma4),
+            "diffusiongemma" => Ok(Self::DiffusionGemma),
             "qwen3vl" => Ok(Self::Qwen3VL),
             "qwen3vlmoe" => Ok(Self::Qwen3VLMoE),
             "qwen3_5" => Ok(Self::Qwen3_5),
             "qwen3_5moe" => Ok(Self::Qwen3_5Moe),
             "voxtral" => Ok(Self::Voxtral),
-            a => Err(format!("Unknown architecture `{a}`. Possible architectures: `phi3v`, `idefics2`, `llava_next`, `llava`, `vllama`, `qwen2vl`, `idefics3`, `minicpmo`, `phi4mm`, `qwen2_5vl`, `gemma3`, `mistral3`, `llama4`, `gemma3n`, `gemma4`, `qwen3vl`, `qwen3vlmoe`, `qwen3_5`, `qwen3_5moe`, `voxtral`.")),
+            a => Err(format!("Unknown architecture `{a}`. Possible architectures: `phi3v`, `idefics2`, `llava_next`, `llava`, `vllama`, `qwen2vl`, `idefics3`, `minicpmo`, `phi4mm`, `qwen2_5vl`, `gemma3`, `mistral3`, `llama4`, `gemma3n`, `gemma4`, `qwen3vl`, `qwen3vlmoe`, `qwen3_5`, `qwen3_5moe`, `voxtral`, `diffusiongemma`.")),
         }
     }
 }
@@ -307,6 +320,7 @@ impl std::fmt::Display for MultimodalLoaderType {
             MultimodalLoaderType::Qwen3_5Moe => "qwen3_5moe",
             MultimodalLoaderType::Voxtral => "voxtral",
             MultimodalLoaderType::Gemma4 => "gemma4",
+            MultimodalLoaderType::DiffusionGemma => "diffusiongemma",
         };
         write!(f, "{name}")
     }
@@ -365,6 +379,7 @@ impl AutoMultimodalLoader {
             MultimodalLoaderType::Qwen3_5Moe => Box::new(Qwen3_5MoeLoader),
             MultimodalLoaderType::Voxtral => Box::new(VoxtralLoader),
             MultimodalLoaderType::Gemma4 => Box::new(Gemma4Loader),
+            MultimodalLoaderType::DiffusionGemma => Box::new(DiffusionGemmaLoader),
         })
     }
 }
@@ -7344,6 +7359,7 @@ impl MultimodalModelLoader for Gemma4Loader {
             supports_audio: cfg.audio_config.is_some(),
             raw_audio_frame_size,
             is_unified: cfg.is_unified(),
+            decode_window: None,
         }))
     }
     fn supports_paged_attention(&self, _config: &str) -> bool {
@@ -7749,6 +7765,334 @@ impl DeviceMappedModelLoader for Gemma4Loader {
 
     fn model_config(&self, config: &str) -> Result<Box<dyn ModelConfigLike>> {
         let cfg: Gemma4Config = serde_json::from_str(config)?;
+        let tc = &cfg.text_config;
+
+        let cfg = ModelConfigMetadata {
+            max_seq_len: tc.max_position_embeddings,
+            num_layers: tc.num_hidden_layers,
+            hidden_size: tc.hidden_size,
+            num_kv_heads: tc.num_key_value_heads,
+            num_attn_heads: tc.num_attention_heads,
+            sliding_window: Some(tc.sliding_window),
+            k_head_dim: tc.global_head_dim,
+            v_head_dim: tc.global_head_dim,
+            kv_cache_layout: crate::paged_attention::KvCacheLayout::Standard,
+        };
+
+        Ok(Box::new(cfg))
+    }
+}
+
+// ── DiffusionGemma ─────────────────────────────────────────────────────────
+
+pub struct DiffusionGemmaLoader;
+
+impl DiffusionGemmaLoader {
+    fn is_sliding(tc: &crate::vision_models::gemma4::config::Gemma4TextConfig, i: usize) -> bool {
+        tc.layer_types[i] == "sliding_attention"
+    }
+}
+
+impl MultimodalModelLoader for DiffusionGemmaLoader {
+    fn load(
+        &self,
+        config: &str,
+        vb: ShardedVarBuilder,
+        normal_loading_metadata: NormalLoadingMetadata,
+        attention_mechanism: AttentionImplementation,
+    ) -> Result<Box<dyn MultimodalModel + Send + Sync>> {
+        let cfg: DiffusionGemmaConfig = serde_json::from_str(config)?;
+        Ok(Box::new(DiffusionGemmaModel::new(
+            &cfg,
+            vb,
+            self.is_gptx(config),
+            normal_loading_metadata,
+            attention_mechanism,
+        )?))
+    }
+    fn is_gptx(&self, _config: &str) -> bool {
+        true
+    }
+    fn get_config_repr(&self, config: &str) -> Result<Box<dyn Debug>> {
+        let config: DiffusionGemmaConfig = serde_json::from_str(config)?;
+        Ok(Box::new(config))
+    }
+    fn get_processor(
+        &self,
+        config: &str,
+        processor_config: Option<ProcessorConfig>,
+        _preprocessor_config: PreProcessorConfig,
+        _max_edge: Option<u32>,
+    ) -> Arc<dyn Processor + Send + Sync> {
+        let cfg: DiffusionGemmaConfig =
+            serde_json::from_str(config).expect("Failed to parse DiffusionGemmaConfig");
+        let (patch_size, pooling_kernel_size, default_output_length, supports_images) = cfg
+            .vision_config
+            .as_ref()
+            .map_or((16, 1, 0, false), |vision_cfg| {
+                (
+                    vision_cfg.patch_size,
+                    vision_cfg.pooling_kernel_size,
+                    vision_cfg.default_output_length,
+                    true,
+                )
+            });
+        Arc::new(Gemma4Processor::new(Gemma4ProcessorSettings {
+            processor_config: processor_config.unwrap_or_default(),
+            patch_size,
+            pooling_kernel_size,
+            default_output_length,
+            supports_images,
+            supports_audio: false,
+            raw_audio_frame_size: None,
+            is_unified: false,
+            decode_window: Some(cfg.canvas_length),
+        }))
+    }
+    fn supports_paged_attention(&self, _config: &str) -> bool {
+        true
+    }
+    fn supports_prefix_cacher(&self, _config: &str) -> bool {
+        true
+    }
+    fn prefixer(&self, _config: &str) -> Arc<dyn MultimodalPromptPrefixer> {
+        Arc::new(Gemma4Prefixer)
+    }
+    fn modalities(&self, config: &str) -> Result<Modalities> {
+        let cfg: DiffusionGemmaConfig = serde_json::from_str(config)?;
+        let mut input = vec![SupportedModality::Text];
+        if cfg.vision_config.is_some() {
+            input.push(SupportedModality::Vision);
+        }
+        Ok(Modalities {
+            input,
+            output: vec![SupportedModality::Text],
+        })
+    }
+}
+
+impl IsqModelLoader for DiffusionGemmaLoader {
+    fn isq_layer_regexes(&self, _config: &str) -> Result<Vec<Regex>> {
+        Ok(vec![
+            Regex::new(r"lm_head\.(weight|bias)$")?,
+            Regex::new(r"layers\.(\d+)\.self_attn\.q_proj\.(weight|bias)$")?,
+            Regex::new(r"layers\.(\d+)\.self_attn\.k_proj\.(weight|bias)$")?,
+            Regex::new(r"layers\.(\d+)\.self_attn\.v_proj\.(weight|bias)$")?,
+            Regex::new(r"layers\.(\d+)\.self_attn\.o_proj\.(weight|bias)$")?,
+            Regex::new(r"layers\.(\d+)\.mlp\.gate_proj\.(weight|bias)$")?,
+            Regex::new(r"layers\.(\d+)\.mlp\.up_proj\.(weight|bias)$")?,
+            Regex::new(r"layers\.(\d+)\.mlp\.down_proj\.(weight|bias)$")?,
+            Regex::new(r"layers\.(\d+)\.moe\.gate_up_proj\.weight$")?,
+            Regex::new(r"layers\.(\d+)\.moe\.down_proj\.weight$")?,
+            Regex::new(r"layers\.(\d+)\.experts\.gate_up_proj\.weight$")?,
+            Regex::new(r"layers\.(\d+)\.experts\.down_proj\.weight$")?,
+            Regex::new(r"self_conditioning\.(gate_proj|up_proj|down_proj)\.(weight|bias)$")?,
+        ])
+    }
+    fn immediate_isq_predicates(&self, _config: &str) -> Result<Vec<Regex>> {
+        Ok(vec![
+            Regex::new(r"lm_head\.(weight|bias)$")?,
+            Regex::new(r"model\.decoder\.layers\.(\d+)\.self_attn\.q_proj\.(weight|bias)$")?,
+            Regex::new(r"model\.decoder\.layers\.(\d+)\.self_attn\.k_proj\.(weight|bias)$")?,
+            Regex::new(r"model\.decoder\.layers\.(\d+)\.self_attn\.v_proj\.(weight|bias)$")?,
+            Regex::new(r"model\.decoder\.layers\.(\d+)\.self_attn\.o_proj\.(weight|bias)$")?,
+            Regex::new(r"model\.decoder\.layers\.(\d+)\.mlp\.gate_proj\.(weight|bias)$")?,
+            Regex::new(r"model\.decoder\.layers\.(\d+)\.mlp\.up_proj\.(weight|bias)$")?,
+            Regex::new(r"model\.decoder\.layers\.(\d+)\.mlp\.down_proj\.(weight|bias)$")?,
+            Regex::new(r"model\.decoder\.layers\.(\d+)\.moe\.gate_up_proj\.weight$")?,
+            Regex::new(r"model\.decoder\.layers\.(\d+)\.moe\.down_proj\.weight$")?,
+            Regex::new(r"model\.decoder\.layers\.(\d+)\.experts\.gate_up_proj\.weight$")?,
+            Regex::new(r"model\.decoder\.layers\.(\d+)\.experts\.down_proj\.weight$")?,
+            Regex::new(
+                r"model\.decoder\.self_conditioning\.(gate_proj|up_proj|down_proj)\.(weight|bias)$",
+            )?,
+        ])
+    }
+}
+
+impl DeviceMappedModelLoader for DiffusionGemmaLoader {
+    fn mapped_max_act_size_elems(
+        &self,
+        config: &str,
+        params: &AutoDeviceMapParams,
+    ) -> Result<usize> {
+        let AutoDeviceMapParams::Multimodal {
+            max_seq_len,
+            max_batch_size,
+            max_image_shape: _,
+            max_num_images,
+        } = params
+        else {
+            anyhow::bail!("Expected multimodal AutoDeviceMapParams for this model!")
+        };
+
+        let cfg: DiffusionGemmaConfig = serde_json::from_str(config)?;
+        let tc = &cfg.text_config;
+
+        let vision_tokens_per_image = if cfg.vision_config.is_some() {
+            cfg.vision_soft_tokens_per_image.unwrap_or(280)
+        } else {
+            0
+        };
+        let total_seq_len = *max_seq_len + vision_tokens_per_image * max_num_images;
+        Ok(max_batch_size * tc.num_attention_heads * total_seq_len * total_seq_len)
+    }
+
+    fn non_mapped_max_act_size_elems(
+        &self,
+        config: &str,
+        params: &AutoDeviceMapParams,
+    ) -> Result<usize> {
+        let AutoDeviceMapParams::Multimodal {
+            max_seq_len: _,
+            max_batch_size,
+            max_image_shape: _,
+            max_num_images,
+        } = params
+        else {
+            anyhow::bail!("Expected multimodal AutoDeviceMapParams for this model!")
+        };
+
+        let cfg: DiffusionGemmaConfig = serde_json::from_str(config)?;
+        let (max_vision_attn, max_vision_hidden) =
+            cfg.vision_config.as_ref().map_or((0, 0), |vc| {
+                let max_patches =
+                    vc.default_output_length * vc.pooling_kernel_size * vc.pooling_kernel_size;
+                let max_vision_attn = max_batch_size
+                    * max_num_images
+                    * vc.num_attention_heads
+                    * max_patches
+                    * max_patches;
+                let max_vision_hidden = max_batch_size
+                    * max_num_images
+                    * max_patches
+                    * vc.hidden_size.max(vc.intermediate_size);
+                (max_vision_attn, max_vision_hidden)
+            });
+
+        // The denoising loop materializes several fp32 [canvas, vocab] transients
+        // (logits, log-probs, probs) on the output device.
+        let canvas_logits = 4 * cfg.canvas_length * cfg.text_config.vocab_size;
+
+        Ok(max_vision_attn.max(max_vision_hidden).max(canvas_logits))
+    }
+
+    fn non_mapped_size_in_bytes(
+        &self,
+        config: &str,
+        dtype: DType,
+        weight_pack_factor: usize,
+        _matformer_config: Option<&MatformerSliceConfig>,
+    ) -> Result<usize> {
+        let cfg: DiffusionGemmaConfig = serde_json::from_str(config)?;
+        let tc = &cfg.text_config;
+        let text_elems = {
+            let embed_tokens = tc.hidden_size * tc.vocab_size;
+            let lm_head = if !tc.tie_word_embeddings || weight_pack_factor != 1 {
+                tc.hidden_size * tc.vocab_size / weight_pack_factor
+            } else {
+                0
+            };
+            let norm = tc.hidden_size;
+            let self_conditioning =
+                3 * tc.hidden_size * tc.intermediate_size / weight_pack_factor + tc.hidden_size;
+            embed_tokens + lm_head + norm + self_conditioning
+        };
+
+        let vision_elems = cfg.vision_config.as_ref().map_or(0, |vc| {
+            let vision_layer_elems = {
+                let quantized = vc.hidden_size * vc.num_attention_heads * vc.head_dim
+                    + 3 * (vc.hidden_size * vc.num_key_value_heads * vc.head_dim)
+                    + 2 * (vc.hidden_size * vc.intermediate_size)
+                    + vc.intermediate_size * vc.hidden_size;
+                let norms = 2 * vc.head_dim + 4 * vc.hidden_size;
+                quantized / weight_pack_factor + norms
+            };
+            let patch_embed = vc.patch_size * vc.patch_size * 3 * vc.hidden_size;
+            let position_embedding_table = 2 * vc.position_embedding_size * vc.hidden_size;
+            let patch_embedder = patch_embed / weight_pack_factor + position_embedding_table;
+            let encoder = vc.num_hidden_layers * vision_layer_elems;
+            let embed_vision = vc.hidden_size * tc.hidden_size / weight_pack_factor;
+            patch_embedder + encoder + embed_vision
+        });
+
+        let vision_dtype = if dtype == DType::F16 {
+            DType::F32
+        } else {
+            dtype
+        };
+
+        Ok(text_elems * dtype.size_in_bytes() + vision_elems * vision_dtype.size_in_bytes())
+    }
+
+    fn layer_sizes_in_bytes(
+        &self,
+        config: &str,
+        dtype: DType,
+        weight_pack_factor: usize,
+        _matformer_config: Option<&MatformerSliceConfig>,
+    ) -> Result<Vec<usize>> {
+        let cfg: DiffusionGemmaConfig = serde_json::from_str(config)?;
+        let tc = &cfg.text_config;
+        let sizes: Vec<usize> = (0..tc.num_hidden_layers)
+            .map(|layer_idx| {
+                let is_sliding = Self::is_sliding(tc, layer_idx);
+                let hd = if is_sliding {
+                    tc.head_dim
+                } else {
+                    tc.global_head_dim
+                };
+                let nkv = if is_sliding {
+                    tc.num_key_value_heads
+                } else {
+                    tc.num_global_key_value_heads
+                        .unwrap_or(tc.num_key_value_heads)
+                };
+                let use_k_eq_v = tc.attention_k_eq_v && !is_sliding;
+
+                let mut attn = tc.hidden_size * tc.num_attention_heads * hd
+                    + tc.hidden_size * nkv * hd
+                    + tc.num_attention_heads * hd * tc.hidden_size;
+                if !use_k_eq_v {
+                    attn += tc.hidden_size * nkv * hd;
+                }
+                attn += 2 * hd;
+
+                let mlp = 3 * tc.hidden_size * tc.intermediate_size;
+
+                let moe = if tc.enable_moe_block {
+                    let ne = tc.num_experts.unwrap_or(0);
+                    let ei = tc.expert_intermediate_size().unwrap_or(0);
+                    ne * tc.hidden_size * ei * 2
+                        + ne * ei * tc.hidden_size
+                        + ne
+                        + ne * tc.hidden_size
+                        + tc.hidden_size
+                        + 3 * tc.hidden_size
+                } else {
+                    0
+                };
+
+                // 4 norms + decoder layer_scalar + encoder layer_scalar
+                let norms = 4 * tc.hidden_size + 2;
+
+                (attn + mlp + moe + norms) * dtype.size_in_bytes() / weight_pack_factor
+            })
+            .collect();
+        Ok(sizes)
+    }
+
+    fn num_layers(&self, config: &str) -> Result<usize> {
+        let cfg: DiffusionGemmaConfig = serde_json::from_str(config)?;
+        Ok(cfg.text_config.num_hidden_layers)
+    }
+
+    fn non_mapped_sub_models(&self) -> Option<Vec<NonMappedSubModel>> {
+        Some(vec![NonMappedSubModel::Vision])
+    }
+
+    fn model_config(&self, config: &str) -> Result<Box<dyn ModelConfigLike>> {
+        let cfg: DiffusionGemmaConfig = serde_json::from_str(config)?;
         let tc = &cfg.text_config;
 
         let cfg = ModelConfigMetadata {

--- a/mistralrs-core/src/pipeline/loaders/multimodal_loaders.rs
+++ b/mistralrs-core/src/pipeline/loaders/multimodal_loaders.rs
@@ -115,6 +115,11 @@ pub trait MultimodalModel: IsqModel + AnyMoeBaseModelMixin + SpeculativeTargetMi
     /// Hand block-diffusion models the checkpoint's raw `generation_config.json` (the source
     /// of truth for denoising parameters). No-op for other models.
     fn configure_block_diffusion(&self, _generation_config_json: &str) {}
+    /// Time the last forward spent in the denoising loop (vs encoding); lets the engine
+    /// book that share as completion time rather than prompt time.
+    fn take_block_denoise_time(&self) -> Option<std::time::Duration> {
+        None
+    }
 }
 
 pub trait MultimodalModelLoader: IsqModelLoader + Send + Sync + DeviceMappedModelLoader {

--- a/mistralrs-core/src/pipeline/loaders/multimodal_loaders.rs
+++ b/mistralrs-core/src/pipeline/loaders/multimodal_loaders.rs
@@ -22,6 +22,7 @@ use self::minicpmo::{MiniCpmOConfig, MiniCpmOModel, MiniCpmOProcessor};
 use super::{DeviceMappedModelLoader, NonMappedSubModel, NormalLoadingMetadata};
 use crate::amoe::AnyMoeBaseModelMixin;
 use crate::attention::ATTENTION_CHUNK_SIZE;
+use crate::block_diffusion::BlockDiffusionMixin;
 use crate::device_map::DeviceMapper;
 use crate::layers::Conv3dConfig;
 use crate::matformer::MatformerSliceConfig;
@@ -78,7 +79,9 @@ use crate::vision_models::voxtral::config::VoxtralConfig;
 use crate::vision_models::voxtral::{VoxtralModel, VoxtralProcessor};
 use crate::vision_models::{minicpmo, phi4};
 
-pub trait MultimodalModel: IsqModel + AnyMoeBaseModelMixin + SpeculativeTargetMixin {
+pub trait MultimodalModel:
+    IsqModel + AnyMoeBaseModelMixin + SpeculativeTargetMixin + BlockDiffusionMixin
+{
     // pixel_values and pixel_attention_mask only specified for prompt seqs
     fn forward(
         &self,
@@ -107,19 +110,6 @@ pub trait MultimodalModel: IsqModel + AnyMoeBaseModelMixin + SpeculativeTargetMi
     /// Reset model-specific state (e.g. cached audio embeddings) between requests.
     /// Called when the pipeline's non-granular state is reset.
     fn reset_model_specific_state(&self) {}
-    /// Block-diffusion models generate a whole block of tokens per engine step. When true,
-    /// `forward` returns committed block token ids as a u32 tensor [bs, block_len], not logits.
-    fn is_block_diffusion(&self) -> bool {
-        false
-    }
-    /// Hand block-diffusion models the checkpoint's raw `generation_config.json` (the source
-    /// of truth for denoising parameters). No-op for other models.
-    fn configure_block_diffusion(&self, _generation_config_json: &str) {}
-    /// Time the last forward spent in the denoising loop (vs encoding); lets the engine
-    /// book that share as completion time rather than prompt time.
-    fn take_block_denoise_time(&self) -> Option<std::time::Duration> {
-        None
-    }
 }
 
 pub trait MultimodalModelLoader: IsqModelLoader + Send + Sync + DeviceMappedModelLoader {

--- a/mistralrs-core/src/pipeline/mod.rs
+++ b/mistralrs-core/src/pipeline/mod.rs
@@ -866,6 +866,7 @@ pub enum ForwardInputsResult {
     },
     BlockGeneration {
         token_blocks: Vec<Vec<u32>>,
+        denoise_time: std::time::Duration,
     },
 }
 
@@ -893,8 +894,12 @@ impl ForwardInputsResult {
                 rates: vec![rates[bs_idx]],
                 channels: vec![channels[bs_idx]],
             }),
-            Self::BlockGeneration { token_blocks } => Ok(Self::BlockGeneration {
+            Self::BlockGeneration {
+                token_blocks,
+                denoise_time,
+            } => Ok(Self::BlockGeneration {
                 token_blocks: vec![token_blocks[bs_idx].clone()],
+                denoise_time: *denoise_time,
             }),
         }
     }
@@ -952,6 +957,7 @@ pub trait Pipeline:
         &self,
         _input_seqs: &mut [&mut Sequence],
         _token_blocks: Vec<Vec<u32>>,
+        _denoise_times: Vec<std::time::Duration>,
         _prefix_cacher: &mut PrefixCacheManagerV2,
         _disable_eos_stop: bool,
     ) -> Result<(), candle_core::Error> {
@@ -1251,16 +1257,21 @@ pub trait Pipeline:
                             .await?;
                     }
                     ForwardInputsResult::BlockGeneration { .. } => {
+                        let mut denoise_times = Vec::with_capacity(logits.len());
                         let token_blocks = logits
                             .into_iter()
                             .map(|r| {
                                 #[allow(irrefutable_let_patterns)]
-                                let ForwardInputsResult::BlockGeneration { token_blocks } = r
+                                let ForwardInputsResult::BlockGeneration {
+                                    token_blocks,
+                                    denoise_time,
+                                } = r
                                 else {
                                     unreachable!(
                                         "All results must have same type, `BlockGeneration`"
                                     )
                                 };
+                                denoise_times.push(denoise_time);
                                 token_blocks
                                     .into_iter()
                                     .next()
@@ -1270,6 +1281,7 @@ pub trait Pipeline:
                         self.sample_block_gen(
                             input_seqs,
                             token_blocks,
+                            denoise_times,
                             prefix_cacher,
                             disable_eos_stop,
                         )
@@ -1666,16 +1678,21 @@ pub trait Pipeline:
                             .await?;
                     }
                     ForwardInputsResult::BlockGeneration { .. } => {
+                        let mut denoise_times = Vec::with_capacity(logits.len());
                         let token_blocks = logits
                             .into_iter()
                             .map(|r| {
                                 #[allow(irrefutable_let_patterns)]
-                                let ForwardInputsResult::BlockGeneration { token_blocks } = r
+                                let ForwardInputsResult::BlockGeneration {
+                                    token_blocks,
+                                    denoise_time,
+                                } = r
                                 else {
                                     unreachable!(
                                         "All results must have same type, `BlockGeneration`"
                                     )
                                 };
+                                denoise_times.push(denoise_time);
                                 token_blocks
                                     .into_iter()
                                     .next()
@@ -1685,6 +1702,7 @@ pub trait Pipeline:
                         self.sample_block_gen(
                             input_seqs,
                             token_blocks,
+                            denoise_times,
                             prefix_cacher,
                             disable_eos_stop,
                         )

--- a/mistralrs-core/src/pipeline/mod.rs
+++ b/mistralrs-core/src/pipeline/mod.rs
@@ -48,12 +48,12 @@ pub use isq::{
 use llguidance::toktrie::TokEnv;
 pub use loaders::{
     AdapterKind, AutoDeviceMapParams, AutoEmbeddingLoader, AutoMultimodalLoader, AutoNormalLoader,
-    DeepSeekV2Loader, DeepSeekV3Loader, DeviceMappedModelLoader, DiffusionLoaderType,
-    DiffusionModel, DiffusionModelLoader, EmbeddingGemmaLoader, EmbeddingLoaderType,
-    EmbeddingModel, EmbeddingModelLoader, EmbeddingModelPaths, EmbeddingModule,
-    EmbeddingModulePaths, EmbeddingModuleType, FluxLoader, GLM4Loader, GLM4MoeLiteLoader,
-    GLM4MoeLoader, Gemma2Loader, Gemma3Loader, Gemma3nLoader, Gemma4Loader, GemmaLoader,
-    GptOssLoader, GraniteMoeHybridLoader, Idefics2Loader, Idefics3Loader, LLaVALoader,
+    DeepSeekV2Loader, DeepSeekV3Loader, DeviceMappedModelLoader, DiffusionGemmaLoader,
+    DiffusionLoaderType, DiffusionModel, DiffusionModelLoader, EmbeddingGemmaLoader,
+    EmbeddingLoaderType, EmbeddingModel, EmbeddingModelLoader, EmbeddingModelPaths,
+    EmbeddingModule, EmbeddingModulePaths, EmbeddingModuleType, FluxLoader, GLM4Loader,
+    GLM4MoeLiteLoader, GLM4MoeLoader, Gemma2Loader, Gemma3Loader, Gemma3nLoader, Gemma4Loader,
+    GemmaLoader, GptOssLoader, GraniteMoeHybridLoader, Idefics2Loader, Idefics3Loader, LLaVALoader,
     LLaVANextLoader, LlamaLoader, Loader, LocalModelPaths, MiniCpmOLoader, Mistral3Loader,
     MistralLoader, MixtralLoader, ModelKind, ModelPaths, MultimodalLoaderType, MultimodalModel,
     MultimodalModelLoader, NormalLoaderType, NormalLoadingMetadata, NormalModel, NormalModelLoader,
@@ -185,6 +185,13 @@ impl<'a> ForwardCache<'a> {
         match self {
             Self::Paged { metadata, .. } => metadata_rope_positions(metadata, device),
             Self::Normal(_) | Self::None => None,
+        }
+    }
+
+    pub(crate) fn is_final_prompt_chunk(&self) -> bool {
+        match self {
+            Self::Paged { metadata, .. } => metadata.is_final_prompt_chunk,
+            Self::Normal(_) | Self::None => true,
         }
     }
 
@@ -441,6 +448,10 @@ impl<'a> ModelForwardContext<'a> {
 
     pub(crate) fn is_first_prompt_chunk(&self) -> bool {
         self.cache.is_first_prompt_chunk()
+    }
+
+    pub(crate) fn is_final_prompt_chunk(&self) -> bool {
+        self.cache.is_final_prompt_chunk()
     }
 
     pub(crate) fn mask_cache<'b>(&'b self, normal_cache: &'b [KvCache]) -> ForwardMaskCache<'b> {
@@ -853,6 +864,9 @@ pub enum ForwardInputsResult {
         rates: Vec<usize>,
         channels: Vec<usize>,
     },
+    BlockGeneration {
+        token_blocks: Vec<Vec<u32>>,
+    },
 }
 
 impl ForwardInputsResult {
@@ -879,6 +893,9 @@ impl ForwardInputsResult {
                 rates: vec![rates[bs_idx]],
                 channels: vec![channels[bs_idx]],
             }),
+            Self::BlockGeneration { token_blocks } => Ok(Self::BlockGeneration {
+                token_blocks: vec![token_blocks[bs_idx].clone()],
+            }),
         }
     }
 
@@ -895,6 +912,7 @@ impl ForwardInputsResult {
             }),
             Self::Image { .. } => Ok(self.clone()),
             Self::Speech { .. } => Ok(self.clone()),
+            Self::BlockGeneration { .. } => Ok(self.clone()),
         }
     }
 }
@@ -925,6 +943,19 @@ pub trait Pipeline:
         _config: crate::speculative::SpeculativeConfig,
     ) -> Result<(), candle_core::Error> {
         candle_core::bail!("This pipeline does not support speculative decoding attachment.")
+    }
+
+    /// Append pre-sampled token blocks (block-diffusion canvases) to the sequences via the
+    /// standard per-token finalize path. Overridden by pipelines whose models emit
+    /// `ForwardInputsResult::BlockGeneration`.
+    async fn sample_block_gen(
+        &self,
+        _input_seqs: &mut [&mut Sequence],
+        _token_blocks: Vec<Vec<u32>>,
+        _prefix_cacher: &mut PrefixCacheManagerV2,
+        _disable_eos_stop: bool,
+    ) -> Result<(), candle_core::Error> {
+        candle_core::bail!("This pipeline does not support block generation.")
     }
 
     #[allow(clippy::too_many_arguments)]
@@ -1219,6 +1250,31 @@ pub trait Pipeline:
                         response::send_speech_responses(input_seqs, &pcms, &rates, &channels)
                             .await?;
                     }
+                    ForwardInputsResult::BlockGeneration { .. } => {
+                        let token_blocks = logits
+                            .into_iter()
+                            .map(|r| {
+                                #[allow(irrefutable_let_patterns)]
+                                let ForwardInputsResult::BlockGeneration { token_blocks } = r
+                                else {
+                                    unreachable!(
+                                        "All results must have same type, `BlockGeneration`"
+                                    )
+                                };
+                                token_blocks
+                                    .into_iter()
+                                    .next()
+                                    .expect("Must have at least 1 element.")
+                            })
+                            .collect::<Vec<_>>();
+                        self.sample_block_gen(
+                            input_seqs,
+                            token_blocks,
+                            prefix_cacher,
+                            disable_eos_stop,
+                        )
+                        .await?;
+                    }
                 }
                 let end = Instant::now();
                 exec_duration += end.duration_since(start);
@@ -1349,6 +1405,9 @@ pub trait Pipeline:
 
                             let mut chunk_metadata = metadata.clone();
                             chunk_metadata.prompt_chunk_attention_policy = attention_policy;
+                            chunk_metadata.is_final_prompt_chunk = active_indices
+                                .iter()
+                                .all(|&idx| plan_indices[idx] + 1 == chunk_plans[idx].len());
                             let mut active_input_seqs = input_seqs
                                 .iter_mut()
                                 .enumerate()
@@ -1605,6 +1664,31 @@ pub trait Pipeline:
                             .collect::<Vec<_>>();
                         response::send_speech_responses(input_seqs, &pcms, &rates, &channels)
                             .await?;
+                    }
+                    ForwardInputsResult::BlockGeneration { .. } => {
+                        let token_blocks = logits
+                            .into_iter()
+                            .map(|r| {
+                                #[allow(irrefutable_let_patterns)]
+                                let ForwardInputsResult::BlockGeneration { token_blocks } = r
+                                else {
+                                    unreachable!(
+                                        "All results must have same type, `BlockGeneration`"
+                                    )
+                                };
+                                token_blocks
+                                    .into_iter()
+                                    .next()
+                                    .expect("Must have at least 1 element.")
+                            })
+                            .collect::<Vec<_>>();
+                        self.sample_block_gen(
+                            input_seqs,
+                            token_blocks,
+                            prefix_cacher,
+                            disable_eos_stop,
+                        )
+                        .await?;
                     }
                 }
                 let end = Instant::now();

--- a/mistralrs-core/src/pipeline/multimodal.rs
+++ b/mistralrs-core/src/pipeline/multimodal.rs
@@ -11,8 +11,9 @@ use super::{
     Qwen3_5Loader, Qwen3_5MoeLoader, TokenSource, VLlama4Loader, VLlamaLoader,
 };
 use super::{
-    Gemma3nLoader, Gemma4Loader, Idefics2Loader, Idefics3Loader, LLaVALoader, LLaVANextLoader,
-    Mistral3Loader, MultimodalLoaderType, Phi3VLoader, Qwen2_5VLLoader, VoxtralLoader,
+    DiffusionGemmaLoader, Gemma3nLoader, Gemma4Loader, Idefics2Loader, Idefics3Loader, LLaVALoader,
+    LLaVANextLoader, Mistral3Loader, MultimodalLoaderType, Phi3VLoader, Qwen2_5VLLoader,
+    VoxtralLoader,
 };
 use crate::attention::ATTENTION_CHUNK_SIZE;
 use crate::device_map::{self, DeviceMapper};
@@ -199,6 +200,7 @@ impl MultimodalLoaderBuilder {
             Some(MultimodalLoaderType::Qwen3_5Moe) => Box::new(Qwen3_5MoeLoader),
             Some(MultimodalLoaderType::Voxtral) => Box::new(VoxtralLoader),
             Some(MultimodalLoaderType::Gemma4) => Box::new(Gemma4Loader),
+            Some(MultimodalLoaderType::DiffusionGemma) => Box::new(DiffusionGemmaLoader),
             None => Box::new(AutoMultimodalLoader),
         };
         Box::new(MultimodalLoader {
@@ -615,6 +617,14 @@ impl Loader for MultimodalLoader {
         let gen_conf: Option<GenerationConfig> = paths
             .get_gen_conf_filename()
             .map(|f| serde_json::from_str(&fs::read_to_string(f).unwrap()).unwrap());
+        if model.is_block_diffusion() {
+            if let Some(raw) = paths
+                .get_gen_conf_filename()
+                .and_then(|f| fs::read_to_string(f).ok())
+            {
+                model.configure_block_diffusion(&raw);
+            }
+        }
         let chat_template_explicit = paths
             .get_chat_template_explicit()
             .as_ref()
@@ -1228,6 +1238,11 @@ impl Pipeline for MultimodalPipeline {
         let logits = self
             .model
             .forward(&input_ids, pixel_values, model_specific_args, &mut ctx)?;
+        if self.model.is_block_diffusion() && !return_raw_logits {
+            return Ok(ForwardInputsResult::BlockGeneration {
+                token_blocks: logits.to_dtype(candle_core::DType::U32)?.to_vec2::<u32>()?,
+            });
+        }
         if return_raw_logits {
             Ok(ForwardInputsResult::RawLogits { logits })
         } else {
@@ -1302,6 +1317,23 @@ impl Pipeline for MultimodalPipeline {
         rng: Arc<std::sync::Mutex<Isaac64Rng>>,
     ) -> Result<(), candle_core::Error> {
         sample_and_add_toks(self, seqs, logits, prefix_cacher, disable_eos_stop, rng).await
+    }
+
+    async fn sample_block_gen(
+        &self,
+        input_seqs: &mut [&mut Sequence],
+        token_blocks: Vec<Vec<u32>>,
+        prefix_cacher: &mut PrefixCacheManagerV2,
+        disable_eos_stop: bool,
+    ) -> Result<(), candle_core::Error> {
+        crate::pipeline::sampling::finalize_block_gen(
+            self,
+            input_seqs,
+            token_blocks,
+            prefix_cacher,
+            disable_eos_stop,
+        )
+        .await
     }
     fn category(&self) -> ModelCategory {
         ModelCategory::Multimodal {

--- a/mistralrs-core/src/pipeline/multimodal.rs
+++ b/mistralrs-core/src/pipeline/multimodal.rs
@@ -1241,6 +1241,7 @@ impl Pipeline for MultimodalPipeline {
         if self.model.is_block_diffusion() && !return_raw_logits {
             return Ok(ForwardInputsResult::BlockGeneration {
                 token_blocks: logits.to_dtype(candle_core::DType::U32)?.to_vec2::<u32>()?,
+                denoise_time: self.model.take_block_denoise_time().unwrap_or_default(),
             });
         }
         if return_raw_logits {
@@ -1323,6 +1324,7 @@ impl Pipeline for MultimodalPipeline {
         &self,
         input_seqs: &mut [&mut Sequence],
         token_blocks: Vec<Vec<u32>>,
+        denoise_times: Vec<std::time::Duration>,
         prefix_cacher: &mut PrefixCacheManagerV2,
         disable_eos_stop: bool,
     ) -> Result<(), candle_core::Error> {
@@ -1330,6 +1332,7 @@ impl Pipeline for MultimodalPipeline {
             self,
             input_seqs,
             token_blocks,
+            denoise_times,
             prefix_cacher,
             disable_eos_stop,
         )

--- a/mistralrs-core/src/pipeline/multimodal.rs
+++ b/mistralrs-core/src/pipeline/multimodal.rs
@@ -758,9 +758,17 @@ impl Loader for MultimodalLoader {
             EitherCache::Normal(normal) => normal.lock().unwrap().0.len(),
             EitherCache::Hybrid(hybrid) => hybrid.lock().unwrap().num_layers(),
         };
-        let generation_defaults = gen_conf
+        let mut generation_defaults = gen_conf
             .as_ref()
             .and_then(GenerationConfig::generation_defaults);
+        // HF's `max_new_tokens` for block-diffusion checkpoints is the per-call generate()
+        // default (a single canvas); applying it as a session cap truncates every answer.
+        if model.is_block_diffusion() {
+            if let Some(defaults) = generation_defaults.as_mut() {
+                defaults.max_new_tokens = None;
+                defaults.max_length = None;
+            }
+        }
         let eos = calculate_eos_tokens(&chat_template, gen_conf.as_ref(), &tokenizer);
         let sliding_window = model.config().sliding_window;
         let tracked_modules = tracker.get().clone();

--- a/mistralrs-core/src/pipeline/sampling.rs
+++ b/mistralrs-core/src/pipeline/sampling.rs
@@ -472,6 +472,49 @@ pub(crate) async fn finish_or_add_toks_to_seq(
     Ok(())
 }
 
+/// Append a block of pre-sampled tokens (e.g. a committed block-diffusion canvas) to each
+/// sequence, running the standard per-token finalize path (EOS/length stop, tool parsing,
+/// streaming, prefix caching) for every token. Stops consuming a block once its sequence
+/// finishes.
+pub(crate) async fn finalize_block_gen(
+    this: &dyn Pipeline,
+    seqs: &mut [&mut Sequence],
+    token_blocks: Vec<Vec<u32>>,
+    prefix_cacher: &mut PrefixCacheManagerV2,
+    disable_eos_stop: bool,
+) -> Result<()> {
+    debug_assert_eq!(token_blocks.len(), seqs.len());
+
+    for (block, seq) in std::iter::zip(token_blocks, seqs.iter_mut()) {
+        let metadata = this.get_metadata();
+        let eos_tok = if disable_eos_stop {
+            None
+        } else {
+            Some(&metadata.eos_tok[..])
+        };
+
+        let mut appended = 0usize;
+        for token in block {
+            if !seq.is_running() {
+                break;
+            }
+            let logprobs = crate::sampler::Logprobs {
+                token,
+                logprob: 0.0,
+                bytes: None,
+                top_logprobs: None,
+            };
+            finish_or_add_toks_to_seq(this, prefix_cacher, seq, logprobs, eos_tok, true).await?;
+            appended += 1;
+        }
+        // These tokens only enter the KV cache on the next step's encoder pass; the prefix
+        // cacher must not register blocks covering them.
+        seq.set_unencoded_tail_len(appended);
+    }
+
+    Ok(())
+}
+
 pub async fn sample_and_add_toks(
     this: &dyn Pipeline,
     seqs: &mut [&mut Sequence],

--- a/mistralrs-core/src/pipeline/sampling.rs
+++ b/mistralrs-core/src/pipeline/sampling.rs
@@ -480,12 +480,16 @@ pub(crate) async fn finalize_block_gen(
     this: &dyn Pipeline,
     seqs: &mut [&mut Sequence],
     token_blocks: Vec<Vec<u32>>,
+    denoise_times: Vec<std::time::Duration>,
     prefix_cacher: &mut PrefixCacheManagerV2,
     disable_eos_stop: bool,
 ) -> Result<()> {
     debug_assert_eq!(token_blocks.len(), seqs.len());
 
-    for (block, seq) in std::iter::zip(token_blocks, seqs.iter_mut()) {
+    for ((block, denoise_time), seq) in
+        std::iter::zip(std::iter::zip(token_blocks, denoise_times), seqs.iter_mut())
+    {
+        seq.add_pending_denoise_time(denoise_time);
         let metadata = this.get_metadata();
         let eos_tok = if disable_eos_stop {
             None

--- a/mistralrs-core/src/reasoning_parsers/tag_based.rs
+++ b/mistralrs-core/src/reasoning_parsers/tag_based.rs
@@ -226,8 +226,18 @@ impl TagReasoningContext {
                     }
                 }
 
+                let open_pos = self.buffer.find(&*self.open_tag);
+                let close_pos = self.buffer.find(&*self.close_tag);
+                // A bare close tag outside any reasoning block is a special-token artifact
+                // (e.g. a dangling `<channel|>` right before EOS) - swallow it.
+                if let Some(close_pos) = close_pos.filter(|&c| open_pos.is_none_or(|o| c < o)) {
+                    let content = self.buffer[..close_pos].to_string();
+                    self.accumulated_content.push_str(&content);
+                    self.buffer = self.buffer[close_pos + self.close_tag.len()..].to_string();
+                    continue;
+                }
                 // Looking for open tag
-                if let Some(start_pos) = self.buffer.find(&*self.open_tag) {
+                if let Some(start_pos) = open_pos {
                     // Found opening tag - extract content before it
                     let content = self.buffer[..start_pos].to_string();
                     self.accumulated_content.push_str(&content);
@@ -240,9 +250,11 @@ impl TagReasoningContext {
                         self.pending_strip = true;
                     }
                 } else {
-                    // No complete opening tag found
-                    // Check if buffer might contain a partial opening tag at the end
-                    let partial_len = self.potential_partial_tag_len_for(&self.open_tag);
+                    // No complete opening tag found; hold back anything that could be the
+                    // start of an opening OR closing tag split across token boundaries.
+                    let partial_len = self
+                        .potential_partial_tag_len_for(&self.open_tag)
+                        .max(self.potential_partial_tag_len_for(&self.close_tag));
                     if partial_len > 0 {
                         // Keep the potential partial tag in buffer, process the rest
                         let safe_len = self.buffer.len() - partial_len;

--- a/mistralrs-core/src/sequence.rs
+++ b/mistralrs-core/src/sequence.rs
@@ -669,6 +669,9 @@ pub struct Sequence {
     /// whole canvas per step; it only enters the cache on the NEXT step's encoder pass, so
     /// the prefix cacher must not register blocks covering it.
     unencoded_tail_len: usize,
+    /// Denoising-loop time inside the latest block-generation step; booked as completion
+    /// time even when the step was a prompt step (the encoder prefill is the prompt part).
+    pending_denoise_time_ms: u128,
 
     // Cache
     normal_cache: Vec<Option<KvCache>>,
@@ -799,6 +802,7 @@ impl Sequence {
             prefix_cache_len: 0,
             block_hash_revision: 0,
             unencoded_tail_len: 0,
+            pending_denoise_time_ms: 0,
             suffix,
             prefix,
             cumulative_logprob: 0.,
@@ -1122,6 +1126,12 @@ impl Sequence {
         self.unencoded_tail_len = len;
     }
 
+    pub(crate) fn add_pending_denoise_time(&mut self, time: std::time::Duration) {
+        self.pending_denoise_time_ms = self
+            .pending_denoise_time_ms
+            .saturating_add(time.as_millis());
+    }
+
     fn bump_block_hash_revision(&mut self) {
         self.block_hash_revision = self.block_hash_revision.wrapping_add(1);
     }
@@ -1314,23 +1324,35 @@ impl Sequence {
     }
 
     pub(crate) fn finish_prompt_timing(&mut self, duration: Duration) {
+        // Block diffusion denoises the first canvas inside the prompt step; book that share
+        // as completion time so prompt T/s reflects the encoder prefill alone.
+        let denoise_ms = std::mem::take(&mut self.pending_denoise_time_ms);
+        let prompt_ms = duration.as_millis().saturating_sub(denoise_ms);
         let total = self
             .total_prompt_time
             .unwrap_or(0)
-            .saturating_add(duration.as_millis());
+            .saturating_add(prompt_ms);
         self.total_prompt_time = Some(total);
+        if denoise_ms > 0 {
+            self.total_completion_time = Some(
+                self.total_completion_time
+                    .unwrap_or(0)
+                    .saturating_add(denoise_ms),
+            );
+        }
         self.step_start_instant = None;
         self.step_timing_kind = None;
-        if duration.as_secs_f32() > 0.0 {
+        if prompt_ms > 0 {
             #[allow(clippy::cast_precision_loss)]
             {
-                self.prompt_tok_per_sec = self.len() as f32 / duration.as_secs_f32();
+                self.prompt_tok_per_sec = self.prompt_len as f32 / (prompt_ms as f32 / 1000.0);
             }
         }
         self.update_time_info();
     }
 
     pub(crate) fn finish_completion_timing(&mut self, duration: Duration) {
+        self.pending_denoise_time_ms = 0;
         let total = self
             .total_completion_time
             .unwrap_or(0)

--- a/mistralrs-core/src/sequence.rs
+++ b/mistralrs-core/src/sequence.rs
@@ -665,6 +665,10 @@ pub struct Sequence {
     /// These tokens should be skipped during prefill.
     prefix_cache_len: usize,
     block_hash_revision: u64,
+    /// Trailing tokens not yet encoded into the KV cache. Block-diffusion models append a
+    /// whole canvas per step; it only enters the cache on the NEXT step's encoder pass, so
+    /// the prefix cacher must not register blocks covering it.
+    unencoded_tail_len: usize,
 
     // Cache
     normal_cache: Vec<Option<KvCache>>,
@@ -794,6 +798,7 @@ impl Sequence {
             prefill_prompt_toks: None,
             prefix_cache_len: 0,
             block_hash_revision: 0,
+            unencoded_tail_len: 0,
             suffix,
             prefix,
             cumulative_logprob: 0.,
@@ -1107,6 +1112,14 @@ impl Sequence {
 
     pub fn block_hash_revision(&self) -> u64 {
         self.block_hash_revision
+    }
+
+    pub fn unencoded_tail_len(&self) -> usize {
+        self.unencoded_tail_len
+    }
+
+    pub fn set_unencoded_tail_len(&mut self, len: usize) {
+        self.unencoded_tail_len = len;
     }
 
     fn bump_block_hash_revision(&mut self) {

--- a/mistralrs-core/src/speculative/cache.rs
+++ b/mistralrs-core/src/speculative/cache.rs
@@ -272,6 +272,7 @@ impl<'a> SpeculativeCacheAccess for PagedSpeculativeCacheAccess<'a> {
                 full_context_lens: Some(map_to_devices(&full_context_lens, device, mapper)?),
                 full_max_context_len: Some(base_len + verify_len),
                 is_first_prompt_chunk: false,
+                is_final_prompt_chunk: true,
                 prompt_chunk_attention_policy:
                     crate::paged_attention::block_hash::MultimodalAttentionPolicy::Causal,
                 has_noncausal_mm_context: false,

--- a/mistralrs-core/src/vision_models/diffusion_gemma/config.rs
+++ b/mistralrs-core/src/vision_models/diffusion_gemma/config.rs
@@ -1,0 +1,62 @@
+use serde::Deserialize;
+
+use crate::serde_default_fn;
+use crate::vision_models::gemma4::config::{Gemma4TextConfig, Gemma4VisionConfig};
+
+pub const DEFAULT_CANVAS_LENGTH: usize = 256;
+
+serde_default_fn!(usize, canvas_length, DEFAULT_CANVAS_LENGTH);
+serde_default_fn!(usize, image_token_id, 258880);
+serde_default_fn!(usize, boi_token_id, 255999);
+serde_default_fn!(usize, eoi_token_id, 258882);
+
+#[derive(Debug, Clone)]
+#[allow(dead_code)]
+pub struct DiffusionGemmaConfig {
+    pub text_config: Gemma4TextConfig,
+    pub vision_config: Option<Gemma4VisionConfig>,
+    pub canvas_length: usize,
+    pub image_token_id: usize,
+    pub boi_token_id: usize,
+    pub eoi_token_id: usize,
+    pub vision_soft_tokens_per_image: Option<usize>,
+}
+
+#[derive(Deserialize)]
+struct DiffusionGemmaRawConfig {
+    text_config: Gemma4TextConfig,
+    vision_config: Option<Gemma4VisionConfig>,
+    #[serde(default = "canvas_length")]
+    canvas_length: usize,
+    #[serde(default = "image_token_id")]
+    image_token_id: usize,
+    #[serde(default = "boi_token_id")]
+    boi_token_id: usize,
+    #[serde(default = "eoi_token_id")]
+    eoi_token_id: usize,
+    vision_soft_tokens_per_image: Option<usize>,
+}
+
+impl<'de> Deserialize<'de> for DiffusionGemmaConfig {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let raw = DiffusionGemmaRawConfig::deserialize(deserializer)?;
+        let mut text_config = raw.text_config;
+        // The HF DiffusionGemma text config removed these fields: the model always
+        // uses MoE blocks and k==v projections on full-attention layers.
+        text_config.enable_moe_block = text_config.num_experts.is_some();
+        text_config.attention_k_eq_v = true;
+
+        Ok(Self {
+            text_config,
+            vision_config: raw.vision_config,
+            canvas_length: raw.canvas_length,
+            image_token_id: raw.image_token_id,
+            boi_token_id: raw.boi_token_id,
+            eoi_token_id: raw.eoi_token_id,
+            vision_soft_tokens_per_image: raw.vision_soft_tokens_per_image,
+        })
+    }
+}

--- a/mistralrs-core/src/vision_models/diffusion_gemma/generation.rs
+++ b/mistralrs-core/src/vision_models/diffusion_gemma/generation.rs
@@ -100,7 +100,7 @@ pub fn generate_canvas(
     canvas_kv: &[(Tensor, Tensor)],
     cache_offsets: &[usize],
     device: &Device,
-) -> Result<Vec<Vec<u32>>> {
+) -> Result<(Vec<Vec<u32>>, std::time::Duration)> {
     let canvas_length = model.canvas_length();
     let vocab_size = model.config().text_config.vocab_size;
     let num_seqs = cache_offsets.len();
@@ -236,7 +236,8 @@ pub fn generate_canvas(
         elapsed * 1000.0 / passes as f64,
     );
 
-    argmax_canvas
+    let blocks = argmax_canvas
         .expect("max_denoising_steps >= 1 guarantees at least one pass")
-        .to_vec2::<u32>()
+        .to_vec2::<u32>()?;
+    Ok((blocks, block_start.elapsed()))
 }

--- a/mistralrs-core/src/vision_models/diffusion_gemma/generation.rs
+++ b/mistralrs-core/src/vision_models/diffusion_gemma/generation.rs
@@ -1,0 +1,242 @@
+use candle_core::{DType, Device, Result, Tensor, D};
+use serde::Deserialize;
+
+use super::DiffusionGemmaModel;
+use crate::pipeline::text_positions_tensor;
+
+const DEFAULT_MAX_DENOISING_STEPS: usize = 48;
+const DEFAULT_ENTROPY_BOUND: f64 = 0.1;
+const DEFAULT_T_MIN: f64 = 0.4;
+const DEFAULT_T_MAX: f64 = 0.8;
+const DEFAULT_STABILITY_THRESHOLD: usize = 1;
+const DEFAULT_CONFIDENCE_THRESHOLD: f64 = 0.005;
+const GUMBEL_EPS: f64 = 1e-20;
+
+/// Diffusion sampling parameters; the checkpoint's `generation_config.json` is the source
+/// of truth (request-level temperature/top_p do not apply to block diffusion).
+#[derive(Debug, Clone)]
+pub struct DiffusionParams {
+    pub max_denoising_steps: usize,
+    pub entropy_bound: f64,
+    pub t_min: f64,
+    pub t_max: f64,
+    pub stability_threshold: usize,
+    pub confidence_threshold: f64,
+}
+
+impl Default for DiffusionParams {
+    fn default() -> Self {
+        Self {
+            max_denoising_steps: DEFAULT_MAX_DENOISING_STEPS,
+            entropy_bound: DEFAULT_ENTROPY_BOUND,
+            t_min: DEFAULT_T_MIN,
+            t_max: DEFAULT_T_MAX,
+            stability_threshold: DEFAULT_STABILITY_THRESHOLD,
+            confidence_threshold: DEFAULT_CONFIDENCE_THRESHOLD,
+        }
+    }
+}
+
+#[derive(Deserialize)]
+struct RawSamplerConfig {
+    entropy_bound: Option<f64>,
+}
+
+#[derive(Deserialize)]
+struct RawGenerationConfig {
+    max_denoising_steps: Option<usize>,
+    sampler_config: Option<RawSamplerConfig>,
+    t_min: Option<f64>,
+    t_max: Option<f64>,
+    stability_threshold: Option<usize>,
+    confidence_threshold: Option<f64>,
+}
+
+impl DiffusionParams {
+    pub fn from_generation_config(raw: &str) -> Self {
+        let defaults = Self::default();
+        let Ok(parsed) = serde_json::from_str::<RawGenerationConfig>(raw) else {
+            return defaults;
+        };
+        Self {
+            max_denoising_steps: parsed
+                .max_denoising_steps
+                .unwrap_or(defaults.max_denoising_steps),
+            entropy_bound: parsed
+                .sampler_config
+                .and_then(|sc| sc.entropy_bound)
+                .unwrap_or(defaults.entropy_bound),
+            t_min: parsed.t_min.unwrap_or(defaults.t_min),
+            t_max: parsed.t_max.unwrap_or(defaults.t_max),
+            stability_threshold: parsed
+                .stability_threshold
+                .unwrap_or(defaults.stability_threshold),
+            confidence_threshold: parsed
+                .confidence_threshold
+                .unwrap_or(defaults.confidence_threshold),
+        }
+    }
+}
+
+fn random_canvas(
+    num_seqs: usize,
+    canvas_length: usize,
+    vocab_size: usize,
+    device: &Device,
+) -> Result<Tensor> {
+    let uniform = Tensor::rand(0f32, 1f32, (num_seqs, canvas_length), device)?;
+    (uniform * vocab_size as f64)?.floor()?.to_dtype(DType::U32)
+}
+
+/// Denoise one canvas per sequence, lockstep across the batch. All sequences share the
+/// same context length (`cache_offsets` may still differ only by prefix-cache trims, so
+/// each gets its own rope offset). Returns each sequence's committed argmax canvas (what
+/// HF commits, NOT the renoised stochastic canvas). Sequences that converge early are
+/// frozen in place; the extra passes they ride along for are nearly free since pass cost
+/// is dominated by streaming the expert weights.
+pub fn generate_canvas(
+    model: &DiffusionGemmaModel,
+    params: &DiffusionParams,
+    canvas_kv: &[(Tensor, Tensor)],
+    cache_offsets: &[usize],
+    device: &Device,
+) -> Result<Vec<Vec<u32>>> {
+    let canvas_length = model.canvas_length();
+    let vocab_size = model.config().text_config.vocab_size;
+    let num_seqs = cache_offsets.len();
+    let positions = text_positions_tensor(cache_offsets, canvas_length, device)?;
+
+    // Validation hook: deterministic canvas, one raw denoise pass, dump logits, exit.
+    // Engine warmup uses a 1-token dummy prompt; skip it and fire on the real prompt.
+    if let (Ok(dump_path), true) = (
+        std::env::var("MISTRALRS_DIFFUSION_DEBUG_DUMP"),
+        num_seqs == 1 && cache_offsets[0] > 1,
+    ) {
+        let ids: Vec<u32> = (0..canvas_length as u32)
+            .map(|i| i * 977 % vocab_size as u32)
+            .collect();
+        let fixed = Tensor::from_vec(ids, (1, canvas_length), device)?;
+        let logits = model.denoise_step(&fixed, None, &positions, canvas_kv)?;
+        logits.to_dtype(DType::F32)?.write_npy(&dump_path)?;
+        tracing::info!(
+            "Wrote diffusion debug logits (offset {}) to {dump_path}",
+            cache_offsets[0]
+        );
+        std::process::exit(0);
+    }
+
+    let mut canvas = random_canvas(num_seqs, canvas_length, vocab_size, device)?;
+    let mut argmax_canvas: Option<Tensor> = None;
+    let mut sc_soft: Option<Tensor> = None;
+    let mut history: Vec<Tensor> = Vec::with_capacity(params.stability_threshold);
+    let mut finished = vec![false; num_seqs];
+    let mut finished_mask: Option<Tensor> = None;
+    let block_start = std::time::Instant::now();
+    let mut passes = 0usize;
+
+    for cur_step in (1..=params.max_denoising_steps).rev() {
+        passes += 1;
+        let logits = model.denoise_step(&canvas, sc_soft.as_ref(), &positions, canvas_kv)?;
+
+        // Linear temperature schedule: cur_step counts down, so the first pass is hottest.
+        let temperature = params.t_min
+            + (params.t_max - params.t_min) * (cur_step as f64 / params.max_denoising_steps as f64);
+        let scaled = (logits.to_dtype(DType::F32)? / temperature)?;
+
+        // Gumbel-max: argmax(logits/T - ln(-ln(u))) ~ softmax(logits/T) sample.
+        let u = scaled.rand_like(GUMBEL_EPS, 1.0)?;
+        let gumbel = u.log()?.neg()?.log()?.neg()?;
+        let denoiser_canvas = (&scaled + gumbel)?
+            .argmax(D::Minus1)?
+            .to_dtype(DType::U32)?;
+        let mut new_argmax = scaled.argmax(D::Minus1)?.to_dtype(DType::U32)?;
+
+        let log_probs = candle_nn::ops::log_softmax(&scaled, D::Minus1)?;
+        let probs = log_probs.exp()?;
+        let token_entropy = (&probs * &log_probs)?.sum(D::Minus1)?.neg()?;
+
+        // Entropy-bound acceptance per sequence: take the k lowest-entropy tokens such that
+        // sum(entropy_1..k) - max(entropy_1..k) <= bound; ascending sort makes the running
+        // max the current element, so no cummax is needed.
+        let (sorted_entropy, sorted_indices) = token_entropy.sort_last_dim(true)?;
+        let cumulative = sorted_entropy.cumsum(D::Minus1)?;
+        let sorted_mask = (cumulative - &sorted_entropy)?
+            .le(params.entropy_bound)?
+            .to_dtype(DType::U8)?;
+        let accept_mask = Tensor::zeros((num_seqs, canvas_length), DType::U8, device)?.scatter(
+            &sorted_indices,
+            &sorted_mask,
+            D::Minus1,
+        )?;
+
+        // Accepted positions take the denoiser sample; the rest are renoised uniformly.
+        let renoised = random_canvas(num_seqs, canvas_length, vocab_size, device)?;
+        let mut new_canvas = accept_mask.where_cond(&denoiser_canvas, &renoised)?;
+
+        // Freeze converged sequences: keep their previous canvas/argmax rows.
+        if let (Some(mask), Some(prev_argmax)) = (&finished_mask, &argmax_canvas) {
+            new_canvas = mask.where_cond(&canvas, &new_canvas)?;
+            new_argmax = mask.where_cond(prev_argmax, &new_argmax)?;
+        }
+        canvas = new_canvas;
+
+        // Stop a sequence when its argmax canvas is stable across `stability_threshold`
+        // steps AND its mean token entropy is confidently low. One host read per signal.
+        let mean_entropy = token_entropy.mean(D::Minus1)?.to_vec1::<f32>()?;
+        let stable: Vec<bool> = if history.len() == params.stability_threshold {
+            let mut all_eq = vec![true; num_seqs];
+            for prev in &history {
+                let mismatches = prev
+                    .ne(&new_argmax)?
+                    .to_dtype(DType::F32)?
+                    .sum(D::Minus1)?
+                    .to_vec1::<f32>()?;
+                for (eq, m) in all_eq.iter_mut().zip(mismatches) {
+                    *eq &= m == 0.0;
+                }
+            }
+            all_eq
+        } else {
+            vec![params.stability_threshold == 0; num_seqs]
+        };
+        if params.stability_threshold > 0 {
+            if history.len() == params.stability_threshold {
+                history.remove(0);
+            }
+            history.push(new_argmax.clone());
+        }
+        argmax_canvas = Some(new_argmax);
+
+        let mut changed = false;
+        for i in 0..num_seqs {
+            if !finished[i] && stable[i] && mean_entropy[i] < params.confidence_threshold as f32 {
+                finished[i] = true;
+                changed = true;
+            }
+        }
+        if finished.iter().all(|&f| f) {
+            break;
+        }
+        if changed || (finished_mask.is_none() && finished.iter().any(|&f| f)) {
+            let mask: Vec<u8> = finished.iter().map(|&f| f as u8).collect();
+            finished_mask = Some(
+                Tensor::from_vec(mask, (num_seqs, 1), device)?
+                    .broadcast_as((num_seqs, canvas_length))?,
+            );
+        }
+
+        sc_soft = Some(model.soft_embed(&probs)?);
+    }
+
+    let elapsed = block_start.elapsed().as_secs_f64();
+    tracing::debug!(
+        "{num_seqs} canvas(es) at offsets {cache_offsets:?}: {passes} denoising passes in {elapsed:.2}s \
+         ({:.1} tok/s effective, {:.0}ms/pass)",
+        (num_seqs * canvas_length) as f64 / elapsed,
+        elapsed * 1000.0 / passes as f64,
+    );
+
+    argmax_canvas
+        .expect("max_denoising_steps >= 1 guarantees at least one pass")
+        .to_vec2::<u32>()
+}

--- a/mistralrs-core/src/vision_models/diffusion_gemma/mod.rs
+++ b/mistralrs-core/src/vision_models/diffusion_gemma/mod.rs
@@ -442,9 +442,17 @@ impl crate::pipeline::MultimodalModel for DiffusionGemmaModel {
     fn model_config(&self) -> Arc<dyn crate::paged_attention::ModelConfigLike + Send + Sync> {
         self.text.model_config_like()
     }
+}
 
+impl crate::block_diffusion::BlockDiffusionMixin for DiffusionGemmaModel {
     fn is_block_diffusion(&self) -> bool {
         true
+    }
+
+    fn configure_block_diffusion(&self, generation_config_json: &str) {
+        self.set_diffusion_params(generation::DiffusionParams::from_generation_config(
+            generation_config_json,
+        ));
     }
 
     fn take_block_denoise_time(&self) -> Option<std::time::Duration> {
@@ -452,11 +460,5 @@ impl crate::pipeline::MultimodalModel for DiffusionGemmaModel {
             .last_denoise_micros
             .swap(0, std::sync::atomic::Ordering::Relaxed);
         (micros > 0).then(|| std::time::Duration::from_micros(micros))
-    }
-
-    fn configure_block_diffusion(&self, generation_config_json: &str) {
-        self.set_diffusion_params(generation::DiffusionParams::from_generation_config(
-            generation_config_json,
-        ));
     }
 }

--- a/mistralrs-core/src/vision_models/diffusion_gemma/mod.rs
+++ b/mistralrs-core/src/vision_models/diffusion_gemma/mod.rs
@@ -1,0 +1,449 @@
+#![allow(clippy::cast_possible_truncation, clippy::cast_precision_loss)]
+
+pub(crate) mod config;
+pub(crate) mod generation;
+
+use std::sync::Arc;
+
+use candle_core::{DType, Module, Result, Tensor, D};
+use mistralrs_quant::{NonZeroOp, QuantMethod, ShardedVarBuilder};
+
+use crate::{
+    layers::{Activation, RmsNorm},
+    paged_attention::AttentionImplementation,
+    pipeline::{ModelForwardContext, NormalLoadingMetadata},
+    vision_models::gemma4::{
+        multimodal_embedding::Gemma4MultimodalEmbedder, text::TextModel, vision::VisionTower,
+    },
+};
+
+pub(crate) use config::DiffusionGemmaConfig;
+
+/// Gated MLP over the previous denoising step's soft embeddings; its output is added to
+/// the canvas input embeddings and post-normalized (norm without learned scale).
+struct SelfConditioning {
+    pre_norm: RmsNorm,
+    post_norm: RmsNorm,
+    gate_proj: Arc<dyn QuantMethod>,
+    up_proj: Arc<dyn QuantMethod>,
+    down_proj: Arc<dyn QuantMethod>,
+    act: Activation,
+}
+
+impl SelfConditioning {
+    fn new(
+        hidden_size: usize,
+        intermediate_size: usize,
+        eps: f64,
+        act: Activation,
+        vb: ShardedVarBuilder,
+    ) -> Result<Self> {
+        let pre_norm = RmsNorm::new(hidden_size, eps, vb.pp("pre_norm"))?;
+        let post_norm = RmsNorm::from_w(Tensor::ones(hidden_size, vb.dtype(), vb.device())?, eps)?;
+        let gate_proj = mistralrs_quant::linear_no_bias(
+            hidden_size,
+            intermediate_size,
+            &None,
+            vb.pp("gate_proj"),
+        )?;
+        let up_proj = mistralrs_quant::linear_no_bias(
+            hidden_size,
+            intermediate_size,
+            &None,
+            vb.pp("up_proj"),
+        )?;
+        let down_proj = mistralrs_quant::linear_no_bias(
+            intermediate_size,
+            hidden_size,
+            &None,
+            vb.pp("down_proj"),
+        )?;
+        Ok(Self {
+            pre_norm,
+            post_norm,
+            gate_proj,
+            up_proj,
+            down_proj,
+            act,
+        })
+    }
+
+    fn forward(&self, inputs_embeds: &Tensor, soft_embeds: &Tensor) -> Result<Tensor> {
+        let normed = self.pre_norm.forward(soft_embeds)?;
+        let gated = self.gate_proj.forward(&normed)?.apply(&self.act)?;
+        let up = self.up_proj.forward(&normed)?;
+        let sc_signal = self.down_proj.forward(&(gated * up)?)?;
+        self.post_norm.forward(&(inputs_embeds + sc_signal)?)
+    }
+}
+
+/// DiffusionGemma: a single Gemma4 backbone run in two modes. Encoder mode is causal and
+/// writes the KV cache (prompt prefill, then each accepted canvas); decoder mode denoises
+/// a canvas with bidirectional attention, reading the cache without writing it.
+///
+/// Checkpoint layout: the backbone lives once under `model.decoder.*` (the encoder ties to
+/// it, except per-layer `layer_scalar` buffers); vision under `model.encoder.vision_tower.*`.
+pub struct DiffusionGemmaModel {
+    text: TextModel,
+    vision: Option<(VisionTower, Gemma4MultimodalEmbedder)>,
+    self_conditioning: SelfConditioning,
+    encoder_layer_scalars: Vec<Tensor>,
+    cfg: DiffusionGemmaConfig,
+    embed_scale: f64,
+    vision_dtype: DType,
+    diffusion_params: std::sync::OnceLock<generation::DiffusionParams>,
+}
+
+impl DiffusionGemmaModel {
+    pub fn new(
+        cfg: &DiffusionGemmaConfig,
+        vb: ShardedVarBuilder,
+        is_gptx: bool,
+        normal_loading_metadata: NormalLoadingMetadata,
+        attention_mechanism: AttentionImplementation,
+    ) -> Result<Self> {
+        let vb = vb.pp("model");
+        let text_cfg = &cfg.text_config;
+
+        let vision_dtype = if vb.dtype() == DType::F16 {
+            DType::F32
+        } else {
+            vb.dtype()
+        };
+
+        let vb_encoder = vb.pp("encoder");
+        let vision = if let Some(ref vision_cfg) = cfg.vision_config {
+            let tower = VisionTower::new(
+                vision_cfg,
+                normal_loading_metadata
+                    .mapper
+                    .set_nm_device(vb_encoder.pp("vision_tower"), false)
+                    .set_dtype(vision_dtype),
+            )?;
+            let embedder = Gemma4MultimodalEmbedder::new(
+                vision_cfg.hidden_size,
+                text_cfg.hidden_size,
+                vision_cfg.rms_norm_eps,
+                normal_loading_metadata
+                    .mapper
+                    .set_nm_device(vb_encoder.pp("embed_vision"), false)
+                    .set_dtype(vision_dtype),
+            )?;
+            Some((tower, embedder))
+        } else {
+            None
+        };
+
+        // Encoder layers tie all weights to the decoder's; only `layer_scalar` is its own.
+        let vb_enc_layers = vb_encoder.pp("language_model").pp("layers");
+        let mut encoder_layer_scalars = Vec::with_capacity(text_cfg.num_hidden_layers);
+        for i in 0..text_cfg.num_hidden_layers {
+            let scalar = normal_loading_metadata
+                .mapper
+                .set_device(i, vb_enc_layers.pp(i), false)
+                .get((1,), "layer_scalar")?;
+            encoder_layer_scalars.push(scalar);
+        }
+
+        let vb_decoder = vb.pp("decoder");
+        let self_conditioning = SelfConditioning::new(
+            text_cfg.hidden_size,
+            text_cfg.intermediate_size,
+            text_cfg.rms_norm_eps,
+            text_cfg.hidden_activation,
+            normal_loading_metadata
+                .mapper
+                .set_nm_device(vb_decoder.pp("self_conditioning"), false),
+        )?;
+
+        let text = TextModel::new(
+            text_cfg,
+            Some(cfg.image_token_id),
+            None,
+            vb_decoder,
+            is_gptx,
+            normal_loading_metadata,
+            attention_mechanism,
+        )?;
+
+        Ok(Self {
+            text,
+            vision,
+            self_conditioning,
+            encoder_layer_scalars,
+            embed_scale: (text_cfg.hidden_size as f64).sqrt(),
+            cfg: cfg.clone(),
+            vision_dtype,
+            diffusion_params: std::sync::OnceLock::new(),
+        })
+    }
+
+    pub fn canvas_length(&self) -> usize {
+        self.cfg.canvas_length
+    }
+
+    pub fn config(&self) -> &DiffusionGemmaConfig {
+        &self.cfg
+    }
+
+    /// Encoder pass: causal, writes the KV cache. `xs` are the (vision-merged) input
+    /// embeddings for the uncached tokens (prompt at prefill, last accepted canvas after).
+    pub fn encoder_forward_embeds(
+        &self,
+        input_ids: &Tensor,
+        xs: Tensor,
+        ctx: &mut ModelForwardContext<'_>,
+        has_images: bool,
+    ) -> Result<Tensor> {
+        self.text.forward_embeds_scaled(
+            input_ids,
+            input_ids,
+            xs,
+            ctx,
+            has_images,
+            Some(&self.encoder_layer_scalars),
+        )
+    }
+
+    /// One denoising pass: embed the canvas, inject self-conditioning, run the decoder
+    /// bidirectionally over [cache + canvas]. Returns softcapped logits [b, CL, vocab].
+    /// `sc_soft_embeds` carries `softmax(prev logits) @ embed * scale` from the prior step.
+    pub fn denoise_step(
+        &self,
+        canvas_ids: &Tensor,
+        sc_soft_embeds: Option<&Tensor>,
+        rope_positions: &Tensor,
+        canvas_kv: &[(Tensor, Tensor)],
+    ) -> Result<Tensor> {
+        let inputs_embeds = self.text.embed_tokens(canvas_ids)?;
+        let soft = match sc_soft_embeds {
+            Some(soft) => soft.to_dtype(inputs_embeds.dtype())?,
+            None => inputs_embeds.zeros_like()?,
+        };
+        let xs = self.self_conditioning.forward(&inputs_embeds, &soft)?;
+        self.text
+            .forward_canvas_embeds(xs, rope_positions, canvas_kv)
+    }
+
+    /// Soft embeddings for self-conditioning: `probs @ embed_tokens * scale`, where `probs`
+    /// is the f32 softmax of the previous step's temperature-scaled logits.
+    pub fn soft_embed(&self, probs: &Tensor) -> Result<Tensor> {
+        let embed_w = self.text.embedding().embeddings();
+        let soft = probs.to_dtype(embed_w.dtype())?.broadcast_matmul(embed_w)?;
+        soft * self.embed_scale
+    }
+
+    pub fn set_diffusion_params(&self, params: generation::DiffusionParams) {
+        let _ = self.diffusion_params.set(params);
+    }
+
+    fn diffusion_params(&self) -> generation::DiffusionParams {
+        self.diffusion_params.get().cloned().unwrap_or_default()
+    }
+
+    fn merge_vision_embeds(
+        &self,
+        input_ids: &Tensor,
+        mut input_embeds: Tensor,
+        pixel_values: &Tensor,
+        image_sizes: &[(u32, u32)],
+    ) -> Result<Tensor> {
+        let (tower, embedder) = self.vision.as_ref().ok_or_else(|| {
+            candle_core::Error::Msg(
+                "DiffusionGemma model was loaded without a vision encoder.".to_string(),
+            )
+        })?;
+
+        let n_images = pixel_values.dim(0)?;
+        let per_image = (0..n_images)
+            .map(|i| {
+                let pv = pixel_values.get(i)?.unsqueeze(0)?;
+                let pv = if let Some((h, w)) = image_sizes.get(i).copied() {
+                    pv.narrow(2, 0, h as usize)?.narrow(3, 0, w as usize)?
+                } else {
+                    pv
+                };
+                pv.to_dtype(self.vision_dtype)
+            })
+            .collect::<Result<Vec<_>>>()?;
+        let features = tower.forward(&per_image)?;
+        let image_embeds = embedder
+            .forward(&features)?
+            .to_dtype(input_embeds.dtype())?
+            .squeeze(0)?;
+
+        let image_mask = input_ids
+            .to_dtype(DType::F32)?
+            .eq(self.cfg.image_token_id as f64)?;
+        let image_mask_expanded = image_mask
+            .unsqueeze(D::Minus1)?
+            .broadcast_as(input_embeds.shape())?
+            .to_dtype(DType::U32)?;
+        let indices = image_mask_expanded.flatten_all()?.nonzero()?.squeeze(1)?;
+        if indices.dim(0)? > 0 {
+            let mut x_flat = input_embeds.flatten_all()?;
+            let src_flat = image_embeds.flatten_all()?;
+            let current_vals = x_flat.gather(&indices, 0)?;
+            let diff = (src_flat - current_vals)?;
+            x_flat = x_flat.scatter_add(&indices, &diff, 0)?;
+            input_embeds = x_flat.reshape(input_embeds.shape())?;
+        }
+        Ok(input_embeds)
+    }
+}
+
+impl crate::pipeline::IsqModel for DiffusionGemmaModel {
+    fn residual_tensors(&self) -> Vec<(String, Tensor)> {
+        let mut tensors: Vec<(String, Tensor)> = self
+            .text
+            .residual_tensors()
+            .into_iter()
+            .map(|(name, t)| (format!("model.decoder.{name}"), t))
+            .collect();
+
+        let uvb = crate::utils::unvarbuilder::UnVarBuilder::new();
+        uvb.pp("model")
+            .pp("decoder")
+            .pp("self_conditioning")
+            .pp("pre_norm")
+            .add(&self.self_conditioning.pre_norm);
+        let uvb_enc_layers = uvb
+            .pp("model")
+            .pp("encoder")
+            .pp("language_model")
+            .pp("layers");
+        for (i, scalar) in self.encoder_layer_scalars.iter().enumerate() {
+            uvb_enc_layers
+                .pp(i)
+                .add_tensor("layer_scalar", scalar.clone());
+        }
+        tensors.extend(uvb.to_safetensors());
+
+        if let Some((tower, embedder)) = &self.vision {
+            tensors.extend(
+                tower
+                    .residual_tensors()
+                    .into_iter()
+                    .map(|(name, t)| (format!("model.encoder.vision_tower.{name}"), t)),
+            );
+            tensors.extend(
+                embedder
+                    .residual_tensors()
+                    .into_iter()
+                    .map(|(name, t)| (format!("model.encoder.embed_vision.{name}"), t)),
+            );
+        }
+
+        tensors
+    }
+}
+
+impl crate::amoe::AnyMoeBaseModelMixin for DiffusionGemmaModel {}
+impl crate::speculative::SpeculativeTargetMixin for DiffusionGemmaModel {}
+
+impl crate::pipeline::MultimodalModel for DiffusionGemmaModel {
+    fn forward(
+        &self,
+        input_ids: &Tensor,
+        pixel_values: Option<Tensor>,
+        model_specific_args: Box<dyn std::any::Any>,
+        ctx: &mut ModelForwardContext<'_>,
+    ) -> Result<Tensor> {
+        let (b_sz, _q_len) = input_ids.dims2()?;
+        let args = model_specific_args
+            .downcast::<crate::vision_models::gemma4::Gemma4SpecificArgs>()
+            .expect("DiffusionGemma expects Gemma4SpecificArgs");
+
+        let mut input_embeds = self.text.embed_tokens(input_ids)?;
+        if let Some(ref pixel_values) = pixel_values {
+            input_embeds =
+                self.merge_vision_embeds(input_ids, input_embeds, pixel_values, &args.image_sizes)?;
+        }
+
+        // Encoder pass fills the KV cache; its next-token logits are unused.
+        let _ =
+            self.encoder_forward_embeds(input_ids, input_embeds, ctx, pixel_values.is_some())?;
+
+        // Chunked prompts encode chunk by chunk; only the final chunk denoises a canvas.
+        if !ctx.is_final_prompt_chunk() {
+            return Tensor::from_vec(Vec::<u32>::new(), (b_sz, 0), &candle_core::Device::Cpu);
+        }
+
+        if let Ok(dump_path) = std::env::var("MISTRALRS_DIFFUSION_DEBUG_DUMP") {
+            if input_ids.dim(1)? > 1 {
+                input_ids
+                    .to_dtype(DType::I64)?
+                    .to_device(&candle_core::Device::Cpu)?
+                    .write_npy(format!("{dump_path}.prompt_ids.npy"))?;
+            }
+        }
+
+        // The whole batch denoises in lockstep: the scheduler buckets sequences by context
+        // length, so KV is rectangular and one batched gather + one batched denoise loop
+        // serve every sequence. Offsets may differ only via prefix-cache trims.
+        let params = self.diffusion_params();
+        let offsets = ctx.seqlen_offsets().to_vec();
+        let context_lens = ctx.context_lens().to_vec();
+        let mut cache_offsets = Vec::with_capacity(b_sz);
+        for seq_idx in 0..b_sz {
+            // (start, len) selects this row's real last position, so start + len is its
+            // unpadded query length.
+            let (sel_start, sel_len) = context_lens[seq_idx];
+            cache_offsets.push(offsets[seq_idx] + sel_start + sel_len);
+        }
+        let kv_len = cache_offsets[0];
+        if cache_offsets.iter().any(|&len| len != kv_len) {
+            candle_core::bail!(
+                "block-diffusion batch must share one context length, got {cache_offsets:?}"
+            );
+        }
+        let canvas_kv = self.text.gather_canvas_kv(ctx, b_sz, kv_len)?;
+        let blocks = generation::generate_canvas(
+            self,
+            &params,
+            &canvas_kv,
+            &cache_offsets,
+            input_ids.device(),
+        )?;
+        let canvas_length = blocks[0].len();
+        Tensor::from_vec(
+            blocks.into_iter().flatten().collect::<Vec<u32>>(),
+            (b_sz, canvas_length),
+            &candle_core::Device::Cpu,
+        )
+    }
+
+    fn default_model_specific_args(&self, _input_ids: &Tensor) -> Box<dyn std::any::Any> {
+        Box::new(crate::vision_models::gemma4::Gemma4SpecificArgs::default())
+    }
+
+    fn cache(&self) -> &crate::pipeline::EitherCache {
+        crate::pipeline::MultimodalModel::cache(&self.text)
+    }
+
+    fn device(&self) -> &candle_core::Device {
+        crate::pipeline::MultimodalModel::device(&self.text)
+    }
+
+    fn max_seq_len(&self) -> usize {
+        crate::pipeline::MultimodalModel::max_seq_len(&self.text)
+    }
+
+    fn config(&self) -> &crate::paged_attention::ModelConfigMetadata {
+        crate::pipeline::MultimodalModel::config(&self.text)
+    }
+
+    fn model_config(&self) -> Arc<dyn crate::paged_attention::ModelConfigLike + Send + Sync> {
+        self.text.model_config_like()
+    }
+
+    fn is_block_diffusion(&self) -> bool {
+        true
+    }
+
+    fn configure_block_diffusion(&self, generation_config_json: &str) {
+        self.set_diffusion_params(generation::DiffusionParams::from_generation_config(
+            generation_config_json,
+        ));
+    }
+}

--- a/mistralrs-core/src/vision_models/diffusion_gemma/mod.rs
+++ b/mistralrs-core/src/vision_models/diffusion_gemma/mod.rs
@@ -92,6 +92,7 @@ pub struct DiffusionGemmaModel {
     embed_scale: f64,
     vision_dtype: DType,
     diffusion_params: std::sync::OnceLock<generation::DiffusionParams>,
+    last_denoise_micros: std::sync::atomic::AtomicU64,
 }
 
 impl DiffusionGemmaModel {
@@ -175,6 +176,7 @@ impl DiffusionGemmaModel {
             cfg: cfg.clone(),
             vision_dtype,
             diffusion_params: std::sync::OnceLock::new(),
+            last_denoise_micros: std::sync::atomic::AtomicU64::new(0),
         })
     }
 
@@ -398,13 +400,17 @@ impl crate::pipeline::MultimodalModel for DiffusionGemmaModel {
             );
         }
         let canvas_kv = self.text.gather_canvas_kv(ctx, b_sz, kv_len)?;
-        let blocks = generation::generate_canvas(
+        let (blocks, denoise_time) = generation::generate_canvas(
             self,
             &params,
             &canvas_kv,
             &cache_offsets,
             input_ids.device(),
         )?;
+        self.last_denoise_micros.store(
+            denoise_time.as_micros() as u64,
+            std::sync::atomic::Ordering::Relaxed,
+        );
         let canvas_length = blocks[0].len();
         Tensor::from_vec(
             blocks.into_iter().flatten().collect::<Vec<u32>>(),
@@ -439,6 +445,13 @@ impl crate::pipeline::MultimodalModel for DiffusionGemmaModel {
 
     fn is_block_diffusion(&self) -> bool {
         true
+    }
+
+    fn take_block_denoise_time(&self) -> Option<std::time::Duration> {
+        let micros = self
+            .last_denoise_micros
+            .swap(0, std::sync::atomic::Ordering::Relaxed);
+        (micros > 0).then(|| std::time::Duration::from_micros(micros))
     }
 
     fn configure_block_diffusion(&self, generation_config_json: &str) {

--- a/mistralrs-core/src/vision_models/gemma3/mod.rs
+++ b/mistralrs-core/src/vision_models/gemma3/mod.rs
@@ -185,6 +185,8 @@ pub struct Gemma3SpecificArgs {
 
 impl crate::speculative::SpeculativeTargetMixin for Gemma3Model {}
 
+impl crate::block_diffusion::BlockDiffusionMixin for Gemma3Model {}
+
 impl MultimodalModel for Gemma3Model {
     fn forward(
         &self,

--- a/mistralrs-core/src/vision_models/gemma3/text.rs
+++ b/mistralrs-core/src/vision_models/gemma3/text.rs
@@ -829,6 +829,8 @@ impl IsqModel for TextModel {
 
 impl crate::speculative::SpeculativeTargetMixin for TextModel {}
 
+impl crate::block_diffusion::BlockDiffusionMixin for TextModel {}
+
 impl MultimodalModel for TextModel {
     fn forward(
         &self,

--- a/mistralrs-core/src/vision_models/gemma3n/mod.rs
+++ b/mistralrs-core/src/vision_models/gemma3n/mod.rs
@@ -449,6 +449,8 @@ pub struct Gemma3nSpecificArgs {
 
 impl crate::speculative::SpeculativeTargetMixin for Gemma3nModel {}
 
+impl crate::block_diffusion::BlockDiffusionMixin for Gemma3nModel {}
+
 impl MultimodalModel for Gemma3nModel {
     fn forward(
         &self,

--- a/mistralrs-core/src/vision_models/gemma3n/text.rs
+++ b/mistralrs-core/src/vision_models/gemma3n/text.rs
@@ -1542,6 +1542,8 @@ impl IsqModel for TextModel {
 
 impl crate::speculative::SpeculativeTargetMixin for TextModel {}
 
+impl crate::block_diffusion::BlockDiffusionMixin for TextModel {}
+
 impl MultimodalModel for TextModel {
     fn forward(
         &self,

--- a/mistralrs-core/src/vision_models/gemma4/inputs_processor.rs
+++ b/mistralrs-core/src/vision_models/gemma4/inputs_processor.rs
@@ -12,7 +12,8 @@ use crate::{
     paged_attention::block_hash::{MultimodalAttentionPolicy, MultimodalKind},
     pipeline::{
         text_models_inputs_processor::{
-            self, get_completion_input, get_prompt_input, PagedAttentionMeta,
+            self, get_completion_input, get_completion_input_windowed, get_prompt_input,
+            PagedAttentionMeta,
         },
         InputProcessorOutput, InputsProcessor, InputsProcessorType, MessagesAction, Processor,
     },
@@ -59,6 +60,7 @@ pub struct Gemma4Processor {
     is_unified: bool,
     supports_images: bool,
     supports_audio: bool,
+    decode_window: Option<usize>,
 }
 
 pub struct Gemma4ProcessorSettings {
@@ -70,6 +72,8 @@ pub struct Gemma4ProcessorSettings {
     pub supports_audio: bool,
     pub raw_audio_frame_size: Option<usize>,
     pub is_unified: bool,
+    /// Tokens fed per decode step; block-diffusion models set this to the canvas length.
+    pub decode_window: Option<usize>,
 }
 
 impl Gemma4Processor {
@@ -83,6 +87,7 @@ impl Gemma4Processor {
             supports_audio,
             raw_audio_frame_size,
             is_unified,
+            decode_window,
         } = settings;
         let max_patches = default_output_length * pooling_kernel_size * pooling_kernel_size;
         let audio_seq_length = processor_config.audio_seq_length.unwrap_or(750);
@@ -99,6 +104,7 @@ impl Gemma4Processor {
             is_unified,
             supports_images,
             supports_audio,
+            decode_window,
         }
     }
 }
@@ -119,6 +125,7 @@ impl Processor for Gemma4Processor {
             is_unified: self.is_unified,
             supports_images: self.supports_images,
             supports_audio: self.supports_audio,
+            decode_window: self.decode_window,
         })
     }
 
@@ -154,6 +161,7 @@ struct Gemma4ImageProcessor {
     is_unified: bool,
     supports_images: bool,
     supports_audio: bool,
+    decode_window: Option<usize>,
 }
 
 type UnifiedImagePreprocessOutput = (Tensor, Tensor, Vec<(u32, u32)>);
@@ -1160,6 +1168,31 @@ impl InputsProcessor for Gemma4ImageProcessor {
                 mapper,
                 sliding_window,
             )?
+        } else if let Some(decode_window) = self.decode_window {
+            let mut out = get_completion_input_windowed(
+                input_seqs
+                    .iter()
+                    .map(|seq| seq.get_toks())
+                    .collect::<Vec<_>>(),
+                input_seqs,
+                device,
+                no_kv_cache,
+                last_n_context_len,
+                return_raw_logits,
+                paged_attn_metadata.as_mut(),
+                mapper,
+                sliding_window,
+                decode_window,
+            )?;
+            // The window is re-encoded context, not parallel decode queries: only the last
+            // position's logits matter downstream.
+            for (start, len) in out.inputs.context_lens.iter_mut() {
+                if *len > 1 {
+                    *start = *len - 1;
+                    *len = 1;
+                }
+            }
+            out
         } else {
             get_completion_input(
                 input_seqs
@@ -1356,6 +1389,7 @@ mod tests {
             supports_audio: true,
             raw_audio_frame_size: None,
             is_unified: false,
+            decode_window: None,
         });
         assert_eq!(processor.audio_seq_length, 750);
     }

--- a/mistralrs-core/src/vision_models/gemma4/mod.rs
+++ b/mistralrs-core/src/vision_models/gemma4/mod.rs
@@ -28,7 +28,7 @@ pub(crate) mod audio_processing;
 pub mod config;
 pub(crate) mod inputs_processor;
 mod mtp;
-mod multimodal_embedding;
+pub(crate) mod multimodal_embedding;
 pub(crate) mod text;
 pub mod vision;
 

--- a/mistralrs-core/src/vision_models/gemma4/mod.rs
+++ b/mistralrs-core/src/vision_models/gemma4/mod.rs
@@ -768,6 +768,8 @@ impl IsqModel for Gemma4Model {
     }
 }
 
+impl crate::block_diffusion::BlockDiffusionMixin for Gemma4Model {}
+
 impl MultimodalModel for Gemma4Model {
     fn forward(
         &self,

--- a/mistralrs-core/src/vision_models/gemma4/mtp.rs
+++ b/mistralrs-core/src/vision_models/gemma4/mtp.rs
@@ -1052,6 +1052,7 @@ fn make_mtp_decode_metadata(
         full_context_lens: Some(full_context_lens_map),
         full_max_context_len: Some(context_lens.iter().copied().max().unwrap_or(0)),
         is_first_prompt_chunk: false,
+        is_final_prompt_chunk: true,
         prompt_chunk_attention_policy:
             crate::paged_attention::block_hash::MultimodalAttentionPolicy::Causal,
         has_noncausal_mm_context: false,

--- a/mistralrs-core/src/vision_models/gemma4/text.rs
+++ b/mistralrs-core/src/vision_models/gemma4/text.rs
@@ -680,6 +680,112 @@ impl Attention {
     }
 }
 
+impl Attention {
+    /// Bidirectional canvas attention for block-diffusion decoding: the batch holds N
+    /// sequences with EQUAL context length (scheduler buckets guarantee it), so queries are
+    /// [N, heads, q_len, hd] and `cached_kv` is one batched [N, kv_heads, ctx, hd] snapshot.
+    /// One flash call, causal=false; the cache is read but never written.
+    pub(in crate::vision_models) fn forward_canvas(
+        &self,
+        xs: &Tensor,
+        rope_positions: &Tensor,
+        cached_kv: Option<&(Tensor, Tensor)>,
+        flash_params: &FlashParams,
+    ) -> Result<Tensor> {
+        let (b_sz, q_len, _) = xs.dims3()?;
+
+        let (q, k, v) = if let Some(merged_qkv_proj) = &self.merged_qkv_proj {
+            let mut parts = merged_qkv_proj.forward(xs)?.into_iter();
+            let q = parts.next().unwrap();
+            let k = parts.next().unwrap();
+            let v = parts.next().unwrap_or_else(|| k.clone());
+            (q, k, v)
+        } else {
+            let k = self.k_proj.forward(xs)?;
+            let v = if let Some(ref v_proj) = self.v_proj {
+                v_proj.forward(xs)?
+            } else {
+                k.clone()
+            };
+            (self.q_proj.forward(xs)?, k, v)
+        };
+        let q = q
+            .reshape((b_sz, q_len, self.num_heads, self.head_dim))?
+            .transpose(1, 2)?;
+        let k = k
+            .reshape((b_sz, q_len, self.num_kv_heads, self.head_dim))?
+            .transpose(1, 2)?;
+        let v = v
+            .reshape((b_sz, q_len, self.num_kv_heads, self.head_dim))?
+            .transpose(1, 2)?;
+
+        let (q, mut k, mut v) = if self.is_sliding {
+            self.rotary_emb_local.forward_qkv_norm(
+                &q,
+                &k,
+                &v,
+                self.q_norm.weight(),
+                self.k_norm.weight(),
+                self.v_norm_rms.weight(),
+                self.q_norm.eps(),
+                self.k_norm.eps(),
+                self.v_norm_rms.eps(),
+                rope_positions,
+            )?
+        } else {
+            self.rotary_emb_global.forward_qkv_norm(
+                &q,
+                &k,
+                &v,
+                self.q_norm.weight(),
+                self.k_norm.weight(),
+                self.v_norm_rms.weight(),
+                self.q_norm.eps(),
+                self.k_norm.eps(),
+                self.v_norm_rms.eps(),
+                rope_positions,
+            )?
+        };
+
+        if let Some((ck, cv)) = cached_kv {
+            let (mut ck, mut cv) = (ck.clone(), cv.clone());
+            // Sliding layers see an anchored window: the last `sliding_window` cached tokens,
+            // shared by every canvas query. Rotating caches are already at most the window.
+            if let (true, Some(window)) = (self.is_sliding, self.sdpa_params.sliding_window) {
+                let cache_len = ck.dim(2)?;
+                if cache_len > window {
+                    ck = ck.narrow(2, cache_len - window, window)?;
+                    cv = cv.narrow(2, cache_len - window, window)?;
+                }
+            }
+            k = Tensor::cat(&[&ck.to_device(k.device())?, &k], 2)?;
+            v = Tensor::cat(&[&cv.to_device(v.device())?, &v], 2)?;
+        }
+
+        // The anchored cache window above already implements the sliding rule; per-query
+        // windows inside the canvas must NOT apply (the canvas is fully bidirectional).
+        let sdpa_params = SdpaParams {
+            sliding_window: None,
+            n_kv_groups: self.sdpa_params.n_kv_groups,
+            softcap: self.sdpa_params.softcap,
+            softmax_scale: self.sdpa_params.softmax_scale,
+            sinks: self.sdpa_params.sinks.clone(),
+        };
+        let attn_output = Sdpa
+            .run_attention(
+                &q,
+                &k,
+                &v,
+                &AttentionMask::None,
+                Some(flash_params),
+                &sdpa_params,
+            )?
+            .transpose(1, 2)?
+            .reshape((b_sz, q_len, ()))?;
+        self.o_proj.forward(&attn_output)
+    }
+}
+
 fn sliding_decode_kv_window(
     is_sliding: bool,
     q_len: usize,
@@ -929,14 +1035,13 @@ impl DecoderLayer {
         kv_caches: &mut [KvCache],
         metadata: Option<((Tensor, Tensor), &PagedAttentionInputMetadata)>,
         flash_params: Option<&FlashParams>,
+        layer_scalar_override: Option<&Tensor>,
     ) -> Result<(Tensor, Option<Tensor>)> {
-        let mut xs = xs.clone();
-
         let residual = xs.clone();
         let normed = if let Some(input_normed) = input_normed {
             input_normed.clone()
         } else {
-            self.input_layernorm.forward(&xs)?
+            self.input_layernorm.forward(xs)?
         };
         let attn_out = self.self_attn.forward(
             &normed,
@@ -955,7 +1060,46 @@ impl DecoderLayer {
                 &residual,
                 &self.pre_feedforward_layernorm,
             )?;
-        xs = post_attn;
+
+        self.forward_post_attn(
+            post_attn,
+            pre_ff_normed,
+            next_input_layernorm,
+            per_layer_input,
+            layer_scalar_override,
+        )
+    }
+
+    /// Block-diffusion canvas pass: bidirectional attention reading the KV cache without
+    /// writing it, then the standard FFN/MoE flow.
+    pub(in crate::vision_models) fn forward_canvas(
+        &self,
+        xs: &Tensor,
+        rope_positions: &Tensor,
+        cached_kv: Option<&(Tensor, Tensor)>,
+        flash_params: &FlashParams,
+    ) -> Result<Tensor> {
+        let normed = self.input_layernorm.forward(xs)?;
+        let attn_out =
+            self.self_attn
+                .forward_canvas(&normed, rope_positions, cached_kv, flash_params)?;
+        let (post_attn, pre_ff_normed) = self
+            .post_attention_layernorm
+            .forward_residual_then_rms_norm(&attn_out, xs, &self.pre_feedforward_layernorm)?;
+        let (out, _) = self.forward_post_attn(post_attn, pre_ff_normed, None, None, None)?;
+        Ok(out)
+    }
+
+    fn forward_post_attn(
+        &self,
+        xs: Tensor,
+        pre_ff_normed: Tensor,
+        next_input_layernorm: Option<&RmsNorm>,
+        per_layer_input: Option<&Tensor>,
+        layer_scalar_override: Option<&Tensor>,
+    ) -> Result<(Tensor, Option<Tensor>)> {
+        let mut xs = xs;
+        let layer_scalar = layer_scalar_override.or(self.layer_scalar.as_ref());
 
         // Feedforward
         let residual = xs.clone();
@@ -1003,8 +1147,7 @@ impl DecoderLayer {
             // Dense path: MLP only
             let mlp_out = self.mlp.forward(&pre_ff_normed)?;
             if self.per_layer_input_gate.is_none() {
-                if let (Some(next_norm), Some(scalar)) = (next_input_layernorm, &self.layer_scalar)
-                {
+                if let (Some(next_norm), Some(scalar)) = (next_input_layernorm, layer_scalar) {
                     layer_scalar_applied = true;
                     let (out, normed) = self
                         .post_feedforward_layernorm
@@ -1047,7 +1190,7 @@ impl DecoderLayer {
                 // projection: Linear(ple_dim -> hidden_size)
                 let projected = proj.forward(&gated)?;
                 // post-norm + residual
-                xs = if let Some(ref scalar) = self.layer_scalar {
+                xs = if let Some(scalar) = layer_scalar {
                     layer_scalar_applied = true;
                     if let Some(next_norm) = next_input_layernorm {
                         let (out, normed) = norm.forward_residual_scaled_then_rms_norm(
@@ -1074,7 +1217,7 @@ impl DecoderLayer {
 
         // Apply layer scalar
         if !layer_scalar_applied {
-            if let Some(ref scalar) = self.layer_scalar {
+            if let Some(scalar) = layer_scalar {
                 xs = xs.broadcast_mul(scalar)?;
             }
         }
@@ -1768,9 +1911,24 @@ impl TextModel {
         &self,
         input_ids: &Tensor,
         ple_input_ids: &Tensor,
+        xs: Tensor,
+        ctx: &mut ModelForwardContext<'_>,
+        has_images: bool,
+    ) -> Result<Tensor> {
+        self.forward_embeds_scaled(input_ids, ple_input_ids, xs, ctx, has_images, None)
+    }
+
+    /// `forward_embeds` with per-layer scalar overrides, used by DiffusionGemma's encoder
+    /// mode (the shared backbone holds the decoder's scalars; the encoder has its own).
+    #[allow(clippy::too_many_arguments)]
+    pub(in crate::vision_models) fn forward_embeds_scaled(
+        &self,
+        input_ids: &Tensor,
+        ple_input_ids: &Tensor,
         mut xs: Tensor,
         ctx: &mut ModelForwardContext<'_>,
         has_images: bool,
+        layer_scalar_overrides: Option<&[Tensor]>,
     ) -> Result<Tensor> {
         let cache = &mut self.cache.normal().0;
         let mut context_lens = ctx.context_lens().to_vec();
@@ -2015,6 +2173,7 @@ impl TextModel {
                     })
                 },
                 this_layer_flash,
+                layer_scalar_overrides.map(|scalars| &scalars[i]),
             )?;
             xs = layer_out;
             input_normed = next_normed;
@@ -2090,11 +2249,81 @@ impl TextModel {
         let override_bool = override_mask.to_dtype(candle_core::DType::U8)?;
         override_bool.where_cond(&zero, causal_mask)
     }
-}
 
-// ────────────────────────────────────────────────────────────────────────────
-//  IsqModel
-// ────────────────────────────────────────────────────────────────────────────
+    /// Block-diffusion canvas pass over already-embedded (and self-conditioned) canvas
+    /// inputs. Bidirectional attention over [cached context + canvas], cache read-only.
+    /// Returns softcapped logits for every canvas position.
+    pub(in crate::vision_models) fn forward_canvas_embeds(
+        &self,
+        mut xs: Tensor,
+        rope_positions: &Tensor,
+        canvas_kv: &[(Tensor, Tensor)],
+    ) -> Result<Tensor> {
+        let flash_params = FlashParams::empty(false);
+        for (i, layer) in self.layers.iter().enumerate() {
+            xs = self.mapper.map(xs, i)?;
+            let positions = rope_positions.to_device(xs.device())?;
+            xs = layer.forward_canvas(&xs, &positions, canvas_kv.get(i), &flash_params)?;
+        }
+        let xs = xs.to_device(&self.device)?.apply(&self.norm)?;
+        let mut logits = self.lm_head.forward(&xs)?;
+        if let Some(cap) = self.final_logit_softcapping {
+            logits = softcap(&logits, cap as f32)?;
+        }
+        Ok(logits)
+    }
+
+    pub(in crate::vision_models) fn embedding(&self) -> &ScaledEmbedding {
+        &self.embed_tokens
+    }
+
+    /// Snapshot the frozen encoder cache for a batch of sequences with EQUAL context
+    /// length: one contiguous [N, kv_heads, kv_len, head_size] pair per layer. Paged caches
+    /// gather all sequences in a single kernel call per layer.
+    pub(in crate::vision_models) fn gather_canvas_kv(
+        &self,
+        ctx: &mut ModelForwardContext<'_>,
+        num_seqs: usize,
+        kv_len: usize,
+    ) -> Result<Vec<(Tensor, Tensor)>> {
+        let mut snapshot = Vec::with_capacity(self.layers.len());
+        if ctx.is_paged() {
+            for (i, layer) in self.layers.iter().enumerate() {
+                let ((key_cache, value_cache), metadata) = ctx.paged_layer(i).ok_or_else(|| {
+                    candle_core::Error::Msg("missing paged layer cache for canvas".to_string())
+                })?;
+                let paged = layer
+                    .self_attn
+                    .paged_attn
+                    .as_ref()
+                    .expect("paged metadata implies paged attention layers");
+                let dtype = layer.self_attn.q_norm.weight().dtype();
+                snapshot.push(paged.gather_canvas_kv(
+                    &key_cache,
+                    &value_cache,
+                    metadata,
+                    num_seqs,
+                    kv_len,
+                    dtype,
+                )?);
+            }
+        } else {
+            let cache = &self.cache.normal().0;
+            for kv in cache.iter() {
+                let (Some(k), Some(v)) = (kv.k()?, kv.v()?) else {
+                    candle_core::bail!("empty KV cache during canvas generation");
+                };
+                let (k, v) = if k.dim(2)? > kv_len && !kv.is_rotating() {
+                    (k.narrow(2, 0, kv_len)?, v.narrow(2, 0, kv_len)?)
+                } else {
+                    (k, v)
+                };
+                snapshot.push((k, v));
+            }
+        }
+        Ok(snapshot)
+    }
+}
 
 impl IsqModel for TextModel {
     fn residual_tensors(&self) -> Vec<(String, Tensor)> {

--- a/mistralrs-core/src/vision_models/gemma4/text.rs
+++ b/mistralrs-core/src/vision_models/gemma4/text.rs
@@ -1514,6 +1514,15 @@ impl TextModel {
                 )
             });
         }
+        if cfg.enable_moe_block {
+            crate::moe::prelog_moe_backend(
+                normal_loading_metadata.real_device.clone(),
+                vb_m.dtype(),
+                normal_loading_metadata.loading_isq,
+                &cfg.quantization_config,
+                cfg.hidden_activation,
+            );
+        }
         let vb_l = vb_m.pp("layers");
         let layers = NiceProgressBar::<_, 'b'>(
             0..cfg.num_hidden_layers,
@@ -2402,6 +2411,8 @@ impl IsqModel for TextModel {
 // ────────────────────────────────────────────────────────────────────────────
 
 impl crate::speculative::SpeculativeTargetMixin for TextModel {}
+
+impl crate::block_diffusion::BlockDiffusionMixin for TextModel {}
 
 impl MultimodalModel for TextModel {
     fn forward(

--- a/mistralrs-core/src/vision_models/idefics2/mod.rs
+++ b/mistralrs-core/src/vision_models/idefics2/mod.rs
@@ -1298,6 +1298,8 @@ impl AnyMoeBaseModelMixin for Idefics2 {
 
 impl crate::speculative::SpeculativeTargetMixin for Idefics2 {}
 
+impl crate::block_diffusion::BlockDiffusionMixin for Idefics2 {}
+
 impl MultimodalModel for Idefics2 {
     fn forward(
         &self,

--- a/mistralrs-core/src/vision_models/idefics3/mod.rs
+++ b/mistralrs-core/src/vision_models/idefics3/mod.rs
@@ -303,6 +303,8 @@ impl AnyMoeBaseModelMixin for Idefics3Model {
 
 impl crate::speculative::SpeculativeTargetMixin for Idefics3Model {}
 
+impl crate::block_diffusion::BlockDiffusionMixin for Idefics3Model {}
+
 impl MultimodalModel for Idefics3Model {
     fn forward(
         &self,

--- a/mistralrs-core/src/vision_models/llama4/mod.rs
+++ b/mistralrs-core/src/vision_models/llama4/mod.rs
@@ -208,6 +208,8 @@ impl NormalModel for Llama4Model {
     }
 }
 
+impl crate::block_diffusion::BlockDiffusionMixin for Llama4Model {}
+
 impl MultimodalModel for Llama4Model {
     fn forward(
         &self,

--- a/mistralrs-core/src/vision_models/llava/llava15.rs
+++ b/mistralrs-core/src/vision_models/llava/llava15.rs
@@ -281,6 +281,8 @@ impl IsqModel for Model {
 
 impl crate::speculative::SpeculativeTargetMixin for Model {}
 
+impl crate::block_diffusion::BlockDiffusionMixin for Model {}
+
 impl MultimodalModel for Model {
     fn forward(
         &self,

--- a/mistralrs-core/src/vision_models/llava/llava_next.rs
+++ b/mistralrs-core/src/vision_models/llava/llava_next.rs
@@ -418,6 +418,8 @@ impl IsqModel for Model {
 
 impl crate::speculative::SpeculativeTargetMixin for Model {}
 
+impl crate::block_diffusion::BlockDiffusionMixin for Model {}
+
 impl MultimodalModel for Model {
     fn forward(
         &self,

--- a/mistralrs-core/src/vision_models/minicpmo/mod.rs
+++ b/mistralrs-core/src/vision_models/minicpmo/mod.rs
@@ -336,6 +336,8 @@ pub(crate) struct MiniCpmOSpecificArgs {
 
 impl crate::speculative::SpeculativeTargetMixin for MiniCpmOModel {}
 
+impl crate::block_diffusion::BlockDiffusionMixin for MiniCpmOModel {}
+
 impl MultimodalModel for MiniCpmOModel {
     fn cache(&self) -> &EitherCache {
         self.llm.cache()

--- a/mistralrs-core/src/vision_models/mistral3/mod.rs
+++ b/mistralrs-core/src/vision_models/mistral3/mod.rs
@@ -330,6 +330,8 @@ pub struct Mistral3SpecificArgs {
 
 impl crate::speculative::SpeculativeTargetMixin for Mistral3Model {}
 
+impl crate::block_diffusion::BlockDiffusionMixin for Mistral3Model {}
+
 impl MultimodalModel for Mistral3Model {
     fn forward(
         &self,

--- a/mistralrs-core/src/vision_models/mllama/mod.rs
+++ b/mistralrs-core/src/vision_models/mllama/mod.rs
@@ -242,6 +242,8 @@ pub(crate) struct MLlamaSpecificArgs {
 
 impl crate::speculative::SpeculativeTargetMixin for MLlamaModel {}
 
+impl crate::block_diffusion::BlockDiffusionMixin for MLlamaModel {}
+
 impl MultimodalModel for MLlamaModel {
     fn cache(&self) -> &EitherCache {
         &self.language_model.cache

--- a/mistralrs-core/src/vision_models/mod.rs
+++ b/mistralrs-core/src/vision_models/mod.rs
@@ -23,6 +23,7 @@ pub(crate) mod idefics3;
 pub(crate) mod minicpmo;
 pub(crate) mod phi4;
 pub(crate) use phi4::inputs_processor;
+pub(crate) mod diffusion_gemma;
 pub(crate) mod gemma3;
 pub(crate) mod gemma3n;
 pub(crate) mod gemma4;

--- a/mistralrs-core/src/vision_models/phi3/mod.rs
+++ b/mistralrs-core/src/vision_models/phi3/mod.rs
@@ -1225,6 +1225,8 @@ pub(crate) struct Phi3VisionSpecificArgs {
 
 impl crate::speculative::SpeculativeTargetMixin for Model {}
 
+impl crate::block_diffusion::BlockDiffusionMixin for Model {}
+
 impl MultimodalModel for Model {
     fn forward(
         &self,

--- a/mistralrs-core/src/vision_models/phi4/mod.rs
+++ b/mistralrs-core/src/vision_models/phi4/mod.rs
@@ -522,6 +522,8 @@ pub(crate) struct Phi4MMVisionSpecificArgs {
 
 impl crate::speculative::SpeculativeTargetMixin for Phi4MMModel {}
 
+impl crate::block_diffusion::BlockDiffusionMixin for Phi4MMModel {}
+
 impl MultimodalModel for Phi4MMModel {
     fn forward(
         &self,

--- a/mistralrs-core/src/vision_models/qwen2_5_vl/mod.rs
+++ b/mistralrs-core/src/vision_models/qwen2_5_vl/mod.rs
@@ -519,6 +519,8 @@ pub(crate) struct Qwen2_5VLVisionSpecificArgs {
 
 impl crate::speculative::SpeculativeTargetMixin for Qwen2_5VLModel {}
 
+impl crate::block_diffusion::BlockDiffusionMixin for Qwen2_5VLModel {}
+
 impl MultimodalModel for Qwen2_5VLModel {
     fn forward(
         &self,

--- a/mistralrs-core/src/vision_models/qwen2vl/mod.rs
+++ b/mistralrs-core/src/vision_models/qwen2vl/mod.rs
@@ -519,6 +519,8 @@ pub(crate) struct Qwen2VLVisionSpecificArgs {
 
 impl crate::speculative::SpeculativeTargetMixin for Qwen2VLModel {}
 
+impl crate::block_diffusion::BlockDiffusionMixin for Qwen2VLModel {}
+
 impl MultimodalModel for Qwen2VLModel {
     fn forward(
         &self,

--- a/mistralrs-core/src/vision_models/qwen3_5/mod.rs
+++ b/mistralrs-core/src/vision_models/qwen3_5/mod.rs
@@ -458,6 +458,8 @@ impl Qwen3_5Model {
 
 impl crate::speculative::SpeculativeTargetMixin for Qwen3_5Model {}
 
+impl crate::block_diffusion::BlockDiffusionMixin for Qwen3_5Model {}
+
 impl MultimodalModel for Qwen3_5Model {
     fn forward(
         &self,

--- a/mistralrs-core/src/vision_models/qwen3_5_moe/mod.rs
+++ b/mistralrs-core/src/vision_models/qwen3_5_moe/mod.rs
@@ -458,6 +458,8 @@ impl Qwen3_5MoeModel {
 
 impl crate::speculative::SpeculativeTargetMixin for Qwen3_5MoeModel {}
 
+impl crate::block_diffusion::BlockDiffusionMixin for Qwen3_5MoeModel {}
+
 impl MultimodalModel for Qwen3_5MoeModel {
     fn forward(
         &self,

--- a/mistralrs-core/src/vision_models/qwen3_vl/mod.rs
+++ b/mistralrs-core/src/vision_models/qwen3_vl/mod.rs
@@ -766,6 +766,8 @@ pub(crate) struct Qwen3VLVisionSpecificArgs {
 
 impl crate::speculative::SpeculativeTargetMixin for Qwen3VLModel {}
 
+impl crate::block_diffusion::BlockDiffusionMixin for Qwen3VLModel {}
+
 impl MultimodalModel for Qwen3VLModel {
     fn forward(
         &self,

--- a/mistralrs-core/src/vision_models/qwen3_vl_moe/mod.rs
+++ b/mistralrs-core/src/vision_models/qwen3_vl_moe/mod.rs
@@ -451,6 +451,8 @@ impl Qwen3VLMoEModel {
 
 impl crate::speculative::SpeculativeTargetMixin for Qwen3VLMoEModel {}
 
+impl crate::block_diffusion::BlockDiffusionMixin for Qwen3VLMoEModel {}
+
 impl MultimodalModel for Qwen3VLMoEModel {
     fn forward(
         &self,

--- a/mistralrs-core/src/vision_models/voxtral/mod.rs
+++ b/mistralrs-core/src/vision_models/voxtral/mod.rs
@@ -684,6 +684,8 @@ impl IsqModel for VoxtralModel {
 
 impl crate::speculative::SpeculativeTargetMixin for VoxtralModel {}
 
+impl crate::block_diffusion::BlockDiffusionMixin for VoxtralModel {}
+
 impl MultimodalModel for VoxtralModel {
     fn forward(
         &self,

--- a/mistralrs-pyo3/mistralrs.pyi
+++ b/mistralrs-pyo3/mistralrs.pyi
@@ -259,6 +259,7 @@ class MultimodalArchitecture(Enum):
     Qwen3_5Moe = "Qwen3_5Moe"
     Voxtral = "Voxtral"
     Gemma4 = "Gemma4"
+    DiffusionGemma = "DiffusionGemma"
 
 @dataclass
 class DiffusionArchitecture(Enum):

--- a/mistralrs-pyo3/src/which.rs
+++ b/mistralrs-pyo3/src/which.rs
@@ -100,6 +100,7 @@ pub enum MultimodalArchitecture {
     Qwen3_5Moe,
     Voxtral,
     Gemma4,
+    DiffusionGemma,
 }
 
 impl From<MultimodalArchitecture> for MultimodalLoaderType {
@@ -125,6 +126,7 @@ impl From<MultimodalArchitecture> for MultimodalLoaderType {
             MultimodalArchitecture::Qwen3_5Moe => MultimodalLoaderType::Qwen3_5Moe,
             MultimodalArchitecture::Voxtral => MultimodalLoaderType::Voxtral,
             MultimodalArchitecture::Gemma4 => MultimodalLoaderType::Gemma4,
+            MultimodalArchitecture::DiffusionGemma => MultimodalLoaderType::DiffusionGemma,
         }
     }
 }

--- a/mistralrs/examples/models/diffusion_gemma/main.rs
+++ b/mistralrs/examples/models/diffusion_gemma/main.rs
@@ -1,0 +1,48 @@
+//! DiffusionGemma: block-diffusion text generation.
+//!
+//! The model denoises 256-token blocks in parallel instead of sampling tokens one at a
+//! time, so streamed output arrives block by block. Sampling parameters are ignored in
+//! favor of the checkpoint's denoising schedule.
+//!
+//! Run with: `cargo run --release --example diffusion_gemma -p mistralrs`
+
+use std::io::Write;
+
+use anyhow::Result;
+use mistralrs::{
+    ChatCompletionChunkResponse, ChunkChoice, Delta, MultimodalModelBuilder, Response,
+    TextMessageRole, TextMessages,
+};
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    let model = MultimodalModelBuilder::new("google/diffusiongemma-26B-A4B-it")
+        .with_logging()
+        .build()
+        .await?;
+
+    let messages = TextMessages::new().add_message(
+        TextMessageRole::User,
+        "Explain how block diffusion differs from autoregressive text generation.",
+    );
+
+    let mut stream = model.stream_chat_request(messages).await?;
+    while let Some(chunk) = stream.next().await {
+        if let Response::Chunk(ChatCompletionChunkResponse { choices, .. }) = chunk {
+            if let Some(ChunkChoice {
+                delta: Delta {
+                    content: Some(content),
+                    ..
+                },
+                ..
+            }) = choices.first()
+            {
+                print!("{content}");
+                std::io::stdout().flush()?;
+            }
+        }
+    }
+    println!();
+
+    Ok(())
+}

--- a/mistralrs/examples/models/multimodal_models/main.rs
+++ b/mistralrs/examples/models/multimodal_models/main.rs
@@ -18,6 +18,7 @@
 /// | Gemma 3                      | `google/gemma-3-4b-it`                                   |
 /// | Gemma 3n                     | `google/gemma-3n-E4B-it`                                 |
 /// | Gemma 4                      | `google/gemma-4-E4B-it`                                  |
+/// | DiffusionGemma               | `google/diffusiongemma-26B-A4B-it`                       |
 /// | MiniCPM-o 2.6                | `openbmb/MiniCPM-o-2_6`                                 |
 /// | Mistral Small 3.1            | `mistralai/Mistral-Small-3.1-24B-Instruct-2503`         |
 /// | Llama 4 Scout                | `meta-llama/Llama-4-Scout-17B-16E-Instruct`             |


### PR DESCRIPTION
## Overview

Adds full support for [DiffusionGemma](https://huggingface.co/google/diffusiongemma-26B-A4B-it) (`DiffusionGemmaForBlockDiffusion`), Google's block-diffusion text generation model.

This is the first non-autoregressive text path in mistral.rs (the model denoises 256-token blocks in parallel instead of sampling tokens one at a time), and so this PR also integrates block diffusion models into pipeline and general infra too so it is drop-in.

## Performance (GB10, bf16, single request)

| | mistral.rs | vLLM (PR #45163 image) |
|---|---|---|
| Denoising pass (256 tok) | 253 ms (`cutile`) | ~250 ms |
| 1024-token essay | 52–69 tok/s | 55–61 tok/s |
| Passes per canvas | 14–26 | 15–24 |
