### PR TITLE
Fix CUDA version extraction in install.sh

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -144,7 +144,7 @@ detect_cuda_driver_version_code() {
         return
     fi
 
-    ver=$(nvidia-smi 2>/dev/null | grep -oE "CUDA Version:[[:space:]]*[0-9]+\.[0-9]+" | head -1 | grep -oE "[0-9]+\.[0-9]+")
+    ver=$(nvidia-smi 2>/dev/null | grep -oE "CUDA.*Version:[[:space:]]*[0-9]+\.[0-9]+" | head -1 | grep -oE "[0-9]+\.[0-9]+")
     if [ -n "$ver" ]; then
         echo $(( ${ver%%.*} * 100 + ${ver#*.} ))
     fi


### PR DESCRIPTION
In my system nvidia-smi the output is like this:
```
+-----------------------------------------------------------------------------------------+
| NVIDIA-SMI 610.43.02              KMD Version: 610.43.02     CUDA UMD Version: 13.3     |
+-----------------------------------------+------------------------+----------------------+
| GPU  Name                 Persistence-M | Bus-Id          Disp.A | Volatile Uncorr. ECC |
| Fan  Temp   Perf          Pwr:Usage/Cap |           Memory-Usage | GPU-Util  Compute M. |
|                                         |                        |               MIG M. |
|=========================================+========================+======================|
|   0  NVIDIA GeForce RTX 5070 ...    Off |   00000000:02:00.0  On |                  N/A |
| N/A   51C    P8              7W /   70W |     273MiB /  12227MiB |      2%      Default |
|                                         |                        |                  N/A |
+-----------------------------------------+------------------------+----------------------+

+-----------------------------------------------------------------------------------------+
| Processes:                                                                              |
|  GPU   GI   CI              PID   Type   Process name                        GPU Memory |
|        ID   ID                                                               Usage      |
|=========================================================================================|
|    0   N/A  N/A             973      G   niri                                      3MiB |
|    0   N/A  N/A           37022      C   mistralrs                               222MiB |
+-----------------------------------------------------------------------------------------+
```

Mistral installer can not detect CUDA version for CUDA UMD.
Installer crashed after this message:

```
> ./mistinst.sh
  __  __ _     _             _
 |  \/  (_)___| |_ _ __ __ _| |  _ __ ___
 | |\/| | / __| __| '__/ _` | | | '__/ __|
 | |  | | \__ \ |_| | | (_| | |_| |  \__ \
 |_|  |_|_|___/\__|_|  \__,_|_(_)_|  |___/

Fast, flexible LLM inference.

info: Detected OS: linux
info: Checking for a prebuilt binary for your platform...
```

PR fix this at least for

```
> uname -a
Linux archlinux 7.0.13-arch1-1 #1 SMP PREEMPT_DYNAMIC Tue, 23 Jun 2026 11:14:21 +0000 x86_64 GNU/Linux
```

