### PR TITLE
fix(tune): detect CUDA backend on Windows

### DIFF
--- a/mistralrs-core/src/tuning.rs
+++ b/mistralrs-core/src/tuning.rs
@@ -145,7 +145,7 @@ fn select_devices(force_cpu: bool) -> Result<Vec<Device>> {
         return Ok(vec![Device::Cpu]);
     }
 
-    #[cfg(all(feature = "cuda", target_family = "unix"))]
+    #[cfg(feature = "cuda")]
     {
         if let Ok(dev) = Device::new_cuda(0) {
             return Ok(crate::device_map::get_all_similar_devices(&dev)?);


### PR DESCRIPTION
## Summary

`mistralrs tune` only tried CUDA device selection on Unix targets, so Windows
builds with the `cuda` feature could report a healthy CUDA setup in `doctor` but
still tune as `backend: cpu`.

This removes the Unix-only gate from the tuner CUDA probe. The runtime behavior
is unchanged otherwise: `Device::new_cuda(0)` is still fallible, and tuning still
falls back to Metal or CPU if CUDA is unavailable.

Fixes #2088.

## Validation

- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo check`
- `cargo clippy -p mistralrs-core -- -D warnings`

I could not run a Windows CUDA build locally, but this matches the CUDA device
selection pattern used by the normal, multimodal, and embedding loaders.
