### PR TITLE
fix(vlm): handle Qwen VL chunked paged prefill

### DIFF
--- a/mistralrs-core/src/vision_models/mod.rs
+++ b/mistralrs-core/src/vision_models/mod.rs
@@ -37,6 +37,71 @@ pub(crate) mod qwen3_vl_moe;
 pub(crate) mod siglip;
 pub(crate) mod voxtral;
 
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) struct ChunkedMultimodalRange {
+    pub batch: usize,
+    pub local_start: usize,
+    pub local_end: usize,
+    pub embed_start: usize,
+    pub len: usize,
+}
+
+// Map full-prompt multimodal spans onto the current prompt chunk. The visual
+// embeddings stay packed in full-prompt order, while input_embeds is chunk-local.
+pub(crate) fn chunked_multimodal_ranges(
+    spans_by_batch: &[Vec<(usize, usize)>],
+    seqlen_offsets: &[usize],
+    seq_len: usize,
+) -> Vec<ChunkedMultimodalRange> {
+    let mut ranges = Vec::new();
+    let mut embed_offset = 0usize;
+    for (batch, spans) in spans_by_batch.iter().enumerate() {
+        let chunk_start = seqlen_offsets.get(batch).copied().unwrap_or(0);
+        let chunk_end = chunk_start + seq_len;
+        for &(start, end) in spans {
+            let span_len = end - start;
+            let intersect_start = start.max(chunk_start);
+            let intersect_end = end.min(chunk_end);
+            if intersect_start < intersect_end {
+                let len = intersect_end - intersect_start;
+                ranges.push(ChunkedMultimodalRange {
+                    batch,
+                    local_start: intersect_start - chunk_start,
+                    local_end: intersect_end - chunk_start,
+                    embed_start: embed_offset + (intersect_start - start),
+                    len,
+                });
+            }
+            embed_offset += span_len;
+        }
+    }
+    ranges
+}
+
+// DeepStack layers are packed like the main visual embeddings, so they must be
+// clipped with the same ranges as the local visual masks.
+pub(crate) fn chunked_multimodal_layers(
+    layers: Vec<Tensor>,
+    ranges: &[ChunkedMultimodalRange],
+) -> Result<Vec<Tensor>> {
+    if ranges.is_empty() {
+        return layers
+            .into_iter()
+            .map(|layer| layer.narrow(0, 0, 0))
+            .collect();
+    }
+    layers
+        .into_iter()
+        .map(|layer| {
+            let chunks = ranges
+                .iter()
+                .map(|range| layer.narrow(0, range.embed_start, range.len))
+                .collect::<Result<Vec<_>>>()?;
+            Tensor::cat(&chunks, 0)
+        })
+        .collect()
+}
+
 use crate::pipeline::{
     text_models_inputs_processor::{FlashParams, PagedAttentionInputMetadata},
     RecurrentBatchKind,

--- a/mistralrs-core/src/vision_models/qwen2_5_vl/mod.rs
+++ b/mistralrs-core/src/vision_models/qwen2_5_vl/mod.rs
@@ -440,7 +440,7 @@ impl Qwen2_5VLModel {
                         &[
                             range.batch..range.batch + 1,
                             range.local_start..range.local_end,
-                            0..xs.dim(1)?,
+                            0..xs.dim(2)?,
                         ],
                         &video_embeds
                             .i((range.embed_start..range.embed_start + range.len, ..))?

--- a/mistralrs-core/src/vision_models/qwen2_5_vl/mod.rs
+++ b/mistralrs-core/src/vision_models/qwen2_5_vl/mod.rs
@@ -405,17 +405,21 @@ impl Qwen2_5VLModel {
                 }
                 .to_dtype(self.text.dtype)?;
 
-                for (batch, batch_ids) in continuous_img_pad.into_iter().enumerate() {
-                    let mut last_end = 0;
-                    for (start, end) in batch_ids {
-                        xs = xs.slice_assign(
-                            &[batch..batch + 1, start..end, 0..xs.dim(2)?],
-                            &image_embeds
-                                .i((last_end..last_end + (end - start), ..))?
-                                .unsqueeze(0)?,
-                        )?;
-                        last_end = end - start;
-                    }
+                for range in crate::vision_models::chunked_multimodal_ranges(
+                    &continuous_img_pad,
+                    seqlen_offsets,
+                    input_ids.dim(1)?,
+                ) {
+                    xs = xs.slice_assign(
+                        &[
+                            range.batch..range.batch + 1,
+                            range.local_start..range.local_end,
+                            0..xs.dim(2)?,
+                        ],
+                        &image_embeds
+                            .i((range.embed_start..range.embed_start + range.len, ..))?
+                            .unsqueeze(0)?,
+                    )?;
                 }
             }
 
@@ -427,17 +431,21 @@ impl Qwen2_5VLModel {
                         .context("pixel_values_videos require video_grid_thw")?,
                 )?;
 
-                for (batch, batch_ids) in continuous_vid_pad.into_iter().enumerate() {
-                    let mut last_end = 0;
-                    for (start, end) in batch_ids {
-                        xs = xs.slice_assign(
-                            &[batch..batch + 1, start..end, 0..xs.dim(1)?],
-                            &video_embeds
-                                .i((last_end..last_end + (end - start), ..))?
-                                .unsqueeze(0)?,
-                        )?;
-                        last_end = end - start;
-                    }
+                for range in crate::vision_models::chunked_multimodal_ranges(
+                    &continuous_vid_pad,
+                    seqlen_offsets,
+                    input_ids.dim(1)?,
+                ) {
+                    xs = xs.slice_assign(
+                        &[
+                            range.batch..range.batch + 1,
+                            range.local_start..range.local_end,
+                            0..xs.dim(1)?,
+                        ],
+                        &video_embeds
+                            .i((range.embed_start..range.embed_start + range.len, ..))?
+                            .unsqueeze(0)?,
+                    )?;
                 }
             }
 

--- a/mistralrs-core/src/vision_models/qwen2vl/mod.rs
+++ b/mistralrs-core/src/vision_models/qwen2vl/mod.rs
@@ -405,17 +405,21 @@ impl Qwen2VLModel {
                 }
                 .to_dtype(self.text.dtype)?;
 
-                for (batch, batch_ids) in continuous_img_pad.into_iter().enumerate() {
-                    let mut last_end = 0;
-                    for (start, end) in batch_ids {
-                        xs = xs.slice_assign(
-                            &[batch..batch + 1, start..end, 0..xs.dim(2)?],
-                            &image_embeds
-                                .i((last_end..last_end + (end - start), ..))?
-                                .unsqueeze(0)?,
-                        )?;
-                        last_end = end - start;
-                    }
+                for range in crate::vision_models::chunked_multimodal_ranges(
+                    &continuous_img_pad,
+                    seqlen_offsets,
+                    input_ids.dim(1)?,
+                ) {
+                    xs = xs.slice_assign(
+                        &[
+                            range.batch..range.batch + 1,
+                            range.local_start..range.local_end,
+                            0..xs.dim(2)?,
+                        ],
+                        &image_embeds
+                            .i((range.embed_start..range.embed_start + range.len, ..))?
+                            .unsqueeze(0)?,
+                    )?;
                 }
             }
 
@@ -427,17 +431,21 @@ impl Qwen2VLModel {
                         .context("pixel_values_videos require video_grid_thw")?,
                 )?;
 
-                for (batch, batch_ids) in continuous_vid_pad.into_iter().enumerate() {
-                    let mut last_end = 0;
-                    for (start, end) in batch_ids {
-                        xs = xs.slice_assign(
-                            &[batch..batch + 1, start..end, 0..xs.dim(2)?],
-                            &video_embeds
-                                .i((last_end..last_end + (end - start), ..))?
-                                .unsqueeze(0)?,
-                        )?;
-                        last_end = end - start;
-                    }
+                for range in crate::vision_models::chunked_multimodal_ranges(
+                    &continuous_vid_pad,
+                    seqlen_offsets,
+                    input_ids.dim(1)?,
+                ) {
+                    xs = xs.slice_assign(
+                        &[
+                            range.batch..range.batch + 1,
+                            range.local_start..range.local_end,
+                            0..xs.dim(2)?,
+                        ],
+                        &video_embeds
+                            .i((range.embed_start..range.embed_start + range.len, ..))?
+                            .unsqueeze(0)?,
+                    )?;
                 }
             }
 

--- a/mistralrs-core/src/vision_models/qwen2vl/mod.rs
+++ b/mistralrs-core/src/vision_models/qwen2vl/mod.rs
@@ -464,9 +464,9 @@ impl Qwen2VLModel {
         }
         let ropeidx_attn_mask = Tensor::stack(&ropeidx_attn_mask_bs, 0)?;
         let mut ropeidx_attn_mask_indices_bs = Vec::new();
-        for (len, offset) in seqlens.iter().zip(seqlen_offsets) {
+        for len in seqlens.iter() {
             ropeidx_attn_mask_indices_bs.push(Tensor::from_vec(
-                (*offset as i64..(*len as i64 + *offset as i64)).collect(),
+                (0_i64..*len as i64).collect(),
                 (*len,),
                 input_ids.device(),
             )?);

--- a/mistralrs-core/src/vision_models/qwen3_5/mod.rs
+++ b/mistralrs-core/src/vision_models/qwen3_5/mod.rs
@@ -258,7 +258,6 @@ impl Qwen3_5Model {
                 .map(|t| t.to_device(&device)?.to_dtype(self.text.dtype))
                 .collect::<Result<Vec<_>>>()?;
 
-            let mut offset = 0usize;
             let mut image_mask =
                 Tensor::zeros((batch_size, seq_len), DType::F32, input_ids.device())?;
             let total_expected: usize = continuous_img_pad
@@ -273,21 +272,35 @@ impl Qwen3_5Model {
                 );
             }
 
-            for (batch, spans) in continuous_img_pad.iter().enumerate() {
-                for &(start, end) in spans {
-                    let len = end - start;
-                    let chunk = image_embeds.narrow(0, offset, len)?;
-                    offset += len;
-                    input_embeds = input_embeds.slice_assign(
-                        &[batch..batch + 1, start..end, 0..hidden_dim],
-                        &chunk.unsqueeze(0)?,
-                    )?;
-                    let ones = Tensor::ones((1, len), DType::F32, input_ids.device())?;
-                    image_mask = image_mask.slice_assign(&[batch..batch + 1, start..end], &ones)?;
-                }
+            let image_ranges = crate::vision_models::chunked_multimodal_ranges(
+                &continuous_img_pad,
+                seqlen_offsets,
+                seq_len,
+            );
+            for range in &image_ranges {
+                let chunk = image_embeds.narrow(0, range.embed_start, range.len)?;
+                input_embeds = input_embeds.slice_assign(
+                    &[
+                        range.batch..range.batch + 1,
+                        range.local_start..range.local_end,
+                        0..hidden_dim,
+                    ],
+                    &chunk.unsqueeze(0)?,
+                )?;
+                let ones = Tensor::ones((1, range.len), DType::F32, input_ids.device())?;
+                image_mask = image_mask.slice_assign(
+                    &[
+                        range.batch..range.batch + 1,
+                        range.local_start..range.local_end,
+                    ],
+                    &ones,
+                )?;
             }
             image_mask_opt = Some(image_mask.to_dtype(DType::U8)?);
-            deepstack_image_opt = Some(deepstack_image_embeds);
+            deepstack_image_opt = Some(crate::vision_models::chunked_multimodal_layers(
+                deepstack_image_embeds,
+                &image_ranges,
+            )?);
         }
 
         if let Some(pixel_values_videos) = &pixel_values_videos {
@@ -308,7 +321,6 @@ impl Qwen3_5Model {
                 .map(|t| t.to_device(&device)?.to_dtype(self.text.dtype))
                 .collect::<Result<Vec<_>>>()?;
 
-            let mut offset = 0usize;
             let mut video_mask =
                 Tensor::zeros((batch_size, seq_len), DType::F32, input_ids.device())?;
             let total_expected: usize = continuous_vid_pad
@@ -323,21 +335,35 @@ impl Qwen3_5Model {
                 );
             }
 
-            for (batch, spans) in continuous_vid_pad.iter().enumerate() {
-                for &(start, end) in spans {
-                    let len = end - start;
-                    let chunk = video_embeds.narrow(0, offset, len)?;
-                    offset += len;
-                    input_embeds = input_embeds.slice_assign(
-                        &[batch..batch + 1, start..end, 0..hidden_dim],
-                        &chunk.unsqueeze(0)?,
-                    )?;
-                    let ones = Tensor::ones((1, len), DType::F32, input_ids.device())?;
-                    video_mask = video_mask.slice_assign(&[batch..batch + 1, start..end], &ones)?;
-                }
+            let video_ranges = crate::vision_models::chunked_multimodal_ranges(
+                &continuous_vid_pad,
+                seqlen_offsets,
+                seq_len,
+            );
+            for range in &video_ranges {
+                let chunk = video_embeds.narrow(0, range.embed_start, range.len)?;
+                input_embeds = input_embeds.slice_assign(
+                    &[
+                        range.batch..range.batch + 1,
+                        range.local_start..range.local_end,
+                        0..hidden_dim,
+                    ],
+                    &chunk.unsqueeze(0)?,
+                )?;
+                let ones = Tensor::ones((1, range.len), DType::F32, input_ids.device())?;
+                video_mask = video_mask.slice_assign(
+                    &[
+                        range.batch..range.batch + 1,
+                        range.local_start..range.local_end,
+                    ],
+                    &ones,
+                )?;
             }
             video_mask_opt = Some(video_mask.to_dtype(DType::U8)?);
-            deepstack_video_opt = Some(deepstack_video_embeds);
+            deepstack_video_opt = Some(crate::vision_models::chunked_multimodal_layers(
+                deepstack_video_embeds,
+                &video_ranges,
+            )?);
         }
 
         let (visual_pos_masks, deepstack_visual_embeds) = match (

--- a/mistralrs-core/src/vision_models/qwen3_5/mod.rs
+++ b/mistralrs-core/src/vision_models/qwen3_5/mod.rs
@@ -112,8 +112,10 @@ impl Qwen3_5Model {
                 ..Default::default()
             },
         )?;
-        let is_first_chunk = ctx.is_first_prompt_chunk();
-        attention_mask = if is_first_chunk {
+        // Non-first paged prompt chunks are still prefill; only decode can drop the mask.
+        let is_paged_prefill_chunk =
+            ctx.is_paged() && input_ids.dim(1)? > 1 && !ctx.is_first_prompt_chunk();
+        attention_mask = if ctx.is_first_prompt_chunk() || is_paged_prefill_chunk {
             attention_mask
         } else {
             AttentionMask::None

--- a/mistralrs-core/src/vision_models/qwen3_5_moe/mod.rs
+++ b/mistralrs-core/src/vision_models/qwen3_5_moe/mod.rs
@@ -258,7 +258,6 @@ impl Qwen3_5MoeModel {
                 .map(|t| t.to_device(&device)?.to_dtype(self.text.dtype))
                 .collect::<Result<Vec<_>>>()?;
 
-            let mut offset = 0usize;
             let mut image_mask =
                 Tensor::zeros((batch_size, seq_len), DType::F32, input_ids.device())?;
             let total_expected: usize = continuous_img_pad
@@ -273,21 +272,35 @@ impl Qwen3_5MoeModel {
                 );
             }
 
-            for (batch, spans) in continuous_img_pad.iter().enumerate() {
-                for &(start, end) in spans {
-                    let len = end - start;
-                    let chunk = image_embeds.narrow(0, offset, len)?;
-                    offset += len;
-                    input_embeds = input_embeds.slice_assign(
-                        &[batch..batch + 1, start..end, 0..hidden_dim],
-                        &chunk.unsqueeze(0)?,
-                    )?;
-                    let ones = Tensor::ones((1, len), DType::F32, input_ids.device())?;
-                    image_mask = image_mask.slice_assign(&[batch..batch + 1, start..end], &ones)?;
-                }
+            let image_ranges = crate::vision_models::chunked_multimodal_ranges(
+                &continuous_img_pad,
+                seqlen_offsets,
+                seq_len,
+            );
+            for range in &image_ranges {
+                let chunk = image_embeds.narrow(0, range.embed_start, range.len)?;
+                input_embeds = input_embeds.slice_assign(
+                    &[
+                        range.batch..range.batch + 1,
+                        range.local_start..range.local_end,
+                        0..hidden_dim,
+                    ],
+                    &chunk.unsqueeze(0)?,
+                )?;
+                let ones = Tensor::ones((1, range.len), DType::F32, input_ids.device())?;
+                image_mask = image_mask.slice_assign(
+                    &[
+                        range.batch..range.batch + 1,
+                        range.local_start..range.local_end,
+                    ],
+                    &ones,
+                )?;
             }
             image_mask_opt = Some(image_mask.to_dtype(DType::U8)?);
-            deepstack_image_opt = Some(deepstack_image_embeds);
+            deepstack_image_opt = Some(crate::vision_models::chunked_multimodal_layers(
+                deepstack_image_embeds,
+                &image_ranges,
+            )?);
         }
 
         if let Some(pixel_values_videos) = &pixel_values_videos {
@@ -308,7 +321,6 @@ impl Qwen3_5MoeModel {
                 .map(|t| t.to_device(&device)?.to_dtype(self.text.dtype))
                 .collect::<Result<Vec<_>>>()?;
 
-            let mut offset = 0usize;
             let mut video_mask =
                 Tensor::zeros((batch_size, seq_len), DType::F32, input_ids.device())?;
             let total_expected: usize = continuous_vid_pad
@@ -323,21 +335,35 @@ impl Qwen3_5MoeModel {
                 );
             }
 
-            for (batch, spans) in continuous_vid_pad.iter().enumerate() {
-                for &(start, end) in spans {
-                    let len = end - start;
-                    let chunk = video_embeds.narrow(0, offset, len)?;
-                    offset += len;
-                    input_embeds = input_embeds.slice_assign(
-                        &[batch..batch + 1, start..end, 0..hidden_dim],
-                        &chunk.unsqueeze(0)?,
-                    )?;
-                    let ones = Tensor::ones((1, len), DType::F32, input_ids.device())?;
-                    video_mask = video_mask.slice_assign(&[batch..batch + 1, start..end], &ones)?;
-                }
+            let video_ranges = crate::vision_models::chunked_multimodal_ranges(
+                &continuous_vid_pad,
+                seqlen_offsets,
+                seq_len,
+            );
+            for range in &video_ranges {
+                let chunk = video_embeds.narrow(0, range.embed_start, range.len)?;
+                input_embeds = input_embeds.slice_assign(
+                    &[
+                        range.batch..range.batch + 1,
+                        range.local_start..range.local_end,
+                        0..hidden_dim,
+                    ],
+                    &chunk.unsqueeze(0)?,
+                )?;
+                let ones = Tensor::ones((1, range.len), DType::F32, input_ids.device())?;
+                video_mask = video_mask.slice_assign(
+                    &[
+                        range.batch..range.batch + 1,
+                        range.local_start..range.local_end,
+                    ],
+                    &ones,
+                )?;
             }
             video_mask_opt = Some(video_mask.to_dtype(DType::U8)?);
-            deepstack_video_opt = Some(deepstack_video_embeds);
+            deepstack_video_opt = Some(crate::vision_models::chunked_multimodal_layers(
+                deepstack_video_embeds,
+                &video_ranges,
+            )?);
         }
 
         let (visual_pos_masks, deepstack_visual_embeds) = match (

--- a/mistralrs-core/src/vision_models/qwen3_5_moe/mod.rs
+++ b/mistralrs-core/src/vision_models/qwen3_5_moe/mod.rs
@@ -112,8 +112,10 @@ impl Qwen3_5MoeModel {
                 ..Default::default()
             },
         )?;
-        let is_first_chunk = ctx.is_first_prompt_chunk();
-        attention_mask = if is_first_chunk {
+        // Non-first paged prompt chunks are still prefill; only decode can drop the mask.
+        let is_paged_prefill_chunk =
+            ctx.is_paged() && input_ids.dim(1)? > 1 && !ctx.is_first_prompt_chunk();
+        attention_mask = if ctx.is_first_prompt_chunk() || is_paged_prefill_chunk {
             attention_mask
         } else {
             AttentionMask::None

--- a/mistralrs-core/src/vision_models/qwen3_vl/mod.rs
+++ b/mistralrs-core/src/vision_models/qwen3_vl/mod.rs
@@ -412,8 +412,10 @@ impl Qwen3VLModel {
                 ..Default::default()
             },
         )?;
-        let is_first_chunk = ctx.is_first_prompt_chunk();
-        attention_mask = if is_first_chunk {
+        // Non-first paged prompt chunks are still prefill; only decode can drop the mask.
+        let is_paged_prefill_chunk =
+            ctx.is_paged() && input_ids.dim(1)? > 1 && !ctx.is_first_prompt_chunk();
+        attention_mask = if ctx.is_first_prompt_chunk() || is_paged_prefill_chunk {
             attention_mask
         } else {
             AttentionMask::None

--- a/mistralrs-core/src/vision_models/qwen3_vl/mod.rs
+++ b/mistralrs-core/src/vision_models/qwen3_vl/mod.rs
@@ -564,7 +564,6 @@ impl Qwen3VLModel {
                 .map(|t| t.to_device(&device)?.to_dtype(self.text.dtype))
                 .collect::<Result<Vec<_>>>()?;
 
-            let mut offset = 0usize;
             let mut image_mask =
                 Tensor::zeros((batch_size, seq_len), DType::F32, input_ids.device())?;
             let total_expected: usize = continuous_img_pad
@@ -579,21 +578,35 @@ impl Qwen3VLModel {
                 );
             }
 
-            for (batch, spans) in continuous_img_pad.iter().enumerate() {
-                for &(start, end) in spans {
-                    let len = end - start;
-                    let chunk = image_embeds.narrow(0, offset, len)?;
-                    offset += len;
-                    input_embeds = input_embeds.slice_assign(
-                        &[batch..batch + 1, start..end, 0..hidden_dim],
-                        &chunk.unsqueeze(0)?,
-                    )?;
-                    let ones = Tensor::ones((1, len), DType::F32, input_ids.device())?;
-                    image_mask = image_mask.slice_assign(&[batch..batch + 1, start..end], &ones)?;
-                }
+            let image_ranges = crate::vision_models::chunked_multimodal_ranges(
+                &continuous_img_pad,
+                seqlen_offsets,
+                seq_len,
+            );
+            for range in &image_ranges {
+                let chunk = image_embeds.narrow(0, range.embed_start, range.len)?;
+                input_embeds = input_embeds.slice_assign(
+                    &[
+                        range.batch..range.batch + 1,
+                        range.local_start..range.local_end,
+                        0..hidden_dim,
+                    ],
+                    &chunk.unsqueeze(0)?,
+                )?;
+                let ones = Tensor::ones((1, range.len), DType::F32, input_ids.device())?;
+                image_mask = image_mask.slice_assign(
+                    &[
+                        range.batch..range.batch + 1,
+                        range.local_start..range.local_end,
+                    ],
+                    &ones,
+                )?;
             }
             image_mask_opt = Some(image_mask.to_dtype(DType::U8)?);
-            deepstack_image_opt = Some(deepstack_image_embeds);
+            deepstack_image_opt = Some(crate::vision_models::chunked_multimodal_layers(
+                deepstack_image_embeds,
+                &image_ranges,
+            )?);
         }
 
         if let Some(pixel_values_videos) = &pixel_values_videos {
@@ -614,7 +627,6 @@ impl Qwen3VLModel {
                 .map(|t| t.to_device(&device)?.to_dtype(self.text.dtype))
                 .collect::<Result<Vec<_>>>()?;
 
-            let mut offset = 0usize;
             let mut video_mask =
                 Tensor::zeros((batch_size, seq_len), DType::F32, input_ids.device())?;
             let total_expected: usize = continuous_vid_pad
@@ -629,21 +641,35 @@ impl Qwen3VLModel {
                 );
             }
 
-            for (batch, spans) in continuous_vid_pad.iter().enumerate() {
-                for &(start, end) in spans {
-                    let len = end - start;
-                    let chunk = video_embeds.narrow(0, offset, len)?;
-                    offset += len;
-                    input_embeds = input_embeds.slice_assign(
-                        &[batch..batch + 1, start..end, 0..hidden_dim],
-                        &chunk.unsqueeze(0)?,
-                    )?;
-                    let ones = Tensor::ones((1, len), DType::F32, input_ids.device())?;
-                    video_mask = video_mask.slice_assign(&[batch..batch + 1, start..end], &ones)?;
-                }
+            let video_ranges = crate::vision_models::chunked_multimodal_ranges(
+                &continuous_vid_pad,
+                seqlen_offsets,
+                seq_len,
+            );
+            for range in &video_ranges {
+                let chunk = video_embeds.narrow(0, range.embed_start, range.len)?;
+                input_embeds = input_embeds.slice_assign(
+                    &[
+                        range.batch..range.batch + 1,
+                        range.local_start..range.local_end,
+                        0..hidden_dim,
+                    ],
+                    &chunk.unsqueeze(0)?,
+                )?;
+                let ones = Tensor::ones((1, range.len), DType::F32, input_ids.device())?;
+                video_mask = video_mask.slice_assign(
+                    &[
+                        range.batch..range.batch + 1,
+                        range.local_start..range.local_end,
+                    ],
+                    &ones,
+                )?;
             }
             video_mask_opt = Some(video_mask.to_dtype(DType::U8)?);
-            deepstack_video_opt = Some(deepstack_video_embeds);
+            deepstack_video_opt = Some(crate::vision_models::chunked_multimodal_layers(
+                deepstack_video_embeds,
+                &video_ranges,
+            )?);
         }
 
         let (visual_pos_masks, deepstack_visual_embeds) = match (

--- a/mistralrs-core/src/vision_models/qwen3_vl_moe/mod.rs
+++ b/mistralrs-core/src/vision_models/qwen3_vl_moe/mod.rs
@@ -112,8 +112,10 @@ impl Qwen3VLMoEModel {
                 ..Default::default()
             },
         )?;
-        let is_first_chunk = ctx.is_first_prompt_chunk();
-        attention_mask = if is_first_chunk {
+        // Non-first paged prompt chunks are still prefill; only decode can drop the mask.
+        let is_paged_prefill_chunk =
+            ctx.is_paged() && input_ids.dim(1)? > 1 && !ctx.is_first_prompt_chunk();
+        attention_mask = if ctx.is_first_prompt_chunk() || is_paged_prefill_chunk {
             attention_mask
         } else {
             AttentionMask::None

--- a/mistralrs-core/src/vision_models/qwen3_vl_moe/mod.rs
+++ b/mistralrs-core/src/vision_models/qwen3_vl_moe/mod.rs
@@ -264,7 +264,6 @@ impl Qwen3VLMoEModel {
                 .map(|t| t.to_device(&device)?.to_dtype(self.text.dtype))
                 .collect::<Result<Vec<_>>>()?;
 
-            let mut offset = 0usize;
             let mut image_mask =
                 Tensor::zeros((batch_size, seq_len), DType::F32, input_ids.device())?;
             let total_expected: usize = continuous_img_pad
@@ -279,21 +278,35 @@ impl Qwen3VLMoEModel {
                 );
             }
 
-            for (batch, spans) in continuous_img_pad.iter().enumerate() {
-                for &(start, end) in spans {
-                    let len = end - start;
-                    let chunk = image_embeds.narrow(0, offset, len)?;
-                    offset += len;
-                    input_embeds = input_embeds.slice_assign(
-                        &[batch..batch + 1, start..end, 0..hidden_dim],
-                        &chunk.unsqueeze(0)?,
-                    )?;
-                    let ones = Tensor::ones((1, len), DType::F32, input_ids.device())?;
-                    image_mask = image_mask.slice_assign(&[batch..batch + 1, start..end], &ones)?;
-                }
+            let image_ranges = crate::vision_models::chunked_multimodal_ranges(
+                &continuous_img_pad,
+                seqlen_offsets,
+                seq_len,
+            );
+            for range in &image_ranges {
+                let chunk = image_embeds.narrow(0, range.embed_start, range.len)?;
+                input_embeds = input_embeds.slice_assign(
+                    &[
+                        range.batch..range.batch + 1,
+                        range.local_start..range.local_end,
+                        0..hidden_dim,
+                    ],
+                    &chunk.unsqueeze(0)?,
+                )?;
+                let ones = Tensor::ones((1, range.len), DType::F32, input_ids.device())?;
+                image_mask = image_mask.slice_assign(
+                    &[
+                        range.batch..range.batch + 1,
+                        range.local_start..range.local_end,
+                    ],
+                    &ones,
+                )?;
             }
             image_mask_opt = Some(image_mask.to_dtype(DType::U8)?);
-            deepstack_image_opt = Some(deepstack_image_embeds);
+            deepstack_image_opt = Some(crate::vision_models::chunked_multimodal_layers(
+                deepstack_image_embeds,
+                &image_ranges,
+            )?);
         }
 
         if let Some(pixel_values_videos) = &pixel_values_videos {
@@ -314,7 +327,6 @@ impl Qwen3VLMoEModel {
                 .map(|t| t.to_device(&device)?.to_dtype(self.text.dtype))
                 .collect::<Result<Vec<_>>>()?;
 
-            let mut offset = 0usize;
             let mut video_mask =
                 Tensor::zeros((batch_size, seq_len), DType::F32, input_ids.device())?;
             let total_expected: usize = continuous_vid_pad
@@ -329,21 +341,35 @@ impl Qwen3VLMoEModel {
                 );
             }
 
-            for (batch, spans) in continuous_vid_pad.iter().enumerate() {
-                for &(start, end) in spans {
-                    let len = end - start;
-                    let chunk = video_embeds.narrow(0, offset, len)?;
-                    offset += len;
-                    input_embeds = input_embeds.slice_assign(
-                        &[batch..batch + 1, start..end, 0..hidden_dim],
-                        &chunk.unsqueeze(0)?,
-                    )?;
-                    let ones = Tensor::ones((1, len), DType::F32, input_ids.device())?;
-                    video_mask = video_mask.slice_assign(&[batch..batch + 1, start..end], &ones)?;
-                }
+            let video_ranges = crate::vision_models::chunked_multimodal_ranges(
+                &continuous_vid_pad,
+                seqlen_offsets,
+                seq_len,
+            );
+            for range in &video_ranges {
+                let chunk = video_embeds.narrow(0, range.embed_start, range.len)?;
+                input_embeds = input_embeds.slice_assign(
+                    &[
+                        range.batch..range.batch + 1,
+                        range.local_start..range.local_end,
+                        0..hidden_dim,
+                    ],
+                    &chunk.unsqueeze(0)?,
+                )?;
+                let ones = Tensor::ones((1, range.len), DType::F32, input_ids.device())?;
+                video_mask = video_mask.slice_assign(
+                    &[
+                        range.batch..range.batch + 1,
+                        range.local_start..range.local_end,
+                    ],
+                    &ones,
+                )?;
             }
             video_mask_opt = Some(video_mask.to_dtype(DType::U8)?);
-            deepstack_video_opt = Some(deepstack_video_embeds);
+            deepstack_video_opt = Some(crate::vision_models::chunked_multimodal_layers(
+                deepstack_video_embeds,
+                &video_ranges,
+            )?);
         }
 
         let (visual_pos_masks, deepstack_visual_embeds) = match (


### PR DESCRIPTION
@EricLBuehler Hi! I ran into a few Qwen VL edge cases while testing OCR models with paged attention / chunked prefill, and wanted to check whether this direction looks reasonable.

The main issue is that paged prefill chunks pass chunk-local `input_ids`, while the Qwen visual embeddings are still packed in full-prompt order. The old image/video placeholder replacement used full-prompt spans directly, so later chunks could either miss the local window or assign the wrong visual rows. This showed up especially with OCR prompts where the image token span is large enough to interact with prompt chunking.

A related issue affects the Qwen3 VL variants: non-first paged prompt chunks were treated like decode because `is_first_prompt_chunk()` was false. Those chunks still have `q_len > 1`, so dropping the mask loses prefill semantics and can route attention through the wrong path.

There are also two smaller fixes:
- Qwen2.5 VL video embedding assignment used the sequence dimension as the hidden slice bound.
- Qwen2 VL MRoPE mask indices used global offsets when indexing into a local input row.

This PR:
- maps full-prompt multimodal spans into the current chunk-local window before assigning image/video embeddings;
- applies the same clipping to Qwen3 DeepStack visual layers;
- keeps the attention mask for non-first paged prefill chunks in Qwen3/Qwen3.5 VL variants;
- fixes the two small Qwen2/Qwen2.5 VL indexing issues above.

Does this approach look right to you, especially the shared chunk-local multimodal range helper?