### PR TITLE
Fix agentic loop not starting for registered tool callbacks

### DIFF
--- a/mistralrs-core/src/engine/add_request.rs
+++ b/mistralrs-core/src/engine/add_request.rs
@@ -36,7 +36,7 @@ impl Engine {
                 let in_agentic_loop =
                     request.max_tool_rounds == agentic_loop::AGENTIC_LOOP_REENTRY_SENTINEL;
                 let has_tooling = !self.tool_callbacks.is_empty()
-                    && request.tools.as_ref().is_some_and(|t| !t.is_empty());
+                    || request.tools.as_ref().is_some_and(|t| !t.is_empty());
                 let has_search = request.web_search_options.is_some();
                 let has_code_exec =
                     request.enable_code_execution && !self.tool_callbacks.is_empty();

--- a/mistralrs-core/src/engine/add_request.rs
+++ b/mistralrs-core/src/engine/add_request.rs
@@ -43,9 +43,6 @@ impl Engine {
                     )
                 });
                 let has_search = request.web_search_options.is_some();
-                let has_code_exec =
-                    request.enable_code_execution && !self.tool_callbacks.is_empty();
-                let has_shell = request.enable_shell && !self.tool_callbacks.is_empty();
                 let has_agentic =
                     request.max_tool_rounds.is_some() || request.tool_dispatch_url.is_some();
                 let has_input_files =
@@ -53,12 +50,7 @@ impl Engine {
 
                 if is_chat
                     && !in_agentic_loop
-                    && (has_search
-                        || has_tooling
-                        || has_code_exec
-                        || has_shell
-                        || has_agentic
-                        || has_input_files)
+                    && (has_search || has_tooling || has_agentic || has_input_files)
                 {
                     agentic_loop::agentic_loop(self.clone(), *request).await;
                 } else if request.files.as_ref().is_some_and(|f| !f.is_empty()) {

--- a/mistralrs-core/src/engine/add_request.rs
+++ b/mistralrs-core/src/engine/add_request.rs
@@ -35,8 +35,13 @@ impl Engine {
                 );
                 let in_agentic_loop =
                     request.max_tool_rounds == agentic_loop::AGENTIC_LOOP_REENTRY_SENTINEL;
-                let has_tooling = !self.tool_callbacks.is_empty()
-                    || request.tools.as_ref().is_some_and(|t| !t.is_empty());
+                let has_tooling = self.tool_callbacks.keys().any(|name| {
+                    agentic_loop::registered_tool_active_for_request(
+                        name,
+                        request.enable_code_execution,
+                        request.enable_shell,
+                    )
+                });
                 let has_search = request.web_search_options.is_some();
                 let has_code_exec =
                     request.enable_code_execution && !self.tool_callbacks.is_empty();

--- a/mistralrs-core/src/engine/agentic_loop.rs
+++ b/mistralrs-core/src/engine/agentic_loop.rs
@@ -723,6 +723,20 @@ fn denied_tool_result(
     (request, data, Vec::new())
 }
 
+pub(super) fn registered_tool_active_for_request(
+    name: &str,
+    enable_code_execution: bool,
+    enable_shell: bool,
+) -> bool {
+    if is_shell_tool(name) {
+        enable_shell
+    } else if is_code_exec_tool(name) {
+        enable_code_execution
+    } else {
+        true
+    }
+}
+
 fn shell_completion_data(arguments: &str, content: &str) -> AgenticToolCallData {
     let val = serde_json::from_str::<serde_json::Value>(content).ok();
     AgenticToolCallData::Shell {


### PR DESCRIPTION
Fixes #2278

Tool callbacks registered via `with_tool_callback_and_tool()` did not trigger `agentic_loop` unless tools were also manually added to the request.