### PR TITLE
Support new format AWQ MoE models

### DIFF
--- a/mistralrs-core/src/moe/experts/backends.rs
+++ b/mistralrs-core/src/moe/experts/backends.rs
@@ -69,9 +69,9 @@ impl Wna16ExpertsWeights {
         if comm.world_size() != 1 {
             candle_core::bail!("WNA16 MoE experts do not support tensor parallelism");
         }
-        // Candle's CUDA copy2d path does not provide a kernel for every packed
-        // integer dtype. Assemble the routed tensors on CPU, then transfer the
-        // already-contiguous stacks to CUDA in one copy per projection.
+        // This Candle/CUDA deployment failed to resolve the copy2d_u32 symbol
+        // while stacking packed tensors on device. Assemble the routed tensors
+        // on CPU, then transfer the contiguous stacks to CUDA once per projection.
         let target_device = vb.device().clone();
         let read_vb = if target_device.is_cuda() {
             vb.clone().set_device(Device::Cpu)

--- a/mistralrs-core/src/moe/experts/backends.rs
+++ b/mistralrs-core/src/moe/experts/backends.rs
@@ -46,6 +46,233 @@ pub(super) struct CutlassExpertsWeights {
     pub(super) w: StackedExpertWeights,
 }
 
+#[cfg(feature = "cuda")]
+pub(super) struct Wna16ExpertsWeights {
+    pub(super) gate_up: Tensor,
+    pub(super) gate_up_scales: Tensor,
+    pub(super) down: Tensor,
+    pub(super) down_scales: Tensor,
+    pub(super) w_size_n: usize,
+    pub(super) bits: usize,
+    pub(super) group_size: usize,
+    pub(super) zero_point: usize,
+}
+
+#[cfg(feature = "cuda")]
+impl Wna16ExpertsWeights {
+    pub(super) fn load(
+        cfg: &MoEExpertsConfig,
+        vb: ShardedVarBuilder,
+        comm: &Arc<mistralrs_quant::Comm>,
+        quantization_config: &QuantizedConfig,
+    ) -> Result<Self> {
+        if comm.world_size() != 1 {
+            candle_core::bail!("WNA16 MoE experts do not support tensor parallelism");
+        }
+        // Candle's CUDA copy2d path does not provide a kernel for every packed
+        // integer dtype. Assemble the routed tensors on CPU, then transfer the
+        // already-contiguous stacks to CUDA in one copy per projection.
+        let target_device = vb.device().clone();
+        let read_vb = if target_device.is_cuda() {
+            vb.clone().set_device(Device::Cpu)
+        } else {
+            vb.clone()
+        };
+        let QuantizedConfig::GptqAwq {
+            bits,
+            group_size,
+            checkpoint_format,
+            is_awq,
+            ..
+        } = quantization_config
+        else {
+            candle_core::bail!("WNA16 MoE requires GPTQ/AWQ quantization metadata");
+        };
+        if !matches!(bits, 4 | 8) || *group_size == 0 {
+            candle_core::bail!("WNA16 MoE requires 4 or 8 bits and a positive group size");
+        }
+        let compressed = checkpoint_format.as_deref() == Some("compressed-tensors");
+        let legacy_gptq = !compressed && !*is_awq;
+        if !compressed && *is_awq {
+            candle_core::bail!("legacy AWQ MoE experts are not supported by the WNA16 backend");
+        }
+        let pack_factor = 32 / bits;
+        if cfg.hidden_size % pack_factor != 0
+            || cfg.moe_intermediate_size % pack_factor != 0
+            || cfg.hidden_size % group_size != 0
+            || cfg.moe_intermediate_size % group_size != 0
+        {
+            candle_core::bail!(
+                "WNA16 MoE dimensions must be divisible by pack factor and group size"
+            );
+        }
+        let projection = |expert: &ShardedVarBuilder,
+                          name: &str,
+                          out: usize,
+                          input: usize|
+         -> Result<(Tensor, Tensor)> {
+            let vb = expert.pp(name);
+            if compressed {
+                Ok((
+                    vb.get_with_hints_dtype(
+                        (out, input / pack_factor),
+                        "weight_packed",
+                        Shard::default(),
+                        DType::U32,
+                    )?,
+                    vb.get_with_hints_dtype(
+                        (out, input / group_size),
+                        "weight_scale",
+                        Shard::default(),
+                        DType::F32,
+                    )?,
+                ))
+            } else {
+                if !vb.contains_tensor("qzeros") {
+                    candle_core::bail!("classic GPTQ MoE projection {name} is missing qzeros");
+                }
+                let packed = vb
+                    .get_with_hints_dtype(
+                        (input / pack_factor, out),
+                        "qweight",
+                        Shard::default(),
+                        DType::U32,
+                    )?
+                    .t()?
+                    .contiguous()?;
+                let scales = vb
+                    .get_with_hints_dtype(
+                        (input / group_size, out),
+                        "scales",
+                        Shard::default(),
+                        DType::F32,
+                    )?
+                    .t()?
+                    .contiguous()?;
+                Ok((packed, scales))
+            }
+        };
+
+        let mut gate_weights = Vec::with_capacity(cfg.num_experts);
+        let mut gate_scales = Vec::with_capacity(cfg.num_experts);
+        let mut up_weights = Vec::with_capacity(cfg.num_experts);
+        let mut up_scales = Vec::with_capacity(cfg.num_experts);
+        let mut down_weights = Vec::with_capacity(cfg.num_experts);
+        let mut down_scales = Vec::with_capacity(cfg.num_experts);
+        for expert_id in 0..cfg.num_experts {
+            let expert = read_vb.pp(expert_id.to_string());
+            let names = cfg.expert_proj_names;
+            let (gate, gate_scale) = projection(
+                &expert,
+                names.gate,
+                cfg.moe_intermediate_size,
+                cfg.hidden_size,
+            )?;
+            let (up, up_scale) = projection(
+                &expert,
+                names.up,
+                cfg.moe_intermediate_size,
+                cfg.hidden_size,
+            )?;
+            let (down, down_scale) = projection(
+                &expert,
+                names.down,
+                cfg.hidden_size,
+                cfg.moe_intermediate_size,
+            )?;
+            gate_weights.push(gate);
+            gate_scales.push(gate_scale);
+            up_weights.push(up);
+            up_scales.push(up_scale);
+            down_weights.push(down);
+            down_scales.push(down_scale);
+        }
+
+        let gate_up = Tensor::cat(
+            &[
+                &Tensor::stack(&gate_weights, 0)?,
+                &Tensor::stack(&up_weights, 0)?,
+            ],
+            1,
+        )?
+        .contiguous()?;
+        let gate_up_scales = Tensor::cat(
+            &[
+                &Tensor::stack(&gate_scales, 0)?,
+                &Tensor::stack(&up_scales, 0)?,
+            ],
+            1,
+        )?
+        .contiguous()?;
+        let down = Tensor::stack(&down_weights, 0)?.contiguous()?;
+        let down_scales = Tensor::stack(&down_scales, 0)?.contiguous()?;
+        let gate_up = gate_up.to_device(&target_device)?;
+        let gate_up_scales = gate_up_scales.to_device(&target_device)?;
+        let down = down.to_device(&target_device)?;
+        let down_scales = down_scales.to_device(&target_device)?;
+        Ok(Self {
+            gate_up,
+            gate_up_scales,
+            down,
+            down_scales,
+            w_size_n: cfg.moe_intermediate_size,
+            bits: *bits,
+            group_size: *group_size,
+            zero_point: if legacy_gptq {
+                (1usize << (bits - 1)) - 1
+            } else {
+                1usize << (bits - 1)
+            },
+        })
+    }
+
+    pub(super) fn forward_impl(
+        &self,
+        forward: &MoEForward,
+        config: MoEForwardConfig,
+    ) -> Result<Tensor> {
+        if forward.lora.is_some() {
+            candle_core::bail!("WNA16 MoE does not support LoRA adapters");
+        }
+        let is_prefill = forward.shape.phase.is_prefill();
+        let (expert_ids, sorted_token_ids) = if is_prefill {
+            use crate::ops::ArgSortOp;
+            forward.topk_ids.flatten_all()?.sort(true)?
+        } else {
+            forward.topk_ids.flatten_all()?.sort_last_dim(true)?
+        };
+        let gate_up = mistralrs_quant::moe::cuda::moe_gemm_wna16(
+            forward.xs_flat,
+            &self.gate_up,
+            &self.gate_up_scales,
+            None,
+            &sorted_token_ids,
+            &expert_ids,
+            config.num_experts_per_tok,
+            self.bits,
+            self.group_size,
+            is_prefill,
+            self.zero_point,
+        )?;
+        let down_inputs = crate::ops::split_mul_and_act(&gate_up, self.w_size_n, config.act)?;
+        let down = mistralrs_quant::moe::cuda::moe_gemm_wna16(
+            &down_inputs,
+            &self.down,
+            &self.down_scales,
+            Some(forward.topk_weights),
+            &sorted_token_ids,
+            &expert_ids,
+            config.num_experts_per_tok,
+            self.bits,
+            self.group_size,
+            is_prefill,
+            self.zero_point,
+        )?;
+        down.reshape((forward.shape.num_tokens, (), forward.shape.hidden_dim))?
+            .sum(D::Minus2)
+    }
+}
+
 /// Below this batch size the grouped-GEMM setup cost exceeds the fused decode kernels.
 #[cfg(feature = "cuda")]
 pub(super) const CUTLASS_MOE_MIN_TOKENS: usize = 64;

--- a/mistralrs-core/src/moe/experts/config.rs
+++ b/mistralrs-core/src/moe/experts/config.rs
@@ -79,6 +79,9 @@ pub(super) enum MoEExpertsBackend {
     /// CUTLASS grouped GEMM over raw ENK tensors (CUDA bf16, GeLU); universal sm_80+ fallback.
     #[cfg(feature = "cuda")]
     Cutlass,
+    /// CUDA WNA16 grouped MoE kernels for AWQ/GPTQ expert tensors.
+    #[cfg(feature = "cuda")]
+    Wna16,
     /// Gather-based (Metal, CPU, ISQ, pre-quantized).
     Fast,
 }
@@ -90,6 +93,7 @@ pub(super) struct BackendChoice {
     pub dtype: DType,
     pub loading_isq: bool,
     pub quantized: bool,
+    pub quantization_config: Option<QuantizedConfig>,
     pub immediate_isq: bool,
     #[cfg_attr(not(feature = "cutile"), allow(dead_code))]
     pub act: Activation,
@@ -108,6 +112,7 @@ impl BackendChoice {
             dtype,
             loading_isq,
             quantized: quantization_config.is_some(),
+            quantization_config: quantization_config.clone(),
             immediate_isq: mistralrs_quant::get_immediate_isq().is_some(),
             act,
         }
@@ -189,6 +194,8 @@ impl MoEExpertsBackend {
             "cutile" => Self::Cutile,
             #[cfg(feature = "cuda")]
             "cutlass" => Self::Cutlass,
+            #[cfg(feature = "cuda")]
+            "wna16" => Self::Wna16,
             _ => return None,
         })
     }
@@ -233,7 +240,20 @@ impl MoEExpertsBackend {
                     }
                     return Ok(Self::Cutlass);
                 }
