### PR TITLE
fix(core): clean up errored scheduler sequences

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -640,7 +640,7 @@ checksum = "ade8366b8bd5ba243f0a58f036cc0ca8a2f069cff1a2351ef1cac6b083e16fc0"
 [[package]]
 name = "candle-core"
 version = "0.10.2"
-source = "git+https://github.com/huggingface/candle.git?rev=d2afd7f#d2afd7f7f746ac72236f81736135de1fcd543426"
+source = "git+https://github.com/huggingface/candle.git?rev=e020e8a#e020e8a42766c497c795c29df25c2ba2ef0e1480"
 dependencies = [
  "accelerate-src",
  "byteorder",
@@ -672,7 +672,7 @@ dependencies = [
 [[package]]
 name = "candle-flash-attn-v3"
 version = "0.10.2"
-source = "git+https://github.com/huggingface/candle.git?rev=d2afd7f#d2afd7f7f746ac72236f81736135de1fcd543426"
+source = "git+https://github.com/huggingface/candle.git?rev=e020e8a#e020e8a42766c497c795c29df25c2ba2ef0e1480"
 dependencies = [
  "anyhow",
  "candle-core",
@@ -685,7 +685,7 @@ dependencies = [
 [[package]]
 name = "candle-kernels"
 version = "0.10.2"
-source = "git+https://github.com/huggingface/candle.git?rev=d2afd7f#d2afd7f7f746ac72236f81736135de1fcd543426"
+source = "git+https://github.com/huggingface/candle.git?rev=e020e8a#e020e8a42766c497c795c29df25c2ba2ef0e1480"
 dependencies = [
  "cudaforge",
 ]
@@ -693,7 +693,7 @@ dependencies = [
 [[package]]
 name = "candle-metal-kernels"
 version = "0.10.2"
-source = "git+https://github.com/huggingface/candle.git?rev=d2afd7f#d2afd7f7f746ac72236f81736135de1fcd543426"
+source = "git+https://github.com/huggingface/candle.git?rev=e020e8a#e020e8a42766c497c795c29df25c2ba2ef0e1480"
 dependencies = [
  "block2",
  "half",
@@ -708,7 +708,7 @@ dependencies = [
 [[package]]
 name = "candle-nn"
 version = "0.10.2"
-source = "git+https://github.com/huggingface/candle.git?rev=d2afd7f#d2afd7f7f746ac72236f81736135de1fcd543426"
+source = "git+https://github.com/huggingface/candle.git?rev=e020e8a#e020e8a42766c497c795c29df25c2ba2ef0e1480"
 dependencies = [
  "accelerate-src",
  "candle-core",
@@ -727,7 +727,7 @@ dependencies = [
 [[package]]
 name = "candle-ug"
 version = "0.10.2"
-source = "git+https://github.com/huggingface/candle.git?rev=d2afd7f#d2afd7f7f746ac72236f81736135de1fcd543426"
+source = "git+https://github.com/huggingface/candle.git?rev=e020e8a#e020e8a42766c497c795c29df25c2ba2ef0e1480"
 dependencies = [
  "ug",
  "ug-cuda",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,10 +34,10 @@ rust-version = "1.94"
 # candle-nn = { version = "0.10.2" }
 # candle-flash-attn-v3 = { version = "0.10.2" }
 # candle-metal-kernels = { version = "0.10.2" }
-candle-core = { git = "https://github.com/huggingface/candle.git", version = "0.10.2", rev = "d2afd7f" }
-candle-nn = { git = "https://github.com/huggingface/candle.git", version = "0.10.2", rev = "d2afd7f" }
-candle-flash-attn-v3 = { git = "https://github.com/huggingface/candle.git", version = "0.10.2", rev = "d2afd7f" }
-candle-metal-kernels = { git = "https://github.com/huggingface/candle.git", version = "0.10.2", rev = "d2afd7f" }
+candle-core = { git = "https://github.com/huggingface/candle.git", version = "0.10.2", rev = "e020e8a" }
+candle-nn = { git = "https://github.com/huggingface/candle.git", version = "0.10.2", rev = "e020e8a" }
+candle-flash-attn-v3 = { git = "https://github.com/huggingface/candle.git", version = "0.10.2", rev = "e020e8a" }
+candle-metal-kernels = { git = "https://github.com/huggingface/candle.git", version = "0.10.2", rev = "e020e8a" }
 # candle-core = { path = "../candle/candle-core", version = "0.10.2" }
 # candle-nn = { path = "../candle/candle-nn", version = "0.10.2" }
 # candle-flash-attn-v3 = { path = "../candle/candle-flash-attn-v3", version = "0.10.2" }

--- a/mistralrs-core/src/engine/mod.rs
+++ b/mistralrs-core/src/engine/mod.rs
@@ -323,6 +323,20 @@ impl Engine {
         }
     }
 
+    fn free_finished_scheduler_sequences(&self, scheduler: &mut dyn Scheduler) {
+        let recurrent_indices = scheduler.get_finished_recurrent_indices();
+        if !recurrent_indices.is_empty() {
+            let pipeline = get_mut_arcmutex!(self.pipeline);
+            if !pipeline.get_metadata().no_kv_cache && pipeline.cache().is_hybrid() {
+                let mut hybrid_cache = pipeline.cache().hybrid();
+                for idx in recurrent_indices {
+                    hybrid_cache.free_seq(idx);
+                }
+            }
+        }
+        scheduler.free_finished_sequence_groups();
+    }
+
     pub async fn run(self: Arc<Self>) {
         if self.throughput_logging_enabled {
             self.logger.enable_logging();
@@ -435,6 +449,7 @@ impl Engine {
                 .as_mut()
                 .map(|v| v as &mut dyn PagedPrefixCacheValidator);
             let mut scheduler = get_mut_arcmutex!(self.scheduler);
+            self.free_finished_scheduler_sequences(&mut *scheduler);
             let scheduled = scheduler.schedule(&self.logger, prefix_validator);
 
             match scheduled {
@@ -815,20 +830,7 @@ impl Engine {
                 }
             }
 
-            // Free recurrent state pool slots for finished sequences (hybrid models)
-            {
-                let pipeline = get_mut_arcmutex!(self.pipeline);
-                if !pipeline.get_metadata().no_kv_cache && pipeline.cache().is_hybrid() {
-                    let recurrent_indices = scheduler.get_finished_recurrent_indices();
-                    if !recurrent_indices.is_empty() {
-                        let mut hybrid_cache = pipeline.cache().hybrid();
-                        for idx in recurrent_indices {
-                            hybrid_cache.free_seq(idx);
-                        }
-                    }
-                }
-            }
-            scheduler.free_finished_sequence_groups();
+            self.free_finished_scheduler_sequences(&mut *scheduler);
         }
     }
 

--- a/mistralrs-core/src/paged_attention/scheduler.rs
+++ b/mistralrs-core/src/paged_attention/scheduler.rs
@@ -497,6 +497,7 @@ impl PagedAttentionScheduler {
     pub fn free_finished_sequence_groups(&mut self) {
         // Collect finished sequence info before modifying self.running
         let mut finished: Vec<SeqCacheInfo> = Vec::new();
+        let mut cacheable_finished: Vec<SeqCacheInfo> = Vec::new();
         for seq in self.running.iter() {
             let seq_guard = get_mut_arcmutex!(seq);
             if seq_guard.is_finished_paged_attn() {
@@ -505,7 +506,11 @@ impl PagedAttentionScheduler {
                 let mm_features = seq_guard.mm_features().to_vec();
                 let block_hash_revision = seq_guard.block_hash_revision();
                 let unencoded_tail = seq_guard.unencoded_tail_len();
-                finished.push((id, tokens, mm_features, block_hash_revision, unencoded_tail));
+                let info = (id, tokens, mm_features, block_hash_revision, unencoded_tail);
+                if !matches!(seq_guard.getstate(), SequenceState::Error) {
+                    cacheable_finished.push(info.clone());
+                }
+                finished.push(info);
             }
         }
 
@@ -515,7 +520,9 @@ impl PagedAttentionScheduler {
 
         // Cache and free blocks for finished sequences
         if self.prefix_caching_enabled {
-            for (id, tokens, mm_features, block_hash_revision, unencoded_tail) in &finished {
+            for (id, tokens, mm_features, block_hash_revision, unencoded_tail) in
+                &cacheable_finished
+            {
                 self.ensure_block_hashes(*id, tokens, mm_features, *block_hash_revision);
                 let block_hashes = self.seq_block_hashes.get(id).cloned().unwrap_or_default();
                 let mut kv_mgr = get_mut_arcmutex!(self.kv_cache_manager);

--- a/mistralrs-core/src/pipeline/sampling.rs
+++ b/mistralrs-core/src/pipeline/sampling.rs
@@ -155,7 +155,7 @@ pub(crate) async fn finish_or_add_toks_to_seq(
                 seq.finalize_reasoning();
             }
             let delta_result = seq.get_delta();
-            if let Some(delta) = crate::handle_seq_error_ok!(delta_result, seq.responder()) {
+            if let Some(delta) = crate::handle_seq_error_stateaware_ok!(delta_result, seq) {
                 if seq.get_mut_group().is_chat {
                     let has_reasoning_parser = seq.reasoning_mode().is_some();
                     let reasoning_delta = if has_reasoning_parser {
@@ -305,17 +305,18 @@ pub(crate) async fn finish_or_add_toks_to_seq(
 
             let logprobs = if seq.return_logprobs() {
                 let mut logprobs = Vec::new();
-                for logprob in seq.logprobs() {
-                    let resp_logprob = crate::ResponseLogprob {
-                        token: crate::handle_seq_error_ok!(
-                        tokenizer
+                let logprobs_for_response = seq.logprobs().to_vec();
+                for logprob in logprobs_for_response {
+                    let token = tokenizer
                         .as_ref()
                         .ok_or(candle_core::Error::Msg(
                             "`finish_or_add_toks_to_seq` requires the pipeline to have a tokenizer"
                                 .to_string(),
-                        ))?.decode(&[logprob.token], false),
-                        seq.responder()
-                    ),
+                        ))?
+                        .decode(&[logprob.token], false);
+                    let token = crate::handle_seq_error_stateaware_ok!(token, seq);
+                    let resp_logprob = crate::ResponseLogprob {
+                        token,
                         bytes: logprob.bytes.clone().map(|b| b.into_bytes()),
                         logprob: logprob.logprob,
                         top_logprobs: logprob.top_logprobs.clone().unwrap(),

--- a/mistralrs-core/src/sequence.rs
+++ b/mistralrs-core/src/sequence.rs
@@ -922,7 +922,8 @@ impl Sequence {
     pub fn is_finished_paged_attn(&self) -> bool {
         matches!(
             *self.state.read().unwrap(),
-            SequenceState::FinishedAborted
+            SequenceState::Error
+                | SequenceState::FinishedAborted
                 | SequenceState::FinishedIgnored
                 | SequenceState::Done(_)
         )


### PR DESCRIPTION
- Treat errored sequences as terminal so scheduler cleanup removes them.
- Prevent paged-attention errored sequences from being rescheduled after an API error response.
- Avoid caching KV blocks from errored paged-attention sequences.
- Make streaming token-finalization errors mark the sequence as errored.

Also closes https://github.com/EricLBuehler/mistral.rs/issues/2214 as it includes the new Candle bump