### PR TITLE
fix(core): stop decode-scheduler livelock and drop memory query from attention hot path

### DIFF
--- a/mistralrs-core/src/paged_attention/scheduler.rs
+++ b/mistralrs-core/src/paged_attention/scheduler.rs
@@ -387,6 +387,7 @@ impl PagedAttentionScheduler {
         self.sort_running_by_priority_fcfs();
 
         let mut running: VecDeque<Arc<Mutex<Sequence>>> = VecDeque::new();
+        let mut deferred: VecDeque<Arc<Mutex<Sequence>>> = VecDeque::new();
         while !self.running.is_empty() {
             let seq = self.running.pop_front().unwrap();
             let mut finished_with_break = false;
@@ -422,12 +423,13 @@ impl PagedAttentionScheduler {
 
             if !finished_with_break {
                 let new_seq_has_images = get_mut_arcmutex!(seq).has_images();
-                if running.is_empty()
-                    || get_mut_arcmutex!(running[0]).has_images() == new_seq_has_images
-                {
+                let batch_head_has_images =
+                    running.front().map(|s| get_mut_arcmutex!(s).has_images());
+                // Defer to a side queue, not back into self.running: the loop only pops, so it terminates.
+                if batch_joins(batch_head_has_images, new_seq_has_images) {
                     running.push_back(seq);
                 } else {
-                    self.running.push_back(seq);
+                    deferred.push_back(seq);
                 }
             }
         }
@@ -484,11 +486,16 @@ impl PagedAttentionScheduler {
             }
         }
 
+        let scheduled: Vec<_> = self.running.clone().into_iter().collect();
+
+        // Re-append after snapshotting scheduled: deferred seqs keep their slots and run next pass.
+        self.running.extend(deferred);
+
         logger.set_num_running(self.running.len());
         logger.set_num_waiting(self.waiting.len());
 
         PagedAttentionSchedulerOutput {
-            scheduled: self.running.clone().into_iter().collect(),
+            scheduled,
             num_cached_tokens: Vec::new(), // No prefix cache for completion
         }
     }
@@ -543,6 +550,14 @@ impl PagedAttentionScheduler {
             self.seq_block_hash_revisions.remove(&id);
             self.waiting_counts.remove(&id);
         }
+    }
+}
+
+/// A batch never mixes image and non-image seqs: joins only if empty or matching the head's flag.
+fn batch_joins(batch_head_has_images: Option<bool>, seq_has_images: bool) -> bool {
+    match batch_head_has_images {
+        None => true,
+        Some(head) => head == seq_has_images,
     }
 }
 
@@ -626,5 +641,60 @@ impl Scheduler for PagedAttentionScheduler {
     }
     fn set_prefix_caching_enabled(&mut self, enabled: bool) {
         self.set_prefix_caching_enabled_sync(enabled);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::batch_joins;
+    use std::collections::VecDeque;
+
+    /// Mirrors the decode drain loop; that it returns at all is the anti-livelock guarantee.
+    fn partition_decode_batch(seqs: &[bool]) -> (Vec<bool>, Vec<bool>) {
+        let mut input: VecDeque<bool> = seqs.iter().copied().collect();
+        let mut batch: Vec<bool> = Vec::new();
+        let mut deferred: Vec<bool> = Vec::new();
+        while let Some(seq) = input.pop_front() {
+            if batch_joins(batch.first().copied(), seq) {
+                batch.push(seq);
+            } else {
+                deferred.push(seq);
+            }
+        }
+        (batch, deferred)
+    }
+
+    #[test]
+    fn all_incompatible_terminates_with_head_only() {
+        let (batch, deferred) = partition_decode_batch(&[true, false, false, false]);
+        assert_eq!(batch, vec![true]);
+        assert_eq!(deferred, vec![false, false, false]);
+    }
+
+    #[test]
+    fn mixed_keeps_head_compatible_defers_rest() {
+        let (batch, deferred) = partition_decode_batch(&[false, false, true, false, true]);
+        assert_eq!(batch, vec![false, false, false]);
+        assert_eq!(deferred, vec![true, true]);
+    }
+
+    #[test]
+    fn all_compatible_schedules_everything() {
+        let (batch, deferred) = partition_decode_batch(&[true, true, true]);
+        assert_eq!(batch, vec![true, true, true]);
+        assert!(deferred.is_empty());
+    }
+
+    #[test]
+    fn empty_input_is_empty() {
+        let (batch, deferred) = partition_decode_batch(&[]);
+        assert!(batch.is_empty());
+        assert!(deferred.is_empty());
+    }
+
+    #[test]
+    fn batch_joins_empty_head_always_joins() {
+        assert!(batch_joins(None, true));
+        assert!(batch_joins(None, false));
     }
 }

