### PR TITLE
fix(sdk): store assistant tool calls under the `tool_calls` message key

### DIFF
--- a/mistralrs/src/messages.rs
+++ b/mistralrs/src/messages.rs
@@ -827,7 +827,7 @@ impl RequestBuilder {
         self.messages.push(IndexMap::from([
             ("role".to_string(), Either::Left(role.to_string())),
             ("content".to_string(), Either::Left(text.to_string())),
-            ("function".to_string(), Either::Right(tool_messages)),
+            ("tool_calls".to_string(), Either::Right(tool_messages)),
         ]));
         self
     }
@@ -1444,5 +1444,50 @@ impl EmbeddingRequestBuilder {
             inputs: self.inputs,
             truncate_sequence: self.truncate_sequence,
         })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn add_message_with_tool_call_uses_tool_calls_key() {
+        let tool_call = ToolCallResponse {
+            index: 0,
+            id: "call-1".to_string(),
+            tp: ToolCallType::Function,
+            function: CalledFunction {
+                name: "get_weather".to_string(),
+                arguments: "{\"city\":\"Paris\"}".to_string(),
+            },
+        };
+
+        let builder = RequestBuilder::new().add_message_with_tool_call(
+            TextMessageRole::Assistant,
+            "",
+            vec![tool_call],
+        );
+        let message = builder.messages_ref().last().expect("message was pushed");
+
+        // Chat templates and the agentic loop read tool calls from `tool_calls`, not `function`.
+        assert!(message.contains_key("tool_calls"));
+        assert!(!message.contains_key("function"));
+
+        let Some(Either::Right(tool_calls)) = message.get("tool_calls") else {
+            panic!("`tool_calls` must hold the tool call array");
+        };
+        assert_eq!(tool_calls.len(), 1);
+        assert_eq!(
+            tool_calls[0].get("id"),
+            Some(&Value::String("call-1".to_string()))
+        );
+        let Some(Value::Object(function)) = tool_calls[0].get("function") else {
+            panic!("each tool call must carry a nested `function` object");
+        };
+        assert_eq!(
+            function.get("name"),
+            Some(&Value::String("get_weather".to_string()))
+        );
     }
 }


### PR DESCRIPTION
### Problem

`RequestBuilder::add_message_with_tool_call` (in the `mistralrs` SDK crate) attaches the assistant's tool calls to the message under the key `"function"`:

```rust
self.messages.push(IndexMap::from([
    ("role".to_string(), Either::Left(role.to_string())),
    ("content".to_string(), Either::Left(text.to_string())),
    ("function".to_string(), Either::Right(tool_messages)),
]));
```

Every consumer of an assistant tool-call message reads the standard OpenAI/HF key `"tool_calls"`, not `"function"`:

- `chat_template.rs` renders tool calls from `message.get_mut("tool_calls")` and clears content based on `contains_key("tool_calls")`.
- The agentic engine matches on `"tool_calls"` (`agentic_session.rs`, `agentic_loop.rs`).
- The server path builds the identical structure under `"tool_calls"` (`chat_completion.rs`).

Because nothing reads a message-level `"function"` key, the tool call is silently dropped: the chat template renders the assistant turn without its tool call, and the following `tool` result then has no preceding call, breaking multi-round tool use.

This is the SDK's recommended API for tool-call messages, and it is used by the SDK's own `Agent` loop (`agent.rs`, both the streaming and non-streaming paths) and by the `examples/advanced/tools` example, so SDK-driven tool conversations are affected.

### Fix

Use the `"tool_calls"` key. The value structure is already correct (each entry has `id`, `type`, and a nested `function` object with `name`/`arguments`) and matches what the server path emits, so this is a one-character-key change with no other behavior difference. Added a unit test asserting the emitted message uses `tool_calls` (not `function`) and preserves the nested call structure.
