### PR TITLE
Fix reversed FCFS priority in PagedAttentionScheduler preemption

### DIFF
--- a/mistralrs-core/src/paged_attention/scheduler.rs
+++ b/mistralrs-core/src/paged_attention/scheduler.rs
@@ -589,7 +589,6 @@ impl PagedAttentionScheduler {
         self.running
             .make_contiguous()
             .sort_by_key(|seq| get_mut_arcmutex!(seq).timestamp());
-        self.running.make_contiguous().reverse();
     }
 }
 


### PR DESCRIPTION
Fixes #2033.

sort_running_by_priority_fcfs sorts self.running ascending by timestamp (oldest
first) and then reverses it to newest first. The decode loop schedules with
pop_front and, under KV-cache pressure, preempts with pop_back. With the reverse
in place the oldest (highest priority) sequences get preempted first and the
newest get scheduled first, the opposite of FCFS and of the function's own name.

Dropping the reverse keeps running oldest-first: pop_front schedules the oldest
sequence first and pop_back preempts the newest (lowest priority) first. This
matches DefaultScheduler, which sorts ascending without reversing.