--- a/mistralrs-core/src/paged_attention/scheduler.rs
+++ b/mistralrs-core/src/paged_attention/scheduler.rs
@@ -61,6 +61,8 @@ pub struct PagedAttentionScheduler {
     seq_block_hash_revisions: HashMap<usize, u64>,
     /// Per-sequence waitlist counter for starvation detection.
     waiting_counts: HashMap<usize, usize>,
+    /// Image-presence of the last decode batch, used to alternate types so neither starves.
+    last_decode_batch_had_images: Option<bool>,
 }
 
 impl PagedAttentionScheduler {
@@ -80,6 +82,7 @@ impl PagedAttentionScheduler {
             seq_block_hashes: HashMap::new(),
             seq_block_hash_revisions: HashMap::new(),
             waiting_counts: HashMap::new(),
+            last_decode_batch_had_images: None,
         }
     }
 
@@ -386,6 +389,19 @@ impl PagedAttentionScheduler {
 
         self.sort_running_by_priority_fcfs();
 
+        // When both image and non-image seqs are running, only one type can batch per pass. FCFS
+        // alone would let the oldest type run forever and starve the other, so lead with the type
+        // opposite to last pass when it is present.
+        if let Some(last_had_images) = self.last_decode_batch_had_images {
+            if let Some(pos) = self
+                .running
+                .iter()
+                .position(|s| get_mut_arcmutex!(s).has_images() != last_had_images)
+            {
+                self.running.rotate_left(pos);
+            }
+        }
+
         let mut running: VecDeque<Arc<Mutex<Sequence>>> = VecDeque::new();
         let mut deferred: VecDeque<Arc<Mutex<Sequence>>> = VecDeque::new();
         while !self.running.is_empty() {
@@ -440,6 +456,16 @@ impl PagedAttentionScheduler {
         let bucketed = self.bucket_and_preempt_sequences(running_for_bucket);
         self.running = bucketed;
 
+        // The scheduled forward-pass batch is exactly the bucketed set; snapshot it before merging
+        // deferred back in. Deferred seqs stay in self.running so terminate-all and state updates
+        // reach them, but they do not join this pass's batch.
+        let scheduled: Vec<_> = self.running.clone().into_iter().collect();
+        self.last_decode_batch_had_images = self
+            .running
+            .front()
+            .map(|seq| get_mut_arcmutex!(seq).has_images());
+        self.running.extend(deferred);
+
         self.running
             .iter()
             .for_each(|seq| get_mut_arcmutex!(seq).set_state(SequenceState::RunningCompletion));
@@ -485,11 +511,6 @@ impl PagedAttentionScheduler {
                 }
             }
         }
-
-        let scheduled: Vec<_> = self.running.clone().into_iter().collect();
-
-        // Re-append after snapshotting scheduled: deferred seqs keep their slots and run next pass.
-        self.running.extend(deferred);
 
         logger.set_num_running(self.running.len());
         logger.set_num_waiting(self.waiting.len());
@@ -664,6 +685,15 @@ mod tests {
         (batch, deferred)
     }
 
+    /// Mirrors the fairness rotation: bring a seq of the type opposite to last pass to the head.
+    fn rotate_for_fairness(running: &mut VecDeque<bool>, last_had_images: Option<bool>) {
+        if let Some(last) = last_had_images {
+            if let Some(pos) = running.iter().position(|&has_images| has_images != last) {
+                running.rotate_left(pos);
+            }
+        }
+    }
+
     #[test]
     fn all_incompatible_terminates_with_head_only() {
         let (batch, deferred) = partition_decode_batch(&[true, false, false, false]);
@@ -696,5 +726,42 @@ mod tests {
     fn batch_joins_empty_head_always_joins() {
         assert!(batch_joins(None, true));
         assert!(batch_joins(None, false));
+    }
+
+    #[test]
+    fn fairness_rotation_leads_with_opposite_type() {
+        // Last pass ran images; a mixed queue should now lead with the first non-image seq.
+        let mut running: VecDeque<bool> = [true, true, false, true].into_iter().collect();
+        rotate_for_fairness(&mut running, Some(true));
+        assert_eq!(running.front(), Some(&false));
+    }
+
+    #[test]
+    fn fairness_rotation_noop_when_single_type() {
+        let mut running: VecDeque<bool> = [true, true, true].into_iter().collect();
+        rotate_for_fairness(&mut running, Some(false));
+        assert_eq!(running, VecDeque::from(vec![true, true, true]));
+    }
+
+    #[test]
+    fn alternation_lets_both_types_make_progress() {
+        // A long image request coexisting with text: over passes, both must get scheduled.
+        let seqs = [true, false, false];
+        let mut last: Option<bool> = None;
+        let mut scheduled_images = false;
+        let mut scheduled_text = false;
+        for _ in 0..4 {
+            let mut running: VecDeque<bool> = seqs.into_iter().collect();
+            rotate_for_fairness(&mut running, last);
+            let (batch, _deferred) = partition_decode_batch(running.make_contiguous());
+            let head = batch[0];
+            if head {
+                scheduled_images = true;
+            } else {
+                scheduled_text = true;
+            }
+            last = Some(head);
+        }
+        assert!(scheduled_images && scheduled_text);
     }
 }

--- a/mistralrs-core/src/utils/memory_usage.rs
+++ b/mistralrs-core/src/utils/memory_usage.rs
@@ -39,7 +39,8 @@ impl MemoryUsage {
     pub fn query(&self, device: &Device) -> Result<DeviceMemory> {
         match device {
             Device::Cpu => {
-                let sys = System::new_all();
+                let mut sys = System::new();
+                sys.refresh_memory();
                 Ok(DeviceMemory::Discrete {
                     total: usize::try_from(sys.total_memory())?,
                     free: usize::try_from(sys.available_memory())?,
@@ -48,7 +49,8 @@ impl MemoryUsage {
             #[cfg(feature = "cuda")]
             Device::Cuda(dev) => {
                 if super::normal::is_integrated_gpu(device) {
-                    let sys = System::new_all();
+                    let mut sys = System::new();
+                    sys.refresh_memory();
                     let total_bytes = usize::try_from(sys.total_memory())?;
                     let avail_bytes = usize::try_from(sys.available_memory())?;
                     let fraction = igpu_memory_fraction();
@@ -117,7 +119,8 @@ fn igpu_memory_fraction() -> f64 {
 
 #[cfg(feature = "metal")]
 fn metal_sysctl_floor_bytes() -> Result<usize> {
-    let sys = System::new_all();
+    let mut sys = System::new();
+    sys.refresh_memory();
     let system_ram_mb = usize::try_from(sys.total_memory())? / SIZE_IN_MB;
 
     let sysctl_mb = std::process::Command::new("sysctl")


### PR DESCRIPTION
Two independent fixes in the paged-attention path.

## Scheduler decode livelock (#2321)

The decode/completion scheduling loop (`while !self.running.is_empty()`) pushed image-incompatible sequences back onto `self.running` -- the very queue it was draining -- with no state change. `has_images()` is state-dependent during chunked prefill, so two vision sequences at different chunk offsets legitimately disagree; the sequence was re-popped, re-evaluated, and re-pushed forever (100% CPU, no progress) on concurrent multimodal requests.

Fix: route image-incompatible sequences to a separate `deferred` queue instead of back into `self.running`. The loop now only pops from `self.running`, so it always terminates.

A batch can only be all-image or all-non-image, so when both types are running only one runs per pass. Two follow-ups keep the deferred type healthy:

- **Fairness (no starvation):** re-appending deferred and relying on FCFS would let the oldest incompatible type win the head every pass and starve the other, since `sort_running_by_priority_fcfs` orders by arrival `timestamp()`. The scheduler now tracks the last batch's image-presence (`last_decode_batch_had_images`) and rotates the FCFS-ordered queue to lead with the opposite type when present, so image and non-image passes alternate.
- **Terminate-all correctness:** the scheduled batch is snapshotted, then deferred sequences are merged back into `self.running` *before* the `RunningCompletion` state update and the `TERMINATE_ALL_NEXT_STEP` block, so cancellation and state updates reach deferred sequences (previously they were merged back only after the flag was cleared and could keep generating).

Deferred sequences keep their allocated KV slots throughout. The `bucket_and_preempt_sequences` behavior (#2343) is untouched.

Adds unit tests for the decode-batch partition (termination when all sequences are image-incompatible, the image-homogeneous batching invariant, edge cases), the fairness rotation, and multi-pass alternation progress.

## Memory query in the attention hot path (#2322)

`MemoryUsage::query` is called per attention op through `maybe_synchronize` on integrated CUDA and Metal. It called `sysinfo::System::new_all()`, which refreshes every process/CPU/disk on the machine, only to read total/available memory.

Fix: replace `System::new_all()` with `System::new()` + `sys.refresh_memory()` at all three sites (CPU, integrated CUDA, Metal `sysctl` helper). The `< 4 GiB` synchronize heuristic and the reported memory values are unchanged; only the incidental full-machine refresh is removed. Discrete CUDA (cheap `mem_get_info`) is unaffected.