### PR TITLE
fix(core): avoid paged scheduler config reuse across models

### DIFF
--- a/mistralrs-core/src/engine/mod.rs
+++ b/mistralrs-core/src/engine/mod.rs
@@ -8,7 +8,7 @@ use crate::{
     },
     prefix_cacher::PrefixCacheManagerV2,
     response::CompletionChoice,
-    scheduler::{PagedPrefixCacheValidator, Scheduler, SchedulerOutput},
+    scheduler::{DefaultSchedulerMethod, PagedPrefixCacheValidator, Scheduler, SchedulerOutput},
     search::{self, rag::SearchPipeline},
     sequence::{SeqStepType, StopReason},
     tools, CompletionResponse, SchedulerConfig, DEBUG,
@@ -261,6 +261,19 @@ impl Engine {
                 &get_mut_arcmutex!(pipeline).device(),
             )?),
             None => None,
+        };
+
+        let config = if no_kv_cache {
+            match config {
+                SchedulerConfig::PagedAttentionMeta { max_num_seqs, .. } => {
+                    SchedulerConfig::DefaultScheduler {
+                        method: DefaultSchedulerMethod::Fixed(max_num_seqs.try_into().unwrap()),
+                    }
+                }
+                config => config,
+            }
+        } else {
+            config
         };
 
         let scheduler = config.into_scheduler();

--- a/mistralrs-server-core/src/mistralrs_for_server_builder.rs
+++ b/mistralrs-server-core/src/mistralrs_for_server_builder.rs
@@ -1021,6 +1021,10 @@ impl MistralRsForServerBuilder {
                 cache_config,
             )?;
 
+            // Each model gets its own scheduler
+            let scheduler_config =
+                init_scheduler_config(&cache_config, &pipeline, self.max_seqs).await;
+
             // Use the pipeline's name() as the canonical ID, but allow an alias.
             let pipeline_name = pipeline.lock().await.name();
             let primary_id = model_config


### PR DESCRIPTION
Build scheduler configs per added model and downgrade no-KV-cache pipelines away from PagedAttention, preventing embedding requests from hitting cache-only paths in mixed model configs.
