### PR TITLE
fix(qwen3): load lm_head unquantized for GPTQ/AWQ checkpoints

### DIFF
--- a/mistralrs-core/src/models/qwen3.rs
+++ b/mistralrs-core/src/models/qwen3.rs
@@ -467,10 +467,15 @@ impl Model {
             mapper.set_nm_device(vb_m.pp("norm"), false),
         )?;
         let lm_head = if !cfg.tie_word_embeddings {
+            // Standard GPTQ/AWQ Qwen3 checkpoints quantize only the transformer
+            // blocks and keep `lm_head` in full precision (a plain `lm_head.weight`,
+            // no qweight/qzeros/scales). Passing the model's quantization_config here
+            // makes the loader demand int4 lm_head tensors and fail to load. Load
+            // lm_head unquantized instead (matching gemma/starcoder2).
             ReplicatedLayer::new(
                 cfg.hidden_size,
                 cfg.vocab_size,
-                &cfg.quantization_config,
+                &None,
                 false,
                 mapper.set_nm_device(vb_lm_head, normal_loading_metadata.loading_isq),
             )?

--- a/mistralrs-quant/src/gptq/gptq_cuda.rs
+++ b/mistralrs-quant/src/gptq/gptq_cuda.rs
@@ -511,7 +511,22 @@ pub fn gptq_linear(
     } else {
         None
     };
-    let workspace = Tensor::zeros(out_dim / pack_factor!(bits), DType::U32, vb.device())?;
+    // Marlin's reduction locks buffer must hold (out_dim / min_thread_n) * max_par
+    // int32 entries (min_thread_n = 64, max_par = 16 in the kernel), i.e. out_dim/4 —
+    // matching vLLM's MarlinWorkspace. The old `out_dim / pack_factor` sizing only
+    // happens to be correct for 8-bit (pack_factor 4 -> out_dim/4); for 4-bit
+    // (pack_factor 8 -> out_dim/8) it under-allocates by 2x, so marlin writes its
+    // cross-block reduction locks out of bounds. Depending on GPU memory layout this
+    // is either silent corruption (overrun lands in an adjacent allocation -> garbage
+    // output) or CUDA_ERROR_ILLEGAL_ADDRESS (overrun crosses a page boundary, seen on
+    // A100/sm_80). Size it correctly for every bit width.
+    const MARLIN_MIN_THREAD_N: usize = 64;
+    const MARLIN_MAX_PAR: usize = 16;
+    let workspace = Tensor::zeros(
+        out_dim.div_ceil(MARLIN_MIN_THREAD_N) * MARLIN_MAX_PAR,
+        DType::U32,
+        vb.device(),
+    )?;
 
     let config = if marlin_format {
         QuantMethodConfig::GptqAwq {


### PR DESCRIPTION
Standard GPTQ/AWQ Qwen3 checkpoints (e.g. Qwen/Qwen3-8B-AWQ) quantize only the transformer blocks and keep lm_head in full precision (plain lm_head.weight, no qweight/qzeros/scales). qwen3.rs passed the model's quantization_config when building lm_head via ReplicatedLayer::new, so the loader demanded int4 lm_head tensors and crashed with:
  'Missing required tensor(s) for gptq_awq_linear at prefix lm_head'
Load lm_head unquantized instead, matching gemma.rs/starcoder2.rs.

Branched from upstream v0.9.0 (chalk/0.9-fixes).