### PR TITLE
Return a clear error instead of panicking on unknown GGUF architecture

### DIFF
--- a/mistralrs-core/src/gguf/content.rs
+++ b/mistralrs-core/src/gguf/content.rs
@@ -148,10 +148,12 @@ impl<'a, R: std::io::Seek + std::io::Read> Content<'a, R> {
                     .to_string()
                     .context("Model metadata should have declared an architecture")
                     .and_then(GGUFArchitecture::from_value)
-                    .unwrap(),
+                    .map_err(candle_core::Error::msg)?,
             );
         }
-        let arch = arch.expect("GGUF files must specify `general.architecture`");
+        let Some(arch) = arch else {
+            candle_core::bail!("GGUF files must specify `general.architecture`");
+        };
 
         let mut all_metadata = HashMap::new();
         for content in &contents {
@@ -253,5 +255,62 @@ impl<'a, R: std::io::Seek + std::io::Read> Content<'a, R> {
     /// Get all metadatas
     pub fn get_metadata(&self) -> &HashMap<String, Value> {
         &self.all_metadata
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::io::Cursor;
+
+    use candle_core::quantized::gguf_file;
+
+    use super::Content;
+
+    fn gguf_with_metadata(metadata: &[(&str, &gguf_file::Value)]) -> Cursor<Vec<u8>> {
+        let mut buf = Cursor::new(Vec::new());
+        gguf_file::write(&mut buf, metadata, &[]).unwrap();
+        buf.set_position(0);
+        buf
+    }
+
+    #[test]
+    fn unknown_architecture_is_an_error() {
+        let arch = gguf_file::Value::String("gemma4".to_string());
+        let mut reader = gguf_with_metadata(&[("general.architecture", &arch)]);
+        let mut readers = [&mut reader];
+        let err = match Content::from_readers(&mut readers) {
+            Ok(_) => panic!("expected an error"),
+            Err(e) => e,
+        };
+        let msg = err.to_string();
+        assert!(msg.contains("Unknown GGUF architecture `gemma4`"), "{msg}");
+        assert!(msg.contains("Supported architectures: llama"), "{msg}");
+    }
+
+    #[test]
+    fn unknown_architecture_error_is_safe_to_print() {
+        let hostile = format!("gemma4\x1b[2J\nFAKE LOG LINE{}", "a".repeat(4096));
+        let arch = gguf_file::Value::String(hostile);
+        let mut reader = gguf_with_metadata(&[("general.architecture", &arch)]);
+        let mut readers = [&mut reader];
+        let err = match Content::from_readers(&mut readers) {
+            Ok(_) => panic!("expected an error"),
+            Err(e) => e,
+        };
+        let msg = err.to_string();
+        assert!(!msg.chars().any(char::is_control), "{msg:?}");
+        assert!(msg.len() < 1024, "len {}: {msg:?}", msg.len());
+        assert!(msg.contains("gemma4"), "{msg:?}");
+    }
+
+    #[test]
+    fn missing_architecture_is_an_error() {
+        let mut reader = gguf_with_metadata(&[]);
+        let mut readers = [&mut reader];
+        let err = match Content::from_readers(&mut readers) {
+            Ok(_) => panic!("expected an error"),
+            Err(e) => e,
+        };
+        assert!(err.to_string().contains("general.architecture"), "{err}");
     }
 }

--- a/mistralrs-core/src/gguf/mod.rs
+++ b/mistralrs-core/src/gguf/mod.rs
@@ -11,7 +11,9 @@ use std::str::FromStr;
 
 pub const GGUF_MULTI_FILE_DELIMITER: &str = ";";
 
-#[derive(Debug, EnumString, Clone, Copy, strum::Display)]
+const MAX_SHOWN_ARCH_LEN: usize = 64;
+
+#[derive(Debug, EnumString, Clone, Copy, strum::Display, strum::VariantNames)]
 #[strum(serialize_all = "lowercase")]
 pub enum GGUFArchitecture {
     Llama,
@@ -37,8 +39,24 @@ pub enum GGUFArchitecture {
 // - Customized error until potential upstream support: https://github.com/Peternator7/strum/issues/332
 impl GGUFArchitecture {
     pub fn from_value<T: AsRef<str> + std::fmt::Display>(value: T) -> Result<Self> {
-        Self::from_str(&value.as_ref().to_ascii_lowercase())
-            .with_context(|| format!("Unknown GGUF architecture `{value}`"))
+        let value = value.as_ref();
+        Self::from_str(&value.to_ascii_lowercase())
+            .with_context(|| {
+                // Untrusted file metadata headed for terminal/logs: cap and escape it.
+                let mut chars = value.chars();
+                let shown: String = chars
+                    .by_ref()
+                    .take(MAX_SHOWN_ARCH_LEN)
+                    .flat_map(char::escape_default)
+                    .collect();
+                let ellipsis = if chars.next().is_some() { "..." } else { "" };
+                format!(
+                    "Unknown GGUF architecture `{shown}{ellipsis}`: the file's metadata declares \
+                    an architecture this version of mistral.rs does not support (the model may \
+                    be newer than this build). Supported architectures: {}",
+                    <Self as strum::VariantNames>::VARIANTS.join(", ")
+                )
+            })
             .map_err(anyhow::Error::msg)
     }
 }


### PR DESCRIPTION
`Content::from_readers` unwrapped the `GGUFArchitecture::from_value` result, so a GGUF file declaring an unsupported architecture (e.g. `gemma4` from Unsloth's Gemma 4 GGUFs) crashed the process. This propagates the error instead, converts the missing-`general.architecture` expect into an error as well, and extends the message with the list of supported architectures (derived via `strum::VariantNames`, so it stays in sync) so users can immediately tell the model is newer than the build rather than suspecting a local fault:

```
Unknown GGUF architecture `gemma4`: the file's metadata declares an architecture this version of mistral.rs does not support (the model may be newer than this build). Supported architectures: llama, mpt, ..., qwen3moe, mistral3
```

Since the architecture string is untrusted file metadata that ends up in terminals and logs, the displayed value is capped at 64 chars with control characters escaped, ruling out ANSI-escape and log-line injection from crafted files.

Adds unit tests covering both error paths plus a hostile-metadata case, using in-memory GGUF files.

Fixes #2098

🤖 Generated with [Claude Code](https://claude.com/claude-code)