### PR TITLE
fix(core): reject out-of-range raw token ids in token requests

### DIFF
--- a/mistralrs-core/src/engine/add_request.rs
+++ b/mistralrs-core/src/engine/add_request.rs
@@ -322,7 +322,7 @@ impl Engine {
                 // Raw token ids come straight from the request; an out-of-range id would index past
                 // the embedding table (a CUDA release build has no bounds check -> OOB read).
                 let vocab_size = tokenizer.get_vocab_size(true);
-                if let Some(&bad) = it.iter().find(|&&t| t as usize >= vocab_size) {
+                if let Err(bad) = first_out_of_range_token(&it, vocab_size) {
                     request
                         .response
                         .send(Response::ValidationError(
@@ -954,5 +954,47 @@ impl Engine {
             .send(Ok(txt))
             .await
             .expect("Sender disconnected unexpectedly!");
+    }
+}
+
+/// Returns `Err(id)` for the first token id at or above `vocab_size`, else `Ok(())`. Ids in
+/// `[0, vocab_size)` are the only valid embedding-table indices.
+fn first_out_of_range_token(tokens: &[u32], vocab_size: usize) -> Result<(), u32> {
+    match tokens.iter().find(|&&t| t as usize >= vocab_size) {
+        Some(&bad) => Err(bad),
+        None => Ok(()),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::first_out_of_range_token;
+
+    #[test]
+    fn accepts_ids_below_vocab_size() {
+        assert_eq!(first_out_of_range_token(&[0, 5, 99], 100), Ok(()));
+    }
+
+    #[test]
+    fn accepts_max_valid_id() {
+        assert_eq!(first_out_of_range_token(&[99], 100), Ok(()));
+    }
+
+    #[test]
+    fn rejects_id_equal_to_vocab_size() {
+        assert_eq!(first_out_of_range_token(&[100], 100), Err(100));
+    }
+
+    #[test]
+    fn rejects_id_above_vocab_size_and_reports_it() {
+        assert_eq!(
+            first_out_of_range_token(&[1, 2, 4294967294], 100),
+            Err(4294967294)
+        );
+    }
+
+    #[test]
+    fn empty_is_ok() {
+        assert_eq!(first_out_of_range_token(&[], 100), Ok(()));
     }
 }

--- a/mistralrs-core/src/engine/add_request.rs
+++ b/mistralrs-core/src/engine/add_request.rs
@@ -319,6 +319,20 @@ impl Engine {
                         .unwrap_or_else(|_| warn!("Receiver disconnected"));
                     return;
                 };
+                // Raw token ids come straight from the request; an out-of-range id would index past
+                // the embedding table (a CUDA release build has no bounds check -> OOB read).
+                let vocab_size = tokenizer.get_vocab_size(true);
+                if let Some(&bad) = it.iter().find(|&&t| t as usize >= vocab_size) {
+                    request
+                        .response
+                        .send(Response::ValidationError(
+                            format!("Token id {bad} is out of range for vocab size {vocab_size}.")
+                                .into(),
+                        ))
+                        .await
+                        .unwrap_or_else(|_| warn!("Receiver disconnected"));
+                    return;
+                }
                 let prompt = tokenizer
                     .decode(&it, false)
                     .map_err(|e| anyhow::Error::msg(e.to_string()));


### PR DESCRIPTION
## Problem

`CompletionTokens` and `EmbeddingTokens` requests carry raw token ids straight from the client (e.g. `POST /v1/embeddings` with `{"input": [[...]]}`). These ids were never range-checked before being handed to the model.

An id `>= vocab_size` indexes past the embedding table. On CPU this returns a graceful error, but on a **CUDA release build the bounds assertion is compiled out** (`NDEBUG`), so the gather performs an out-of-bounds device memory read. A single unauthenticated request such as `{"model":"default","input":[4294967294]}` can therefore hit undefined behavior in the engine instead of a clean rejection.

## Fix

In the shared `CompletionTokens | EmbeddingTokens` arm of `Engine::handle_request`, validate every id against `tokenizer.get_vocab_size(true)` and return a `ValidationError` (HTTP 422) before the tokens reach the model. This mirrors the tokenizer-missing validation already present a few lines above in the same arm.

Covers both raw-token entry points (embeddings and completions) since they share the arm.

## Tests

The range check is extracted into a pure `first_out_of_range_token` helper with unit tests covering: ids below vocab size, the max valid id (`vocab_size - 1`), an id equal to `vocab_size` (rejected at the boundary), an out-of-range id reported back to the caller, and the empty-input case.