### PR TITLE
fix(scheduler): preempt image-incompatible sequences instead of re-queueing them

### DIFF
--- a/mistralrs-core/src/paged_attention/scheduler.rs
+++ b/mistralrs-core/src/paged_attention/scheduler.rs
@@ -427,7 +427,9 @@ impl PagedAttentionScheduler {
                 {
                     running.push_back(seq);
                 } else {
-                    self.running.push_back(seq);
+                    // Re-pushing onto the queue being drained livelocks when the mismatch is stable
+                    // (chunked-prefill mm windows never advance while schedule() spins); recompute instead.
+                    self._preempt(seq);
                 }
             }
         }


### PR DESCRIPTION
## Description

The completion loop in `PagedAttentionScheduler::schedule` drains `self.running` and pushes any sequence whose `has_images()` differs from the batch head back onto `self.running` — the same queue the `while !self.running.is_empty()` loop is draining. `has_images()` is chunk-window-dependent during chunked prefill, so two batched multimodal sequences can disagree persistently. When they do, the loop never terminates: the mismatched sequence allocates successfully (running request, zero new blocks — so no timeout or preemption path fires), fails the image check, and is re-queued, forever. One engine thread spins at 100% CPU with the GPU idle and no diagnostics; the engine is permanently hung for all requests.

Stack of the spinning thread:

```
#0 KVCacheManager::allocate_slots
#1 PagedAttentionScheduler::schedule
#2 Engine::run
```

This changes the incompatible-sequence handling to `self._preempt(seq)` — the same semantics the allocation-failure path uses a few lines above — so the sequence returns to the waiting queue and is rescheduled through the prompt path. `schedule()` terminates, batched multimodal runs complete.

The preempt costs a recompute each time the incompatibility recurs. A follow-up could defer without freeing blocks (skip the current batch round only), but that requires carrying the deferred sequence across the `self.running = running` snapshot, so it is left out of this minimal fix.

Fixes #2321.
