### PR TITLE
fix(lfm2): fix batched inference crash and corruption

### DIFF
--- a/mistralrs-core/src/kv_cache/hybrid_cache.rs
+++ b/mistralrs-core/src/kv_cache/hybrid_cache.rs
@@ -127,10 +127,13 @@ impl RecurrentStatePool {
         Some(slot_idx)
     }
 
-    /// Free a state slot when a sequence completes.
+    /// Free a state slot when a sequence completes. Idempotent: a duplicate entry in the
+    /// free list would hand the same slot to two live sequences and corrupt their state.
     pub fn free(&mut self, slot_idx: usize) {
         debug_assert!(slot_idx < self.capacity);
-        self.free_slots.push(slot_idx);
+        if !self.free_slots.contains(&slot_idx) {
+            self.free_slots.push(slot_idx);
+        }
     }
 
     /// Gather conv states for the given slot indices

--- a/mistralrs-core/src/models/lfm2.rs
+++ b/mistralrs-core/src/models/lfm2.rs
@@ -642,7 +642,8 @@ impl ShortConv {
             new_col
         };
         let weight = self.conv.weight().squeeze(1)?.unsqueeze(0)?;
-        let mut conv_out = (conv_state.clone() * weight)?.sum(D::Minus1)?;
+        // state is (n_seqs, d, l) vs the (1, d, l) weight, so a plain mul fails on batched decode
+        let mut conv_out = conv_state.broadcast_mul(&weight)?.sum(D::Minus1)?;
         if let Some(bias) = self.conv.bias() {
             conv_out = conv_out.broadcast_add(&bias.reshape((1, bias.dim(0)?))?)?;
         }
@@ -674,7 +675,9 @@ impl ShortConv {
                 .narrow(2, 0, seq_len)?
         };
 
-        let y = (c_proj * conv_out)?.transpose(1, 2)?.contiguous()?;
+        // At seq_len 1 the transpose leaves a degenerate stride that contiguous() keeps and
+        // candle's CPU batched matmul then misreads, so force a real copy.
+        let y = (c_proj * conv_out)?.transpose(1, 2)?.force_contiguous()?;
         self.out_proj.forward(&y)
     }
 }


### PR DESCRIPTION
Batched LFM2 inference (2+ concurrent requests) either crashed with `shape mismatch in mul, lhs: [n, 2048, 3], rhs: [1, 2048, 3]` or silently produced corrupted text (#2306). This turned out to be three independent bugs:

1. **Decode conv shape error**: `decode_conv` multiplied the gathered per-sequence conv state `(n_seqs, d, l)` against the shared `(1, d, l)` weight with a non-broadcasting mul. Fixed with `broadcast_mul`.

2. **Recurrent state slot reuse**: `RecurrentStatePool::free` pushed slots unconditionally, so engine-side re-frees left duplicate entries in the free list and two live sequences could be handed the same slot, silently cross-contaminating their conv state. `free` is now idempotent. This affects all hybrid/recurrent models on every backend, not just LFM2.

3. **Degenerate-stride matmul misread (CPU)**: `ShortConv` builds its `out_proj` input as `(b, d, 1).transpose(1, 2)`. At seq_len 1 the result passes candle's `is_contiguous` check with stride `[d, 1, 1]`, so `.contiguous()` is a no-op. candle's CPU batched matmul then collapses the broadcasted batch into rows using `stride[rank - 2] == 1` as the row stride, so batch row `b` reads its input shifted by `b` elements: row 0 is correct and every other row is garbage. `force_contiguous` normalizes the layout before the matmul. A standalone candle repro exists; upstream issue to follow (will link in a comment).

Verified on `LiquidAI/LFM2.5-1.2B-Instruct` (CPU, F32): 4 identical concurrent greedy requests now return 4 identical coherent completions (previously a shape error or 3/4 corrupted), mixed-prompt batches are coherent, and single-request output is unchanged. The VL variant shares this conv path but was not separately verified.

Fixes #2306