### PR TITLE
fix(mllama): image inference crash on CUDA, eager-only paged flag, vision head config

### DIFF
--- a/mistralrs-core/src/pipeline/loaders/multimodal_loaders.rs
+++ b/mistralrs-core/src/pipeline/loaders/multimodal_loaders.rs
@@ -1792,7 +1792,8 @@ impl MultimodalModelLoader for VLlamaLoader {
         Arc::new(MLlamaProcessor::new())
     }
     fn supports_paged_attention(&self, _config: &str) -> bool {
-        true
+        // MLlamaTextModel requires eager attention (cross-attn has no paged path).
+        false
     }
     fn supports_prefix_cacher(&self, _config: &str) -> bool {
         true

--- a/mistralrs-core/src/vision_models/mllama/config.rs
+++ b/mistralrs-core/src/vision_models/mllama/config.rs
@@ -36,7 +36,7 @@ pub(crate) struct MLlamaVisionConfig {
     pub(crate) hidden_act: VisionActivation,
     pub(crate) num_hidden_layers: usize,
     pub(crate) num_global_layers: usize,
-    #[serde(default = "d_attn_heads")]
+    #[serde(alias = "attention_heads", default = "d_attn_heads")]
     pub(crate) num_attention_heads: usize,
     pub(crate) num_channels: usize,
     pub(crate) intermediate_size: usize,

--- a/mistralrs-core/src/vision_models/mllama/inputs_processor.rs
+++ b/mistralrs-core/src/vision_models/mllama/inputs_processor.rs
@@ -275,7 +275,13 @@ impl InputsProcessor for MLlamaImageProcessor {
 
         let has_images = input_seqs.iter().all(|seq| seq.has_images());
 
-        let (pixel_values, aspect_ratio_ids, aspect_ratio_mask, cross_attn_mask) = if has_images {
+        // Only process image inputs on the prompt step. On decode steps the input has no
+        // `<|image|>` tokens, so the cross-attention mask would collapse to a zero-image
+        // (0-element) tensor and `to_dtype` on it aborts the CUDA stream with
+        // CUDA_ERROR_INVALID_VALUE. Cross-attention is skipped during decode anyway.
+        let (pixel_values, aspect_ratio_ids, aspect_ratio_mask, cross_attn_mask) = if has_images
+            && is_prompt
+        {
             let mut pixel_values_accum = Vec::new();
             let mut aspect_ratio_ids_accum = Vec::new();
             let mut aspect_ratio_mask_accum = Vec::new();


### PR DESCRIPTION
Fixes three issues that together make `Llama-3.2-11B-Vision` (mllama / `vllama`) unusable for image inputs. Closes #2335.

### 1. Image inference crashes on CUDA (main fix)

On decode steps the mllama inputs processor still ran its image block, because `Sequence::take_images()` clones (rather than empties) the images when `has_changed_prompt` is false, so `has_images()` stays true after prefill. A decode input has no `<|image|>` token, so `convert_sparse_cross_attention_mask_to_dense` produced a cross-attention mask with a zero-sized `max_num_images` dimension, e.g. `[1, 1, 0, 4]` (0 elements). `prepare_cross_attention_mask` then calls `.to_dtype(F32)` on that tensor; launching a CUDA kernel over 0 elements returns `CUDA_ERROR_INVALID_VALUE`. On CPU it is a harmless no-op, which is why text generation (and CPU) worked.

Fix: gate the image block on `is_prompt`, matching `Qwen2VLImageProcessor` (`let mut pixel_values = if is_prompt { pixel_values } else { None };`). Cross-attention is skipped during decode anyway (`mllama/text.rs`: `if cross_attn_states.is_none() { continue }`), so passing image inputs on decode was both wasteful and, on CUDA, fatal.

### 2. `supports_paged_attention` advertised support the model can't do

`VLlamaLoader::supports_paged_attention` returned `true`, but `MLlamaTextModel` requires eager attention, so a default launch aborted with `Error: Expected eager attention implementation` rather than auto-disabling PagedAttention. Return `false`, matching the Qwen2-VL / Qwen2.5-VL loaders (which have the same eager requirement and correctly fall back).

### 3. Vision `attention_heads` config key ignored

`MLlamaVisionConfig::num_attention_heads` had `#[serde(default = "d_attn_heads")]` (=16) but no alias for HF's actual key `attention_heads`, so the vision head count from `config.json` was ignored and always 16. The stock 11B has 16 vision heads so it was masked; any mllama checkpoint with a different vision head count loaded with wrong dimensions or a weight shape mismatch. Added `#[serde(alias = "attention_heads")]`.

### Reproduction / verification

Reproduced and verified all three on an RTX 4070 Ti SUPER (CUDA 12.9) using a tiny same-architecture model, `yujiepan/llama-3.2-vision-tiny-random` (~22 MB), which hits the identical `MLlamaModel` forward path without the 20 GB download. Before: default launch errors; `--paged-attn off` + first image request -> `CUDA_ERROR_INVALID_VALUE`. After: model loads by default and small/large/repeat image requests plus text all return `200` with no CUDA errors. The stock `meta-llama/Llama-3.2-11B-Vision-Instruct` reproduces (1) and (2) identically.
