### PR TITLE
fix(webui): send chat images as data URLs (fix HTTP 500 on image send)

### DIFF
--- a/mistralrs-cli/webui/src/lib/components/ChatInput.svelte
+++ b/mistralrs-cli/webui/src/lib/components/ChatInput.svelte
@@ -9,6 +9,15 @@
   let pendingVideos = $state<{ file: File; url: string; uploadedUrl?: string }[]>([]);
   let isDragging = $state(false);
 
+  function fileToDataUrl(file: File): Promise<string> {
+    return new Promise((resolve, reject) => {
+      const reader = new FileReader();
+      reader.onload = () => resolve(reader.result as string);
+      reader.onerror = () => reject(reader.error);
+      reader.readAsDataURL(file);
+    });
+  }
+
   function autoResize() {
     if (!textareaEl) return;
     textareaEl.style.height = "auto";
@@ -20,15 +29,15 @@
     const content = inputValue.trim();
     if (!content && !pendingImages.length && !pendingVideos.length) return;
 
-    // Upload pending images
+    // Encode as data URLs; the /v1/chat/completions endpoint only accepts
+    // http/https/data sources, not the server's relative `uploads/...` paths.
     const imageUrls: string[] = [];
     for (const img of pendingImages) {
       if (!img.uploadedUrl) {
         try {
-          const result = await api.uploadImage(img.file);
-          img.uploadedUrl = result.url;
+          img.uploadedUrl = await fileToDataUrl(img.file);
         } catch (e) {
-          console.error("Upload failed:", e);
+          console.error("Failed to read image:", e);
           continue;
         }
       }
@@ -37,15 +46,13 @@
       }
     }
 
-    // Upload pending videos
     const videoUrls: string[] = [];
     for (const vid of pendingVideos) {
       if (!vid.uploadedUrl) {
         try {
-          const result = await api.uploadVideo(vid.file);
-          vid.uploadedUrl = result.url;
+          vid.uploadedUrl = await fileToDataUrl(vid.file);
         } catch (e) {
-          console.error("Video upload failed:", e);
+          console.error("Failed to read video:", e);
           continue;
         }
       }


### PR DESCRIPTION
Sending an image from the built-in web UI (`/ui`) failed with HTTP 500 `invalid image source, expected http https or data url: relative url without a base`, while the same image through `/v1/chat/completions` worked. Closes #2336.

### Cause

The UI uploaded the picked image to `/api/upload_image`, which saves it under the cache dir and returns a **relative** URL (`uploads/<uuid>.png`). The UI stored that string and sent it back as `image_url.url` to `/v1/chat/completions`, which resolves image sources under the `ServerRequest` media policy - accepting only `http` / `https` / `data` URLs. `Url::parse("uploads/<uuid>.png")` fails with `RelativeUrlWithoutBase`, producing the 500. The v1 API worked because callers pass a `data:`/`http(s)` URL.

### Fix

Encode picked files as `data:` URLs client-side (via `FileReader.readAsDataURL`) and send those - exactly what the working v1 path sends - instead of round-tripping through the upload endpoint. This also fixes the identical relative-URL failure for videos, and works for display-on-reload since a data URL is self-contained.
