### PR TITLE
fix(sampler): return natural-log probabilities from `logprobs`, not log10

### DIFF
--- a/mistralrs-core/src/sampler.rs
+++ b/mistralrs-core/src/sampler.rs
@@ -432,7 +432,7 @@ impl Sampler {
         let mut probs_copy = probs.to_vec();
         let top_k = partial_sort_top_k(&mut probs_copy, k, false);
 
-        // Build the result vector with log10 of probabilities and optional decoding
+        // Build the result vector with natural log of probabilities and optional decoding
         let mut result = Vec::with_capacity(k);
         if let Some(tokenizer) = &self.tokenizer {
             for (token, prob) in top_k {
@@ -441,7 +441,7 @@ impl Sampler {
                     .map_err(|e| Error::Msg(e.to_string()))?;
                 result.push(TopLogprob {
                     token,
-                    logprob: prob.log(10.0),
+                    logprob: prob.ln(),
                     bytes: Some(decoded),
                 });
             }
@@ -449,7 +449,7 @@ impl Sampler {
             for (token, prob) in top_k {
                 result.push(TopLogprob {
                     token,
-                    logprob: prob.log(10.0),
+                    logprob: prob.ln(),
                     bytes: None,
                 });
             }
@@ -460,7 +460,7 @@ impl Sampler {
     fn sample_argmax(&self, logits: Tensor, return_logprobs: bool) -> Result<Logprobs> {
         let probs: Vec<f32> = logits.to_vec1()?;
         let next_token = argmax_f32(&probs);
-        let logprob = probs[next_token as usize].log(10.0);
+        let logprob = probs[next_token as usize].ln();
 
         let top_logprobs = if return_logprobs {
             Some(self.get_top_logprobs(&probs)?)
@@ -538,7 +538,7 @@ impl Sampler {
 
         // Find argmax directly on the Vec (O(n) scan, no Tensor creation)
         let next_token = argmax_f32(&probs);
-        let logprob = probs[next_token as usize].log(10.0);
+        let logprob = probs[next_token as usize].ln();
 
         let top_logprobs = if return_logprobs {
             Some(self.get_top_logprobs(&probs)?)
@@ -605,7 +605,7 @@ impl Sampler {
 
         let mut mut_ref_rng = &mut *rng.lock().expect("could not lock rng mutex");
         let next_token = distr.sample(&mut mut_ref_rng); // "Find the first item which has a weight *higher* than the chosen weight."
-        let logprob = probs[next_token].log(10.0);
+        let logprob = probs[next_token].ln();
 
         let top_logprobs = if return_logprobs {
             Some(self.get_top_logprobs(probs)?)
@@ -832,7 +832,7 @@ impl Sampler {
         let mut mut_ref_rng = &mut *rng.lock().expect("could not lock rng mutex");
         let selected = distr.sample(&mut mut_ref_rng);
         let next_token = top_indices[selected];
-        let logprob = probs[selected].log(10.0);
+        let logprob = probs[selected].ln();
 
         Ok(Logprobs {
             token: next_token,
@@ -967,7 +967,7 @@ impl Sampler {
         let mut mut_ref_rng = &mut *rng.lock().expect("could not lock rng mutex");
         let selected = distr.sample(&mut mut_ref_rng);
         let next_token = top_indices[selected];
-        let logprob = probs[selected].log(10.0);
+        let logprob = probs[selected].ln();
         let bytes = if let Some(tokenizer) = &self.tokenizer {
             Some(
                 tokenizer
@@ -1087,7 +1087,7 @@ impl Sampler {
     ) -> Result<Logprobs> {
         let prob = probs.get(token as usize).copied().unwrap_or(0.0);
         let logprob = if prob > 0.0 {
-            prob.log(10.0)
+            prob.ln()
         } else {
             f32::NEG_INFINITY
         };
@@ -1472,7 +1472,7 @@ mod tests {
             .unwrap();
         assert_eq!(res.token, 1023);
         assert_eq!(res.top_logprobs, None);
-        assert_eq!(res.logprob, 1023f64.log(10.) as f32)
+        assert_eq!(res.logprob, 1023f64.ln() as f32)
     }
 
     #[test]
@@ -1513,7 +1513,7 @@ mod tests {
             .unwrap();
         assert_eq!(res.token, 1023);
         assert_eq!(res.top_logprobs, None);
-        assert_eq!(res.logprob, 1023f64.log(10.) as f32)
+        assert_eq!(res.logprob, 1023f64.ln() as f32)
     }
 
     #[test]


### PR DESCRIPTION
# fix(sampler): return natural-log probabilities from `logprobs`, not log10

## What breaks

The completions API's `logprobs.content[i].logprob` and `top_logprobs[i].logprob` are read as natural log by every OpenAI-compatible client (`openai-python`, LangChain, LiteLLM, eval harnesses). Every sampler code path in `sampler.rs` computes `prob.log(10.0)`, so returned values are off by `ln(10) ≈ 2.3026` in magnitude.

Reproducer with `Qwen/Qwen3-0.6B`, `temperature=1.0` so the input to `log(...)` is a real probability from `softmax`:

```python
import requests
r = requests.post("http://127.0.0.1:8766/v1/completions", json={
    "model": "Qwen/Qwen3-0.6B",
    "prompt": "Once upon a time, there",
    "max_tokens": 1,
    "temperature": 1.0, "top_p": 1.0, "top_k": 0,
    "logprobs": 5,
})
for t in r.json()["choices"][0]["logprobs"]["content"][0]["top_logprobs"]:
    print(f"  {t['bytes']!r:12}  logprob={t['logprob']:+.4f}")
```

HF `transformers` `log_softmax` reference against the same model and prompt:

| token | `ln(prob)` (HF reference) | mistral.rs on `master` | ratio |
|---|---:|---:|---:|
| `' were'`  | -0.809 | -0.311 | 2.60 |
| `' was'`   | -1.059 | -0.460 | 2.30 |
| `' are'`   | -1.934 | -0.840 | 2.30 |
| `' is'`    | -3.309 | -1.437 | 2.30 |
| `' lived'` | -4.684 | -2.034 | 2.30 |

Every value except the first differs from the reference by exactly `ln(10)`. The `' were'` row is BF16 rounding noise on a very peaked, high-logit token.

## Sites

Eight `.log(10.0)` calls in seven functions, all in `mistralrs-core/src/sampler.rs`:

```
get_top_logprobs                (2 branches, top-N alternatives)
sample_argmax                   (sampled token)
sample_speculative_top_kp_min_p (sampled token)
sample_multinomial              (sampled token)
sample_topk_on_device           (sampled token, CUDA fast path)
sample_topk_on_device_metal     (sampled token, Metal fast path)
logprobs_from_probs             (speculative acceptance path)
```

No `* LN_10` compensation exists on the read side. Two unit tests (`test_argmax`, `test_gumbel_speculative`) baked the log10 formula into `assert_eq!(res.logprob, 1023f64.log(10.) as f32)`; those two assertions get switched to `1023f64.ln()`.

## Fix

Replace the eight `.log(10.0)` calls with `.ln()`. Update the two test assertions. Update a stale `// log10 of probabilities` comment above the top-N loop.

## Known follow-up (not in this PR)

The greedy branches in `Sampler::sample` skip the `softmax_last_dim` that the temperature-sampled branches do, so `sample_argmax` and `sample_speculative_top_kp_min_p` end up applying `.ln()` to a raw logit. After this PR the greedy `logprob` becomes `raw_logit.ln()` instead of `raw_logit.log(10.0)`, still not the correct `ln(softmax(logits)[token])`. Filed as #2329 since adding the missing softmax interacts with function naming, the extra softmax computation cost, and a separate top-N-vs-filter policy question.

## Validation

- `cargo test -p mistralrs-core --lib -- sampler::tests` all pass.
- Reran the reproducer against a locally rebuilt `mistralrs-server`: returned `logprob` values now match HF `transformers` `log_softmax` to within f32 precision on the `temperature=1.0` path.
