### PR TITLE
fix(llg): honor tokenizer special flag in toktrie detok

### DIFF
--- a/mistralrs-core/src/pipeline/llg.rs
+++ b/mistralrs-core/src/pipeline/llg.rs
@@ -28,6 +28,16 @@ pub fn build_llg_factory(mut tokenizer: Tokenizer) -> Result<Arc<ParserFactory>>
         .map(|(id, at)| (id, at.content))
         .collect();
 
+    // toktrie_hf_tokenizers marks every added-vocab token special; honor the tokenizer's own
+    // `special` flag so non-special added tokens (e.g. PaddleOCR-VL OTSL <fcel>/<nl>) decode as
+    // content, matching transformers decode(skip_special_tokens=True) instead of being dropped.
+    let added_nonspecial: Vec<u32> = tokenizer
+        .get_added_tokens_decoder()
+        .into_iter()
+        .filter(|(_, at)| !at.special)
+        .map(|(id, _)| id)
+        .collect();
+
     let bt = toktrie_hf_tokenizers::ByteTokenizer::from_tokenizer(tokenizer)?;
     let info = bt.tokrx_info();
     let mut token_bytes = bt.token_bytes();
@@ -44,6 +54,15 @@ pub fn build_llg_factory(mut tokenizer: Tokenizer) -> Result<Arc<ParserFactory>>
             let mut bytes = content.as_bytes().to_vec();
             bytes.insert(0, toktrie::TokTrie::SPECIAL_TOKEN_MARKER);
             token_bytes[idx] = bytes;
+        }
+    }
+
+    for id in &added_nonspecial {
+        let idx = *id as usize;
+        if idx < token_bytes.len()
+            && token_bytes[idx].first() == Some(&toktrie::TokTrie::SPECIAL_TOKEN_MARKER)
+        {
+            token_bytes[idx].remove(0);
         }
     }
 
