### PR TITLE
Validate GGUF special token ids against vocab to prevent OOB panic

### DIFF
--- a/mistralrs-core/src/gguf/gguf_tokenizer.rs
+++ b/mistralrs-core/src/gguf/gguf_tokenizer.rs
@@ -62,6 +62,24 @@ impl TryFrom<ContentMetadata<'_>> for PropsGGUF {
             bos: c.get_value("bos_token_id").ok(),
         };
 
+        // Special token ids come from untrusted GGUF metadata; reject out-of-range ids
+        // so a malformed file errors instead of panicking when indexing `tokens`.
+        let vocab_size = props.tokens.len();
+        let check = |name: &str, id: u32| -> Result<()> {
+            anyhow::ensure!(
+                (id as usize) < vocab_size,
+                "GGUF `{name}` token id {id} is out of bounds for vocab size {vocab_size}"
+            );
+            Ok(())
+        };
+        check("eos", props.eos)?;
+        if let Some(bos) = props.bos {
+            check("bos", bos)?;
+        }
+        if let Some(unk) = props.unk {
+            check("unk", unk)?;
+        }
+
         Ok(props)
     }
 }


### PR DESCRIPTION
## Summary

`convert_gguf_to_hf_tokenizer` reads `eos`/`bos`/`unk` token ids from GGUF
metadata and indexes straight into `props.tokens` without bounds-checking
(`tokens[id as usize]`). GGUF metadata is untrusted input, so a file whose
special-token ids exceed the vocab size panics the process during model load
instead of returning an error.

There are several such indexing sites: the `GgufTokenizerConversion` build
(`eos`/`bos`/`unk`) plus the per-token-id lookups in `unigram_tokenizer` and
`bpe_tokenizer`.

Fixes #2225.

## Repro

A GGUF with a 1-token vocab and `tokenizer.ggml.eos_token_id = 4294967295`
(`u32::MAX`) aborts on load:

```
thread 'main' panicked at mistralrs-core/src/gguf/gguf_tokenizer.rs:
index out of bounds: the len is 1 but the index is 4294967295
```

`eos_token_id` is required for embedded-tokenizer GGUFs, so this path is always
hit when loading one.

## Fix

Validate `eos`, `bos`, and `unk` against `tokens.len()` in
`PropsGGUF::try_from`, right after the struct is built. A single check before
any indexing covers every downstream lookup, and a malformed file now returns
a clear error:

```
GGUF `eos` token id 4294967295 is out of bounds for vocab size 1
```

Since `eos` is required and validated, `vocab_size >= 1` holds, so the
`unk.unwrap_or(0)` -> `tokens[0]` path in `unigram_tokenizer` stays safe.
