### PR TITLE
fix(quant): skip CUTLASS MoE kernels on MSVC to unblock Windows CUDA builds

### DIFF
--- a/mistralrs-quant/build.rs
+++ b/mistralrs-quant/build.rs
@@ -79,6 +79,12 @@ fn main() -> Result<(), String> {
         let compute_cap = builder.get_compute_cap().unwrap_or(80);
         // ======== Handle optional kernel compilation via rustc-cfg flags
         let cc_over_80 = compute_cap >= 80;
+        let target = std::env::var("TARGET").unwrap();
+
+        // The CUTLASS 2.x grouped-GEMM MoE kernels include gemm_universal.hpp, which textually pulls in
+        // CUTLASS's Sm90 warp-specialized headers; cl (MSVC) fails to parse their dependent SharedStorage
+        // types. Skip them on MSVC and let the engine fall back to the Fused MoE backend.
+        let cutlass_moe = cc_over_80 && !target.contains("msvc");
 
         if cc_over_80 {
             println!("cargo:rustc-cfg=has_marlin_kernels");
@@ -87,13 +93,15 @@ fn main() -> Result<(), String> {
             println!("cargo:rustc-cfg=has_vector_fp8_kernels");
             // WMMA tensor core MXFP4 kernel (FP16/BF16 WMMA requires SM >= 80)
             println!("cargo:rustc-cfg=has_mxfp4_wmma_kernels");
-            // CUTLASS grouped-GEMM MoE fallback (Sm80 tensor-op, runs on sm_80+)
+        }
+        // CUTLASS grouped-GEMM MoE fallback (Sm80 tensor-op, runs on sm_80+)
+        if cutlass_moe {
             println!("cargo:rustc-cfg=has_cutlass_moe_kernels");
         }
         // MXFP4 is always enabled with CUDA (uses LUT-based dequantization)
         println!("cargo:rustc-cfg=has_mxfp4_kernels");
 
-        let excluded_files = if cc_over_80 {
+        let mut excluded_files = if cc_over_80 {
             vec!["dummy_*.cu", "*_dummy.cu"]
         } else {
             vec![
@@ -105,6 +113,10 @@ fn main() -> Result<(), String> {
                 "grouped_mm_*.cu",
             ]
         };
+        if cc_over_80 && !cutlass_moe {
+            excluded_files.push("moe_data.cu");
+            excluded_files.push("grouped_mm_*.cu");
+        }
         builder = builder.exclude(&excluded_files);
         // cutlass_moe kernels need the CUTLASS headers; same pinned checkout as mistralrs-flash-attn.
         builder = builder.with_cutlass(Some("7d49e6c7e2f8896c47f586706e67e1fb215529dc"));
@@ -115,7 +127,6 @@ fn main() -> Result<(), String> {
             builder = builder.arg(cuda_nvcc_flags_env);
         }
 
-        let target = std::env::var("TARGET").unwrap();
         let build_dir = PathBuf::from(std::env::var("OUT_DIR").unwrap());
 
         // CUDA 13.x CCCL headers require MSVC's conforming preprocessor.


### PR DESCRIPTION
## Summary

Fixes the Windows/MSVC CUDA build, which panics in `mistralrs-quant/build.rs` while compiling the CUTLASS 2.x grouped-GEMM MoE kernels (`kernels/cutlass_moe/*.cu`) added in #2202.

Two MSVC-specific CUTLASS problems block these kernels:

1. `cutlass::const_min` is only `constexpr` under `#if 201700L <= __cplusplus`, but MSVC reports `__cplusplus == 199711L` even with `/std:c++17` unless `/Zc:__cplusplus` is set, so `output_tile_thread_map.h` fails with "cannot call non-constexpr function".
2. Even with `/Zc:__cplusplus`, `gemm_universal.hpp` textually pulls in `sm90_gemm_tma_warpspecialized_pingpong.hpp`, whose dependent `SharedStorage` types MSVC cannot parse (`C2061`); `/permissive-` does not help. The Sm80 grouped GEMM never instantiates that header, but MSVC still parses the template body in the pinned CUTLASS revision.

## Approach

These kernels are an optional MoE fast-path, already gated behind `has_cutlass_moe_kernels` with a runtime fallback to the `Fused` MoE backend (`mistralrs-core/src/moe/experts/config.rs`), and already excluded for `cc < 80`. This extends that same exclusion to MSVC targets: on MSVC the `cutlass_moe` kernels are skipped, `has_cutlass_moe_kernels` is not set, and the engine falls back to the `Fused` backend. The integration test is already `#![cfg(... has_cutlass_moe_kernels)]`, so it self-disables.

Verified with `cargo build -p mistralrs-quant --features cuda` on Windows 11, MSVC 14.44.35207, CUDA 12.9, sm_86 (previously failing, now builds; 36/36 remaining kernels compile). Non-MSVC targets are unaffected.

Closes #2238