@@ -74,4 +93,177 @@ pub fn constraint_from_llg_grammar(
 ) -> Result<llguidance::Matcher> {
     let parser = factory.create_parser(grm)?;
     Ok(llguidance::Matcher::new(Ok(parser)))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // Mirrors build_llg_factory's toktrie assembly; `apply_fix=false` reproduces the pre-fix
+    // behavior (every added-vocab token stays special-marked), `true` honors the tokenizer's own
+    // `special` flag. Returns the trie so decode_ext can be asserted directly.
+    fn build_trie(mut tokenizer: Tokenizer, apply_fix: bool) -> toktrie::TokTrie {
+        let decoder = match tokenizer.get_decoder() {
+            Some(DecoderWrapper::Sequence(sequence)) if sequence.get_decoders().len() == 1 => {
+                match &sequence.get_decoders()[0] {
+                    DecoderWrapper::ByteLevel(decoder) => Some(DecoderWrapper::ByteLevel(*decoder)),
+                    _ => None,
+                }
+            }
+            _ => None,
+        };
+        if let Some(decoder) = decoder {
+            tokenizer.with_decoder(Some(decoder));
+        }
+        let added_special: Vec<(u32, String)> = tokenizer
+            .get_added_tokens_decoder()
+            .into_iter()
+            .filter(|(_, at)| at.special)
+            .map(|(id, at)| (id, at.content))
+            .collect();
+        let added_nonspecial: Vec<u32> = tokenizer
+            .get_added_tokens_decoder()
+            .into_iter()
+            .filter(|(_, at)| !at.special)
+            .map(|(id, _)| id)
+            .collect();
+        let bt = toktrie_hf_tokenizers::ByteTokenizer::from_tokenizer(tokenizer).unwrap();
+        let info = bt.tokrx_info();
+        let mut token_bytes = bt.token_bytes();
+        for (id, content) in &added_special {
+            let idx = *id as usize;
+            if idx < token_bytes.len()
+                && (token_bytes[idx].is_empty()
+                    || token_bytes[idx][0] != toktrie::TokTrie::SPECIAL_TOKEN_MARKER)
+            {
+                let mut bytes = content.as_bytes().to_vec();
+                bytes.insert(0, toktrie::TokTrie::SPECIAL_TOKEN_MARKER);
+                token_bytes[idx] = bytes;
+            }
+        }
+        if apply_fix {
+            for id in &added_nonspecial {
+                let idx = *id as usize;
+                if idx < token_bytes.len()
+                    && token_bytes[idx].first() == Some(&toktrie::TokTrie::SPECIAL_TOKEN_MARKER)
+                {
+                    token_bytes[idx].remove(0);
+                }
+            }
+        }
+        toktrie::TokTrie::from(&info, &token_bytes)
+    }
+
+    fn dec(trie: &toktrie::TokTrie, id: u32) -> String {
+        String::from_utf8_lossy(&trie.decode_ext(&[id], false)).into_owned()
+    }
+
+    // Env-gated on local tokenizer files (skips in CI). Proves: non-special added tokens now decode
+    // as content, while special=true tokens (EOS, chat delimiters, image) stay dropped as before.
+    #[test]
+    fn honors_tokenizer_special_flag() {
+        if let Ok(p) = std::env::var("REGRESSION_PADDLE_TOK") {
+            let tok = Tokenizer::from_file(&p).unwrap();
+            let fcel = tok.token_to_id("<fcel>").unwrap();
+            let eos = tok.token_to_id("</s>").unwrap();
+            let imend = tok.token_to_id("<|IMAGE_END|>").unwrap();
+            let (before, after) = (build_trie(tok.clone(), false), build_trie(tok, true));
+            println!(
+                "paddle <fcel>  before={:?} after={:?}",
+                dec(&before, fcel),
+                dec(&after, fcel)
+            );
+            println!(
+                "paddle </s>    before={:?} after={:?}",
+                dec(&before, eos),
+                dec(&after, eos)
+            );
+            println!(
+                "paddle IMG_END before={:?} after={:?}",
+                dec(&before, imend),
+                dec(&after, imend)
+            );
+            assert!(
+                dec(&before, fcel).is_empty(),
+                "pre-fix drops the non-special OTSL token"
+            );
+            assert_eq!(
+                dec(&after, fcel),
+                "<fcel>",
+                "fix keeps non-special content token"
+            );
+            assert!(
+                dec(&after, eos).is_empty(),
+                "special=true </s> still dropped"
+            );
+            assert!(
+                dec(&after, imend).is_empty(),
+                "special=true image token still dropped"
+            );
+        }
+        if let Ok(p) = std::env::var("REGRESSION_QWEN_TOK") {
+            let tok = Tokenizer::from_file(&p).unwrap();
+            let im_start = tok.token_to_id("<|im_start|>").unwrap();
+            let im_end = tok.token_to_id("<|im_end|>").unwrap();
+            let tool = tok.token_to_id("<tool_call>").unwrap();
+            let (before, after) = (build_trie(tok.clone(), false), build_trie(tok, true));
+            println!(
+                "qwen im_start  before={:?} after={:?}",
+                dec(&before, im_start),
+                dec(&after, im_start)
+            );
+            println!(
+                "qwen tool_call before={:?} after={:?}",
+                dec(&before, tool),
+                dec(&after, tool)
+            );
+            assert!(
+                dec(&before, im_start).is_empty() && dec(&after, im_start).is_empty(),
+                "chat delimiter <|im_start|> (special=true) stays dropped before AND after"
+            );
+            assert!(
+                dec(&after, im_end).is_empty(),
+                "chat delimiter <|im_end|> stays dropped"
+            );
+        }
+    }
+
+    // Self-contained (runs in CI, no external files): a byte-fallback tokenizer with a special=false
+    // <x> and a special=true <s>. Both are <...>-shaped, so from_tokenizer's heuristic marks both;
+    // pre-fix drops <x>, the fix keeps it as content while <s> stays dropped.
+    #[test]
+    fn honors_special_flag_inline_fixture() {
+        use tokenizers::{
+            decoders::byte_level::ByteLevel as ByteLevelDecoder, models::bpe::BpeBuilder,
+            AddedToken,
+        };
+        let vocab = ahash::AHashMap::from([("a".to_string(), 0u32)]);
+        let bpe = BpeBuilder::new()
+            .vocab_and_merges(vocab, vec![])
+            .build()
+            .unwrap();
+        let mut tok = Tokenizer::new(bpe);
+        tok.with_decoder(Some(ByteLevelDecoder::new(true, false, false)));
+        tok.add_tokens(&[
+            AddedToken::from("<x>", false),
+            AddedToken::from("<s>", true),
+        ]);
+        let x = tok.token_to_id("<x>").unwrap();
+        let s = tok.token_to_id("<s>").unwrap();
+        let before = build_trie(tok.clone(), false);
+        let after = build_trie(tok, true);
+        assert!(
+            dec(&before, x).is_empty(),
+            "pre-fix: <...> heuristic drops the special=false token"
+        );
+        assert_eq!(
+            dec(&after, x),
+            "<x>",
+            "fix keeps the special=false content token"
+        );
+        assert!(
+            dec(&after, s).is_empty(),
+            "special=true token stays dropped"
+        );
+    }
 }


### PR DESCRIPTION
### Problem

