### PR TITLE
feat(core): expose inference-level metrics via Prometheus

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3897,6 +3897,7 @@ dependencies = [
  "libc",
  "llguidance",
  "lrtable",
+ "metrics",
  "mime_guess",
  "minijinja",
  "minijinja-contrib",

--- a/mistralrs-core/Cargo.toml
+++ b/mistralrs-core/Cargo.toml
@@ -34,6 +34,7 @@ half.workspace = true
 accelerate-src = { workspace = true, optional = true }
 intel-mkl-src = { workspace = true, optional = true }
 tracing.workspace = true
+metrics.workspace = true
 rand.workspace = true
 rand_distr.workspace = true
 regex-automata.workspace = true

--- a/mistralrs-core/src/engine/logger.rs
+++ b/mistralrs-core/src/engine/logger.rs
@@ -57,6 +57,15 @@ impl IntervalLogger {
                 let num_running = t_num_running.load(Ordering::Relaxed);
                 let num_waiting = t_num_waiting.load(Ordering::Relaxed);
 
+                // Emit inference-level metrics every interval, including when
+                // idle, so the gauges report current state without gaps. The
+                // token counter increments by this window's count (the atomic
+                // was already swapped to 0 above for the throughput log).
+                metrics::gauge!("inference_requests_running").set(num_running as f64);
+                metrics::gauge!("inference_requests_waiting").set(num_waiting as f64);
+                metrics::counter!("inference_tokens_processed_total")
+                    .increment(tokens_processed as u64);
+
                 if total_new_seqs != 0 && tokens_processed != 0 {
                     let enc_cache_info =
                         if let (Some(ref hits), Some(ref misses)) = (&t_enc_hits, &t_enc_misses) {

--- a/mistralrs-core/src/engine/logger.rs
+++ b/mistralrs-core/src/engine/logger.rs
@@ -57,12 +57,10 @@ impl IntervalLogger {
                 let num_running = t_num_running.load(Ordering::Relaxed);
                 let num_waiting = t_num_waiting.load(Ordering::Relaxed);
 
-                // Emit inference-level metrics every interval, including when
-                // idle, so the gauges report current state without gaps. The
-                // token counter increments by this window's count (the atomic
-                // was already swapped to 0 above for the throughput log).
-                metrics::gauge!("inference_requests_running").set(num_running as f64);
-                metrics::gauge!("inference_requests_waiting").set(num_waiting as f64);
+                // Emit total tokens processed as a process-level counter.
+                // This is additive across engines, so it stays well-defined in
+                // a multi-model server. Incremented by this window's count (the
+                // atomic was already swapped to 0 above for the throughput log).
                 metrics::counter!("inference_tokens_processed_total")
                     .increment(tokens_processed as u64);
 


### PR DESCRIPTION
Follow-up to #2189, which added the /metrics endpoint and the Prometheus recorder. That PR exposed transport-level metrics (HTTP request count and latency); this one adds the inference-level counters the engine already tracks, addressing the runtime-metrics direction discussed in #831.

Metrics added (all sourced from values the IntervalLogger already computes):
- inference_tokens_processed_total (counter): tokens processed
- inference_requests_running (gauge): sequences currently running
- inference_requests_waiting (gauge): sequences waiting in queue

Implementation notes:
- Emitted from the existing IntervalLogger loop, reusing the metrics facade already installed by the server. mistralrs-core gains only the metrics facade dependency; the recorder stays in the server.
- Emissions sit outside the existing log guard, so the gauges report current state on every interval including when idle, with no gaps in the scrape.
- The counter increments by the window's token count (the atomic is already swapped to 0 for the throughput log), so it stays monotonic and cumulative.
- Because they live in the IntervalLogger, the metrics share its sampling cadence and enable/disable switch: a deliberate choice to reuse the existing sampling point at zero added cost.

Verified locally against Qwen2.5-0.5B (GGUF). At idle all three report 0; after traffic the scrape shows inference_tokens_processed_total 294, inference_requests_running 1, inference_requests_waiting 0.