+                #[cfg(feature = "cuda")]
+                Self::Wna16 => {
+                    if !c.device.is_cuda() {
+                        candle_core::bail!("MISTRALRS_MOE_BACKEND=wna16 requires a CUDA device");
+                    }
+                    return Ok(Self::Wna16);
+                }
             }
+        }
+        #[cfg(feature = "cuda")]
+        if c.device.is_cuda()
+            && matches!(c.quantization_config, Some(QuantizedConfig::GptqAwq { .. }))
+        {
+            return Ok(Self::Wna16);
         }
         if c.device.is_cuda()
             && !c.quantized

--- a/mistralrs-core/src/moe/experts/config.rs
+++ b/mistralrs-core/src/moe/experts/config.rs
@@ -93,6 +93,7 @@ pub(super) struct BackendChoice {
     pub dtype: DType,
     pub loading_isq: bool,
     pub quantized: bool,
+    #[allow(dead_code)]
     pub quantization_config: Option<QuantizedConfig>,
     pub immediate_isq: bool,
     #[cfg_attr(not(feature = "cutile"), allow(dead_code))]
@@ -318,6 +319,7 @@ mod tests {
             dtype,
             loading_isq: false,
             quantized: false,
+            quantization_config: None,
             immediate_isq: false,
             act,
         }

--- a/mistralrs-core/src/moe/experts/mod.rs
+++ b/mistralrs-core/src/moe/experts/mod.rs
@@ -23,11 +23,11 @@ pub use config::{prelog_moe_backend, ExpertProj, ExpertProjNames, MoEExpertsConf
 
 #[cfg(feature = "cutile")]
 use backends::CutileExpertsWeights;
-#[cfg(feature = "cuda")]
-use backends::CutlassExpertsWeights;
 use backends::{
     experts_are_prequantized, FastExpertsWeights, FusedExpertsWeights, StackedExpertWeights,
 };
+#[cfg(feature = "cuda")]
+use backends::{CutlassExpertsWeights, Wna16ExpertsWeights};
 use checkpoint::ExpertCheckpoint;
 use config::{BackendChoice, MoEExpertsBackend};
 use forward::{MoEForward, MoEForwardConfig, MoEForwardShape};
@@ -50,6 +50,8 @@ enum MoEExpertsBackendImpl {
     Cutile(CutileExpertsWeights),
     #[cfg(feature = "cuda")]
     Cutlass(CutlassExpertsWeights),
+    #[cfg(feature = "cuda")]
+    Wna16(Wna16ExpertsWeights),
     Fast(FastExpertsWeights),
 }
 
@@ -65,6 +67,10 @@ impl MoEExpertsBackendImpl {
             Self::Cutlass(w) => w
                 .forward_impl(forward, config)
                 .map_err(|err| err.context("moe experts cutlass")),
+            #[cfg(feature = "cuda")]
+            Self::Wna16(w) => w
+                .forward_impl(forward, config)
+                .map_err(|err| err.context("moe experts wna16")),
             Self::Fast(w) => w.forward_impl(forward, config),
         }
     }
@@ -137,6 +143,15 @@ impl MoEExperts {
                     &ExpertCheckpoint::new(cfg, experts_vb.clone(), comm)?,
                 )?)
             }
