### PR TITLE
feat(quant): add isq executor and planning

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4011,6 +4011,7 @@ dependencies = [
  "safetensors 0.8.0",
  "serde",
  "serde_json",
+ "sysinfo",
  "tempfile",
  "thiserror 2.0.18",
  "tokio",

--- a/mistralrs-core/src/pipeline/embedding.rs
+++ b/mistralrs-core/src/pipeline/embedding.rs
@@ -401,7 +401,12 @@ impl Loader for EmbeddingLoader {
             let device = mapper.device_for(layer, false).cloned();
             layer_devices.push(device);
         }
-        let dtype = mapper.get_min_dtype(dtype)?;
+        let dtype = super::isq_flow::resolve_weight_load_dtype(
+            dtype,
+            mapper.as_ref(),
+            &available_devices,
+            write_uqff,
+        )?;
 
         trace!("Model config: {:?}", self.inner.get_config_repr(&config)?);
         if crate::using_flash_attn() {

--- a/mistralrs-core/src/pipeline/isq.rs
+++ b/mistralrs-core/src/pipeline/isq.rs
@@ -555,6 +555,8 @@ fn write_uqff_type(
         ty,
         |m| m.ty.unwrap_or(ty),
         &|key| imatrix.get(key).cloned(),
+        mistralrs_quant::IsqConsumer::UqffWrite,
+        MAX_UQFF_SIZE_BYTES,
         Some(quant_report.clone()),
     )?;
     let guard = mistralrs_quant::QuantizeOntoGuard::new();
@@ -562,9 +564,10 @@ fn write_uqff_type(
         bar.set_message(module.key.clone());
         bar.tick();
         let resolved_ty = module.ty.unwrap_or(ty);
-        let layer = rx
+        let output = rx
             .recv()
             .map_err(|e| anyhow::anyhow!("Requantize channel error: {e}"))??;
+        let layer = &output.value;
         let serialized_tensors = layer.serialize_uqff(&module.key, resolved_ty)?;
         let (stored, shape) =
             mistralrs_quant::stored_type_from_tensors(&serialized_tensors, &module.key)?;
@@ -609,9 +612,9 @@ fn write_uqff_type(
         if swap_runtime {
             let target = module.ct.resolve()?.dtype_and_device().1;
             let layer = if layer.dtype_and_device().1.same_device(&target) {
-                layer
+                output.value.clone()
             } else {
-                layer.clone().apply_isq(
+                output.value.clone().apply_isq(
                     None,
                     target,
                     &std::sync::atomic::AtomicUsize::new(0),

--- a/mistralrs-core/src/pipeline/isq_flow/mod.rs
+++ b/mistralrs-core/src/pipeline/isq_flow/mod.rs
@@ -27,12 +27,20 @@ pub(crate) fn requantize_and_swap(
     ty_for: impl Fn(&TrackedModule) -> IsqType,
     imatrix_for: &dyn Fn(&str) -> Option<Vec<f32>>,
 ) -> Result<()> {
-    let handles = mistralrs_quant::requantize_tracked(modules, pool_ty, ty_for, imatrix_for, None)?;
+    let handles = mistralrs_quant::requantize_tracked(
+        modules,
+        pool_ty,
+        ty_for,
+        imatrix_for,
+        mistralrs_quant::IsqConsumer::RuntimeSwap,
+        0,
+        None,
+    )?;
     // drain everything; failed layers keep their prior resident, so a partial swap stays consistent
     let mut errors: Vec<String> = Vec::new();
     for (module, rx) in modules.iter().zip(handles.receivers) {
         match rx.recv() {
-            Ok(Ok(layer)) => module.ct.replace(layer),
+            Ok(Ok(output)) => module.ct.replace(output.value),
             Ok(Err(e)) => errors.push(format!("{}: {e}", module.key)),
             Err(e) => errors.push(format!("{}: channel error: {e}", module.key)),
         }

--- a/mistralrs-core/src/pipeline/isq_flow/mod.rs
+++ b/mistralrs-core/src/pipeline/isq_flow/mod.rs
@@ -13,7 +13,7 @@ pub(crate) use drive::{
 };
 pub use online::CalibrationStatus;
 pub(crate) use online::{apply_calibration, begin_calibration, calibration_status};
-pub(crate) use plan::{resolve_and_install_isq_plan, IsqPlanInputs};
+pub(crate) use plan::{resolve_and_install_isq_plan, resolve_weight_load_dtype, IsqPlanInputs};
 
 use std::collections::HashMap;
 

--- a/mistralrs-core/src/pipeline/isq_flow/online.rs
+++ b/mistralrs-core/src/pipeline/isq_flow/online.rs
@@ -223,25 +223,35 @@ pub(crate) fn requantize_from_source(
         fallback.len()
     );
 
-    let (pool, _) = mistralrs_quant::create_isq_thread_pool(Some(pool_ty));
+    let (executor, _) = mistralrs_quant::create_isq_executor(Some(pool_ty));
     let guard = mistralrs_quant::QuantizeOntoGuard::new();
-    let (tx, rx) = std::sync::mpsc::channel::<Result<()>>();
     let n_jobs = dense.len();
+    let mut dense_receivers = Vec::with_capacity(n_jobs);
     for module in dense {
         let mmap = source.mmap.clone();
         let guard = guard.clone().with_module_key(module.key.clone());
-        let tx = tx.clone();
         let (ty, imatrix) = module_imatrix(&module, pool_ty, imatrix_map);
         let source_has_bias = source.shapes.contains_key(&format!("{}.bias", module.key));
-        pool.spawn(move || {
+        let resident = module.ct.resolve()?;
+        let (_, device) = resident.dtype_and_device();
+        let resident_has_bias = resident.has_bias();
+        let request = mistralrs_quant::IsqRequest {
+            ty: Some(ty),
+            device: device.clone(),
+            has_imatrix: imatrix.is_some(),
+            capture: mistralrs_quant::IsqCaptureMode::Immediate,
+            consumer: mistralrs_quant::IsqConsumer::RuntimeSwap,
+            module_key: module.key.clone(),
+        };
+        let plan = resident.plan_isq(&request)?;
+        let key = module.key.clone();
+        let rx = executor.submit(plan, request.consumer, move || {
             let job = || -> Result<()> {
-                let resident = module.ct.resolve()?;
-                let (_, device) = resident.dtype_and_device();
                 let shard = module.shard.expect("partition requires a shard");
                 let w = mmap.load(&format!("{}.weight", module.key), &Device::Cpu, None)?;
                 // force_contiguous: offset views share storage, and QTensor::quantize reads raw storage
                 let w = shard.apply_to(&w)?.force_contiguous()?;
-                let b = if resident.has_bias() && source_has_bias {
+                let b = if resident_has_bias && source_has_bias {
                     let b = mmap.load(&format!("{}.bias", module.key), &Device::Cpu, None)?;
                     // Out-dim shards slice the bias the same way; in-dim shards leave it whole.
                     let sharded_dim0 = matches!(
@@ -262,10 +272,10 @@ pub(crate) fn requantize_from_source(
                     .replace(quantize_source_tensor(w, b, ty, device, imatrix, guard)?);
                 Ok(())
             };
-            let _ = tx.send(job());
+            job().map_err(|e| candle_core::Error::msg(format!("{e:#}")))
         });
+        dense_receivers.push((key, rx));
     }
-    drop(tx);
 
     let mut errors: Vec<String> = Vec::new();
     for module in &experts {
@@ -292,10 +302,12 @@ pub(crate) fn requantize_from_source(
 
     // drain everything; failed layers keep their prior resident, so a partial apply stays consistent
     let mut received = 0usize;
-    for result in rx {
+    for (key, rx) in dense_receivers {
         received += 1;
-        if let Err(e) = result {
-            errors.push(format!("{e:#}"));
+        match rx.recv() {
+            Ok(Ok(_)) => {}
+            Ok(Err(e)) => errors.push(format!("{key}: {e:#}")),
+            Err(e) => errors.push(format!("{key}: channel error: {e}")),
         }
     }
     anyhow::ensure!(
@@ -357,7 +369,8 @@ mod tests {
             },
         )?) as std::sync::Arc<dyn QuantMethod>;
         let (tx, rx) = mistralrs_quant::pending_isq_channel();
-        tx.send(Ok(resident)).unwrap();
+        tx.send(Ok(mistralrs_quant::IsqJobOutput::ready(resident)))
+            .unwrap();
         let ct = std::sync::Arc::new(mistralrs_quant::PendingIsqLayer::new(rx));
         let module = TrackedModule {
             key: "m.lin".to_string(),
@@ -410,7 +423,8 @@ mod tests {
             },
         )?) as std::sync::Arc<dyn QuantMethod>;
         let (tx, rx) = mistralrs_quant::pending_isq_channel();
-        tx.send(Ok(resident)).unwrap();
+        tx.send(Ok(mistralrs_quant::IsqJobOutput::ready(resident)))
+            .unwrap();
         let ct = std::sync::Arc::new(mistralrs_quant::PendingIsqLayer::new(rx));
         let module = TrackedModule {
             key: "m.experts.gate_proj".to_string(),

--- a/mistralrs-core/src/pipeline/isq_flow/online.rs
+++ b/mistralrs-core/src/pipeline/isq_flow/online.rs
@@ -223,7 +223,9 @@ pub(crate) fn requantize_from_source(
         fallback.len()
     );
 
-    let (executor, _) = mistralrs_quant::create_isq_executor(Some(pool_ty));
+    let (executor, _) = mistralrs_quant::create_isq_executor(
+        mistralrs_quant::IsqExecutorConfig::new(Some(pool_ty)),
+    );
     let guard = mistralrs_quant::QuantizeOntoGuard::new();
     let n_jobs = dense.len();
     let mut dense_receivers = Vec::with_capacity(n_jobs);

--- a/mistralrs-core/src/pipeline/isq_flow/plan.rs
+++ b/mistralrs-core/src/pipeline/isq_flow/plan.rs
@@ -1,9 +1,11 @@
 //! Load-time ISQ planning: flag validation, capture-mode selection, pool install.
 
 use anyhow::Result;
-use candle_core::Device;
+use candle_core::{DType, Device};
 use mistralrs_quant::IsqType;
 use tracing::info;
+
+use crate::{device_map::DeviceMapper, TryIntoDType};
 
 use super::super::isq::{format_isq_types, IsqModelLoader, IsqOrganization};
 
@@ -28,6 +30,19 @@ pub(crate) struct IsqLoadPlan {
     pub write_types: Option<Vec<IsqType>>,
     pub loading_isq: bool,
     pub load_device: Device,
+}
+
+pub(crate) fn resolve_weight_load_dtype(
+    dtype: &dyn TryIntoDType,
+    mapper: &dyn DeviceMapper,
+    available_devices: &[Device],
+    write_uqff: bool,
+) -> Result<DType> {
+    if write_uqff {
+        dtype.try_into_dtype(&available_devices.iter().collect::<Vec<_>>())
+    } else {
+        Ok(mapper.get_min_dtype(dtype)?)
+    }
 }
 
 /// Validate the ISQ/imatrix/UQFF flag combination, install the immediate-ISQ thread pool and

--- a/mistralrs-core/src/pipeline/isq_flow/plan.rs
+++ b/mistralrs-core/src/pipeline/isq_flow/plan.rs
@@ -88,7 +88,9 @@ pub(crate) fn resolve_and_install_isq_plan(i: IsqPlanInputs<'_>) -> Result<IsqLo
         }
 
         let capture = capture_mode(i.has_write_uqff, wants_imatrix);
-        let (executor, num_threads) = mistralrs_quant::create_isq_executor(immediate_ty);
+        let (executor, num_threads) = mistralrs_quant::create_isq_executor(
+            mistralrs_quant::IsqExecutorConfig::new(immediate_ty),
+        );
         tracing::debug!("Using {num_threads} worker thread(s) for weight quantization.");
         mistralrs_quant::set_immediate_isq_with_executor(
             immediate_ty,
@@ -98,7 +100,9 @@ pub(crate) fn resolve_and_install_isq_plan(i: IsqPlanInputs<'_>) -> Result<IsqLo
             executor,
         );
     } else if !i.topology_overrides.is_empty() {
-        let (executor, num_threads) = mistralrs_quant::create_isq_executor(immediate_ty);
+        let (executor, num_threads) = mistralrs_quant::create_isq_executor(
+            mistralrs_quant::IsqExecutorConfig::new(immediate_ty),
+        );
         tracing::debug!("Using {num_threads} worker thread(s) for weight quantization.");
         mistralrs_quant::set_immediate_isq_with_executor(
             immediate_ty,

--- a/mistralrs-core/src/pipeline/isq_flow/plan.rs
+++ b/mistralrs-core/src/pipeline/isq_flow/plan.rs
@@ -88,24 +88,24 @@ pub(crate) fn resolve_and_install_isq_plan(i: IsqPlanInputs<'_>) -> Result<IsqLo
         }
 
         let capture = capture_mode(i.has_write_uqff, wants_imatrix);
-        let (pool, num_threads) = mistralrs_quant::create_isq_thread_pool(immediate_ty);
+        let (executor, num_threads) = mistralrs_quant::create_isq_executor(immediate_ty);
         tracing::debug!("Using {num_threads} worker thread(s) for weight quantization.");
-        mistralrs_quant::set_immediate_isq_with_pool(
+        mistralrs_quant::set_immediate_isq_with_executor(
             immediate_ty,
             immediate_predicates,
             i.topology_overrides.clone(),
             capture,
-            pool,
+            executor,
         );
     } else if !i.topology_overrides.is_empty() {
-        let (pool, num_threads) = mistralrs_quant::create_isq_thread_pool(immediate_ty);
+        let (executor, num_threads) = mistralrs_quant::create_isq_executor(immediate_ty);
         tracing::debug!("Using {num_threads} worker thread(s) for weight quantization.");
-        mistralrs_quant::set_immediate_isq_with_pool(
+        mistralrs_quant::set_immediate_isq_with_executor(
             immediate_ty,
             Vec::new(),
             i.topology_overrides.clone(),
             capture_mode(i.has_write_uqff, wants_imatrix),
-            pool,
+            executor,
         );
     }
 

--- a/mistralrs-core/src/pipeline/multimodal.rs
+++ b/mistralrs-core/src/pipeline/multimodal.rs
@@ -470,7 +470,12 @@ impl Loader for MultimodalLoader {
             let device = mapper.device_for(layer, false).cloned();
             layer_devices.push(device);
         }
-        let dtype = mapper.get_min_dtype(dtype)?;
+        let dtype = super::isq_flow::resolve_weight_load_dtype(
+            dtype,
+            mapper.as_ref(),
+            &available_devices,
+            write_uqff,
+        )?;
 
         // TODO: PagedAttention is not supported with CPU for now.
         // This check is not really necessary because `get_device_layers` should prevent it.

--- a/mistralrs-core/src/pipeline/normal.rs
+++ b/mistralrs-core/src/pipeline/normal.rs
@@ -489,7 +489,12 @@ impl Loader for NormalLoader {
             let device = mapper.device_for(layer, false).cloned();
             layer_devices.push(device);
         }
-        let dtype = mapper.get_min_dtype(dtype)?;
+        let dtype = super::isq_flow::resolve_weight_load_dtype(
+            dtype,
+            mapper.as_ref(),
+            &available_devices,
+            write_uqff,
+        )?;
 
         // TODO: PagedAttention is not supported with CPU for now.
         // This check is not really necessary because `get_device_layers` should prevent it.

--- a/mistralrs-quant/Cargo.toml
+++ b/mistralrs-quant/Cargo.toml
@@ -38,6 +38,7 @@ regex.workspace = true
 hf-hub.workspace = true
 tokio.workspace = true
 futures.workspace = true
+sysinfo.workspace = true
 cutile = { workspace = true, optional = true }
 cutile-compiler = { workspace = true, optional = true }
 cutile-ir = { workspace = true, optional = true }

--- a/mistralrs-quant/src/afq/mod.rs
+++ b/mistralrs-quant/src/afq/mod.rs
@@ -274,6 +274,20 @@ impl QuantMethod for AfqLayer {
         (self.scales.dtype(), self.scales.device().clone())
     }
 
+    fn plan_isq(&self, request: &crate::IsqRequest) -> Result<crate::IsqPlanParams> {
+        let mut shape = self.scales.dims().to_vec();
+        if let Some(last) = shape.last_mut() {
+            *last = last.saturating_mul(self.group_size as usize);
+        }
+        Ok(crate::plan_weight_isq(
+            self.scales.dtype(),
+            self.scales.device().clone(),
+            shape,
+            request,
+            true,
+        ))
+    }
+
     fn has_bias(&self) -> bool {
         self.bias.is_some()
     }

--- a/mistralrs-quant/src/bitsandbytes/mod.rs
+++ b/mistralrs-quant/src/bitsandbytes/mod.rs
@@ -254,6 +254,23 @@ impl QuantMethod for BnbLinear {
         (self.params.dtype.into(), self.weight.device().clone())
     }
 
+    fn plan_isq(&self, request: &crate::IsqRequest) -> Result<crate::IsqPlanParams> {
+        let shape = self
+            .params
+            .shape
+            .as_ref()
+            .unwrap_or_else(|| self.weight.shape())
+            .dims()
+            .to_vec();
+        Ok(crate::plan_weight_isq(
+            self.params.dtype.into(),
+            self.weight.device().clone(),
+            shape,
+            request,
+            true,
+        ))
+    }
+
     fn apply_isq(
         self: Arc<Self>,
         _dtype: Option<IsqType>,

--- a/mistralrs-quant/src/blockwise_fp8/mod.rs
+++ b/mistralrs-quant/src/blockwise_fp8/mod.rs
@@ -213,6 +213,16 @@ impl QuantMethod for BlockwiseFP8Linear {
         (DType::F8E4M3, self.weight.device().clone())
     }
 
+    fn plan_isq(&self, request: &crate::IsqRequest) -> Result<crate::IsqPlanParams> {
+        Ok(crate::plan_weight_isq(
+            self.dequant_dtype,
+            self.weight.device().clone(),
+            self.weight.dims().to_vec(),
+            request,
+            true,
+        ))
+    }
+
     fn apply_isq(
         self: Arc<Self>,
         dtype: Option<IsqType>,

--- a/mistralrs-quant/src/distributed/layers.rs
+++ b/mistralrs-quant/src/distributed/layers.rs
@@ -286,6 +286,10 @@ impl QuantMethod for RowParallelLayer {
         self.weight.dtype_and_device()
     }
 
+    fn plan_isq(&self, request: &crate::IsqRequest) -> Result<crate::IsqPlanParams> {
+        self.weight.plan_isq(request)
+    }
+
     fn begin_track_stats(&self) -> Result<()> {
         self.weight.begin_track_stats()
     }
@@ -614,6 +618,10 @@ impl QuantMethod for ColumnParallelLayer {
 
     fn dtype_and_device(&self) -> (candle_core::DType, candle_core::Device) {
         self.weight.dtype_and_device()
+    }
+
+    fn plan_isq(&self, request: &crate::IsqRequest) -> Result<crate::IsqPlanParams> {
+        self.weight.plan_isq(request)
     }
 
     fn begin_track_stats(&self) -> Result<()> {
@@ -953,6 +961,10 @@ impl QuantMethod for ReplicatedLayer {
 
     fn dtype_and_device(&self) -> (candle_core::DType, candle_core::Device) {
         self.0.dtype_and_device()
+    }
+
+    fn plan_isq(&self, request: &crate::IsqRequest) -> Result<crate::IsqPlanParams> {
+        self.0.plan_isq(request)
     }
 
     fn begin_track_stats(&self) -> Result<()> {

--- a/mistralrs-quant/src/dummy/mod.rs
+++ b/mistralrs-quant/src/dummy/mod.rs
@@ -78,6 +78,15 @@ impl QuantMethod for DummyLayer {
     fn dtype_and_device(&self) -> (candle_core::DType, candle_core::Device) {
         (candle_core::DType::F32, candle_core::Device::Cpu)
     }
+    fn plan_isq(&self, request: &crate::IsqRequest) -> Result<crate::IsqPlanParams> {
+        Ok(crate::plan_weight_isq(
+            candle_core::DType::F32,
+            candle_core::Device::Cpu,
+            Vec::new(),
+            request,
+            false,
+        ))
+    }
     fn forward_raw(&self, _a: &candle_core::Tensor) -> candle_core::Result<candle_core::Tensor> {
         candle_core::bail!("{}", self.info.message("forward pass"))
     }

--- a/mistralrs-quant/src/f8q8/mod.rs
+++ b/mistralrs-quant/src/f8q8/mod.rs
@@ -298,6 +298,16 @@ impl QuantMethod for F8Q8Linear {
         (DType::F32, Device::Cpu)
     }
 
+    fn plan_isq(&self, request: &crate::IsqRequest) -> Result<crate::IsqPlanParams> {
+        Ok(crate::plan_weight_isq(
+            DType::F32,
+            Device::Cpu,
+            self.shape.dims().to_vec(),
+            request,
+            true,
+        ))
+    }
+
     fn add_delta_w(&self, delta: &Tensor) -> Result<Arc<dyn QuantMethod>> {
         let dequant = self.dequantize(delta.dtype())?;
         let new_w = (dequant + delta)?;

--- a/mistralrs-quant/src/fp8/mod.rs
+++ b/mistralrs-quant/src/fp8/mod.rs
@@ -211,6 +211,16 @@ impl QuantMethod for FP8Linear {
         (DType::F8E4M3, self.lin.weight().device().clone())
     }
 
+    fn plan_isq(&self, request: &crate::IsqRequest) -> Result<crate::IsqPlanParams> {
+        Ok(crate::plan_weight_isq(
+            self.dtype,
+            self.lin.weight().device().clone(),
+            self.lin.weight().dims().to_vec(),
+            request,
+            true,
+        ))
+    }
+
     fn apply_isq(
         self: Arc<Self>,
         dtype: Option<IsqType>,

--- a/mistralrs-quant/src/gguf/mod.rs
+++ b/mistralrs-quant/src/gguf/mod.rs
@@ -424,6 +424,16 @@ impl QuantMethod for GgufMatMul {
         }
     }
 
+    fn plan_isq(&self, request: &crate::IsqRequest) -> Result<crate::IsqPlanParams> {
+        let (dtype, device, shape) = match &self.w {
+            QMatMul::QTensor(q) => (DType::F32, q.device(), q.shape().dims().to_vec()),
+            QMatMul::Tensor(t) | QMatMul::TensorF16(t) => {
+                (t.dtype(), t.device().clone(), t.dims().to_vec())
+            }
+        };
+        Ok(crate::plan_weight_isq(dtype, device, shape, request, true))
+    }
+
     fn apply_isq(
         self: Arc<Self>,
         dtype: Option<IsqType>,

--- a/mistralrs-quant/src/gptq/gptq_cpu.rs
+++ b/mistralrs-quant/src/gptq/gptq_cpu.rs
@@ -52,6 +52,10 @@ impl QuantMethod for GptqLayer {
         todo!()
     }
 
+    fn plan_isq(&self, _request: &crate::IsqRequest) -> Result<crate::IsqPlanParams> {
+        candle_core::bail!("GPTQ CPU quantization does not support ISQ planning.")
+    }
+
     fn apply_isq(
         self: Arc<Self>,
         _dtype: Option<IsqType>,

--- a/mistralrs-quant/src/gptq/gptq_cuda.rs
+++ b/mistralrs-quant/src/gptq/gptq_cuda.rs
@@ -409,6 +409,21 @@ impl QuantMethod for GptqLayer {
         (self.scales.dtype(), self.scales.device().clone())
     }
 
+    fn plan_isq(&self, request: &crate::IsqRequest) -> Result<crate::IsqPlanParams> {
+        let pack = 32usize / usize::try_from(self.bits).unwrap_or(1).max(1);
+        let shape = vec![
+            self.q_weight.dim(1)?,
+            self.q_weight.dim(0)?.saturating_mul(pack),
+        ];
+        Ok(crate::plan_weight_isq(
+            self.scales.dtype(),
+            self.scales.device().clone(),
+            shape,
+            request,
+            true,
+        ))
+    }
+
     fn apply_isq(
         self: Arc<Self>,
         _dtype: Option<IsqType>,

--- a/mistralrs-quant/src/hqq/mod.rs
+++ b/mistralrs-quant/src/hqq/mod.rs
@@ -1024,6 +1024,16 @@ impl QuantMethod for HqqLayer {
         (self.scales.dtype(), self.scales.device().clone())
     }
 
+    fn plan_isq(&self, request: &crate::IsqRequest) -> Result<crate::IsqPlanParams> {
+        Ok(crate::plan_weight_isq(
+            self.scales.dtype(),
+            self.scales.device().clone(),
+            self.w_shape.dims().to_vec(),
+            request,
+            true,
+        ))
+    }
+
     fn apply_isq(
         self: Arc<Self>,
         dtype: Option<IsqType>,

--- a/mistralrs-quant/src/isq_executor.rs
+++ b/mistralrs-quant/src/isq_executor.rs
@@ -122,7 +122,7 @@ impl IsqExecutorConfig {
         Self {
             worker_threads,
             host_budget_bytes: default_host_budget(),
-            max_large_jobs: worker_threads.min(4).max(1),
+            max_large_jobs: worker_threads.clamp(1, 4),
         }
     }
 

--- a/mistralrs-quant/src/isq_executor.rs
+++ b/mistralrs-quant/src/isq_executor.rs
@@ -1,0 +1,699 @@
+use std::{
+    collections::{HashSet, VecDeque},
+    fmt::Debug,
+    panic::{catch_unwind, AssertUnwindSafe},
+    sync::{
+        atomic::{AtomicUsize, Ordering},
+        mpsc::{self, Receiver},
+        Arc, Condvar, Mutex,
+    },
+    thread::JoinHandle,
+};
+
+use candle_core::{quantized::GgmlDType, DType, Device, Result};
+use sysinfo::System;
+
+use crate::{IsqCaptureMode, IsqType};
+
+const SIZE_IN_GIB: usize = 1024 * 1024 * 1024;
+const HOST_RESERVE_BYTES: usize = 8 * SIZE_IN_GIB;
+const LARGE_JOB_THRESHOLD_BYTES: usize = SIZE_IN_GIB;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum IsqConsumer {
+    ImmediateLoad,
+    RuntimeSwap,
+    UqffWrite,
+}
+
+impl IsqConsumer {
+    fn retains_output(self) -> bool {
+        matches!(self, Self::RuntimeSwap | Self::UqffWrite)
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct IsqRequest {
+    pub ty: Option<IsqType>,
+    pub device: Device,
+    pub has_imatrix: bool,
+    pub capture: IsqCaptureMode,
+    pub consumer: IsqConsumer,
+    pub module_key: String,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum IsqKernelKind {
+    Copy,
+    Ggml,
+    GgmlImatrix,
+    GgmlExpertStack,
+    Afq,
+    Hqq,
+    F8,
+    Mxfp4,
+    Other,
+}
+
+#[derive(Clone, Debug, Default)]
+pub struct IsqResourceEstimate {
+    pub host_scratch_bytes: usize,
+    pub device_scratch_bytes: usize,
+    pub output_bytes: usize,
+    pub large_job: bool,
+    pub exclusive_device: bool,
+}
+
+impl IsqResourceEstimate {
+    pub fn host_peak_bytes(&self) -> usize {
+        self.host_scratch_bytes.saturating_add(self.output_bytes)
+    }
+
+    pub fn mark_large(mut self) -> Self {
+        self.large_job = self.host_peak_bytes() >= LARGE_JOB_THRESHOLD_BYTES;
+        self
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct IsqPlanParams {
+    pub kernel: IsqKernelKind,
+    pub source_dtype: DType,
+    pub source_device: Device,
+    pub shape: Vec<usize>,
+    pub resources: IsqResourceEstimate,
+}
+
+pub struct IsqJobOutput<T> {
+    pub value: T,
+    _output_permit: Option<IsqOutputPermit>,
+}
+
+impl<T> IsqJobOutput<T> {
+    pub(crate) fn new(value: T, output_permit: Option<IsqOutputPermit>) -> Self {
+        Self {
+            value,
+            _output_permit: output_permit,
+        }
+    }
+
+    pub fn ready(value: T) -> Self {
+        Self {
+            value,
+            _output_permit: None,
+        }
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct IsqExecutorConfig {
+    pub worker_threads: usize,
+    pub host_budget_bytes: usize,
+    pub max_large_jobs: usize,
+}
+
+impl IsqExecutorConfig {
+    pub fn for_ty(ty: Option<IsqType>) -> Self {
+        let worker_threads = isq_worker_threads(ty);
+        Self {
+            worker_threads,
+            host_budget_bytes: default_host_budget(),
+            max_large_jobs: worker_threads.min(4).max(1),
+        }
+    }
+
+    pub fn for_ty_with_extra_host_reserve(ty: Option<IsqType>, extra_host_reserve: usize) -> Self {
+        let mut config = Self::for_ty(ty);
+        config.host_budget_bytes = config.host_budget_bytes.saturating_sub(extra_host_reserve);
+        config
+    }
+
+    pub fn for_tests(worker_threads: usize, host_budget_bytes: usize) -> Self {
+        Self {
+            worker_threads: worker_threads.max(1),
+            host_budget_bytes,
+            max_large_jobs: worker_threads.max(1),
+        }
+    }
+}
+
+pub struct IsqExecutor {
+    inner: Arc<ExecutorInner>,
+}
+
+impl IsqExecutor {
+    pub fn new(ty: Option<IsqType>) -> Self {
+        Self::with_config(IsqExecutorConfig::for_ty(ty))
+    }
+
+    pub fn with_extra_host_reserve(ty: Option<IsqType>, extra_host_reserve: usize) -> Self {
+        Self::with_config(IsqExecutorConfig::for_ty_with_extra_host_reserve(
+            ty,
+            extra_host_reserve,
+        ))
+    }
+
+    pub fn with_config(config: IsqExecutorConfig) -> Self {
+        let inner = Arc::new(ExecutorInner {
+            state: Mutex::new(ExecutorState::default()),
+            cvar: Condvar::new(),
+            config,
+            workers: Mutex::new(Vec::new()),
+            owners: AtomicUsize::new(1),
+        });
+        let executor = Self { inner };
+        executor.start_workers();
+        executor
+    }
+
+    pub fn worker_threads(&self) -> usize {
+        self.inner.config.worker_threads
+    }
+
+    pub fn submit<T, F>(
+        &self,
+        plan: IsqPlanParams,
+        consumer: IsqConsumer,
+        job: F,
+    ) -> Receiver<Result<IsqJobOutput<T>>>
+    where
+        T: Send + 'static,
+        F: FnOnce() -> Result<T> + Send + 'static,
+    {
+        let (tx, rx) = mpsc::sync_channel(1);
+        let task = Box::new(move || {
+            let result = catch_unwind(AssertUnwindSafe(job));
+            let (success, send) = match result {
+                Ok(result) => {
+                    let success = result.is_ok();
+                    let send = Box::new(move |permit| {
+                        let result = result.map(|value| IsqJobOutput::new(value, permit));
+                        let _ = tx.send(result);
+                    }) as JobSend;
+                    (success, send)
+                }
+                Err(_) => {
+                    let send = Box::new(move |_| {
+                        let _ = tx.send(Err(candle_core::Error::msg("ISQ worker panicked")));
+                    }) as JobSend;
+                    (false, send)
+                }
+            };
+            JobOutcome { success, send }
+        }) as JobTask;
+        self.inner.enqueue(QueuedJob {
+            plan,
+            consumer,
+            task,
+        });
+        rx
+    }
+
+    fn start_workers(&self) {
+        let mut workers = self.inner.workers.lock().expect("ISQ worker lock poisoned");
+        if !workers.is_empty() {
+            return;
+        }
+        for _ in 0..self.inner.config.worker_threads {
+            let inner = self.inner.clone();
+            workers.push(std::thread::spawn(move || worker_loop(inner)));
+        }
+    }
+}
+
+impl Clone for IsqExecutor {
+    fn clone(&self) -> Self {
+        self.inner.owners.fetch_add(1, Ordering::Relaxed);
+        Self {
+            inner: self.inner.clone(),
+        }
+    }
+}
+
+impl Debug for IsqExecutor {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("IsqExecutor")
+            .field("worker_threads", &self.worker_threads())
+            .field("host_budget_bytes", &self.inner.config.host_budget_bytes)
+            .field("max_large_jobs", &self.inner.config.max_large_jobs)
+            .finish()
+    }
+}
+
+impl Drop for IsqExecutor {
+    fn drop(&mut self) {
+        if self.inner.owners.fetch_sub(1, Ordering::AcqRel) != 1 {
+            return;
+        }
+        {
+            let mut state = self.inner.state.lock().expect("ISQ executor lock poisoned");
+            state.shutdown = true;
+            self.inner.cvar.notify_all();
+        }
+        let mut workers = self.inner.workers.lock().expect("ISQ worker lock poisoned");
+        for worker in workers.drain(..) {
+            let _ = worker.join();
+        }
+    }
+}
+
+type JobSend = Box<dyn FnOnce(Option<IsqOutputPermit>) + Send>;
+type JobTask = Box<dyn FnOnce() -> JobOutcome + Send>;
+
+struct JobOutcome {
+    success: bool,
+    send: JobSend,
+}
+
+struct QueuedJob {
+    plan: IsqPlanParams,
+    consumer: IsqConsumer,
+    task: JobTask,
+}
+
+struct RunningJob {
+    plan: IsqPlanParams,
+    consumer: IsqConsumer,
+}
+
+struct ExecutorInner {
+    state: Mutex<ExecutorState>,
+    cvar: Condvar,
+    config: IsqExecutorConfig,
+    workers: Mutex<Vec<JoinHandle<()>>>,
+    owners: AtomicUsize,
+}
+
+#[derive(Default)]
+struct ExecutorState {
+    pending: VecDeque<QueuedJob>,
+    active_host_scratch: usize,
+    retained_output: usize,
+    active_large_jobs: usize,
+    active_exclusive_devices: HashSet<String>,
+    shutdown: bool,
+}
+
+impl ExecutorInner {
+    fn enqueue(&self, job: QueuedJob) {
+        let mut state = self.state.lock().expect("ISQ executor lock poisoned");
+        state.pending.push_back(job);
+        self.cvar.notify_all();
+    }
+
+    fn release_output(self: &Arc<Self>, bytes: usize) {
+        let mut state = self.state.lock().expect("ISQ executor lock poisoned");
+        state.retained_output = state.retained_output.saturating_sub(bytes);
+        self.cvar.notify_all();
+    }
+}
+
+pub(crate) struct IsqOutputPermit {
+    inner: Arc<ExecutorInner>,
+    bytes: usize,
+}
+
+impl Drop for IsqOutputPermit {
+    fn drop(&mut self) {
+        self.inner.release_output(self.bytes);
+    }
+}
+
+fn worker_loop(inner: Arc<ExecutorInner>) {
+    loop {
+        let Some(job) = next_job(&inner) else {
+            return;
+        };
+        let running = RunningJob {
+            plan: job.plan.clone(),
+            consumer: job.consumer,
+        };
+        let outcome = (job.task)();
+        let permit = finish_job(&inner, running, outcome.success);
+        (outcome.send)(permit);
+    }
+}
+
+fn next_job(inner: &Arc<ExecutorInner>) -> Option<QueuedJob> {
+    let mut state = inner.state.lock().expect("ISQ executor lock poisoned");
+    loop {
+        if state.shutdown && state.pending.is_empty() {
+            return None;
+        }
+        if let Some(index) = state
+            .pending
+            .iter()
+            .position(|job| can_start(&state, &inner.config, job))
+        {
+            let job = state.pending.remove(index).expect("pending job exists");
+            reserve_job(&mut state, &job);
+            return Some(job);
+        }
+        state = inner.cvar.wait(state).expect("ISQ executor lock poisoned");
+    }
+}
+
+fn can_start(state: &ExecutorState, config: &IsqExecutorConfig, job: &QueuedJob) -> bool {
+    let resources = &job.plan.resources;
+    let host_next = state
+        .active_host_scratch
+        .saturating_add(state.retained_output)
+        .saturating_add(resources.host_scratch_bytes)
+        .saturating_add(resources.output_bytes);
+    let no_active_host_work = state.active_host_scratch == 0 && state.retained_output == 0;
+    if host_next > config.host_budget_bytes && !no_active_host_work {
+        return false;
+    }
+    if resources.large_job && state.active_large_jobs >= config.max_large_jobs {
+        return false;
+    }
+    if resources.exclusive_device {
+        if let Some(key) = device_key(&job.plan.source_device) {
+            if state.active_exclusive_devices.contains(&key) {
+                return false;
+            }
+        }
+    }
+    true
+}
+
+fn reserve_job(state: &mut ExecutorState, job: &QueuedJob) {
+    let resources = &job.plan.resources;
+    state.active_host_scratch = state
+        .active_host_scratch
+        .saturating_add(resources.host_scratch_bytes);
+    state.retained_output = state.retained_output.saturating_add(resources.output_bytes);
+    if resources.large_job {
+        state.active_large_jobs += 1;
+    }
+    if resources.exclusive_device {
+        if let Some(key) = device_key(&job.plan.source_device) {
+            state.active_exclusive_devices.insert(key);
+        }
+    }
+}
+
+fn finish_job(
+    inner: &Arc<ExecutorInner>,
+    running: RunningJob,
+    success: bool,
+) -> Option<IsqOutputPermit> {
+    let resources = &running.plan.resources;
+    let retain_output = success && running.consumer.retains_output();
+    let mut state = inner.state.lock().expect("ISQ executor lock poisoned");
+    state.active_host_scratch = state
+        .active_host_scratch
+        .saturating_sub(resources.host_scratch_bytes);
+    if resources.large_job {
+        state.active_large_jobs = state.active_large_jobs.saturating_sub(1);
+    }
+    if resources.exclusive_device {
+        if let Some(key) = device_key(&running.plan.source_device) {
+            state.active_exclusive_devices.remove(&key);
+        }
+    }
+    if !retain_output {
+        state.retained_output = state.retained_output.saturating_sub(resources.output_bytes);
+    }
+    inner.cvar.notify_all();
+    drop(state);
+    retain_output.then(|| IsqOutputPermit {
+        inner: inner.clone(),
+        bytes: resources.output_bytes,
+    })
+}
+
+fn default_host_budget() -> usize {
+    let mut sys = System::new();
+    sys.refresh_memory();
+    let total = usize::try_from(sys.total_memory()).unwrap_or(usize::MAX);
+    let available = usize::try_from(sys.available_memory()).unwrap_or(total);
+    let reserve = HOST_RESERVE_BYTES.max(total / 10);
+    available.saturating_sub(reserve).max(HOST_RESERVE_BYTES)
+}
+
+pub fn isq_worker_threads(ty: Option<IsqType>) -> usize {
+    if std::env::var("MISTRALRS_ISQ_SINGLETHREAD").is_ok() {
+        return 1;
+    }
+    if let Some(ty) = ty.and_then(|ty| ty.get_max_isq_cpu_threads()) {
+        return usize::from(ty);
+    }
+    std::thread::available_parallelism()
+        .map(usize::from)
+        .unwrap_or(1)
+}
+
+pub fn elem_count(shape: &[usize]) -> usize {
+    shape.iter().copied().product()
+}
+
+pub fn tensor_bytes(shape: &[usize], dtype: DType) -> usize {
+    elem_count(shape).saturating_mul(dtype.size_in_bytes())
+}
+
+pub fn ggml_output_bytes(shape: &[usize], ty: IsqType) -> Option<usize> {
+    let dtype = ggml_dtype_for_estimate(ty)?;
+    let elements = elem_count(shape);
+    Some(
+        elements
+            .div_ceil(dtype.block_size())
+            .saturating_mul(dtype.type_size()),
+    )
+}
+
+pub fn conservative_plan(
+    kernel: IsqKernelKind,
+    source_dtype: DType,
+    source_device: Device,
+    shape: Vec<usize>,
+    output_bytes: usize,
+    exclusive_device: bool,
+) -> IsqPlanParams {
+    let source_bytes = tensor_bytes(&shape, source_dtype);
+    let host_scratch_bytes = source_bytes.max(elem_count(&shape).saturating_mul(4));
+    IsqPlanParams {
+        kernel,
+        source_dtype,
+        source_device,
+        shape,
+        resources: IsqResourceEstimate {
+            host_scratch_bytes,
+            device_scratch_bytes: 0,
+            output_bytes,
+            large_job: false,
+            exclusive_device,
+        }
+        .mark_large(),
+    }
+}
+
+pub fn plan_weight_isq(
+    source_dtype: DType,
+    source_device: Device,
+    shape: Vec<usize>,
+    request: &IsqRequest,
+    dequantize_before_quantize: bool,
+) -> IsqPlanParams {
+    let elements = elem_count(&shape);
+    let source_bytes = tensor_bytes(&shape, source_dtype);
+    let output_bytes = request
+        .ty
+        .map(|ty| estimate_output_bytes(&shape, source_dtype, ty))
+        .unwrap_or(source_bytes);
+    let kernel = kernel_for(request, shape.len());
+    let ggml = matches!(
+        kernel,
+        IsqKernelKind::Ggml | IsqKernelKind::GgmlImatrix | IsqKernelKind::GgmlExpertStack
+    );
+    let host_scratch_bytes = if request.ty.is_none() {
+        0
+    } else if ggml || dequantize_before_quantize {
+        elements.saturating_mul(4)
+    } else {
+        source_bytes
+    };
+    let device_scratch_bytes = if request.device.is_cpu() {
+        0
+    } else if matches!(
+        kernel,
+        IsqKernelKind::Afq | IsqKernelKind::Hqq | IsqKernelKind::F8 | IsqKernelKind::Mxfp4
+    ) {
+        host_scratch_bytes.max(output_bytes)
+    } else {
+        0
+    };
+    let exclusive_device = !request.device.is_cpu()
+        && matches!(
+            kernel,
+            IsqKernelKind::Afq | IsqKernelKind::Hqq | IsqKernelKind::F8 | IsqKernelKind::Mxfp4
+        );
+    IsqPlanParams {
+        kernel,
+        source_dtype,
+        source_device,
+        shape,
+        resources: IsqResourceEstimate {
+            host_scratch_bytes,
+            device_scratch_bytes,
+            output_bytes,
+            large_job: false,
+            exclusive_device,
+        }
+        .mark_large(),
+    }
+}
+
+pub fn estimate_output_bytes(shape: &[usize], source_dtype: DType, ty: IsqType) -> usize {
+    if let Some(bytes) = ggml_output_bytes(shape, ty) {
+        return bytes;
+    }
+    let source_bytes = tensor_bytes(shape, source_dtype);
+    match ty {
+        IsqType::F8Q8 => elem_count(shape).div_ceil(32).saturating_mul(33),
+        IsqType::F8E4M3 => elem_count(shape),
+        _ => source_bytes
+            .checked_div(ty.pack_factor(source_dtype).max(1))
+            .unwrap_or(source_bytes)
+            .max(source_dtype.size_in_bytes()),
+    }
+}
+
+fn kernel_for(request: &IsqRequest, rank: usize) -> IsqKernelKind {
+    match request.ty {
+        None => IsqKernelKind::Copy,
+        Some(ty) if is_ggml_isq(ty) && request.has_imatrix && rank == 3 => {
+            IsqKernelKind::GgmlExpertStack
+        }
+        Some(ty) if is_ggml_isq(ty) && request.has_imatrix => IsqKernelKind::GgmlImatrix,
+        Some(ty) if is_ggml_isq(ty) => IsqKernelKind::Ggml,
+        Some(IsqType::AFQ2 | IsqType::AFQ3 | IsqType::AFQ4 | IsqType::AFQ6 | IsqType::AFQ8) => {
+            IsqKernelKind::Afq
+        }
+        Some(IsqType::HQQ4 | IsqType::HQQ8) => IsqKernelKind::Hqq,
+        Some(IsqType::F8E4M3 | IsqType::F8Q8) => IsqKernelKind::F8,
+        Some(IsqType::MXFP4) => IsqKernelKind::Mxfp4,
+        Some(_) => IsqKernelKind::Other,
+    }
+}
+
+fn is_ggml_isq(ty: IsqType) -> bool {
+    matches!(
+        ty,
+        IsqType::Q2K
+            | IsqType::Q3K
+            | IsqType::Q4K
+            | IsqType::Q4_0
+            | IsqType::Q4_1
+            | IsqType::Q5K
+            | IsqType::Q5_0
+            | IsqType::Q5_1
+            | IsqType::Q6K
+            | IsqType::Q8K
+            | IsqType::Q8_0
+            | IsqType::Q8_1
+    )
+}
+
+fn ggml_dtype_for_estimate(ty: IsqType) -> Option<GgmlDType> {
+    Some(match ty {
+        IsqType::Q2K => GgmlDType::Q2K,
+        IsqType::Q3K => GgmlDType::Q3K,
+        IsqType::Q4K => GgmlDType::Q4K,
+        IsqType::Q4_0 => GgmlDType::Q4_0,
+        IsqType::Q4_1 => GgmlDType::Q4_1,
+        IsqType::Q5K => GgmlDType::Q5K,
+        IsqType::Q5_0 => GgmlDType::Q5_0,
+        IsqType::Q5_1 => GgmlDType::Q5_1,
+        IsqType::Q6K => GgmlDType::Q6K,
+        IsqType::Q8K => GgmlDType::Q8K,
+        IsqType::Q8_0 => GgmlDType::Q8_0,
+        IsqType::Q8_1 => GgmlDType::Q8_1,
+        _ => return None,
+    })
+}
+
+fn device_key(device: &Device) -> Option<String> {
+    if device.is_cpu() {
+        None
+    } else {
+        Some(format!("{device:?}"))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::{
+        atomic::{AtomicUsize, Ordering},
+        Arc, Mutex as StdMutex,
+    };
+    use std::time::Duration;
+
+    use super::*;
+
+    static ENV_LOCK: StdMutex<()> = StdMutex::new(());
+
+    fn plan(bytes: usize) -> IsqPlanParams {
+        IsqPlanParams {
+            kernel: IsqKernelKind::Ggml,
+            source_dtype: DType::BF16,
+            source_device: Device::Cpu,
+            shape: vec![bytes / 2],
+            resources: IsqResourceEstimate {
+                host_scratch_bytes: bytes,
+                output_bytes: bytes,
+                ..Default::default()
+            }
+            .mark_large(),
+        }
+    }
+
+    #[test]
+    fn q8_0_estimate_uses_block_size() {
+        let shape = vec![2_415_919_104usize];
+        assert_eq!(
+            ggml_output_bytes(&shape, IsqType::Q8_0),
+            Some(2_566_914_048)
+        );
+    }
+
+    #[test]
+    fn executor_waits_for_budget_release() {
+        let executor = IsqExecutor::with_config(IsqExecutorConfig::for_tests(2, 100));
+        let started = Arc::new(AtomicUsize::new(0));
+        let first_started = started.clone();
+        let rx1 = executor.submit(plan(60), IsqConsumer::UqffWrite, move || {
+            first_started.fetch_add(1, Ordering::SeqCst);
+            std::thread::sleep(Duration::from_millis(100));
+            Ok(1usize)
+        });
+        let second_started = started.clone();
+        let rx2 = executor.submit(plan(60), IsqConsumer::UqffWrite, move || {
+            second_started.fetch_add(1, Ordering::SeqCst);
+            Ok(2usize)
+        });
+
+        std::thread::sleep(Duration::from_millis(30));
+        assert_eq!(started.load(Ordering::SeqCst), 1);
+        let first = rx1.recv().unwrap().unwrap();
+        assert_eq!(started.load(Ordering::SeqCst), 1);
+        drop(first);
+        assert_eq!(rx2.recv().unwrap().unwrap().value, 2);
+    }
+
+    #[test]
+    fn singlethread_env_sets_one_worker() {
+        let _guard = ENV_LOCK.lock().unwrap();
+        let old = std::env::var_os("MISTRALRS_ISQ_SINGLETHREAD");
+        std::env::set_var("MISTRALRS_ISQ_SINGLETHREAD", "1");
+        assert_eq!(
+            IsqExecutorConfig::for_ty(Some(IsqType::Q8_0)).worker_threads,
+            1
+        );
+        if let Some(old) = old {
+            std::env::set_var("MISTRALRS_ISQ_SINGLETHREAD", old);
+        } else {
+            std::env::remove_var("MISTRALRS_ISQ_SINGLETHREAD");
+        }
+    }
+}

--- a/mistralrs-quant/src/isq_executor.rs
+++ b/mistralrs-quant/src/isq_executor.rs
@@ -16,8 +16,9 @@ use sysinfo::System;
 use crate::{IsqCaptureMode, IsqType};
 
 const SIZE_IN_GIB: usize = 1024 * 1024 * 1024;
-const HOST_RESERVE_BYTES: usize = 8 * SIZE_IN_GIB;
 const LARGE_JOB_THRESHOLD_BYTES: usize = SIZE_IN_GIB;
+const HOST_BUDGET_NUMERATOR: usize = 9;
+const HOST_BUDGET_DENOMINATOR: usize = 10;
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum IsqConsumer {
@@ -58,7 +59,6 @@ pub enum IsqKernelKind {
 #[derive(Clone, Debug, Default)]
 pub struct IsqResourceEstimate {
     pub host_scratch_bytes: usize,
-    pub device_scratch_bytes: usize,
     pub output_bytes: usize,
     pub large_job: bool,
     pub exclusive_device: bool,
@@ -110,45 +110,28 @@ impl<T> IsqJobOutput<T> {
 pub struct IsqExecutorConfig {
     pub worker_threads: usize,
     pub host_budget_bytes: usize,
-    pub device_budget_bytes: Option<usize>,
     pub max_large_jobs: usize,
 }
 
 impl IsqExecutorConfig {
-    pub fn for_ty(ty: Option<IsqType>) -> Self {
+    pub fn new(ty: Option<IsqType>) -> Self {
         let worker_threads = isq_worker_threads(ty);
         Self {
             worker_threads,
             host_budget_bytes: default_host_budget(),
-            device_budget_bytes: None,
             max_large_jobs: worker_threads.min(4).max(1),
         }
     }
 
-    pub fn for_ty_with_extra_host_reserve(ty: Option<IsqType>, extra_host_reserve: usize) -> Self {
-        let mut config = Self::for_ty(ty);
-        config.host_budget_bytes = config.host_budget_bytes.saturating_sub(extra_host_reserve);
-        config
+    pub fn with_external_reserved_host_bytes(mut self, bytes: usize) -> Self {
+        self.host_budget_bytes = self.host_budget_bytes.saturating_sub(bytes);
+        self
     }
 
     pub fn for_tests(worker_threads: usize, host_budget_bytes: usize) -> Self {
         Self {
             worker_threads: worker_threads.max(1),
             host_budget_bytes,
-            device_budget_bytes: None,
-            max_large_jobs: worker_threads.max(1),
-        }
-    }
-
-    pub fn for_tests_with_device_budget(
-        worker_threads: usize,
-        host_budget_bytes: usize,
-        device_budget_bytes: usize,
-    ) -> Self {
-        Self {
-            worker_threads: worker_threads.max(1),
-            host_budget_bytes,
-            device_budget_bytes: Some(device_budget_bytes),
             max_large_jobs: worker_threads.max(1),
         }
     }
@@ -159,18 +142,7 @@ pub struct IsqExecutor {
 }
 
 impl IsqExecutor {
-    pub fn new(ty: Option<IsqType>) -> Self {
-        Self::with_config(IsqExecutorConfig::for_ty(ty))
-    }
-
-    pub fn with_extra_host_reserve(ty: Option<IsqType>, extra_host_reserve: usize) -> Self {
-        Self::with_config(IsqExecutorConfig::for_ty_with_extra_host_reserve(
-            ty,
-            extra_host_reserve,
-        ))
-    }
-
-    pub fn with_config(config: IsqExecutorConfig) -> Self {
+    pub fn new(config: IsqExecutorConfig) -> Self {
         let inner = Arc::new(ExecutorInner {
             state: Mutex::new(ExecutorState::default()),
             cvar: Condvar::new(),
@@ -252,10 +224,6 @@ impl Debug for IsqExecutor {
         f.debug_struct("IsqExecutor")
             .field("worker_threads", &self.worker_threads())
             .field("host_budget_bytes", &self.inner.config.host_budget_bytes)
-            .field(
-                "device_budget_bytes",
-                &self.inner.config.device_budget_bytes,
-            )
             .field("max_large_jobs", &self.inner.config.max_large_jobs)
             .finish()
     }
@@ -309,7 +277,6 @@ struct ExecutorInner {
 struct ExecutorState {
     pending: VecDeque<QueuedJob>,
     active_host_scratch: usize,
-    active_device_scratch: usize,
     retained_output: usize,
     active_large_jobs: usize,
     active_exclusive_devices: HashSet<DeviceLocation>,
@@ -389,14 +356,6 @@ fn can_start(state: &ExecutorState, config: &IsqExecutorConfig, job: &QueuedJob)
     if host_next > config.host_budget_bytes && !no_active_host_work {
         return false;
     }
-    if let Some(device_budget) = config.device_budget_bytes {
-        let device_next = state
-            .active_device_scratch
-            .saturating_add(resources.device_scratch_bytes);
-        if device_next > device_budget {
-            return false;
-        }
-    }
     if resources.large_job && state.active_large_jobs >= config.max_large_jobs {
         return false;
     }
@@ -415,9 +374,6 @@ fn reserve_job(state: &mut ExecutorState, job: &QueuedJob) {
     state.active_host_scratch = state
         .active_host_scratch
         .saturating_add(resources.host_scratch_bytes);
-    state.active_device_scratch = state
-        .active_device_scratch
-        .saturating_add(resources.device_scratch_bytes);
     state.retained_output = state.retained_output.saturating_add(resources.output_bytes);
     if resources.large_job {
         state.active_large_jobs += 1;
@@ -440,9 +396,6 @@ fn finish_job(
     state.active_host_scratch = state
         .active_host_scratch
         .saturating_sub(resources.host_scratch_bytes);
-    state.active_device_scratch = state
-        .active_device_scratch
-        .saturating_sub(resources.device_scratch_bytes);
     if resources.large_job {
         state.active_large_jobs = state.active_large_jobs.saturating_sub(1);
     }
@@ -465,10 +418,10 @@ fn finish_job(
 fn default_host_budget() -> usize {
     let mut sys = System::new();
     sys.refresh_memory();
-    let total = usize::try_from(sys.total_memory()).unwrap_or(usize::MAX);
-    let available = usize::try_from(sys.available_memory()).unwrap_or(total);
-    let reserve = HOST_RESERVE_BYTES.max(total / 10);
-    available.saturating_sub(reserve).max(HOST_RESERVE_BYTES)
+    let available = usize::try_from(sys.available_memory()).unwrap_or(usize::MAX);
+    available
+        .saturating_mul(HOST_BUDGET_NUMERATOR)
+        .saturating_div(HOST_BUDGET_DENOMINATOR)
 }
 
 pub fn isq_worker_threads(ty: Option<IsqType>) -> usize {
@@ -519,7 +472,6 @@ pub fn conservative_plan(
         shape,
         resources: IsqResourceEstimate {
             host_scratch_bytes,
-            device_scratch_bytes: 0,
             output_bytes,
             large_job: false,
             exclusive_device,
@@ -553,16 +505,6 @@ pub fn plan_weight_isq(
     } else {
         source_bytes
     };
-    let device_scratch_bytes = if request.device.is_cpu() {
-        0
-    } else if matches!(
-        kernel,
-        IsqKernelKind::Afq | IsqKernelKind::Hqq | IsqKernelKind::F8 | IsqKernelKind::Mxfp4
-    ) {
-        host_scratch_bytes.max(output_bytes)
-    } else {
-        0
-    };
     let exclusive_device = !request.device.is_cpu()
         && matches!(
             kernel,
@@ -576,7 +518,6 @@ pub fn plan_weight_isq(
         shape,
         resources: IsqResourceEstimate {
             host_scratch_bytes,
-            device_scratch_bytes,
             output_bytes,
             large_job: false,
             exclusive_device,
@@ -701,7 +642,7 @@ mod tests {
 
     #[test]
     fn executor_waits_for_budget_release() {
-        let executor = IsqExecutor::with_config(IsqExecutorConfig::for_tests(2, 100));
+        let executor = IsqExecutor::new(IsqExecutorConfig::for_tests(2, 100));
         let started = Arc::new(AtomicUsize::new(0));
         let first_started = started.clone();
         let rx1 = executor.submit(plan(60), IsqConsumer::UqffWrite, move || {
@@ -725,7 +666,7 @@ mod tests {
 
     #[test]
     fn retained_out_of_order_output_blocks_later_jobs() {
-        let executor = IsqExecutor::with_config(IsqExecutorConfig::for_tests(2, 170));
+        let executor = IsqExecutor::new(IsqExecutorConfig::for_tests(2, 170));
         let started = Arc::new(AtomicUsize::new(0));
         let mut output_plan = plan(80);
         output_plan.resources.host_scratch_bytes = 0;
@@ -758,40 +699,12 @@ mod tests {
     }
 
     #[test]
-    fn executor_enforces_device_budget_when_configured() {
-        let executor = IsqExecutor::with_config(IsqExecutorConfig::for_tests_with_device_budget(
-            2, 1_000, 100,
-        ));
-        let started = Arc::new(AtomicUsize::new(0));
-        let mut device_plan = plan(10);
-        device_plan.resources.host_scratch_bytes = 0;
-        device_plan.resources.output_bytes = 0;
-        device_plan.resources.device_scratch_bytes = 60;
-        let first_started = started.clone();
-        let rx1 = executor.submit(device_plan.clone(), IsqConsumer::ImmediateLoad, move || {
-            first_started.fetch_add(1, Ordering::SeqCst);
-            std::thread::sleep(Duration::from_millis(100));
-            Ok(1usize)
-        });
-        let second_started = started.clone();
-        let rx2 = executor.submit(device_plan, IsqConsumer::ImmediateLoad, move || {
-            second_started.fetch_add(1, Ordering::SeqCst);
-            Ok(2usize)
-        });
-
-        std::thread::sleep(Duration::from_millis(30));
-        assert_eq!(started.load(Ordering::SeqCst), 1);
-        assert_eq!(rx1.recv().unwrap().unwrap().value, 1);
-        assert_eq!(rx2.recv().unwrap().unwrap().value, 2);
-    }
-
-    #[test]
     fn singlethread_env_sets_one_worker() {
         let _guard = ENV_LOCK.lock().unwrap();
         let old = std::env::var_os("MISTRALRS_ISQ_SINGLETHREAD");
         std::env::set_var("MISTRALRS_ISQ_SINGLETHREAD", "1");
         assert_eq!(
-            IsqExecutorConfig::for_ty(Some(IsqType::Q8_0)).worker_threads,
+            IsqExecutorConfig::new(Some(IsqType::Q8_0)).worker_threads,
             1
         );
         if let Some(old) = old {

--- a/mistralrs-quant/src/isq_executor.rs
+++ b/mistralrs-quant/src/isq_executor.rs
@@ -58,6 +58,7 @@ pub enum IsqKernelKind {
 
 #[derive(Clone, Debug, Default)]
 pub struct IsqResourceEstimate {
+    pub input_bytes: usize,
     pub host_scratch_bytes: usize,
     pub output_bytes: usize,
     pub large_job: bool,
@@ -66,7 +67,9 @@ pub struct IsqResourceEstimate {
 
 impl IsqResourceEstimate {
     pub fn host_peak_bytes(&self) -> usize {
-        self.host_scratch_bytes.saturating_add(self.output_bytes)
+        self.input_bytes
+            .saturating_add(self.host_scratch_bytes)
+            .saturating_add(self.output_bytes)
     }
 
     pub fn mark_large(mut self) -> Self {
@@ -276,6 +279,7 @@ struct ExecutorInner {
 #[derive(Default)]
 struct ExecutorState {
     pending: VecDeque<QueuedJob>,
+    held_input_bytes: usize,
     active_host_scratch: usize,
     retained_output: usize,
     active_large_jobs: usize,
@@ -286,6 +290,12 @@ struct ExecutorState {
 impl ExecutorInner {
     fn enqueue(&self, job: QueuedJob) {
         let mut state = self.state.lock().expect("ISQ executor lock poisoned");
+        while !can_enqueue(&state, &self.config, &job) {
+            state = self.cvar.wait(state).expect("ISQ executor lock poisoned");
+        }
+        state.held_input_bytes = state
+            .held_input_bytes
+            .saturating_add(job.plan.resources.input_bytes);
         state.pending.push_back(job);
         self.cvar.notify_all();
     }
@@ -345,10 +355,23 @@ fn next_job(inner: &Arc<ExecutorInner>) -> Option<QueuedJob> {
     }
 }
 
+fn can_enqueue(state: &ExecutorState, config: &IsqExecutorConfig, job: &QueuedJob) -> bool {
+    let resources = &job.plan.resources;
+    let host_next = state
+        .held_input_bytes
+        .saturating_add(state.active_host_scratch)
+        .saturating_add(state.retained_output)
+        .saturating_add(resources.input_bytes);
+    let no_host_work =
+        state.held_input_bytes == 0 && state.active_host_scratch == 0 && state.retained_output == 0;
+    host_next <= config.host_budget_bytes || no_host_work
+}
+
 fn can_start(state: &ExecutorState, config: &IsqExecutorConfig, job: &QueuedJob) -> bool {
     let resources = &job.plan.resources;
     let host_next = state
-        .active_host_scratch
+        .held_input_bytes
+        .saturating_add(state.active_host_scratch)
         .saturating_add(state.retained_output)
         .saturating_add(resources.host_scratch_bytes)
         .saturating_add(resources.output_bytes);
@@ -393,6 +416,7 @@ fn finish_job(
     let resources = &running.plan.resources;
     let retain_output = success && running.consumer.retains_output();
     let mut state = inner.state.lock().expect("ISQ executor lock poisoned");
+    state.held_input_bytes = state.held_input_bytes.saturating_sub(resources.input_bytes);
     state.active_host_scratch = state
         .active_host_scratch
         .saturating_sub(resources.host_scratch_bytes);
@@ -471,6 +495,7 @@ pub fn conservative_plan(
         target_device: source_device,
         shape,
         resources: IsqResourceEstimate {
+            input_bytes: 0,
             host_scratch_bytes,
             output_bytes,
             large_job: false,
@@ -505,6 +530,11 @@ pub fn plan_weight_isq(
     } else {
         source_bytes
     };
+    let input_bytes = if request.consumer == IsqConsumer::ImmediateLoad {
+        source_bytes
+    } else {
+        0
+    };
     let exclusive_device = !request.device.is_cpu()
         && matches!(
             kernel,
@@ -517,6 +547,7 @@ pub fn plan_weight_isq(
         target_device: request.device.clone(),
         shape,
         resources: IsqResourceEstimate {
+            input_bytes,
             host_scratch_bytes,
             output_bytes,
             large_job: false,
@@ -631,6 +662,13 @@ mod tests {
         }
     }
 
+    fn input_plan(bytes: usize) -> IsqPlanParams {
+        let mut plan = plan(0);
+        plan.resources.input_bytes = bytes;
+        plan.resources.large_job = false;
+        plan
+    }
+
     #[test]
     fn q8_0_estimate_uses_block_size() {
         let shape = vec![2_415_919_104usize];
@@ -661,6 +699,36 @@ mod tests {
         let first = rx1.recv().unwrap().unwrap();
         assert_eq!(started.load(Ordering::SeqCst), 1);
         drop(first);
+        assert_eq!(rx2.recv().unwrap().unwrap().value, 2);
+    }
+
+    #[test]
+    fn executor_blocks_submit_for_queued_input_bytes() {
+        let executor = IsqExecutor::new(IsqExecutorConfig::for_tests(2, 100));
+        let rx1 = executor.submit(input_plan(70), IsqConsumer::ImmediateLoad, move || {
+            std::thread::sleep(Duration::from_millis(100));
+            Ok(1usize)
+        });
+
+        let submitted = Arc::new(AtomicUsize::new(0));
+        let submitted_clone = submitted.clone();
+        let executor_clone = executor.clone();
+        let (tx, rx) = std::sync::mpsc::channel();
+        std::thread::spawn(move || {
+            submitted_clone.store(1, Ordering::SeqCst);
+            let rx2 =
+                executor_clone.submit(input_plan(70), IsqConsumer::ImmediateLoad, move || {
+                    Ok(2usize)
+                });
+            submitted_clone.store(2, Ordering::SeqCst);
+            tx.send(rx2).unwrap();
+        });
+
+        std::thread::sleep(Duration::from_millis(30));
+        assert_eq!(submitted.load(Ordering::SeqCst), 1);
+        assert!(rx.try_recv().is_err());
+        assert_eq!(rx1.recv().unwrap().unwrap().value, 1);
+        let rx2 = rx.recv_timeout(Duration::from_secs(1)).unwrap();
         assert_eq!(rx2.recv().unwrap().unwrap().value, 2);
     }
 

--- a/mistralrs-quant/src/isq_executor.rs
+++ b/mistralrs-quant/src/isq_executor.rs
@@ -10,7 +10,7 @@ use std::{
     thread::JoinHandle,
 };
 
-use candle_core::{quantized::GgmlDType, DType, Device, Result};
+use candle_core::{quantized::GgmlDType, DType, Device, DeviceLocation, Result};
 use sysinfo::System;
 
 use crate::{IsqCaptureMode, IsqType};
@@ -80,6 +80,7 @@ pub struct IsqPlanParams {
     pub kernel: IsqKernelKind,
     pub source_dtype: DType,
     pub source_device: Device,
+    pub target_device: Device,
     pub shape: Vec<usize>,
     pub resources: IsqResourceEstimate,
 }
@@ -109,6 +110,7 @@ impl<T> IsqJobOutput<T> {
 pub struct IsqExecutorConfig {
     pub worker_threads: usize,
     pub host_budget_bytes: usize,
+    pub device_budget_bytes: Option<usize>,
     pub max_large_jobs: usize,
 }
 
@@ -118,6 +120,7 @@ impl IsqExecutorConfig {
         Self {
             worker_threads,
             host_budget_bytes: default_host_budget(),
+            device_budget_bytes: None,
             max_large_jobs: worker_threads.min(4).max(1),
         }
     }
@@ -132,6 +135,20 @@ impl IsqExecutorConfig {
         Self {
             worker_threads: worker_threads.max(1),
             host_budget_bytes,
+            device_budget_bytes: None,
+            max_large_jobs: worker_threads.max(1),
+        }
+    }
+
+    pub fn for_tests_with_device_budget(
+        worker_threads: usize,
+        host_budget_bytes: usize,
+        device_budget_bytes: usize,
+    ) -> Self {
+        Self {
+            worker_threads: worker_threads.max(1),
+            host_budget_bytes,
+            device_budget_bytes: Some(device_budget_bytes),
             max_large_jobs: worker_threads.max(1),
         }
     }
@@ -235,6 +252,10 @@ impl Debug for IsqExecutor {
         f.debug_struct("IsqExecutor")
             .field("worker_threads", &self.worker_threads())
             .field("host_budget_bytes", &self.inner.config.host_budget_bytes)
+            .field(
+                "device_budget_bytes",
+                &self.inner.config.device_budget_bytes,
+            )
             .field("max_large_jobs", &self.inner.config.max_large_jobs)
             .finish()
     }
@@ -288,9 +309,10 @@ struct ExecutorInner {
 struct ExecutorState {
     pending: VecDeque<QueuedJob>,
     active_host_scratch: usize,
+    active_device_scratch: usize,
     retained_output: usize,
     active_large_jobs: usize,
-    active_exclusive_devices: HashSet<String>,
+    active_exclusive_devices: HashSet<DeviceLocation>,
     shutdown: bool,
 }
 
@@ -320,6 +342,9 @@ impl Drop for IsqOutputPermit {
 }
 
 fn worker_loop(inner: Arc<ExecutorInner>) {
+    unsafe {
+        crate::set_isq_thread_affinity();
+    }
     loop {
         let Some(job) = next_job(&inner) else {
             return;
@@ -364,11 +389,19 @@ fn can_start(state: &ExecutorState, config: &IsqExecutorConfig, job: &QueuedJob)
     if host_next > config.host_budget_bytes && !no_active_host_work {
         return false;
     }
+    if let Some(device_budget) = config.device_budget_bytes {
+        let device_next = state
+            .active_device_scratch
+            .saturating_add(resources.device_scratch_bytes);
+        if device_next > device_budget {
+            return false;
+        }
+    }
     if resources.large_job && state.active_large_jobs >= config.max_large_jobs {
         return false;
     }
     if resources.exclusive_device {
-        if let Some(key) = device_key(&job.plan.source_device) {
+        if let Some(key) = device_key(&job.plan.target_device) {
             if state.active_exclusive_devices.contains(&key) {
                 return false;
             }
@@ -382,12 +415,15 @@ fn reserve_job(state: &mut ExecutorState, job: &QueuedJob) {
     state.active_host_scratch = state
         .active_host_scratch
         .saturating_add(resources.host_scratch_bytes);
+    state.active_device_scratch = state
+        .active_device_scratch
+        .saturating_add(resources.device_scratch_bytes);
     state.retained_output = state.retained_output.saturating_add(resources.output_bytes);
     if resources.large_job {
         state.active_large_jobs += 1;
     }
     if resources.exclusive_device {
-        if let Some(key) = device_key(&job.plan.source_device) {
+        if let Some(key) = device_key(&job.plan.target_device) {
             state.active_exclusive_devices.insert(key);
         }
     }
@@ -404,11 +440,14 @@ fn finish_job(
     state.active_host_scratch = state
         .active_host_scratch
         .saturating_sub(resources.host_scratch_bytes);
+    state.active_device_scratch = state
+        .active_device_scratch
+        .saturating_sub(resources.device_scratch_bytes);
     if resources.large_job {
         state.active_large_jobs = state.active_large_jobs.saturating_sub(1);
     }
     if resources.exclusive_device {
-        if let Some(key) = device_key(&running.plan.source_device) {
+        if let Some(key) = device_key(&running.plan.target_device) {
             state.active_exclusive_devices.remove(&key);
         }
     }
@@ -475,7 +514,8 @@ pub fn conservative_plan(
     IsqPlanParams {
         kernel,
         source_dtype,
-        source_device,
+        source_device: source_device.clone(),
+        target_device: source_device,
         shape,
         resources: IsqResourceEstimate {
             host_scratch_bytes,
@@ -532,6 +572,7 @@ pub fn plan_weight_isq(
         kernel,
         source_dtype,
         source_device,
+        target_device: request.device.clone(),
         shape,
         resources: IsqResourceEstimate {
             host_scratch_bytes,
@@ -613,11 +654,11 @@ fn ggml_dtype_for_estimate(ty: IsqType) -> Option<GgmlDType> {
     })
 }
 
-fn device_key(device: &Device) -> Option<String> {
+fn device_key(device: &Device) -> Option<DeviceLocation> {
     if device.is_cpu() {
         None
     } else {
-        Some(format!("{device:?}"))
+        Some(device.location())
     }
 }
 
@@ -638,6 +679,7 @@ mod tests {
             kernel: IsqKernelKind::Ggml,
             source_dtype: DType::BF16,
             source_device: Device::Cpu,
+            target_device: Device::Cpu,
             shape: vec![bytes / 2],
             resources: IsqResourceEstimate {
                 host_scratch_bytes: bytes,
@@ -678,6 +720,68 @@ mod tests {
         let first = rx1.recv().unwrap().unwrap();
         assert_eq!(started.load(Ordering::SeqCst), 1);
         drop(first);
+        assert_eq!(rx2.recv().unwrap().unwrap().value, 2);
+    }
+
+    #[test]
+    fn retained_out_of_order_output_blocks_later_jobs() {
+        let executor = IsqExecutor::with_config(IsqExecutorConfig::for_tests(2, 170));
+        let started = Arc::new(AtomicUsize::new(0));
+        let mut output_plan = plan(80);
+        output_plan.resources.host_scratch_bytes = 0;
+        let first_started = started.clone();
+        let rx1 = executor.submit(output_plan.clone(), IsqConsumer::UqffWrite, move || {
+            first_started.fetch_add(1, Ordering::SeqCst);
+            std::thread::sleep(Duration::from_millis(120));
+            Ok(1usize)
+        });
+        let second_started = started.clone();
+        let rx2 = executor.submit(output_plan.clone(), IsqConsumer::UqffWrite, move || {
+            second_started.fetch_add(1, Ordering::SeqCst);
+            Ok(2usize)
+        });
+        let third_started = started.clone();
+        let rx3 = executor.submit(output_plan, IsqConsumer::UqffWrite, move || {
+            third_started.fetch_add(1, Ordering::SeqCst);
+            Ok(3usize)
+        });
+
+        std::thread::sleep(Duration::from_millis(30));
+        assert_eq!(started.load(Ordering::SeqCst), 2);
+        let second = rx2.recv().unwrap().unwrap();
+        std::thread::sleep(Duration::from_millis(30));
+        assert_eq!(started.load(Ordering::SeqCst), 2);
+        let first = rx1.recv().unwrap().unwrap();
+        drop(second);
+        drop(first);
+        assert_eq!(rx3.recv().unwrap().unwrap().value, 3);
+    }
+
+    #[test]
+    fn executor_enforces_device_budget_when_configured() {
+        let executor = IsqExecutor::with_config(IsqExecutorConfig::for_tests_with_device_budget(
+            2, 1_000, 100,
+        ));
+        let started = Arc::new(AtomicUsize::new(0));
+        let mut device_plan = plan(10);
+        device_plan.resources.host_scratch_bytes = 0;
+        device_plan.resources.output_bytes = 0;
+        device_plan.resources.device_scratch_bytes = 60;
+        let first_started = started.clone();
+        let rx1 = executor.submit(device_plan.clone(), IsqConsumer::ImmediateLoad, move || {
+            first_started.fetch_add(1, Ordering::SeqCst);
+            std::thread::sleep(Duration::from_millis(100));
+            Ok(1usize)
+        });
+        let second_started = started.clone();
+        let rx2 = executor.submit(device_plan, IsqConsumer::ImmediateLoad, move || {
+            second_started.fetch_add(1, Ordering::SeqCst);
+            Ok(2usize)
+        });
+
+        std::thread::sleep(Duration::from_millis(30));
+        assert_eq!(started.load(Ordering::SeqCst), 1);
+        assert_eq!(rx1.recv().unwrap().unwrap().value, 1);
         assert_eq!(rx2.recv().unwrap().unwrap().value, 2);
     }
 

--- a/mistralrs-quant/src/lib.rs
+++ b/mistralrs-quant/src/lib.rs
@@ -231,12 +231,8 @@ unsafe fn set_isq_thread_affinity() {
 #[cfg(not(target_os = "macos"))]
 unsafe fn set_isq_thread_affinity() {}
 
-/// Create a rayon thread pool for parallel immediate ISQ.
-/// Returns `(pool, num_threads)` so callers can log the thread count.
-///
-/// Thread count is based on the quantization type:
-/// - GGML types (Q2K-Q8K) and F8E4M3: `rayon::current_num_threads()` (CPU quantization)
-/// - HQQ/AFQ: 1 thread (GPU quantization, serialized by `QuantizeOntoGuard`)
+/// Legacy Rayon pool helper for callers that still need raw pool semantics.
+/// New ISQ scheduling should use `create_isq_executor`.
 pub fn create_isq_thread_pool(ty: Option<IsqType>) -> (rayon::ThreadPool, usize) {
     let num_threads = if std::env::var("MISTRALRS_ISQ_SINGLETHREAD").is_ok() {
         1

--- a/mistralrs-quant/src/lib.rs
+++ b/mistralrs-quant/src/lib.rs
@@ -1,7 +1,7 @@
 use std::{
     fmt::Debug,
     num::NonZeroUsize,
-    sync::{atomic::AtomicUsize, Arc, Condvar, Mutex, MutexGuard},
+    sync::{atomic::AtomicUsize, Arc, Mutex, MutexGuard},
 };
 
 use blockwise_fp8::blockwise_fp8_linear_b;
@@ -31,6 +31,7 @@ mod gguf;
 mod gptq;
 mod hqq;
 mod imatrix;
+mod isq_executor;
 mod lora;
 #[cfg(feature = "cuda")]
 pub mod moe;
@@ -99,6 +100,11 @@ pub use gguf::GgufMatMul;
 pub use gptq::GptqLayer;
 pub use hqq::{HqqAxis, HqqBits, HqqConfig, HqqLayer};
 pub use imatrix::{CollectedImatrixData, ImatrixLayerStats};
+pub use isq_executor::{
+    conservative_plan, elem_count, estimate_output_bytes, ggml_output_bytes, plan_weight_isq,
+    tensor_bytes, IsqConsumer, IsqExecutor, IsqExecutorConfig, IsqJobOutput, IsqKernelKind,
+    IsqPlanParams, IsqRequest, IsqResourceEstimate,
+};
 pub use lora::{
     clear_applied_loras, get_applied_loras, linear_no_bias_static_lora, push_applied_lora,
     LoraAdapter, LoraConfig, StaticLoraConfig, MULTI_LORA_DELIMITER,
@@ -126,65 +132,13 @@ pub use vector_fp8::{fp8_vector_dequantize, fp8_vector_quantize};
 use candle_nn::{Conv1d, Conv2d, Linear, Module};
 use serde::{Deserialize, Deserializer, Serialize};
 
-/// Limits outstanding async ISQ jobs to prevent unbounded memory growth.
-///
-/// Without backpressure, MoE models (e.g. Gemma4 with 128 experts × 30 layers)
-/// queue BF16 tensor data in the rayon pool faster than the pool can quantize,
-/// causing OOM on memory-constrained systems like macOS Metal with unified memory.
-pub struct IsqBackpressure {
-    count: Mutex<usize>,
-    cvar: Condvar,
-    max: usize,
-}
-
-impl IsqBackpressure {
-    pub fn new(max: usize) -> Self {
-        Self {
-            count: Mutex::new(0),
-            cvar: Condvar::new(),
-            max,
-        }
-    }
-
-    /// Block until a slot is available, then increment the outstanding count.
-    pub fn acquire(&self) {
-        let mut count = self.count.lock().expect("ISQ backpressure lock poisoned");
-        while *count >= self.max {
-            count = self
-                .cvar
-                .wait(count)
-                .expect("ISQ backpressure lock poisoned");
-        }
-        *count += 1;
-    }
-
-    /// Decrement the outstanding count and wake a blocked loader thread.
-    pub fn release(&self) {
-        let mut count = self.count.lock().expect("ISQ backpressure lock poisoned");
-        *count = count.saturating_sub(1);
-        self.cvar.notify_one();
-    }
-}
-
-impl Debug for IsqBackpressure {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        let count = self.count.lock().map(|c| *c).unwrap_or(0);
-        f.debug_struct("IsqBackpressure")
-            .field("outstanding", &count)
-            .field("max", &self.max)
-            .finish()
-    }
-}
-
 #[derive(Clone, Debug)]
 pub struct ImmediateIsqParams {
     pub guard: QuantizeOntoGuard,
     pub ty: Option<IsqType>,
     pub predicates: Vec<Regex>,
     pub overrides: Vec<ImmediateIsqOverride>,
-    pub pool: Arc<rayon::ThreadPool>,
-    /// Backpressure to limit outstanding async ISQ jobs.
-    pub backpressure: Arc<IsqBackpressure>,
+    pub executor: IsqExecutor,
     pub capture: IsqCaptureMode,
 }
 
@@ -245,28 +199,24 @@ thread_local! {
 }
 
 pub fn set_immediate_isq(isq: Option<IsqType>, predicates: Vec<Regex>, capture: IsqCaptureMode) {
-    let (pool, _) = create_isq_thread_pool(isq);
-    set_immediate_isq_with_pool(isq, predicates, Vec::new(), capture, pool);
+    let (executor, _) = create_isq_executor(isq);
+    set_immediate_isq_with_executor(isq, predicates, Vec::new(), capture, executor);
 }
 
-pub fn set_immediate_isq_with_pool(
+pub fn set_immediate_isq_with_executor(
     isq: Option<IsqType>,
     predicates: Vec<Regex>,
     overrides: Vec<ImmediateIsqOverride>,
     capture: IsqCaptureMode,
-    pool: rayon::ThreadPool,
+    executor: IsqExecutor,
 ) {
-    // Allow pool threads + 1 outstanding jobs: enough for pipeline overlap
-    // (load next tensor while pool quantizes current) without unbounded growth.
-    let max_outstanding = pool.current_num_threads() + 1;
     ENGINE_IMMEDIATE_ISQ.with(|cell| {
         *cell.borrow_mut() = Some(ImmediateIsqParams {
             guard: QuantizeOntoGuard::new(),
             ty: isq,
             predicates,
             overrides,
-            backpressure: Arc::new(IsqBackpressure::new(max_outstanding)),
-            pool: Arc::new(pool),
+            executor,
             capture,
         });
     });
@@ -306,6 +256,21 @@ pub fn create_isq_thread_pool(ty: Option<IsqType>) -> (rayon::ThreadPool, usize)
         .build()
         .expect("Failed to create ISQ thread pool");
     (pool, num_threads)
+}
+
+pub fn create_isq_executor(ty: Option<IsqType>) -> (IsqExecutor, usize) {
+    let executor = IsqExecutor::new(ty);
+    let num_threads = executor.worker_threads();
+    (executor, num_threads)
+}
+
+pub fn create_isq_executor_with_extra_host_reserve(
+    ty: Option<IsqType>,
+    extra_host_reserve: usize,
+) -> (IsqExecutor, usize) {
+    let executor = IsqExecutor::with_extra_host_reserve(ty, extra_host_reserve);
+    let num_threads = executor.worker_threads();
+    (executor, num_threads)
 }
 
 pub fn get_immediate_isq() -> Option<ImmediateIsqParams> {
@@ -1275,6 +1240,8 @@ pub trait QuantMethod: Send + Sync + Debug + QuantizedSerde {
 
     /// Weight dtype and device
     fn dtype_and_device(&self) -> (DType, Device);
+
+    fn plan_isq(&self, request: &IsqRequest) -> Result<IsqPlanParams>;
 
     /// Add a delta weight from LoRA to the weights. This should be prescaled with alpha.
     fn add_delta_w(&self, delta: &Tensor) -> Result<Arc<dyn QuantMethod>>;

--- a/mistralrs-quant/src/lib.rs
+++ b/mistralrs-quant/src/lib.rs
@@ -199,7 +199,7 @@ thread_local! {
 }
 
 pub fn set_immediate_isq(isq: Option<IsqType>, predicates: Vec<Regex>, capture: IsqCaptureMode) {
-    let (executor, _) = create_isq_executor(isq);
+    let (executor, _) = create_isq_executor(IsqExecutorConfig::new(isq));
     set_immediate_isq_with_executor(isq, predicates, Vec::new(), capture, executor);
 }
 
@@ -254,17 +254,8 @@ pub fn create_isq_thread_pool(ty: Option<IsqType>) -> (rayon::ThreadPool, usize)
     (pool, num_threads)
 }
 
-pub fn create_isq_executor(ty: Option<IsqType>) -> (IsqExecutor, usize) {
-    let executor = IsqExecutor::new(ty);
-    let num_threads = executor.worker_threads();
-    (executor, num_threads)
-}
-
-pub fn create_isq_executor_with_extra_host_reserve(
-    ty: Option<IsqType>,
-    extra_host_reserve: usize,
-) -> (IsqExecutor, usize) {
-    let executor = IsqExecutor::with_extra_host_reserve(ty, extra_host_reserve);
+pub fn create_isq_executor(config: IsqExecutorConfig) -> (IsqExecutor, usize) {
+    let executor = IsqExecutor::new(config);
     let num_threads = executor.worker_threads();
     (executor, num_threads)
 }

--- a/mistralrs-quant/src/mxfp4/mod.rs
+++ b/mistralrs-quant/src/mxfp4/mod.rs
@@ -192,6 +192,20 @@ impl QuantMethod for MXFP4Layer {
         (DType::BF16, self.scales.device().clone())
     }
 
+    fn plan_isq(&self, request: &crate::IsqRequest) -> Result<crate::IsqPlanParams> {
+        let mut shape = self.blocks.dims().to_vec();
+        if let Some(last) = shape.last_mut() {
+            *last = last.saturating_mul(2);
+        }
+        Ok(crate::plan_weight_isq(
+            DType::BF16,
+            self.scales.device().clone(),
+            shape,
+            request,
+            true,
+        ))
+    }
+
     fn apply_isq(
         self: Arc<Self>,
         _dtype: Option<IsqType>,

--- a/mistralrs-quant/src/pending_layer.rs
+++ b/mistralrs-quant/src/pending_layer.rs
@@ -10,11 +10,12 @@ use std::{
 use candle_core::{DType, Device, Result, Tensor};
 
 use crate::{
-    DistributedKind, IsqType, QuantMethod, QuantMethodConfig, QuantizeOntoGuard, QuantizedSerde,
+    DistributedKind, IsqJobOutput, IsqType, QuantMethod, QuantMethodConfig, QuantizeOntoGuard,
+    QuantizedSerde,
 };
 
 enum PendingState {
-    Pending(Receiver<Result<Arc<dyn QuantMethod>>>),
+    Pending(Receiver<Result<IsqJobOutput<Arc<dyn QuantMethod>>>>),
     Ready(Arc<dyn QuantMethod>),
     /// Transitional state used during resolve to avoid holding both the old
     /// receiver and the new layer simultaneously.
@@ -29,7 +30,7 @@ pub struct PendingIsqLayer {
 }
 
 impl PendingIsqLayer {
-    pub fn new(rx: Receiver<Result<Arc<dyn QuantMethod>>>) -> Self {
+    pub fn new(rx: Receiver<Result<IsqJobOutput<Arc<dyn QuantMethod>>>>) -> Self {
         Self {
             inner: Mutex::new(PendingState::Pending(rx)),
         }
@@ -58,7 +59,8 @@ impl PendingIsqLayer {
                         .recv()
                         .map_err(|e| candle_core::Error::Msg(format!("ISQ channel error: {e}")))?;
                     match result {
-                        Ok(layer) => {
+                        Ok(output) => {
+                            let layer = output.value;
                             *state = PendingState::Ready(layer.clone());
                             Ok(layer)
                         }
@@ -150,6 +152,10 @@ impl QuantMethod for PendingIsqLayer {
             .dtype_and_device()
     }
 
+    fn plan_isq(&self, request: &crate::IsqRequest) -> Result<crate::IsqPlanParams> {
+        self.resolve()?.plan_isq(request)
+    }
+
     fn add_delta_w(&self, delta: &Tensor) -> Result<Arc<dyn QuantMethod>> {
         self.resolve()?.add_delta_w(delta)
     }
@@ -203,8 +209,8 @@ impl QuantMethod for PendingIsqLayer {
     }
 }
 
-pub type IsqSender = mpsc::SyncSender<Result<Arc<dyn QuantMethod>>>;
-pub type IsqReceiver = Receiver<Result<Arc<dyn QuantMethod>>>;
+pub type IsqSender = mpsc::SyncSender<Result<IsqJobOutput<Arc<dyn QuantMethod>>>>;
+pub type IsqReceiver = Receiver<Result<IsqJobOutput<Arc<dyn QuantMethod>>>>;
 
 /// Create a channel pair for use with `PendingIsqLayer`. The sender should be
 /// given to a thread pool task; the receiver is passed to `PendingIsqLayer::new`.

--- a/mistralrs-quant/src/pertensor_fp8/mod.rs
+++ b/mistralrs-quant/src/pertensor_fp8/mod.rs
@@ -86,6 +86,16 @@ impl QuantMethod for PerTensorFP8Linear {
         (DType::F8E4M3, self.weight.device().clone())
     }
 
+    fn plan_isq(&self, request: &crate::IsqRequest) -> Result<crate::IsqPlanParams> {
+        Ok(crate::plan_weight_isq(
+            self.weight.dtype(),
+            self.weight.device().clone(),
+            self.weight.dims().to_vec(),
+            request,
+            true,
+        ))
+    }
+
     fn apply_isq(
         self: Arc<Self>,
         dtype: Option<IsqType>,

--- a/mistralrs-quant/src/unquantized/mod.rs
+++ b/mistralrs-quant/src/unquantized/mod.rs
@@ -309,6 +309,16 @@ impl QuantMethod for UnquantLinear {
         (self.w.dtype(), self.w.device().clone())
     }
 
+    fn plan_isq(&self, request: &crate::IsqRequest) -> Result<crate::IsqPlanParams> {
+        Ok(crate::plan_weight_isq(
+            self.w.dtype(),
+            self.w.device().clone(),
+            self.w.dims().to_vec(),
+            request,
+            false,
+        ))
+    }
+
     fn has_bias(&self) -> bool {
         self.b.is_some()
     }

--- a/mistralrs-quant/src/utils/isq.rs
+++ b/mistralrs-quant/src/utils/isq.rs
@@ -3,8 +3,8 @@ use std::sync::{atomic::AtomicUsize, Arc};
 use candle_core::{quantized::GgmlDType, Device, Result, Tensor};
 
 use crate::{
-    get_immediate_isq, pending_layer, ImmediateIsqMatch, ImmediateIsqParams, IsqType,
-    PendingIsqLayer, QuantMethod, ShardedVarBuilder, TrackedModule,
+    get_immediate_isq, pending_layer, ImmediateIsqMatch, ImmediateIsqParams, IsqConsumer,
+    IsqRequest, IsqType, PendingIsqLayer, QuantMethod, ShardedVarBuilder, TrackedModule,
 };
 
 pub enum QuantizationBehavior {
@@ -81,24 +81,34 @@ pub(crate) fn spawn_pending_isq(
     params: &ImmediateIsqParams,
     module_key: String,
 ) -> Arc<PendingIsqLayer> {
-    params.backpressure.acquire();
-    let backpressure = params.backpressure.clone();
-    let guard = params.guard.clone().with_module_key(module_key);
-    let (tx, rx) = pending_layer::pending_isq_channel();
-    params.pool.spawn(move || {
-        let result = layer
-            .clone()
-            .apply_isq(ty, device, &AtomicUsize::new(0), None, guard);
-        let _ = tx.send(result);
-        backpressure.release();
-    });
+    let guard = params.guard.clone().with_module_key(module_key.clone());
+    let request = IsqRequest {
+        ty,
+        device: device.clone(),
+        has_imatrix: false,
+        capture: params.capture,
+        consumer: IsqConsumer::ImmediateLoad,
+        module_key,
+    };
+    let rx = match layer.plan_isq(&request) {
+        Ok(plan) => params.executor.submit(plan, request.consumer, move || {
+            layer
+                .clone()
+                .apply_isq(ty, device, &AtomicUsize::new(0), None, guard)
+        }),
+        Err(e) => {
+            let (tx, rx) = pending_layer::pending_isq_channel();
+            let _ = tx.send(Err(e));
+            rx
+        }
+    };
     Arc::new(PendingIsqLayer::new(rx))
 }
 
 /// In-flight parallel requantization; receivers are in the same order as the input modules.
 /// Holds the pool so spawned jobs outlive the call.
 pub struct RequantizeHandles {
-    _pool: rayon::ThreadPool,
+    _executor: crate::IsqExecutor,
     pub receivers: Vec<pending_layer::IsqReceiver>,
 }
 
@@ -141,9 +151,12 @@ pub fn requantize_tracked(
     pool_ty: IsqType,
     ty_for: impl Fn(&TrackedModule) -> IsqType,
     imatrix_for: &dyn Fn(&str) -> Option<Vec<f32>>,
+    consumer: IsqConsumer,
+    extra_host_reserve_bytes: usize,
     report: Option<crate::QuantizationReport>,
 ) -> Result<RequantizeHandles> {
-    let (pool, _) = crate::create_isq_thread_pool(Some(pool_ty));
+    let (executor, _) =
+        crate::create_isq_executor_with_extra_host_reserve(Some(pool_ty), extra_host_reserve_bytes);
     let guard = crate::QuantizeOntoGuard::new();
     let mut receivers = Vec::with_capacity(modules.len());
     for module in modules {
@@ -167,18 +180,24 @@ pub fn requantize_tracked(
         if let Some(report) = &report {
             guard = guard.with_report(report.clone());
         }
-        let (tx, rx) = pending_layer::pending_isq_channel();
-        pool.spawn(move || {
-            let result =
-                layer
-                    .clone()
-                    .apply_isq(Some(ty), device, &AtomicUsize::new(0), imatrix, guard);
-            let _ = tx.send(result);
+        let request = IsqRequest {
+            ty: Some(ty),
+            device: device.clone(),
+            has_imatrix: imatrix.is_some(),
+            capture: crate::IsqCaptureMode::Immediate,
+            consumer,
+            module_key: module.key.clone(),
+        };
+        let plan = layer.plan_isq(&request)?;
+        let rx = executor.submit(plan, consumer, move || {
+            layer
+                .clone()
+                .apply_isq(Some(ty), device, &AtomicUsize::new(0), imatrix, guard)
         });
         receivers.push(rx);
     }
     Ok(RequantizeHandles {
-        _pool: pool,
+        _executor: executor,
         receivers,
     })
 }

--- a/mistralrs-quant/src/utils/isq.rs
+++ b/mistralrs-quant/src/utils/isq.rs
@@ -143,9 +143,7 @@ pub fn quantize_expert_stack(
     )
 }
 
-/// Quantize every tracked module on a fresh pool sized for `pool_ty`. The per-module type is
-/// the caller's policy: `|m| m.ty.unwrap_or(default)` honors the load-time plan (topology pins),
-/// `|_| ty` forces a uniform type.
+/// Quantize every tracked module on an executor sized for `pool_ty`.
 pub fn requantize_tracked(
     modules: &[TrackedModule],
     pool_ty: IsqType,
@@ -155,8 +153,9 @@ pub fn requantize_tracked(
     extra_host_reserve_bytes: usize,
     report: Option<crate::QuantizationReport>,
 ) -> Result<RequantizeHandles> {
-    let (executor, _) =
-        crate::create_isq_executor_with_extra_host_reserve(Some(pool_ty), extra_host_reserve_bytes);
+    let config = crate::IsqExecutorConfig::new(Some(pool_ty))
+        .with_external_reserved_host_bytes(extra_host_reserve_bytes);
+    let (executor, _) = crate::create_isq_executor(config);
     let guard = crate::QuantizeOntoGuard::new();
     let mut receivers = Vec::with_capacity(modules.len());
     for module in modules {

--- a/mistralrs-quant/src/vector_fp8/mod.rs
+++ b/mistralrs-quant/src/vector_fp8/mod.rs
@@ -74,6 +74,16 @@ impl QuantMethod for VectorFP8Linear {
         (DType::F8E4M3, self.weight.device().clone())
     }
 
+    fn plan_isq(&self, request: &crate::IsqRequest) -> Result<crate::IsqPlanParams> {
+        Ok(crate::plan_weight_isq(
+            self.dequant_dtype,
+            self.weight.device().clone(),
+            self.weight.dims().to_vec(),
+            request,
+            true,
+        ))
+    }
+
     fn apply_isq(
         self: Arc<Self>,
         dtype: Option<IsqType>,


### PR DESCRIPTION
Adds `IsqExecutor`, which is a ~thread pool that knows about ISQ metadata/temporaries/etc and knows how to schedule ISQ tasks accordingly.