### PR TITLE
feat(docs): regenerate Python reference, add calibration endpoints to HTTP API reference

### DIFF
--- a/docs/src/content/docs/reference/http-api.md
+++ b/docs/src/content/docs/reference/http-api.md
@@ -301,6 +301,18 @@ Returns a diagnostic report equivalent to `mistralrs doctor` output.
 
 Re-apply ISQ to the loaded model.
 
+### `POST /calibration/start`
+
+Begin online calibration: collect activation statistics from live traffic on every ISQ-tracked layer. Returns the collection status. Errors unless the model was loaded with ISQ from source weights. See [Online calibration](/mistral.rs/guides/perf/online-calibration/).
+
+### `GET /calibration/status`
+
+Per-layer collection progress: `collecting`, `layers`, `layers_tracking`, `total_rows`, `min_rows`, `max_rows`.
+
+### `POST /calibration/apply`
+
+Requantize from the source weights with the collected statistics and hot-swap the layers. Returns the pre-apply status. Body: `{"save_cimatrix": "<path>.cimatrix"}` (optional) writes the collected importance matrix for reuse with `--imatrix`.
+
 ## Streaming event types
 
 Streaming responses are Server-Sent Events. Default (unnamed) `data:` lines carry chat completion chunks in OpenAI format; the stream ends with `data: [DONE]`. Named events are used for the agentic timeline:

--- a/docs/src/content/docs/reference/python/enums.md
+++ b/docs/src/content/docs/reference/python/enums.md
@@ -69,6 +69,7 @@ Members and their wire/config names where relevant. The members are fieldless Py
 | `MultimodalArchitecture.Qwen3_5Moe` | `'Qwen3_5Moe'` |
 | `MultimodalArchitecture.Voxtral` | `'Voxtral'` |
 | `MultimodalArchitecture.Gemma4` | `'Gemma4'` |
+| `MultimodalArchitecture.DiffusionGemma` | `'DiffusionGemma'` |
 
 
 ## `DiffusionArchitecture`

--- a/docs/src/content/docs/reference/python/runner.md
+++ b/docs/src/content/docs/reference/python/runner.md
@@ -195,6 +195,54 @@ Send a request to re-ISQ the model. If the model was loaded as GGUF or GGML then
 | `dtype` | `str` | required | The ISQ dtype (e.g., "Q4K", "Q8_0"). |
 | `model_id` | `str \| None` | `None` | Optional model ID to re-ISQ. If None, uses the default model. |
 
+### `Runner.begin_calibration`
+
+```text
+begin_calibration(model_id: str | None = None) -> CalibrationStatus
+```
+
+Begin online calibration: collect activation statistics from live traffic on every
+ISQ-tracked layer. The model must have been loaded with ISQ.
+
+**Parameters**
+
+| Name | Type | Default | Description |
+| --- | --- | --- | --- |
+| `model_id` | `str \| None` | `None` | Optional model ID. If None, uses the default model. |
+
+### `Runner.calibration_status`
+
+```text
+calibration_status(model_id: str | None = None) -> CalibrationStatus
+```
+
+Report per-layer calibration collection progress.
+
+**Parameters**
+
+| Name | Type | Default | Description |
+| --- | --- | --- | --- |
+| `model_id` | `str \| None` | `None` | Optional model ID. If None, uses the default model. |
+
+### `Runner.apply_calibration`
+
+```text
+apply_calibration(
+    save_cimatrix: str | None = None,
+    model_id: str | None = None,
+) -> CalibrationStatus
+```
+
+Requantize from the source weights with the collected statistics and hot-swap the
+layers into the live model. Returns the pre-apply status.
+
+**Parameters**
+
+| Name | Type | Default | Description |
+| --- | --- | --- | --- |
+| `save_cimatrix` | `str \| None` | `None` | Optional `.cimatrix` path to save the collected importance matrix. |
+| `model_id` | `str \| None` | `None` | Optional model ID. If None, uses the default model. |
+
 ### `Runner.tokenize_text`
 
 ```text

--- a/docs/src/content/docs/reference/python/which.md
+++ b/docs/src/content/docs/reference/python/which.md
@@ -43,6 +43,8 @@ Usage:
 | `from_uqff` | `str \| list[str] \| None` | `None` |
 | `dtype` | `ModelDType` | `ModelDType.Auto` |
 | `hf_cache_path` | `str \| None` | `None` |
+| `imatrix` | `str \| None` | `None` |
+| `calibration_file` | `str \| None` | `None` |
 
 ### `Which.XLora`
 


### PR DESCRIPTION
The Python reference pages are generated from `mistralrs.pyi` by `docs/scripts/render_pyi.py`, which was not re-run for the online calibration merge. Regenerating picks up:

- `Runner.begin_calibration` / `calibration_status` / `apply_calibration` and the `CalibrationStatus` class (runner.md)
- `Which.Embedding` `imatrix` / `calibration_file` parameters (which.md)
- `MultimodalArchitecture.DiffusionGemma` (enums.md)

Also adds the three `/calibration/*` endpoints to `reference/http-api.md`, which documents every server route.