### PR TITLE
fix(lfm2): support legacy full_attn_idxs config field

### DIFF
--- a/mistralrs-core/src/models/lfm2.rs
+++ b/mistralrs-core/src/models/lfm2.rs
@@ -112,6 +112,8 @@ pub struct Config {
     pub tie_embedding: Option<bool>,
     #[serde(default)]
     pub layer_types: Vec<String>,
+    #[serde(default)]
+    pub full_attn_idxs: Option<Vec<usize>>,
     #[serde(default = "default_moe_intermediate_size")]
     pub moe_intermediate_size: usize,
     #[serde(default = "default_num_dense_layers")]
@@ -166,6 +168,18 @@ impl Config {
 
     pub fn layer_types(&self) -> Vec<LayerType> {
         if self.layer_types.is_empty() {
+            // older LFM2 configs list attention layers via full_attn_idxs instead of layer_types
+            if let Some(full_attn_idxs) = &self.full_attn_idxs {
+                return (0..self.num_hidden_layers)
+                    .map(|idx| {
+                        if full_attn_idxs.contains(&idx) {
+                            LayerType::Attention
+                        } else {
+                            LayerType::Conv
+                        }
+                    })
+                    .collect();
+            }
             return vec![LayerType::Attention; self.num_hidden_layers];
         }
         self.layer_types


### PR DESCRIPTION
Older LFM2 checkpoints (e.g. [LiquidAI/LFM2-350M](https://huggingface.co/LiquidAI/LFM2-350M)) declare their attention layers via `full_attn_idxs` instead of the newer `layer_types` field:

```json
"full_attn_idxs": [2, 5, 8, 10, 12, 14],
"num_hidden_layers": 16
```

Since `layer_types` is absent, `Config::layer_types()` currently falls back to treating every layer as attention, and loading fails on the first conv layer:

```
Error: Missing required tensor(s) for column_parallel_linear at prefix `model.layers.0.self_attn.q_proj`: model.layers.0.self_attn.q_proj.weight.
```

This adds a fallback that derives the layer types from `full_attn_idxs` when `layer_types` is empty, matching the transformers behavior. Configs with `layer_types` are unaffected.

Verified LFM2-350M now loads and generates correctly; LFM2.5-1.2B-Instruct and LFM2-8B-A1B (`lfm2_moe`, both `layer_types`-style) still work.