### PR TITLE
perf(core): read only memory stats in MemoryUsage::query

### DIFF
--- a/mistralrs-core/src/utils/memory_usage.rs
+++ b/mistralrs-core/src/utils/memory_usage.rs
@@ -39,7 +39,9 @@ impl MemoryUsage {
     pub fn query(&self, device: &Device) -> Result<DeviceMemory> {
         match device {
             Device::Cpu => {
-                let sys = System::new_all();
+                // new_all scans every /proc entry; this runs on hot paths (naive_sdpa) and only memory is read
+                let mut sys = System::new();
+                sys.refresh_memory();
                 Ok(DeviceMemory::Discrete {
                     total: usize::try_from(sys.total_memory())?,
                     free: usize::try_from(sys.available_memory())?,
@@ -48,7 +50,8 @@ impl MemoryUsage {
             #[cfg(feature = "cuda")]
             Device::Cuda(dev) => {
                 if super::normal::is_integrated_gpu(device) {
-                    let sys = System::new_all();
+                    let mut sys = System::new();
+                    sys.refresh_memory();
                     let total_bytes = usize::try_from(sys.total_memory())?;
                     let avail_bytes = usize::try_from(sys.available_memory())?;
                     let fraction = igpu_memory_fraction();
@@ -117,7 +120,8 @@ fn igpu_memory_fraction() -> f64 {
 
 #[cfg(feature = "metal")]
 fn metal_sysctl_floor_bytes() -> Result<usize> {
-    let sys = System::new_all();
+    let mut sys = System::new();
+    sys.refresh_memory();
     let system_ram_mb = usize::try_from(sys.total_memory())? / SIZE_IN_MB;
 
     let sysctl_mb = std::process::Command::new("sysctl")


### PR DESCRIPTION
## Description

`MemoryUsage::query` is called from `maybe_synchronize` on every `naive_sdpa` invocation. The `Device::Cpu` and integrated-CUDA branches (and `metal_sysctl_floor_bytes`) construct `sysinfo::System::new_all()`, which enumerates and reads every process in /proc plus CPUs and disks, even though only `total_memory()` and `available_memory()` are consumed. On integrated-memory CUDA devices (DGX Spark GB10, Jetson) and CPU inference this lands a full process-table scan inside the per-layer forward.

Replace the three call sites with:

```rust
let mut sys = System::new();
sys.refresh_memory();
```

Measured on a DGX Spark (GB10, CUDA 13.0, Gemma-4-26B-A4B Q6K UQFF, two concurrent vision requests): per-request time 312-721s -> 152-160s (~4x), GPU from ~16W/idle (engine thread at 100% CPU in /proc reads) to 42W/87% util. Discrete CUDA is unaffected (that branch already uses `mem_get_info`).

gdb sample that caught it, engine thread mid-forward:

```
#14 sysinfo::System::new_all
#15 MemoryUsage::query
#16 naive_sdpa
#17 Sdpa::run_attention_noflash
#18 PagedAttention::forward_impl
#19 gemma4::text::DecoderLayer::forward
```

Fixes #2322.