+            #[cfg(feature = "cuda")]
+            MoEExpertsBackend::Wna16 => MoEExpertsBackendImpl::Wna16(Wna16ExpertsWeights::load(
+                cfg,
+                experts_vb.clone(),
+                comm,
+                quantization_config
+                    .as_ref()
+                    .expect("WNA16 requires quantization config"),
+            )?),
             MoEExpertsBackend::Fast => {
                 if experts_are_prequantized(quantization_config, &experts_vb) {
                     MoEExpertsBackendImpl::Fast(FastExpertsWeights::load_prequantized(
@@ -211,6 +226,15 @@ impl MoEExperts {
                     &ExpertCheckpoint::new(cfg, experts_vb.clone(), comm)?,
                 )?)
             }
+            #[cfg(feature = "cuda")]
+            MoEExpertsBackend::Wna16 => MoEExpertsBackendImpl::Wna16(Wna16ExpertsWeights::load(
+                cfg,
+                experts_vb.clone(),
+                comm,
+                quantization_config
+                    .as_ref()
+                    .expect("WNA16 requires quantization config"),
+            )?),
             MoEExpertsBackend::Fast => {
                 if experts_are_prequantized(quantization_config, &experts_vb) {
                     candle_core::bail!(

--- a/mistralrs-quant/kernels/moe_wna16/moe_wna16.cu
+++ b/mistralrs-quant/kernels/moe_wna16/moe_wna16.cu
@@ -1,0 +1,346 @@
+// Adapted from: 
+// moe_gemm_grouped_kernel_wna16_prefill: https://github.com/guoqingbao/attention.rs/tree/main/src/kernels/src/moe_gemm.cu
+// moe_gemv_kernel_wna16: https://github.com/guoqingbao/attention.rs/tree/main/src/kernels/src/moe_gemv.cu
+
+#include <cuda_bf16.h>
+#include <cuda_fp16.h>
+#include <cuda_runtime.h>
+#include <mma.h>
+#include <cstdint>
+
+using namespace nvcuda::wmma;
+
+namespace {
+
+constexpr int WARP_SIZE = 32;
+constexpr int M_TILE = 32;
+constexpr int N_TILE = 32;
+constexpr int K_TILE = 16;
+constexpr int THREADS = 128;
+
+template <typename T>
+__device__ inline T from_float(float value);
+
+template <>
+__device__ inline half from_float<half>(float value) {
+  return __float2half(value);
+}
+
+#ifndef NO_BF16_KERNEL
+template <>
+__device__ inline nv_bfloat16 from_float<nv_bfloat16>(float value) {
+  return __float2bfloat16(value);
+}
+#endif
+
+template <typename T>
+__device__ inline float to_float(T value);
+
+template <>
+__device__ inline float to_float<half>(half value) {
+  return __half2float(value);
+}
+
+#ifndef NO_BF16_KERNEL
+template <>
+__device__ inline float to_float<nv_bfloat16>(nv_bfloat16 value) {
+  return __bfloat162float(value);
+}
+#endif
+
+__global__ void count_and_scan(const int32_t* ids, int32_t* counts,
+                               int32_t* offsets, int num_experts, int size_m) {
+  extern __shared__ int32_t counts_s[];
+  const int tid = threadIdx.x;
+  for (int expert = tid; expert < num_experts; expert += blockDim.x) {
+    counts_s[expert] = 0;
+  }
+  __syncthreads();
+  for (int index = tid; index < size_m; index += blockDim.x) {
+    const int expert = ids[index];
+    if (expert >= 0 && expert < num_experts) atomicAdd(&counts_s[expert], 1);
+  }
+  __syncthreads();
+  if (tid == 0) {
+    int32_t offset = 0;
+    for (int expert = 0; expert < num_experts; ++expert) {
+      counts[expert] = counts_s[expert];
+      offsets[expert] = offset;
+      offset += counts_s[expert];
+    }
+    offsets[num_experts] = offset;
+  }
+}
+
+template <typename T, int BITS, int ROWS_PER_BLOCK>
+__global__ void moe_gemv_kernel(
+    const T* __restrict__ input, const uint32_t* __restrict__ weights,
+    const float* __restrict__ scales, const int32_t* __restrict__ sorted_ids,
+    const int32_t* __restrict__ expert_ids, const float* __restrict__ topk_weights,
+    T* __restrict__ output, int num_experts, int topk, int size_m, int size_n,
+    int size_k, int group_size, int zero_point) {
+  const int assignment = blockIdx.y;
+  const int row = blockIdx.x * ROWS_PER_BLOCK + threadIdx.x / WARP_SIZE;
+  const int lane = threadIdx.x % WARP_SIZE;
+  if (assignment >= size_m || row >= size_n) return;
+
+  const int token_id = sorted_ids[assignment];
+  const int expert = expert_ids[assignment];
+  if (expert < 0 || expert >= num_experts) return;
+  const int input_id = topk_weights ? token_id : token_id / topk;
+
+  extern __shared__ unsigned char raw[];
+  T* input_s = reinterpret_cast<T*>(raw);
+  const T* input_row = input + static_cast<size_t>(input_id) * size_k;
+  for (int k = threadIdx.x; k < size_k; k += blockDim.x) input_s[k] = input_row[k];
+  __syncthreads();
+
+  constexpr int PACK_FACTOR = 32 / BITS;
+  const int packed_k = (size_k + PACK_FACTOR - 1) / PACK_FACTOR;
+  const int scale_k = (size_k + group_size - 1) / group_size;
+  const uint32_t mask = (1u << BITS) - 1u;
+  const uint32_t* weight_row = weights +
+      (static_cast<size_t>(expert) * size_n + row) * packed_k;
+  const float* scale_row = scales +
+      (static_cast<size_t>(expert) * size_n + row) * scale_k;
+
+  float sum = 0.0f;
+  for (int packed = lane; packed < packed_k; packed += WARP_SIZE) {
+    const uint32_t word = weight_row[packed];
+#pragma unroll
+    for (int q_index = 0; q_index < PACK_FACTOR; ++q_index) {
+      const int k = packed * PACK_FACTOR + q_index;
+      if (k < size_k) {
+        const int q = static_cast<int>((word >> (q_index * BITS)) & mask) - zero_point;
+        sum += to_float(input_s[k]) * (static_cast<float>(q) * scale_row[k / group_size]);
+      }
+    }
+  }
+#pragma unroll
+  for (int offset = WARP_SIZE / 2; offset > 0; offset >>= 1)
+    sum += __shfl_xor_sync(0xffffffff, sum, offset);
+  if (lane == 0) {
+    if (topk_weights) sum *= topk_weights[token_id];
+    output[static_cast<size_t>(token_id) * size_n + row] = from_float<T>(sum);
+  }
+}
+
+template <typename T, int BITS>
+__global__ void moe_gemm_kernel(
+    const T* __restrict__ input, const uint32_t* __restrict__ weights,
+    const float* __restrict__ scales, const int32_t* __restrict__ sorted_ids,
+    const int32_t* __restrict__ offsets, const float* __restrict__ topk_weights,
+    T* __restrict__ output, int num_experts, int topk, int size_m, int size_n,
+    int size_k, int group_size, int zero_point) {
+  const int expert = blockIdx.x;
+  const int n_base = blockIdx.y * N_TILE;
+  if (expert >= num_experts || n_base >= size_n) return;
+  const int start = offsets[expert];
+  const int end = offsets[expert + 1];
+  if (start >= end) return;
+
+  constexpr int PACK_FACTOR = 32 / BITS;
+  const int packed_k = (size_k + PACK_FACTOR - 1) / PACK_FACTOR;
+  const int scale_k = (size_k + group_size - 1) / group_size;
+  const uint32_t mask = (1u << BITS) - 1u;
+  const uint32_t* expert_w = weights + static_cast<size_t>(expert) * size_n * packed_k;
+  const float* expert_s = scales + static_cast<size_t>(expert) * size_n * scale_k;
+
+  extern __shared__ unsigned char raw[];
+  T* a_s = reinterpret_cast<T*>(raw);
+  T* b_s = a_s + M_TILE * K_TILE;
+  float* c_s = reinterpret_cast<float*>(b_s + N_TILE * K_TILE);
+  const int tid = threadIdx.x;
+  const int warp = tid / WARP_SIZE;
+  const int warp_m = warp / 2;
+  const int warp_n = warp % 2;
+
+  for (int m_base = 0; m_base < end - start; m_base += M_TILE) {
+    fragment<accumulator, 16, 16, K_TILE, float> acc;
+    fill_fragment(acc, 0.0f);
+    for (int k_base = 0; k_base < size_k; k_base += K_TILE) {
+      for (int index = tid; index < N_TILE * K_TILE; index += THREADS) {
+        const int n = index / K_TILE;
+        const int k = index % K_TILE;
+        const int ng = n_base + n;
+        const int kg = k_base + k;
+        if (ng < size_n && kg < size_k) {
+          const uint32_t word = expert_w[static_cast<size_t>(ng) * packed_k + kg / PACK_FACTOR];
+          const int q = static_cast<int>((word >> ((kg % PACK_FACTOR) * BITS)) & mask) - zero_point;
+          b_s[n * K_TILE + k] = from_float<T>(static_cast<float>(q) * expert_s[static_cast<size_t>(ng) * scale_k + kg / group_size]);
+        } else {
+          b_s[n * K_TILE + k] = from_float<T>(0.0f);
+        }
+      }
+      for (int index = tid; index < M_TILE * K_TILE; index += THREADS) {
+        const int m = index / K_TILE;
+        const int k = index % K_TILE;
+        const int route = start + m_base + m;
+        const int kg = k_base + k;
+        if (route < end && kg < size_k) {
+          const int token_id = sorted_ids[route];
+          const int input_id = topk_weights ? token_id : token_id / topk;
+          a_s[m * K_TILE + k] = input[static_cast<size_t>(input_id) * size_k + kg];
+        } else {
+          a_s[m * K_TILE + k] = from_float<T>(0.0f);
+        }
+      }
+      __syncthreads();
+      fragment<matrix_a, 16, 16, K_TILE, T, row_major> a;
+      fragment<matrix_b, 16, 16, K_TILE, T, col_major> b;
+      load_matrix_sync(a, a_s + warp_m * 16 * K_TILE, K_TILE);
+      load_matrix_sync(b, b_s + warp_n * 16 * K_TILE, K_TILE);
+      mma_sync(acc, a, b, acc);
+      __syncthreads();
+    }
+    store_matrix_sync(c_s + warp_m * 16 * N_TILE + warp_n * 16, acc, N_TILE, mem_row_major);
+    __syncthreads();
+    for (int index = tid; index < M_TILE * N_TILE; index += THREADS) {
+      const int m = index / N_TILE;
+      const int n = index % N_TILE;
+      const int route = start + m_base + m;
+      const int ng = n_base + n;
+      if (route < end && route < size_m && ng < size_n) {
+        const int token_id = sorted_ids[route];
+        float value = c_s[m * N_TILE + n];
+        if (topk_weights) value *= topk_weights[token_id];
+        output[static_cast<size_t>(token_id) * size_n + ng] = from_float<T>(value);
+      }
+    }
+    __syncthreads();
+  }
+}
+
+template <typename T, int BITS, int ROWS_PER_BLOCK>
+void launch_gemv_rows(const void* input, const uint32_t* weights, const float* scales,
+                 const int32_t* sorted_ids, const int32_t* expert_ids,
+                 const float* topk_weights, void* output, int num_experts,
+                 int topk, int size_m, int size_n, int size_k, int group_size,
+                 int zero_point, cudaStream_t stream) {
+  constexpr int rows = ROWS_PER_BLOCK;
+  dim3 grid((size_n + rows - 1) / rows, size_m);
+  dim3 block(rows * WARP_SIZE);
+  moe_gemv_kernel<T, BITS, ROWS_PER_BLOCK><<<grid, block, static_cast<size_t>(size_k) * sizeof(T), stream>>>(
+      static_cast<const T*>(input), weights, scales, sorted_ids, expert_ids,
+      topk_weights, static_cast<T*>(output), num_experts, topk, size_m, size_n,
+      size_k, group_size, zero_point);
+}
+
+template <typename T, int BITS>
+void launch_gemv(const void* input, const uint32_t* weights, const float* scales,
+                 const int32_t* sorted_ids, const int32_t* expert_ids,
+                 const float* topk_weights, void* output, int num_experts,
+                 int topk, int size_m, int size_n, int size_k, int group_size,
+                 int zero_point, cudaStream_t stream) {
+  const int rows = size_n <= 512 ? 16 : size_n <= 2048 ? 8 : size_n <= 4096 ? 4 : 2;
+  switch (rows) {
+    case 16:
+      launch_gemv_rows<T, BITS, 16>(input, weights, scales, sorted_ids, expert_ids,
+                                     topk_weights, output, num_experts, topk, size_m, size_n,
+                                     size_k, group_size, zero_point, stream);
+      break;
+    case 8:
+      launch_gemv_rows<T, BITS, 8>(input, weights, scales, sorted_ids, expert_ids,
+                                    topk_weights, output, num_experts, topk, size_m, size_n,
+                                    size_k, group_size, zero_point, stream);
+      break;
+    case 4:
+      launch_gemv_rows<T, BITS, 4>(input, weights, scales, sorted_ids, expert_ids,
+                                    topk_weights, output, num_experts, topk, size_m, size_n,
+                                    size_k, group_size, zero_point, stream);
+      break;
+    default:
+      launch_gemv_rows<T, BITS, 2>(input, weights, scales, sorted_ids, expert_ids,
+                                    topk_weights, output, num_experts, topk, size_m, size_n,
+                                    size_k, group_size, zero_point, stream);
+      break;
+  }
+}
+
+template <typename T, int BITS>
+void launch_gemm(const void* input, const uint32_t* weights, const float* scales,
+                 const int32_t* sorted_ids, const int32_t* expert_ids,
+                 const float* topk_weights, void* output, int32_t* counts,
+                 int32_t* offsets, int num_experts, int topk, int size_m,
+                 int size_n, int size_k, int group_size, int zero_point,
+                 bool prefill, cudaStream_t stream) {
+  count_and_scan<<<1, 1024, static_cast<size_t>(num_experts) * sizeof(int32_t), stream>>>(
+      expert_ids, counts, offsets, num_experts, size_m);
+  if (!prefill) {
+    launch_gemv<T, BITS>(input, weights, scales, sorted_ids, expert_ids, topk_weights,
+                         output, num_experts, topk, size_m, size_n, size_k,
+                         group_size, zero_point, stream);
+    return;
+  }
+  dim3 grid(num_experts, (size_n + N_TILE - 1) / N_TILE);
+  dim3 block(THREADS);
+  const size_t smem = (M_TILE * K_TILE + N_TILE * K_TILE) * sizeof(T) +
+                      M_TILE * N_TILE * sizeof(float);
+  moe_gemm_kernel<T, BITS><<<grid, block, smem, stream>>>(
+      static_cast<const T*>(input), weights, scales, sorted_ids, offsets,
+      topk_weights, static_cast<T*>(output), num_experts, topk, size_m, size_n,
+      size_k, group_size, zero_point);
+}
+
+}  // namespace
+
+extern "C" void moe_gemv_wna16(
+    const void* input, const uint32_t* weights, const void* weight_scales,
+    const int32_t* sorted_token_ids, const int32_t* expert_ids,
+    const float* topk_weights, void* output, int num_experts, int topk,
+    int size_m, int size_n, int size_k, int bits, int group_size, int zero_point,
+    int data_type, int64_t stream) {
+  auto cuda_stream = reinterpret_cast<cudaStream_t>(stream);
+  const auto* scales = static_cast<const float*>(weight_scales);
+  if (data_type == 0) {
+    if (bits == 4) launch_gemv<half, 4>(input, weights, scales, sorted_token_ids, expert_ids,
+                                         topk_weights, output, num_experts, topk, size_m, size_n,
+                                         size_k, group_size, zero_point, cuda_stream);
+    else if (bits == 8) launch_gemv<half, 8>(input, weights, scales, sorted_token_ids, expert_ids,
+                                              topk_weights, output, num_experts, topk, size_m, size_n,
+                                              size_k, group_size, zero_point, cuda_stream);
+  }
+#ifndef NO_BF16_KERNEL
+  else if (data_type == 1) {
+    if (bits == 4) launch_gemv<nv_bfloat16, 4>(input, weights, scales, sorted_token_ids, expert_ids,
+                                               topk_weights, output, num_experts, topk, size_m, size_n,
+                                               size_k, group_size, zero_point, cuda_stream);
+    else if (bits == 8) launch_gemv<nv_bfloat16, 8>(input, weights, scales, sorted_token_ids, expert_ids,
+                                                   topk_weights, output, num_experts, topk, size_m, size_n,
+                                                   size_k, group_size, zero_point, cuda_stream);
+  }
+#endif
+}
+
+extern "C" void moe_gemm_wmma_wna16(
+    const void* input, const uint32_t* weights, const void* weight_scales,
+    const int32_t* sorted_token_ids, const int32_t* expert_ids,
+    const float* topk_weights, void* output, int32_t* expert_counts,
+    int32_t* expert_offsets, int num_experts, int topk, int size_m, int size_n,
+    int size_k, int bits, int group_size, int zero_point, int data_type,
+    bool is_prefill, int64_t stream) {
+  auto cuda_stream = reinterpret_cast<cudaStream_t>(stream);
+  const auto* scales = static_cast<const float*>(weight_scales);
+  if (data_type == 0) {
+    if (bits == 4) launch_gemm<half, 4>(input, weights, scales, sorted_token_ids, expert_ids,
+                                         topk_weights, output, expert_counts, expert_offsets,
+                                         num_experts, topk, size_m, size_n, size_k, group_size,
+                                         zero_point, is_prefill, cuda_stream);
+    else if (bits == 8) launch_gemm<half, 8>(input, weights, scales, sorted_token_ids, expert_ids,
+                                              topk_weights, output, expert_counts, expert_offsets,
+                                              num_experts, topk, size_m, size_n, size_k, group_size,
+                                              zero_point, is_prefill, cuda_stream);
+  }
+#ifndef NO_BF16_KERNEL
+  else if (data_type == 1) {
+    if (bits == 4) launch_gemm<nv_bfloat16, 4>(input, weights, scales, sorted_token_ids, expert_ids,
+                                               topk_weights, output, expert_counts, expert_offsets,
+                                               num_experts, topk, size_m, size_n, size_k, group_size,
+                                               zero_point, is_prefill, cuda_stream);
+    else if (bits == 8) launch_gemm<nv_bfloat16, 8>(input, weights, scales, sorted_token_ids, expert_ids,
+                                                   topk_weights, output, expert_counts, expert_offsets,
+                                                   num_experts, topk, size_m, size_n, size_k, group_size,
+                                                   zero_point, is_prefill, cuda_stream);
+  }
+#endif
+}

--- a/mistralrs-quant/src/gptq/gptq_cuda.rs
+++ b/mistralrs-quant/src/gptq/gptq_cuda.rs
@@ -465,6 +465,13 @@ pub fn gptq_linear(
     };
 
     let is_awq = *is_awq;
+    // compressed-tensors checkpoints can leave selected modules (for example
+    // lm_head, embeddings, or router weights) in their original dense form.
+    // The global quantization config still reaches this loader, so prefer the
+    // dense tensor whenever the module was explicitly left unquantized.
+    if vb.contains_tensor("weight") {
+        return crate::linear_b(in_dim, out_dim, false, &None, vb);
+    }
     let mut required = vec!["qweight", "qzeros", "scales"];
     if !is_awq {
         required.push("g_idx");

--- a/mistralrs-quant/src/lib.rs
+++ b/mistralrs-quant/src/lib.rs
@@ -439,6 +439,7 @@ struct RawConfig {
     bits: Option<usize>,
     group_size: Option<usize>,
     checkpoint_format: Option<String>,
+    config_groups: Option<serde_json::Value>,
     weight_block_size: Option<Vec<usize>>,
     bnb_4bit_quant_type: Option<String>,
 }
@@ -452,18 +453,30 @@ impl<'de> Deserialize<'de> for QuantizedConfig {
         let raw = RawConfig::deserialize(deserializer)?;
 
         match &raw.quant_method {
-            Some(m) if m == "gptq" || m == "awq" => {
-                let bits = raw
-                    .bits
-                    .ok_or_else(|| serde::de::Error::missing_field("bits"))?;
-                let group_size = raw
-                    .group_size
-                    .ok_or_else(|| serde::de::Error::missing_field("group_size"))?;
+            Some(m) if m == "gptq" || m == "awq" || m == "compressed-tensors" => {
+                let (bits, group_size) = if m == "compressed-tensors" {
+                    compressed_tensor_params(&raw).ok_or_else(|| {
+                        serde::de::Error::custom(
+                            "compressed-tensors config is missing num_bits/group_size",
+                        )
+                    })?
+                } else {
+                    (
+                        raw.bits
+                            .ok_or_else(|| serde::de::Error::missing_field("bits"))?,
+                        raw.group_size
+                            .ok_or_else(|| serde::de::Error::missing_field("group_size"))?,
+                    )
+                };
                 Ok(QuantizedConfig::GptqAwq {
                     bits,
                     group_size,
-                    checkpoint_format: raw.checkpoint_format,
-                    is_awq: m == "awq",
+                    checkpoint_format: if m == "compressed-tensors" {
+                        Some("compressed-tensors".to_string())
+                    } else {
+                        raw.checkpoint_format
+                    },
+                    is_awq: m != "gptq",
                 })
             }
             Some(m) if m == "fp8" => {
@@ -503,6 +516,41 @@ impl<'de> Deserialize<'de> for QuantizedConfig {
             },
         }
     }
+}
+
+fn compressed_tensor_params(raw: &RawConfig) -> Option<(usize, usize)> {
+    if let (Some(bits), Some(group_size)) = (raw.bits, raw.group_size) {
+        return Some((bits, group_size));
+    }
+    fn visit(value: &serde_json::Value) -> Option<(usize, usize)> {
+        if let Some(object) = value.as_object() {
+            let bits = object
+                .get("num_bits")
+                .or_else(|| object.get("bits"))
+                .and_then(serde_json::Value::as_u64)
+                .map(|value| value as usize);
+            let group_size = object
+                .get("group_size")
+                .and_then(serde_json::Value::as_u64)
+                .map(|value| value as usize);
+            if let (Some(bits), Some(group_size)) = (bits, group_size) {
+                return Some((bits, group_size));
+            }
+            for child in object.values() {
+                if let Some(params) = visit(child) {
+                    return Some(params);
+                }
+            }
+        } else if let Some(array) = value.as_array() {
+            for child in array {
+                if let Some(params) = visit(child) {
+                    return Some(params);
+                }
+            }
+        }
+        None
+    }
+    raw.config_groups.as_ref().and_then(visit)
 }
 
 impl QuantizedConfig {

--- a/mistralrs-quant/src/moe/cuda.rs
+++ b/mistralrs-quant/src/moe/cuda.rs
@@ -59,6 +59,320 @@ mod ffi {
             expert_capacity: i32,
             stream: CUstream,
         );
+
+        pub fn moe_gemm_wmma_wna16(
+            input: *const c_void,
+            weights: *const u32,
+            weight_scales: *const c_void,
+            sorted_token_ids: *const i32,
+            expert_ids: *const i32,
+            topk_weights: *const f32,
+            output: *mut c_void,
+            expert_counts: *mut i32,
+            expert_offsets: *mut i32,
+            num_experts: i32,
+            topk: i32,
+            size_m: i32,
+            size_n: i32,
+            size_k: i32,
+            bits: i32,
+            group_size: i32,
+            zero_point: i32,
+            data_type: i32,
+            is_prefill: bool,
+            stream: i64,
+        );
+
+        pub fn moe_gemv_wna16(
+            input: *const c_void,
+            weights: *const u32,
+            weight_scales: *const c_void,
+            sorted_token_ids: *const i32,
+            expert_ids: *const i32,
+            topk_weights: *const f32,
+            output: *mut c_void,
+            num_experts: i32,
+            topk: i32,
+            size_m: i32,
+            size_n: i32,
+            size_k: i32,
+            bits: i32,
+            group_size: i32,
+            zero_point: i32,
+            data_type: i32,
+            stream: i64,
+        );
+    }
+}
+
+#[cfg(feature = "cuda")]
+#[allow(clippy::too_many_arguments)]
+pub fn moe_gemm_wna16(
+    input: &Tensor,
+    weights: &Tensor,
+    weight_scales: &Tensor,
+    topk_weights: Option<&Tensor>,
+    sorted_token_ids: &Tensor,
+    expert_ids: &Tensor,
+    topk: usize,
+    bits: usize,
+    group_size: usize,
+    is_prefill: bool,
+    zero_point: usize,
+) -> Result<Tensor> {
+    use candle_core::cuda::cudarc::driver::{CudaStream, DevicePtrMut, SyncOnDrop};
+    use core::ffi::c_void;
+    let dev = input.device().as_cuda_device()?;
+
+    fn tensor_ptr<'a>(
+        storage: &'a candle_core::CudaStorage,
+        dtype: candle_core::DType,
+        offset: usize,
+        stream: &'a CudaStream,
+    ) -> Result<(u64, SyncOnDrop<'a>)> {
+        let (ptr, guard) = match dtype {
+            candle_core::DType::F16 => {
+                let slice = storage.as_cuda_slice::<half::f16>()?;
+                slice_ptr_on_stream(slice, offset, stream)
+            }
+            candle_core::DType::BF16 => {
+                let slice = storage.as_cuda_slice::<half::bf16>()?;
+                slice_ptr_on_stream(slice, offset, stream)
+            }
+            candle_core::DType::F32 => {
+                let slice = storage.as_cuda_slice::<f32>()?;
+                slice_ptr_on_stream(slice, offset, stream)
+            }
+            candle_core::DType::U32 => {
+                let slice = storage.as_cuda_slice::<u32>()?;
+                slice_ptr_on_stream(slice, offset, stream)
+            }
+            candle_core::DType::I32 => {
+                let slice = storage.as_cuda_slice::<i32>()?;
+                slice_ptr_on_stream(slice, offset, stream)
+            }
+            dtype => candle_core::bail!("unsupported WNA16 tensor dtype {dtype:?}"),
+        };
+        Ok((ptr, guard))
+    }
+
+    fn cuda_fwd<
+        T: candle_core::cuda_backend::CudaDType + candle_core::cuda::cudarc::driver::DeviceRepr,
+    >(
+        input: &Tensor,
+        weights: &Tensor,
+        weight_scales: &Tensor,
+        topk_weights: Option<&Tensor>,
+        sorted_token_ids: &Tensor,
+        expert_ids: &Tensor,
+        topk: usize,
+        bits: usize,
+        group_size: usize,
+        is_prefill: bool,
+        zero_point: usize,
+        dev: &candle_core::CudaDevice,
+    ) -> Result<Tensor> {
+        let (input_rows, size_k) = input.dims2()?;
+        let (num_experts, size_n, packed_k) = weights.dims3()?;
+        if num_experts > 1024 {
+            candle_core::bail!("WNA16 MoE supports at most 1024 experts");
+        }
+        let output_rows = if topk_weights.is_some() {
+            input_rows
+        } else {
+            input_rows * topk
+        };
+        let expected_packed_k = (size_k + (32 / bits) - 1) / (32 / bits);
+        if !matches!(bits, 4 | 8) || packed_k != expected_packed_k {
+            candle_core::bail!("invalid WNA16 packed shape or bit width");
+        }
+        if group_size == 0 || !size_k.is_multiple_of(group_size) {
+            candle_core::bail!("WNA16 requires K divisible by group_size");
+        }
+        let expected_scale_shape = (num_experts, size_n, size_k / group_size);
+        if weight_scales.dims3()? != expected_scale_shape {
+            candle_core::bail!(
+                "invalid WNA16 scale shape: expected {:?}, got {:?}",
+                expected_scale_shape,
+                weight_scales.dims()
+            );
+        }
+        if weight_scales.dtype() != candle_core::DType::F32 {
+            candle_core::bail!("WNA16 scales must be F32, got {:?}", weight_scales.dtype());
+        }
+        let data_type = match input.dtype() {
+            candle_core::DType::F16 => 0,
+            candle_core::DType::BF16 => 1,
+            dtype => candle_core::bail!("WNA16 only supports F16/BF16 input, got {dtype:?}"),
+        };
+        let stream = dev.cuda_stream();
+        let (input_storage, input_layout) = input.storage_and_layout();
+        let (weights_storage, weights_layout) = weights.storage_and_layout();
+        let (scales_storage, scales_layout) = weight_scales.storage_and_layout();
+        let (sorted_storage, sorted_layout) = sorted_token_ids.storage_and_layout();
+        let (experts_storage, experts_layout) = expert_ids.storage_and_layout();
+        let Storage::Cuda(input_storage) = &*input_storage else {
+            candle_core::bail!("WNA16 input must be on CUDA")
+        };
+        let Storage::Cuda(weights_storage) = &*weights_storage else {
+            candle_core::bail!("WNA16 weights must be on CUDA")
+        };
+        let Storage::Cuda(scales_storage) = &*scales_storage else {
+            candle_core::bail!("WNA16 scales must be on CUDA")
+        };
+        let Storage::Cuda(sorted_storage) = &*sorted_storage else {
+            candle_core::bail!("WNA16 sorted ids must be on CUDA")
+        };
+        let Storage::Cuda(experts_storage) = &*experts_storage else {
+            candle_core::bail!("WNA16 expert ids must be on CUDA")
+        };
+        let (input_ptr, _input_guard) = tensor_ptr(
+            input_storage,
+            input.dtype(),
+            input_layout.start_offset(),
+            &stream,
+        )?;
+        let (weights_ptr, _weights_guard) = tensor_ptr(
+            weights_storage,
+            weights.dtype(),
+            weights_layout.start_offset(),
+            &stream,
+        )?;
+        let (scales_ptr, _scales_guard) = tensor_ptr(
+            scales_storage,
+            weight_scales.dtype(),
+            scales_layout.start_offset(),
+            &stream,
+        )?;
+        let (sorted_ptr, _sorted_guard) = tensor_ptr(
+            sorted_storage,
+            sorted_token_ids.dtype(),
+            sorted_layout.start_offset(),
+            &stream,
+        )?;
+        let (experts_ptr, _experts_guard) = tensor_ptr(
+            experts_storage,
+            expert_ids.dtype(),
+            experts_layout.start_offset(),
+            &stream,
+        )?;
+        let topk_storage = topk_weights.map(Tensor::storage_and_layout);
+        let (topk_ptr, _topk_guard) =
+            if let Some((topk_storage, topk_layout)) = topk_storage.as_ref() {
+                let topk_weights = topk_weights.expect("top-k storage without top-k tensor");
+                let Storage::Cuda(topk_storage) = &**topk_storage else {
+                    candle_core::bail!("WNA16 top-k weights must be on CUDA")
+                };
+                let (ptr, guard) = tensor_ptr(
+                    topk_storage,
+                    topk_weights.dtype(),
+                    topk_layout.start_offset(),
+                    &stream,
+                )?;
+                (ptr as *const f32, Some(guard))
+            } else {
+                (std::ptr::null(), None)
+            };
+        let (input_ptr, weights_ptr, scales_ptr, sorted_ptr, experts_ptr) = (
+            input_ptr as *const c_void,
+            weights_ptr as *const u32,
+            scales_ptr as *const c_void,
+            sorted_ptr as *const i32,
+            experts_ptr as *const i32,
+        );
+        let stream_id = stream.cu_stream() as i64;
+        let mut output = unsafe { dev.alloc::<T>(output_rows * size_n) }?;
+        let (output_ptr, _output_guard) = output.device_ptr_mut(&stream);
+
+        if is_prefill {
+            let mut counts = unsafe { dev.alloc::<i32>(num_experts) }?;
+            let mut offsets = unsafe { dev.alloc::<i32>(num_experts + 1) }?;
+            unsafe {
+                ffi::moe_gemm_wmma_wna16(
+                    input_ptr,
+                    weights_ptr,
+                    scales_ptr,
+                    sorted_ptr,
+                    experts_ptr,
+                    topk_ptr,
+                    output_ptr as *mut c_void,
+                    counts.device_ptr_mut(&stream).0 as *mut i32,
+                    offsets.device_ptr_mut(&stream).0 as *mut i32,
+                    num_experts as i32,
+                    topk as i32,
+                    output_rows as i32,
+                    size_n as i32,
+                    size_k as i32,
+                    bits as i32,
+                    group_size as i32,
+                    zero_point as i32,
+                    data_type,
+                    true,
+                    stream_id,
+                );
+            }
+        } else {
+            unsafe {
+                ffi::moe_gemv_wna16(
+                    input_ptr,
+                    weights_ptr,
+                    scales_ptr,
+                    sorted_ptr,
+                    experts_ptr,
+                    topk_ptr,
+                    output_ptr as *mut c_void,
+                    num_experts as i32,
+                    topk as i32,
+                    output_rows as i32,
+                    size_n as i32,
+                    size_k as i32,
+                    bits as i32,
+                    group_size as i32,
+                    zero_point as i32,
+                    data_type,
+                    stream_id,
+                );
+            }
+        }
+
+        drop(_output_guard);
+        let storage = candle_core::CudaStorage::wrap_cuda_slice(output, dev.clone());
+        Ok(Tensor::from((
+            Storage::Cuda(storage),
+            (output_rows, size_n),
+        )))
+    }
+
+    match input.dtype() {
+        candle_core::DType::F16 => cuda_fwd::<half::f16>(
+            input,
+            weights,
+            weight_scales,
+            topk_weights,
+            sorted_token_ids,
+            expert_ids,
+            topk,
+            bits,
+            group_size,
+            is_prefill,
+            zero_point,
+            dev,
+        ),
+        candle_core::DType::BF16 => cuda_fwd::<half::bf16>(
+            input,
+            weights,
+            weight_scales,
+            topk_weights,
+            sorted_token_ids,
+            expert_ids,
+            topk,
+            bits,
+            group_size,
+            is_prefill,
+            zero_point,
+            dev,
+        ),
+        dtype => candle_core::bail!("WNA16 only supports F16/BF16 input, got {dtype:?}"),
     }
 }
 


### PR DESCRIPTION
Add support for AWQ MoE model support, tested with:

```
cargo build --release --features cuda,nccl
CUDA_VISIBLE_DEVICES=0 target/release/mistralrs run -m cyankiwi/Qwen3-Coder-Next-AWQ-4bit
```

Perf **w/o** flashattn

```
CLI time to first token: 0.14s
Prompt: 579 tokens, 4226.28 T/s
Decode: 1550 tokens, 61.83 T/s
Prefix cache: 1 hits / 2 turns
Sampling: temp=1, top_k=40, top_p=0.95, min_p=off
```