### PR TITLE
fix(core): stream raw chat deltas without tool state

### DIFF
--- a/mistralrs-core/src/pipeline/sampling.rs
+++ b/mistralrs-core/src/pipeline/sampling.rs
@@ -36,21 +36,34 @@ fn parse_text_and_tool_calls(
     Ok((parsed.content, parsed.tool_calls))
 }
 
-#[cfg(test)]
 fn parse_streaming_text_and_tool_calls(
     content_delta: Option<String>,
     raw_delta: &str,
-    has_reasoning_parser: bool,
+    has_external_reasoning_parser: bool,
+    is_done: bool,
     state: Option<&mut ToolCallState>,
-) -> Result<(Option<String>, Vec<crate::tools::ToolCallResponse>)> {
+) -> Result<crate::tools::state::ToolCallParse> {
     let Some(state) = state else {
-        return Ok((
-            content_delta.or_else(|| Some(raw_delta.to_string())),
-            Vec::new(),
-        ));
+        return Ok(crate::tools::state::ToolCallParse {
+            content: content_delta.or_else(|| {
+                if has_external_reasoning_parser {
+                    None
+                } else {
+                    Some(raw_delta.to_string())
+                }
+            }),
+            reasoning_content: None,
+            tool_calls: Vec::new(),
+            tool_use_still_possible: false,
+            tool_use_is_done: false,
+        });
     };
-    let parsed = state.parse_streaming(content_delta, raw_delta, has_reasoning_parser, false)?;
-    Ok((parsed.content, parsed.tool_calls))
+    state.parse_streaming(
+        content_delta,
+        raw_delta,
+        has_external_reasoning_parser,
+        is_done,
+    )
 }
 
 fn activate_required_tool_call_grammar(
@@ -203,23 +216,20 @@ pub(crate) async fn finish_or_add_toks_to_seq(
                         None
                     };
 
-                    let tool_calls = if let Some(state) = seq.tool_call_state.as_mut() {
-                        let parsed = state.parse_streaming(
-                            content_delta.take(),
-                            delta.as_str(),
-                            has_external_reasoning_parser,
-                            is_done.is_some(),
-                        )?;
-                        content_delta = parsed.content;
-                        let parsed_tool_use_is_done = parsed.tool_use_is_done;
-                        let _parsed_tool_use_still_possible = parsed.tool_use_still_possible;
-                        if parsed_tool_use_is_done || !parsed.tool_calls.is_empty() {
-                            is_done = Some(StopReason::ToolCalls);
-                        }
-                        parsed.tool_calls
-                    } else {
-                        Vec::new()
-                    };
+                    let parsed = parse_streaming_text_and_tool_calls(
+                        content_delta.take(),
+                        delta.as_str(),
+                        has_external_reasoning_parser,
+                        is_done.is_some(),
+                        seq.tool_call_state.as_mut(),
+                    )?;
+                    content_delta = parsed.content;
+                    let parsed_tool_use_is_done = parsed.tool_use_is_done;
+                    let _parsed_tool_use_still_possible = parsed.tool_use_still_possible;
+                    if parsed_tool_use_is_done || !parsed.tool_calls.is_empty() {
+                        is_done = Some(StopReason::ToolCalls);
+                    }
+                    let tool_calls = parsed.tool_calls;
 
                     seq.add_streaming_chunk_choice_to_group(crate::ChunkChoice {
                         delta: crate::Delta {
@@ -764,16 +774,34 @@ mod tests {
     }
 
     #[test]
+    fn no_tool_state_stream_uses_raw_delta() {
+        let parsed =
+            parse_streaming_text_and_tool_calls(None, "hello", false, false, None).unwrap();
+
+        assert_eq!(parsed.content, Some("hello".to_string()));
+        assert!(parsed.tool_calls.is_empty());
+    }
+
+    #[test]
+    fn external_reasoning_without_content_does_not_fallback_to_raw_delta() {
+        let parsed =
+            parse_streaming_text_and_tool_calls(None, "<think>secret", true, false, None).unwrap();
+
+        assert_eq!(parsed.content, None);
+        assert!(parsed.tool_calls.is_empty());
+    }
+
+    #[test]
     fn reasoning_stream_does_not_fallback_to_raw_delta() {
         let tool = weather_tool();
         let mut state = ToolCallState::new(ToolChoice::Auto, Some(&[tool]), None).unwrap();
         let raw = r#"<|tool_call>call:get_weather{city:<|"|>Paris<|"|>}"#;
 
-        let (content, tool_calls) =
-            parse_streaming_text_and_tool_calls(None, raw, true, Some(&mut state)).unwrap();
+        let parsed =
+            parse_streaming_text_and_tool_calls(None, raw, true, false, Some(&mut state)).unwrap();
 
-        assert_eq!(content, None);
-        assert!(tool_calls.is_empty());
+        assert_eq!(parsed.content, None);
+        assert!(parsed.tool_calls.is_empty());
     }
 
     #[test]
@@ -782,11 +810,11 @@ mod tests {
         let mut state = ToolCallState::new(ToolChoice::Auto, Some(&[tool]), None).unwrap();
         let raw = r#"<|tool_call>call:get_weather{city:<|"|>Paris<|"|>}"#;
 
-        let (content, tool_calls) =
-            parse_streaming_text_and_tool_calls(None, raw, false, Some(&mut state)).unwrap();
+        let parsed =
+            parse_streaming_text_and_tool_calls(None, raw, false, false, Some(&mut state)).unwrap();
 
-        assert_eq!(content, None);
-        assert_eq!(tool_calls.len(), 1);
-        assert_eq!(tool_calls[0].function.name, "get_weather");
+        assert_eq!(parsed.content, None);
+        assert_eq!(parsed.tool_calls.len(), 1);
+        assert_eq!(parsed.tool_calls[0].function.name, "get_weather");
     }
 }


### PR DESCRIPTION
@EricLBuehler hi! This fixes a small OpenAI-compatible chat streaming issue I ran into while testing the server.

## Summary

Ordinary `/v1/chat/completions` streaming responses could emit chunks where `choices[].delta.content` stayed `null`, even though the model generated text and the equivalent non-streaming request returned `choices[].message.content` correctly.

The issue was in chat streaming chunk assembly: when there was no reasoning parser and no tool-call state, the raw decoded token delta from `seq.get_delta()` was not copied into `delta.content`.

This patch falls back to the raw delta only when no parser/tool state owns the stream, while preserving the existing reasoning/tool-call suppression behavior.

## What Changed

- Promoted the existing streaming text/tool-call helper into the production path.
- For ordinary chat streaming with no tool state, use the raw token delta as `delta.content`.
- If an external reasoning parser is active, do not fall back to raw delta.
- If tool-call state exists, keep delegating to `ToolCallState::parse_streaming`.
- Added regression coverage for:
  - no tool state uses raw delta
  - external reasoning does not leak raw delta
  - existing tool-call streaming behavior

## Verification

```bash
cargo test -p mistralrs-core pipeline::sampling::tests
```

I also verified the behavior end-to-end with a local OpenAI-compatible server.

<details>
<summary>End-to-end reproduction script and output</summary>

Model used:

```text
Qwen/Qwen2.5-0.5B-Instruct
```

Start the server:

```bash
target/debug/mistralrs serve \
  --host 127.0.0.1 \
  --port 8123 \
  --no-ui \
  --cpu \
  --max-seq-len 512 \
  --max-batch-size 1 \
  -m Qwen/Qwen2.5-0.5B-Instruct
```

Run this script with the server base URL:

```bash
python3 repro_chat_streaming_content.py http://127.0.0.1:8123
```

Script:

```python
#!/usr/bin/env python3
import json
import sys
import time
import urllib.request


BASE_URL = sys.argv[1] if len(sys.argv) > 1 else "http://127.0.0.1:1234"


def post_json(path, payload, timeout=120):
    data = json.dumps(payload).encode("utf-8")
    req = urllib.request.Request(
        BASE_URL + path,
        data=data,
        headers={"Content-Type": "application/json"},
        method="POST",
    )
    return urllib.request.urlopen(req, timeout=timeout)


def wait_for_server(timeout=180):
    deadline = time.time() + timeout
    while time.time() < deadline:
        try:
            urllib.request.urlopen(BASE_URL + "/v1/models", timeout=2).read()
            return
        except Exception:
            time.sleep(1)
    raise RuntimeError(f"server did not become ready at {BASE_URL}")


def main():
    wait_for_server()

    common = {
        "model": "default",
        "messages": [
            {
                "role": "user",
                "content": "Reply with exactly this word and nothing else: banana",
            }
        ],
        "max_tokens": 16,
        "temperature": 0.0,
    }

    non_stream = json.load(post_json("/v1/chat/completions", {**common, "stream": False}))
    message_content = non_stream["choices"][0]["message"].get("content")
    print("NON_STREAM_CONTENT:", repr(message_content))
    if not message_content:
        raise SystemExit("non-streaming response had empty message.content")

    content_chunks = []
    null_chunks = 0
    total_chunks = 0
    finish_reasons = []

    with post_json("/v1/chat/completions", {**common, "stream": True}) as resp:
        for raw_line in resp:
            line = raw_line.decode("utf-8").strip()
            if not line.startswith("data:"):
                continue
            data = line[len("data:") :].strip()
            if data == "[DONE]":
                break
            event = json.loads(data)
            for choice in event.get("choices", []):
                total_chunks += 1
                finish_reasons.append(choice.get("finish_reason"))
                delta = choice.get("delta", {})
                content = delta.get("content")
                if content is None:
                    null_chunks += 1
                elif content:
                    content_chunks.append(content)

    stream_text = "".join(content_chunks)
    print("STREAM_TOTAL_CHUNKS:", total_chunks)
    print("STREAM_NULL_CONTENT_CHUNKS:", null_chunks)
    print("STREAM_NONEMPTY_CONTENT_CHUNKS:", len(content_chunks))
    print("STREAM_JOINED_CONTENT:", repr(stream_text))
    print("STREAM_FINISH_REASONS:", finish_reasons)

    if not content_chunks:
        raise SystemExit(
            "streaming response produced no non-empty choices[].delta.content chunks"
        )


if __name__ == "__main__":
    main()
```

On current `master`, non-streaming returns content, but streaming produces no non-empty `choices[].delta.content` chunks:

```text
NON_STREAM_CONTENT: 'banana'
STREAM_TOTAL_CHUNKS: 2
STREAM_NULL_CONTENT_CHUNKS: 2
STREAM_NONEMPTY_CONTENT_CHUNKS: 0
STREAM_JOINED_CONTENT: ''
STREAM_FINISH_REASONS: [None, 'stop']
streaming response produced no non-empty choices[].delta.content chunks
```

After this patch, the same request streams content as expected:

```text
NON_STREAM_CONTENT: 'banana'
STREAM_TOTAL_CHUNKS: 2
STREAM_NULL_CONTENT_CHUNKS: 0
STREAM_NONEMPTY_CONTENT_CHUNKS: 1
STREAM_JOINED_CONTENT: 'banana'
STREAM_FINISH_REASONS: [None, 'stop']
```

</details>