### PR TITLE
ci(docs): check generated docs artifacts

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -4,13 +4,25 @@ on:
   push:
     branches: ["master"]
     paths:
+      - "Cargo.lock"
+      - "Cargo.toml"
       - "docs/**"
+      - "examples/**"
+      - "mistralrs/examples/**"
+      - "mistralrs-cli/**"
       - "mistralrs-pyo3/**"
+      - "mistralrs-server-core/**"
       - ".github/workflows/docs.yml"
   pull_request:
     paths:
+      - "Cargo.lock"
+      - "Cargo.toml"
       - "docs/**"
+      - "examples/**"
+      - "mistralrs/examples/**"
+      - "mistralrs-cli/**"
       - "mistralrs-pyo3/**"
+      - "mistralrs-server-core/**"
       - ".github/workflows/docs.yml"
   workflow_dispatch:
 
@@ -36,17 +48,35 @@ jobs:
         with:
           python-version: "3.11"
 
-      - name: Check generated Python reference is fresh
-        run: python docs/scripts/render_pyi.py --check
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
 
-      # E4 placeholder: uncomment once the CLI docgen golden test lands.
-      # Needs a Rust toolchain step (dtolnay/rust-toolchain@stable) before it.
-      # - name: Check generated CLI reference is fresh
-      #   run: cargo test -p mistralrs-cli docgen::cli_reference_matches_committed
+      - name: Setup Rust
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
 
-      # E3/E5 placeholder: uncomment once the OpenAPI dump test lands.
-      # - name: Check committed OpenAPI dump is fresh
-      #   run: cargo test -p mistralrs-server-core openapi_matches_committed
+      - name: Regenerate docs artifacts
+        working-directory: docs
+        run: npm run generate
+
+      - name: Ensure generated artifacts are committed
+        run: |
+          if [ -n "$(git status --porcelain)" ]; then
+            echo "Generated artifacts are out of date."
+            echo
+            echo "Run this locally and commit the result:"
+            echo "  cd docs && npm run generate"
+            echo
+            git status --short
+            git diff --stat
+            git diff --exit-code
+            exit 1
+          fi
 
   build:
     if: github.repository == 'EricLBuehler/mistral.rs'

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -9,7 +9,7 @@
     "license": {
       "name": "MIT"
     },
-    "version": "0.8.3"
+    "version": "0.8.4"
   },
   "paths": {
     "/calibration/apply": {

--- a/docs/package.json
+++ b/docs/package.json
@@ -4,6 +4,7 @@
   "private": true,
   "type": "module",
   "scripts": {
+    "generate": "python3 scripts/render_pyi.py && python3 scripts/render_examples.py && cargo test -p mistralrs-cli --manifest-path ../Cargo.toml regenerate_cli_reference -- --ignored && cargo test -p mistralrs-server-core --manifest-path ../Cargo.toml regenerate_openapi -- --ignored",
     "render-pyi": "python3 scripts/render_pyi.py",
     "refresh-openapi": "cargo test -p mistralrs-server-core --manifest-path ../Cargo.toml regenerate_openapi -- --ignored",
     "predev": "npm run render-pyi",

--- a/mistralrs-cli/src/commands/manage.rs
+++ b/mistralrs-cli/src/commands/manage.rs
@@ -34,7 +34,9 @@ fn print_source_install_hint(action: &str) {
     println!("`mistralrs {action}` only manages prebuilt installs.");
     println!("This binary is at {} (built from source).", exe.display());
     match action {
-        "update" => println!("Update it with: cargo install --git {REPO_URL} --locked --force mistralrs-cli"),
+        "update" => println!(
+            "Update it with: cargo install --git {REPO_URL} --locked --force mistralrs-cli"
+        ),
         _ => println!("Remove it with: cargo uninstall mistralrs-cli"),
     }
 }
@@ -86,8 +88,13 @@ pub fn run_uninstall(yes: bool) -> Result<()> {
 
     #[cfg(windows)]
     {
-        println!("Automatic uninstall is not yet supported on Windows (the running .exe is locked).");
-        println!("Delete {} and the mistralrs.exe on your PATH manually.", pre.display());
+        println!(
+            "Automatic uninstall is not yet supported on Windows (the running .exe is locked)."
+        );
+        println!(
+            "Delete {} and the mistralrs.exe on your PATH manually.",
+            pre.display()
+        );
         Ok(())
     }
 
@@ -110,7 +117,10 @@ pub fn run_uninstall(yes: bool) -> Result<()> {
             }
         }
         std::fs::remove_dir_all(&pre).with_context(|| format!("removing {}", pre.display()))?;
-        println!("Removed {} and symlinks. mistral.rs uninstalled.", pre.display());
+        println!(
+            "Removed {} and symlinks. mistral.rs uninstalled.",
+            pre.display()
+        );
         Ok(())
     }
 }


### PR DESCRIPTION
Regenerates all committed docs artifacts through one `npm run generate` command and fails docs CI if the worktree changes.

Also refreshes the committed OpenAPI spec version to `0.8.4`.

Checks:
- `cd docs && npm run generate`
- `cd docs && npm run build`
- `cargo check`