### PR TITLE
fix(sampler): keep do_sample=false greedy when defaults also set temperature

### DIFF
--- a/mistralrs-core/src/sampler.rs
+++ b/mistralrs-core/src/sampler.rs
@@ -131,23 +131,23 @@ impl SamplingParams {
             self.top_k = Some(1);
             self.top_p = None;
             self.min_p = None;
-        }
-
-        if let Some(temperature) = defaults.temperature {
-            self.temperature = if temperature == 0.0 {
-                None
-            } else {
-                Some(temperature)
-            };
-        }
-        if let Some(top_k) = defaults.top_k {
-            self.top_k = if top_k == 0 { None } else { Some(top_k) };
-        }
-        if let Some(top_p) = defaults.top_p {
-            self.top_p = Some(top_p);
-        }
-        if let Some(min_p) = defaults.min_p {
-            self.min_p = Some(min_p);
+        } else {
+            if let Some(temperature) = defaults.temperature {
+                self.temperature = if temperature == 0.0 {
+                    None
+                } else {
+                    Some(temperature)
+                };
+            }
+            if let Some(top_k) = defaults.top_k {
+                self.top_k = if top_k == 0 { None } else { Some(top_k) };
+            }
+            if let Some(top_p) = defaults.top_p {
+                self.top_p = Some(top_p);
+            }
+            if let Some(min_p) = defaults.min_p {
+                self.min_p = Some(min_p);
+            }
         }
         if let Some(repetition_penalty) = defaults.repetition_penalty {
             self.repetition_penalty = Some(repetition_penalty);
@@ -1624,6 +1624,26 @@ mod tests {
         };
         params.apply_model_defaults(&ModelGenerationDefaults {
             do_sample: Some(false),
+            ..Default::default()
+        });
+
+        assert_eq!(params.temperature, None);
+        assert_eq!(params.top_k, Some(1));
+        assert_eq!(params.top_p, None);
+        assert_eq!(params.min_p, None);
+    }
+
+    #[test]
+    fn test_apply_model_defaults_do_sample_false_ignores_sampling_defaults() {
+        // generation_config.json commonly carries `do_sample: false` alongside
+        // leftover temperature/top_p; like HF transformers, greedy must win.
+        let mut params = SamplingParams::neutral();
+        params.apply_model_defaults(&ModelGenerationDefaults {
+            do_sample: Some(false),
+            temperature: Some(0.6),
+            top_k: Some(20),
+            top_p: Some(0.9),
+            min_p: Some(0.05),
             ..Default::default()
         });
 


### PR DESCRIPTION
### Problem

`SamplingParams::apply_model_defaults` forces greedy decoding when a model's generation defaults set `do_sample: false`, but then unconditionally re-applies the sampling parameters right after, undoing it:

```rust
if defaults.do_sample == Some(false) {
    self.temperature = None;
    self.top_k = Some(1);
    self.top_p = None;
    self.min_p = None;
}

if let Some(temperature) = defaults.temperature { /* re-applies temperature */ }
if let Some(top_k) = defaults.top_k { /* re-applies top_k */ }
if let Some(top_p) = defaults.top_p { /* re-applies top_p */ }
if let Some(min_p) = defaults.min_p { /* re-applies min_p */ }
```

Real `generation_config.json` files frequently carry `do_sample: false` together with leftover `temperature`/`top_p` values. HF `transformers` warns about that combination and does greedy anyway. Here the unconditional blocks win, so a model configured for deterministic output silently samples instead.

Concretely, defaults `{ do_sample: false, temperature: 0.6, top_p: 0.9 }` currently yield `temperature = Some(0.6)`, `top_p = Some(0.9)` (stochastic) rather than greedy.

The existing test `test_apply_model_defaults_disables_sampling_when_requested` doesn't catch this because its defaults set no `temperature`, so the re-apply blocks are inert.

### Fix

Apply the sampling-parameter overrides only when `do_sample` is not `false`, matching HF semantics. `repetition_penalty`, `max_new_tokens`, and `suppress_tokens` stay unconditional (they're orthogonal to greedy vs. sampling). Added a regression test covering `do_sample: false` with a co-present `temperature`/`top_p`/`min_p`.
