### PR TITLE
Fix Qwen3 and other GGUF device mismatch when layers are split across CPU and GPU

### DIFF
--- a/mistralrs-core/src/models/quantized_phi3.rs
+++ b/mistralrs-core/src/models/quantized_phi3.rs
@@ -409,7 +409,9 @@ impl ModelWeights {
             let ys = layer.mlp.forward(&ys)?;
             xs = (ys + residual)?
         }
+        // Trailing layers may be device mapped to CPU; the norm weight is not.
         let xs = xs
+            .to_device(&self.device)?
             .apply(&self.output_norm)?
             .i((.., seq_len - 1, ..))?
             .contiguous()?;

--- a/mistralrs-core/src/models/quantized_qwen.rs
+++ b/mistralrs-core/src/models/quantized_qwen.rs
@@ -486,6 +486,8 @@ impl ModelWeights {
             let x = (x + residual)?;
             layer_in = x;
         }
+        // Trailing layers may be device mapped to CPU; the norm weight is not.
+        let layer_in = layer_in.to_device(&self.device)?;
         let x = self.norm.forward(&layer_in)?;
         let x = extract_logits(&x, context_lens)?;
         self.output.forward(&x.contiguous()?)

--- a/mistralrs-core/src/models/quantized_qwen3.rs
+++ b/mistralrs-core/src/models/quantized_qwen3.rs
@@ -455,6 +455,8 @@ impl ModelWeights {
             let x = (x + residual)?;
             layer_in = x;
         }
+        // Trailing layers may be device mapped to CPU; the norm weight is not.
+        let layer_in = layer_in.to_device(&self.device)?;
         let x = self.norm.forward(&layer_in)?;
         let x = extract_logits(&x, context_lens)?;
         self.output.forward(&x.contiguous()?)

--- a/mistralrs-core/src/models/quantized_qwen3_moe.rs
+++ b/mistralrs-core/src/models/quantized_qwen3_moe.rs
@@ -575,6 +575,8 @@ impl ModelWeights {
             let x = (x + residual)?;
             layer_in = x;
         }
+        // Trailing layers may be device mapped to CPU; the norm weight is not.
+        let layer_in = layer_in.to_device(&self.device)?;
         let x = self.norm.forward(&layer_in)?;
         let x = extract_logits(&x, context_lens)?;
         self.output.forward(&x.contiguous()?)

--- a/mistralrs-core/src/models/quantized_starcoder2.rs
+++ b/mistralrs-core/src/models/quantized_starcoder2.rs
@@ -402,7 +402,9 @@ impl ModelWeights {
             let ys = layer.mlp.forward(&ys)?;
             xs = (ys + residual)?
         }
+        // Trailing layers may be device mapped to CPU; the norm weight is not.
         let xs = xs
+            .to_device(&self.device)?
             .apply(&self.output_norm)?
             .i((.., seq_len - 1, ..))?
             .contiguous()?;


### PR DESCRIPTION
The final norm runs on the primary device, but device mapping may place trailing layers on CPU, so the hidden state reaching it can be a CPU tensor: rms-norm then fails with `device mismatch, lhs: Cpu, rhs: Cuda`. Move the tensor back before the norm, as quantized_llama.rs already does.

-----

This issue was debugged and fixed by AI. I'm not familiar enough with the repo to know whether it's appropriate. However the change is small and the "as quantized_llama.rs already does" lends an air of correctness. I gather qwen3 support is fairly recent. Take it if it's obviously useful, otherwise I can file an issue with repro instructions.