### PR TITLE
fix(gguf): read MoE expert_count with the architecture-prefixed metadata key

### DIFF
--- a/mistralrs-core/src/utils/gguf_metadata.rs
+++ b/mistralrs-core/src/utils/gguf_metadata.rs
@@ -402,7 +402,7 @@ impl DeviceMappedModelLoader for GgufDeviceMapLoaderInner<'_, '_> {
                 let n_expert = self
                     .model
                     .get_metadata()
-                    .get("expert_count")
+                    .get(&format!("{}.expert_count", self.arch))
                     .map(|x| x.to_u64().unwrap() as usize)
                     .unwrap_or(0);
                 let moe_or_mlp = if n_expert <= 1 {


### PR DESCRIPTION
### Problem

In `layer_sizes_in_bytes` (the `Llama` arch branch of the GGUF device-map loader), the expert count is read with a bare metadata key:

```rust
let n_expert = self
    .model
    .get_metadata()
    .get("expert_count")
    .map(|x| x.to_u64().unwrap() as usize)
    .unwrap_or(0);
```

GGUF metadata keys are architecture-prefixed. Every other read in this file uses the prefix, e.g. `format!("{}.block_count", self.arch)` and `format!("{}.attention.head_count", self.arch)`, and the model code reads this same value prefixed via `ContentMetadata::get_value::<u32>("expert_count")` (which prepends the arch path). The only bare `get(...)` calls in the file are for the genuinely un-prefixed `general.architecture`.

Because a MoE GGUF stores this as `llama.expert_count` (e.g. `8` for Mixtral), the bare `get("expert_count")` never matches, so `n_expert` is always `0`. The code then takes the dense `n_expert <= 1` branch and calls `tensor_info("blk.0.ffn_gate.weight")`, a tensor that does not exist in a MoE GGUF (which has `blk.0.ffn_gate_exps.weight`). The `?` propagates an error, so automatic device mapping / memory estimation fails for Mixtral-style GGUF models.

### Fix

Read the key with the architecture prefix, consistent with the rest of the file:

```rust
.get(&format!("{}.expert_count", self.arch))
```

With this, a MoE GGUF correctly reports its expert count and takes the MoE branch that sums the `ffn_*_exps` tensors.