Any model whose tokenizer has **added tokens flagged `special = false`** loses those tokens from the
decoded completion string, diverging from HuggingFace `transformers`. It's silent — no error, the
token ids are generated correctly; only the decode drops them.

Surfaced with PaddleOCR-VL, whose tables are emitted as OTSL added tokens `<fcel>` / `<nl>`
(`special = false`). They were dropped, collapsing a table into a run-on string of cell text with no
rows or columns:

```
greedy tokens = [<fcel>, A, <fcel>, B, <nl>, <fcel>, 1, <fcel>, 2, <nl>, </s>]

transformers  tokenizer.decode(..., skip_special_tokens=True) -> "<fcel>A<fcel>B<nl><fcel>1<fcel>2<nl>"
mistral.rs    engine completion (before this PR)              -> "AB12"   # <fcel>/<nl> stripped
```

This is general, not PaddleOCR-specific: any `special = false` `<...>`-shaped added token (e.g.
Qwen2.5-VL's `<tool_call>`) is affected.

### Root cause (upstream heuristic)

`toktrie_hf_tokenizers::ByteTokenizer::from_tokenizer` marks a token special by a name-shape
heuristic that overrides the tokenizer's own flag (`src/lib.rs:121-122` in the v1.4.0 this repo
resolves; `:188` on current `llguidance` main):

```rust
if info.special || (info.content.starts_with("<") && info.content.ends_with(">")) {
```

So every `<...>`-shaped added token gets the `SPECIAL_TOKEN_MARKER`, and the completion detok —
`tok_trie().decode_ext(tokens, include_special=false)` — strips it. The heuristic is intentional
upstream (added in guidance-ai/llguidance#202 to mirror the `transformers` path for GGUF, where a
reliable flag is often absent), but it also overrides an **explicit** `special = false`. Filed
upstream: guidance-ai/llguidance#361. This PR is a correct local correction valid regardless of the
upstream outcome.

### Precedent

Same class of bug was fixed narrowly in #1950 (merged), which enabled `include_special` during
decode so `<think>`/`</think>` delimiters appear — but only in think-tag mode. This PR fixes the
general case at the token-classification source instead of per-feature.

### Fix

After `from_tokenizer`, strip the `SPECIAL_TOKEN_MARKER` from the `token_bytes` of added tokens the
tokenizer flags `special = false`, so they decode as content — matching
`transformers.decode(skip_special_tokens=True)`. The existing loop that marks `special = true`
tokens is untouched, so EOS/BOS/image/chat-delimiter tokens are dropped exactly as before.
Decode-only: it never changes which token id is generated.

### Verification (`llg::tests::honors_tokenizer_special_flag`, before/after on real tokenizers)

| token | tokenizer flag | before | after |
|---|---|---|---|
| `<fcel>` (PaddleOCR-VL OTSL) | special=false | `""` (dropped) | `"<fcel>"` (kept) |
| `</s>` (PaddleOCR-VL EOS) | special=true | `""` | `""` |
| `<\|IMAGE_END\|>` (PaddleOCR-VL) | special=true | `""` | `""` |
| `<\|im_start\|>` (Qwen2.5-VL chat delimiter) | special=true | `""` | `""` (no leak) |
| `<tool_call>` (Qwen2.5-VL) | special=false | `""` | `"<tool_call>"` (now content, per HF) |

`special = true` tokens stay dropped; only tokenizer-flagged `special = false` tokens survive.
`clippy -p mistralrs-core --tests -- -D warnings` clean. Two tests cover this:
`honors_special_flag_inline_fixture` builds a tiny byte-level tokenizer in-process (one
`special=false` `<x>`, one `special=true` `<s>`) and runs in CI with no external files;
`honors_tokenizer_special_flag` is the same before/after check against the real PaddleOCR-VL and
Qwen2.5-VL tokenizers (env-gated on local files, so it skips in CI when they're absent).

### Tool-calling safety

The `<tool_call>` row changes a shipped feature's detok, so it was checked explicitly. Qwen
`<tool_call>` (`special = false`) surviving into content in a **non**-tool-calling generation does
not break tool-calling: `seq.tool_call_state` is `Some` only when tools are requested, and every
tool-parse entrypoint (`prefix_status`, `complete_if_tool_call`,
`maybe_activate_continuation_grammar`, `finalize_for_response`, the Gemma content matcher) is gated
on it — there is no ungated content-stream scan for tool markers. When `tool_call_state.is_some()`
detok already runs `include_special=true`, so `<tool_call>` is in the stream regardless of this fix;
**tool sessions are byte-identical before/after.** Non-tool sessions run no parser, so the token is
inert text (matching HF).