### PR TITLE
fix(completions): stop stripping leading whitespace from generated responses

### DIFF
--- a/mistralrs-core/src/pipeline/sampling.rs
+++ b/mistralrs-core/src/pipeline/sampling.rs
@@ -352,16 +352,14 @@ pub(crate) async fn finish_or_add_toks_to_seq(
                 | crate::sequence::StopReason::StopTok(_)
                 | crate::sequence::StopReason::Canceled
                 | crate::sequence::StopReason::ToolCalls => {
-                    String::from_utf8_lossy(seq.completion_bytes())
-                        .trim_start()
-                        .to_string()
+                    String::from_utf8_lossy(seq.completion_bytes()).to_string()
                 }
                 crate::sequence::StopReason::StopString {
                     completion_bytes_pos,
                     ..
                 } => {
                     let txt = String::from_utf8_lossy(seq.completion_bytes());
-                    txt[..completion_bytes_pos].trim_start().to_string()
+                    txt[..completion_bytes_pos].to_string()
                 }
                 crate::sequence::StopReason::GeneratedImage
                 | crate::sequence::StopReason::GeneratedSpeech => {

--- a/mistralrs-core/src/sequence.rs
+++ b/mistralrs-core/src/sequence.rs
@@ -1313,18 +1313,10 @@ impl Sequence {
 
     /// Peeks at the delta between the last two decoded sequences, but does not advance the stream index.
     pub fn peek_delta(&self) -> Result<Option<String>, Box<dyn std::error::Error + Send + Sync>> {
-        let is_first = self.stream_idx == 0;
         let new_decoded = String::from_utf8_lossy(&self.completion_bytes[self.stream_idx..]);
         // Check if the sequence ends with valid utf8, if not skip it as it probably is a multi token sequence
         if new_decoded.ends_with('�') {
             return Ok(None);
-        }
-
-        // The first token usually starts with a space. We don't want to add that to the delta.
-        // Since we're using the completion_bytes, we need to take care of that ourselves.
-        // Had we used HF's Tokenizer, it would have taken care of that for us.
-        if is_first {
-            return Ok(Some(new_decoded.trim_start().to_string()));
         }
         Ok(Some(new_decoded.to_string()))
     }


### PR DESCRIPTION
# fix(completions): stop stripping leading whitespace from generated responses

## What breaks

Whenever the first generated token starts with a space, the space is silently dropped, so the first word of the completion gets glued to the last word of the prompt.

Reproducer (`Qwen/Qwen3-0.6B`, greedy):

```python
import mistralrs
runner = mistralrs.Runner(
    which=mistralrs.Which.Plain(model_id="Qwen/Qwen3-0.6B",
                                dtype=mistralrs.ModelDType.BF16),
    max_seqs=1, no_paged_attn=True, prefix_cache_n=0,
)
for prompt in [
    "Once upon a time, there",
    "The capital of France is",
    "def factorial(n):\n   ",   # 3-space indent
]:
    req = mistralrs.CompletionRequest(
        model="Qwen/Qwen3-0.6B", prompt=prompt, max_tokens=6,
        temperature=0.0, top_p=1.0, top_k=1,
    )
    print(repr(prompt + runner.send_completion_request(req).choices[0].text))
```

Output on `master`:

```
'Once upon a time, therewere 3000'
'The capital of France isParis. The capital of Italy'
'def factorial(n):\n   if n < 0:\n'                     # 3-space indent, not PEP-8 4
```

Every other OpenAI-compatible server (OpenAI itself, HF `transformers`) returns the leading space, e.g. `'Once upon a time, there were 3000'`.

The same response can also self-contradict. After starting `mistralrs serve -p 8766 -m Qwen/Qwen3-0.6B --dtype bf16 --paged-attn off`:

```python
import requests
r = requests.post("http://127.0.0.1:8766/v1/completions", json={
    "model": "Qwen/Qwen3-0.6B",
    "prompt": "Once upon a time, there",
    "max_tokens": 1,
    "temperature": 0.0, "top_p": 1.0, "top_k": 1,
    "logprobs": 1,
}).json()["choices"][0]
print("text                      =", repr(r["text"]))
print("logprobs.content[0].token =", repr(r["logprobs"]["content"][0]["token"]))
```

Output:

```
text                      = 'were'
logprobs.content[0].token = ' were'
```

`text` and `logprobs.content[0].token` are two views of the same sampled token and should be byte-identical.

## Root cause: 3 call sites doing the same `.trim_start()`

`mistralrs-core/src/pipeline/sampling.rs`, inside `finish_or_add_toks_to_seq`:

```rust
| crate::sequence::StopReason::ToolCalls => {
    String::from_utf8_lossy(seq.completion_bytes())
        .trim_start()
        .to_string()
}
```

Same file, a few lines below, in the user-supplied `stop=` string branch:

```rust
let txt = String::from_utf8_lossy(seq.completion_bytes());
txt[..completion_bytes_pos].trim_start().to_string()
```

`mistralrs-core/src/sequence.rs`, in `Sequence::peek_delta`, the `is_first` branch:

```rust
if is_first {
    return Ok(Some(new_decoded.trim_start().to_string()));
}
```

All three fire for both `/v1/chat/completions` and `/v1/completions`; there is no opt-out. Only the streaming site (`peek_delta`) has a rationale, addressed below.

### Why the rationale doesn't hold

> *"The first token usually starts with a space. We don't want to add that to > the delta. Had we used HF's Tokenizer, it would have taken care of that."* > (from the comment above `peek_delta`)

* **"Usually starts with a space"**: true only for raw text continuation. In chat mode the assistant-header template ends in `\n\n`, so the first content token is almost always `Hello`, not ` Hello`. The trim fires uniformly for both cases.
* **"Not something we want to add"**: the leading space isn't an artefact. For a prompt like `"Once upon a time, there"` the model's next-token distribution peaks on `" were"` precisely because English needs a separator. Dropping it (a) alters the byte content of the sampled token, (b) glues the two words together (`"therewere"`), which is the very artefact the trim was presumably meant to prevent, just relocated into the middle of the reconstructed text.
* **"HF's Tokenizer would take care of it"**: it wouldn't. The `tokenizers` crate `decode()` and its streaming `DecodeStream` return `" 0"` for `[220, 15]` verbatim. `transformers` doesn't strip either, except inside an opt-in [`heal_tokens()`](https://github.com/huggingface/transformers/blob/main/src/transformers/generation/utils.py) path, off by default and paired with a re-tokenization + prefix-search compensation with no counterpart here.

## History

Introduced in April 2024 by [8311b8867](https://github.com/EricLBuehler/mistral.rs/commit/8311b8867) ("Refactor streaming code") and [b1cb4d855](https://github.com/EricLBuehler/mistral.rs/commit/b1cb4d855) ("Optimize completion strings"), as side effects of unrelated refactors. Neither PR body mentions the trim. No tests pin the behaviour and no docs describe it, consistent with an unintended side effect rather than deliberate design.

## Fix

Remove the three `.trim_start()` calls (two in `finish_or_add_toks_to_seq`, one in `Sequence::peek_delta`) and drop the now inaccurate three-line comment above `peek_delta`. Chat / streaming / stop-string / tool-call paths are otherwise untouched.

### What callers see

* Raw `/v1/completions`: `choices[0].text` now begins with the first byte the model emitted instead of the second. `prompt + text` reconstructs what the model actually said.
* Chat `/v1/chat/completions`: preserves a leading space when the model emits one. Matches OpenAI; most UIs trim on display anyway, and chat models rarely emit a leading-space first token.
* Streaming first chunk is now byte-identical to what subsequent chunks would produce, and `text` and `logprobs.content[i].token` no longer contradict.

## Validation

- `cargo test -p mistralrs-core --lib` — all existing tests still pass.
- Reran the reproducer above against a locally rebuilt `mistralrs-server`: leading space is preserved on all three prompts, and `text == logprobs.content[0].token` for the greedy `logprobs=1` case.
