### PR TITLE
fix(release): build CPU binaries on ubuntu-22.04 for GLIBC portability

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -85,8 +85,8 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - { runner: ubuntu-latest, triple: x86_64-unknown-linux-gnu }
-          - { runner: ubuntu-24.04-arm, triple: aarch64-unknown-linux-gnu }
+          - { runner: ubuntu-22.04, triple: x86_64-unknown-linux-gnu }
+          - { runner: ubuntu-22.04-arm, triple: aarch64-unknown-linux-gnu }
     env:
       RUSTFLAGS: "-C target-cpu=generic"
     steps:


### PR DESCRIPTION
Closes #1948.

## Symptom

The reporter in #1948 ran the published `cpu-0.7` image and got:

```
mistralrs-server: /lib/x86_64-linux-gnu/libc.so.6: version 'GLIBC_2.38' not found (required by mistralrs-server)
mistralrs-server: /lib/x86_64-linux-gnu/libc.so.6: version 'GLIBC_2.39' not found (required by mistralrs-server)
```

This bug is still live on master with the new prebuilt-binary release pipeline introduced by #2218.

## Root cause

The CPU release matrix builds on `ubuntu-latest` and `ubuntu-24.04-arm`:

https://github.com/EricLBuehler/mistral.rs/blob/15986c037/.github/workflows/release.yml#L88-L89

Both are Ubuntu 24.04, which ships GLIBC 2.39. With `RUSTFLAGS=\"-C target-cpu=generic\"` the binary is otherwise portable, but glibc symbol versions cap portability at the build host's glibc.

Two consumers of this binary cannot satisfy GLIBC 2.39:

- The Docker image (`Dockerfile`) uses `debian:bookworm-slim` (GLIBC 2.36). It copies the prebuilt binary directly into the runtime image, so the image fails to run.
- `install.sh` downloads the same prebuilt and installs it locally. Any user on Ubuntu 22.04 / Debian 12 / RHEL 9 / etc. (GLIBC 2.35 or 2.36) gets the same `GLIBC_2.39 not found` error.

The `linux-cuda` matrix already builds inside `nvidia/cuda:*-cudnn-devel-ubuntu22.04` containers (GLIBC 2.35), so 22.04 is the existing portability floor for this release pipeline.

## Fix

Switch the CPU matrix runners from Ubuntu 24.04 to Ubuntu 22.04:

```yaml
- { runner: ubuntu-22.04, triple: x86_64-unknown-linux-gnu }
- { runner: ubuntu-22.04-arm, triple: aarch64-unknown-linux-gnu }
```

The resulting binary links against GLIBC 2.35, which satisfies:

- `debian:bookworm-slim` runtime image (2.36)
- `install.sh` users on Ubuntu 22.04+, Debian 12+, RHEL 9+, current Alpine via gcompat, etc.

`ubuntu-22.04-arm` is the same family as the currently-used `ubuntu-24.04-arm` runner label.

The wheel job in the same matrix uses `PyO3/maturin-action@v1` with `manylinux: auto`, which runs in a manylinux container independent of the host, so it is unaffected by the runner switch.

## Verification

- `python -c \"import yaml; yaml.safe_load(open('.github/workflows/release.yml'))\"` parses cleanly.
- The diff is two lines and only touches `runs-on` matrix labels - no script changes, no toolchain changes, no Dockerfile changes.

End-to-end verification needs a release tag to trigger the workflow; I cannot run that as an outside contributor.