### PR TITLE
fix(core): detect CUDA backend in tune on Windows

### DIFF
--- a/mistralrs-core/src/tuning.rs
+++ b/mistralrs-core/src/tuning.rs
@@ -145,7 +145,7 @@ fn select_devices(force_cpu: bool) -> Result<Vec<Device>> {
         return Ok(vec![Device::Cpu]);
     }
 
-    #[cfg(all(feature = "cuda", target_family = "unix"))]
+    #[cfg(feature = "cuda")]
     {
         if let Ok(dev) = Device::new_cuda(0) {
             return Ok(crate::device_map::get_all_similar_devices(&dev)?);


### PR DESCRIPTION
Closes #2088.

## Root cause

`select_devices` in `mistralrs-core/src/tuning.rs` gates the CUDA branch with `#[cfg(all(feature = "cuda", target_family = "unix"))]`. `target_family = "unix"` is false on Windows, so a Windows `--features cuda` build skips the block entirely and the function falls through to `Ok(vec![Device::Cpu])`. `mistralrs tune` then reports `Backend: cpu` even when CUDA is available, which is what the reporter in #2088 sees.

`target_family = "unix"` is the correct gate elsewhere in the crate where it protects code that uses custom CUDA kernels compiled by `mistralrs-paged-attn/build.rs` (paged attention, flash attention, MLA, flashinfer). `select_devices` does not depend on any of those kernels - it only calls candle's `Device::new_cuda(0)`, which is platform-independent under `feature = "cuda"`.

The matching runtime CUDA detection in `mistralrs-core/src/utils/normal.rs` already uses the unguarded `#[cfg(feature = "cuda")]` form and runs on the reporter's Windows build to produce the `Detected minimum CUDA compute capability 12` log line that immediately precedes the wrong `Backend: cpu` line. So candle's CUDA path is provably reachable on the platform.

## Fix

Drop `target_family = "unix"` from the cfg gate. The CUDA branch now mirrors the unguarded `#[cfg(feature = "metal")]` branch right below it.

## Verification

- `cargo fmt --all -- --check` clean.
- `cargo check -p mistralrs-core` clean before and after the diff on Linux. On Linux the gate is true in both states, so the same code path is type-checked; widening the gate to include Windows is an additive change.

End-to-end Windows + CUDA reproduction needs the original hardware setup from #2088.