### PR TITLE
YaRN rope scaling, 4-bit F4 packed KV cache, and hybrid paged attention for Qwen3.5-Next long-context serving

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,6 @@ docs/node_modules/
 docs/dist/
 docs/.astro/
 out/
+/bin
+/graphify-out
+/graphify-rs-out

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19,15 +19,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "415ed64958754dbe991900f3940677e6a7eefb4d7367afd70d642677b0c7d19d"
 
 [[package]]
-name = "addr2line"
-version = "0.25.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b5d307320b3181d6d7954e663bd7c774a838b8220fe0593c86d9fb09f498b4b"
-dependencies = [
- "gimli",
-]
-
-[[package]]
 name = "adler2"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -141,7 +132,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -152,17 +143,14 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
 name = "anyhow"
-version = "1.0.100"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a23eb6b1614318a8071c9b2521f36b424b2c83db5eb3a0fead4a6c0809af6e61"
-dependencies = [
- "backtrace",
-]
+checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 
 [[package]]
 name = "apodize"
@@ -377,21 +365,6 @@ dependencies = [
  "tower-layer",
  "tower-service",
  "tracing",
-]
-
-[[package]]
-name = "backtrace"
-version = "0.3.76"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb531853791a215d7c62a30daf0dde835f381ab5de4589cfe7c649d2cbe92bd6"
-dependencies = [
- "addr2line",
- "cfg-if",
- "libc",
- "miniz_oxide",
- "object",
- "rustc-demangle",
- "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -1068,9 +1041,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]
@@ -1645,7 +1618,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users 0.5.2",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1845,7 +1818,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2456,7 +2429,7 @@ dependencies = [
  "libc",
  "log",
  "rustversion",
- "windows-link 0.2.1",
+ "windows-link 0.1.3",
  "windows-result 0.4.1",
 ]
 
@@ -2527,12 +2500,6 @@ dependencies = [
  "color_quant",
  "weezl",
 ]
-
-[[package]]
-name = "gimli"
-version = "0.32.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e629b9b98ef3dd8afe6ca2bd0f89306cec16d43d907889945bc5d6687f2f13c7"
 
 [[package]]
 name = "glob"
@@ -3519,9 +3486,9 @@ checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
 
 [[package]]
 name = "memmap2"
-version = "0.9.9"
+version = "0.9.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "744133e4a0e0a658e1374cf3bf8e415c4052a15a111acd372764c55b4177d490"
+checksum = "d1219ed1b7f229ee7104d281dd01d6802fe28bb6e95d292942c4daacdeb798c0"
 dependencies = [
  "libc",
  "stable_deref_trait",
@@ -4148,7 +4115,7 @@ dependencies = [
  "num-complex",
  "num-rational",
  "num-traits",
- "rand 0.8.5",
+ "rand 0.8.6",
  "rand_distr 0.4.3",
  "simba",
  "typenum",
@@ -4251,7 +4218,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4661,7 +4628,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c80231409c20246a13fddb31776fb942c38553c51e871f8cbd687a4cfb5843d"
 dependencies = [
  "phf_shared 0.11.3",
- "rand 0.8.5",
+ "rand 0.8.6",
 ]
 
 [[package]]
@@ -5052,9 +5019,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.14"
+version = "0.11.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+checksum = "4fcb935c5bec503c2f0e306bdd3e58bb9029dcb14fa8d9ac76e3a5256ac0763e"
 dependencies = [
  "aws-lc-rs",
  "bytes",
@@ -5113,9 +5080,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.8.5"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
 dependencies = [
  "libc",
  "rand_chacha 0.3.1",
@@ -5177,7 +5144,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32cb0b9bc82b0a0876c2dd994a7e7a2683d3e7390ca40e6886785ef0c7e3ee31"
 dependencies = [
  "num-traits",
- "rand 0.8.5",
+ "rand 0.8.6",
 ]
 
 [[package]]
@@ -5610,12 +5577,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rustc-demangle"
-version = "0.1.27"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b50b8869d9fc858ce7266cce0194bd74df58b9d0e3f6df3a9fc8eb470d95c09d"
-
-[[package]]
 name = "rustc-hash"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5673,7 +5634,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.11.0",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -5732,7 +5693,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -6341,7 +6302,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "psm",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -6359,7 +6320,7 @@ dependencies = [
  "approx",
  "nalgebra",
  "num-traits",
- "rand 0.8.5",
+ "rand 0.8.6",
 ]
 
 [[package]]
@@ -6687,9 +6648,9 @@ dependencies = [
 
 [[package]]
 name = "tar"
-version = "0.4.45"
+version = "0.4.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22692a6476a21fa75fdfc11d452fda482af402c008cdbaf3476414e122040973"
+checksum = "3f6221d9a6003c78398e3b239969f352578258df48c8eb051caadae0015bc840"
 dependencies = [
  "filetime",
  "libc",
@@ -6712,7 +6673,7 @@ dependencies = [
  "getrandom 0.3.4",
  "once_cell",
  "rustix 1.1.3",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -7822,7 +7783,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/F4-KV-STORAGE-ASSESSMENT.md
+++ b/F4-KV-STORAGE-ASSESSMENT.md
@@ -1,0 +1,93 @@
+# F4 (4-bit) KV cache storage assessment — Phase 0 evidence
+
+Date: 2026-08-16. Unit 3 (llama.cpp-equivalent long context) Phase 0.
+All claims verified against the pinned candle-core git dependency at rev
+35d7ae7ca5c93e17c77359c3617376b8a72e96a4 (Cargo.lock) and the mistral.rs
+working tree at HEAD 6f4b4cce4.
+
+## Verdict
+
+candle-core 0.11.0 (rev 35d7ae7) CANNOT store or cast DType::F4 on CUDA.
+The 4-bit KV cache must use custom packed storage on DType::U8 tensors with
+pack/unpack inside the mistralrs-paged-attn kernels (llama.cpp-style). This
+matches the fallback the plan anticipated; no candle patch is needed.
+
+## Evidence, from the pinned candle source
+
+- DType::F4 exists (candle-core/src/dtype.rs:35) with size_in_bytes() == 0
+  (dtype.rs:110) and a CUDA storage variant CudaStorageSlice::F4(CudaSlice<u8>)
+  (cuda_backend/mod.rs:114).
+- CUDA allocation is REJECTED: CudaDevice::alloc_uninit rejects
+  DType::F6E2M3 | F6E3M2 | F4 | F8E8M0 with "Dummy types not supported in CUDA
+  backend" (cuda_backend/device.rs:644). Tensor::empty(.., DType::F4, cuda)
+  therefore fails. This is the alloc path CacheEngine::allocate_gpu_cache uses
+  for the KV block tensors (cache_engine.rs:164, 209, 266, 325).
+- CUDA casts are REJECTED both directions: to_dtype rejects F4 as a source
+  (cuda_backend/mod.rs:1564, UnsupportedDtype op to_dtype) and as a target
+  (mod.rs:1672, "Dummy types not supported in CUDA backend").
+- No F4 cast kernels exist in candle-kernels (cast.cu defines casts only for
+  f16/bf16/f32/f64/u8/u32/fp8).
+
+## Design implication for Phase 2b
+
+- PagedCacheType::F4 is added to the enum (cache_engine.rs:13-17) and its
+  to_dtype returns DType::U8 for storage, not DType::F4.
+- Block shape math (cache_engine.rs:379-390) needs a sub-byte branch: today
+  x = 16 / element_size, which divides by zero for F4 (size_in_bytes() == 0).
+  For F4 use x = 32 (16 bytes per x-row, 2 values per byte), keeping the same
+  byte stride as the F8E4M3 layout so the kernel pointer math stays uniform.
+- The kernels already take cache_dtype + k_scale/v_scale pointers (paged-attn
+  ffi.rs: reshape_and_cache, paged_attention_v1/v2_*, gather_kv_cache), so an
+  F4 branch means in-kernel pack (F32 -> 4-bit + block scale) on write and
+  dequant on read, mirroring the existing F8E4M3 + kv_scale_update flow
+  (paged_attention.rs:747-760, update_kvscales.cu).
+- Reference format: llama.cpp q4_0 KV blocks (f16 scale per 32 values,
+  4-bit symmetric values biased by 8), the format of the reference
+  implementation this unit is matching.
+
+## KV cache numbers (authoritative, source-derived)
+
+Model: Qwen3.6-14B-A3B FableVibes Q4_K_M, architecture qwen35moe.
+Full-attention geometry (GGUF tensor shapes + config.rs ModelConfigMetadata
+at qwen3_next.rs:925-937): 16 Q heads x 256, 2 KV heads x 256 (K and V both
+256), so 1024 KV elements per token per layer.
+
+- Today (40 layers paged, BF16): 80 KB/token -> 640 MiB at 8192 (measured,
+  matches the block math: 256 blocks x 40 layers x 64 KB/block).
+- With Phase 2a (10 paged layers): BF16 20 KB/token, F8E4M3 10 KB/token,
+  F4 5 KB/token (0.5 B/el) or ~5.6 KB/token (q4_0 with f16 scales).
+- At 320000 tokens: F8E4M3 ~3.1 GiB, F4 ~1.56 GiB (0.5 B/el).
+  The handoff's "4.88 KB/token" (F4) and "9.77 KB/token" (F8E4M3) figures
+  were close but derived from a slightly different element count; the
+  authoritative per-token figures are 5 KB/token (F4) and 10 KB/token
+  (F8E4M3).
+
+## GDN prefill accounting (Phase 3 ground truth)
+
+The deployed CUDA build never runs the CPU f32 path the plan assumed.
+apply_recurrence (gdn/backend.rs:487-500) dispatches CUDA devices to
+recurrence_cuda; RECURRENCE_CHUNK_THRESHOLD = 64 (backend.rs:9), so any
+prefill >= 64 tokens uses chunked_gated_delta_rule_recurrence_cuda or
+warp_gated_delta_rule_recurrence_cuda (head_k_dim 64|128) — both already
+memory-light. Per GDN layer, sequential peak:
+
+- q/k/v/g/beta prep buffers (cuda/gdn.rs:553-558): 16 k-heads x 128 and 32
+  v-heads x 128 in f32 -> ~40 KB/token.
+- output_buf (cuda/gdn.rs:187): bh x v_dim f32 -> 8 KB/token.
+- mixed_qkv input (conv_dim = 2 x 2048 + 4096 = 6144) -> ~24 KB/token.
+- Total ~72 KB/token per layer, freed per layer (30 GDN layers run
+  sequentially). This does NOT explain the measured "~0.48 MB/token"
+  (+480 MB for a 1k prompt). Phase 3 must re-measure empirically before
+  changing anything; the CUDA path is already chunked.
+
+## Repro
+
+mistralrs-core/tests/f4_cache_storage.rs in this unit:
+- Asserts candle F4 size_in_bytes() == 0 (sub-byte).
+- Asserts a CUDA F4 Tensor::empty fails with the expected "Dummy types"
+  error (cuda feature gate).
+- Asserts a DType::U8 CUDA tensor round-trips (the storage vehicle for the
+  packed cache).
+- Asserts the q4_0-style pack/unpack round-trip on CPU U8 storage closes to
+  the original f32 values within the format's tolerance (2^-4 relative on
+  the block scale).

--- a/OSV-EVIDENCE.md
+++ b/OSV-EVIDENCE.md
@@ -1,0 +1,79 @@
+OSV vulnerability scan evidence - mistral.rs workspace
+Date: 2026-08-16
+Method: osv__osv_map_dependencies on /data/mistral.rs (reads Cargo.lock, OSV batch API)
+Baseline: 804 packages scanned, 13 vulnerable packages (18 advisory ids)
+
+Fixes applied (cargo update --precise, Cargo.lock only, no manifest changes):
+
+1. anyhow 1.0.100 -> 1.0.103
+   RUSTSEC-2026-0190: unsoundness in Error::downcast_mut after Error::context.
+   Direct dependency. Patch-level semver-compatible bump.
+
+2. crossbeam-epoch 0.9.18 -> 0.9.20
+   RUSTSEC-2026-0204: invalid pointer dereference in fmt::Pointer for Atomic/Shared.
+   Transitive. Patch-level bump.
+
+3. memmap2 0.9.9 -> 0.9.11
+   RUSTSEC-2026-0186: unchecked pointer offset in advise_range/flush_range.
+   Transitive. Patch-level bump.
+
+4. quinn-proto 0.11.14 -> 0.11.15
+   GHSA-4w2j-m93h-cj5j / RUSTSEC-2026-0185 (CVE-2026-25800): remote memory
+   exhaustion via out-of-order stream reassembly. Transitive. Patch-level bump.
+
+5. rand 0.8.5 -> 0.8.6
+   GHSA-cq8v-f236-94qc / RUSTSEC-2026-0097: unsound with custom logger calling
+   rand::rng() plus reseed plus trace logging. Transitive. Patch-level bump.
+
+6. tar 0.4.45 -> 0.4.46
+   GHSA-3pv8-6f4r-ffg2: PAX header desynchronization on crafted archives.
+   Transitive. Patch-level bump.
+
+Re-scan after fixes: 800 packages scanned, 8 vulnerable packages remain.
+
+Accepted risk (no fix applied, reasoning per package):
+
+1. aws-lc-sys 0.37.0 (10 advisories; records read: GHSA-394x-vwmw-crm3 CN
+   name-constraints bypass, GHSA-65p9-r9h6-22vj AES-CCM tag timing side
+   channel, GHSA-9f94-5g5w-gf6r CRL distribution point logic error).
+   All three are TLS/certificate-path issues in the crypto library behind
+   rustls. This deployment serves plain HTTP on 0.0.0.0:8891 with no TLS
+   listener, so the rustls path is not exercised. Fix requires aws-lc-sys
+   0.39.0, a minor-line jump that ripples through aws-lc-rs/rustls in the
+   lockfile and diverges from the upstream-pinned tree. Accepted: TLS not
+   reachable in this deployment.
+
+2. pyo3 0.25.1 (RUSTSEC-2026-0176 OOB read in PyList/PyTuple iterators;
+   GHSA-chgr-c6px-7xpp missing Sync bound on PyCFunction closures).
+   pyo3 is compiled only into mistralrs-pyo3 (the Python SDK crate), which
+   is not part of the mistralrs-cli binary built in this session. Fix
+   (0.29.0) is a four-minor upgrade. Accepted: crate not in the deliverable.
+
+3. core2 0.4.0 (RUSTSEC-2026-0105): unmaintained, all versions yanked, no
+   fix version. Transitive. Accepted.
+
+4. fxhash 0.2.1 (RUSTSEC-2025-0057): unmaintained, no fix version.
+   Transitive. Accepted.
+
+5. number_prefix 0.4.0 (RUSTSEC-2025-0119): unmaintained, no fix version.
+   Transitive (via comfy-table). Accepted.
+
+6. paste 1.0.15 (RUSTSEC-2024-0436): unmaintained, no fix version.
+   Build-time proc macro. Accepted.
+
+7. proc-macro-error2 2.0.1 (RUSTSEC-2026-0173): unmaintained, no fix
+   version. Build-time proc macro. Accepted.
+
+Notes:
+- Cargo.lock is modified relative to upstream; revert with
+  git checkout -- Cargo.lock if upstream tracking is preferred.
+- Re-scan before the next release and whenever the lockfile changes;
+  OSV.dev only knows advisories published so far.
+- Re-scan 2026-08-16 (after the cuda_topk fix, no lockfile change):
+  800 packages scanned, 7 vulnerable packages (10 advisory ids) -
+  exactly the accepted-risk set listed above. No new findings.
+- Re-scan 2026-08-16 (after Units 1-2 of feat/qwen35-native-context-fix:
+  recurrent snapshot host parking + 2048 prefill chunk + flash-attn build;
+  no lockfile change - flash-attn uses existing workspace members):
+  800 packages scanned, 7 vulnerable packages (10 advisory ids) - same
+  accepted-risk set. No new findings.

--- a/YARN-SOURCE-VERIFICATION.md
+++ b/YARN-SOURCE-VERIFICATION.md
@@ -1,0 +1,189 @@
+YaRN source verification - Phase A evidence (2026-08-16)
+==========================================================
+
+Branch: feat/qwen35-yarn-long-context. Scope: pin the qwen35 YaRN partial
+rotary to the reference implementations before any rebuild or serve.
+Reference order (rule 15): llama.cpp source at /data/llama.cpp first, the
+in-repo DeepSeek yarn as pattern, HF yarn formulas cited in llama.cpp
+comments only. Nothing here was invented from memory; every number below
+reproduces the llama.cpp code path.
+
+Section 1 - What llama.cpp actually computes for Qwen3.5 YaRN
+
+Command-level inputs (the planned serve equivalence):
+  --rope-scaling yarn --rope-scale 1.220703125 --yarn-orig-ctx 262144
+This sets rope_freq_scale = 1/1.220703125 = 0.8192 exactly
+(arg.cpp:2333-2339). yarn_ext_factor defaults to 1.0 for YARN
+(llama-context.cpp:172-174).
+
+The GGUF carries NO rope.scaling metadata (only dimension_count 64,
+dimension_sections [11,11,10,0], freq_base 1e7), so hparams.rope_yarn_log_mul
+== 0 and the log-multiplier branch in llama-context.cpp is skipped:
+
+  yarn_attn_factor = get_mscale(factor, 1.0)              (else branch, line 202)
+  yarn_attn_factor *= 1 / (1 + 0.1*log(factor))           (cancellation, line 210)
+  yarn_attn_factor *= rope_attn_factor (1.0)              (line 213)
+
+  get_mscale(scale, m) = scale > 1.0 ? 0.1*m*log(scale) + 1.0 : 1.0  (lines 177-179)
+  factor = 1/freq_scale = 1.220703125, log(factor) = 0.19942702
+
+So yarn_attn_factor = (1.0199427025) * (1/1.0199427025) * 1.0 = 1.0.
+This is the value that reaches ggml as the rope mscale/attn_factor op
+param (llama-graph.cpp:1449).
+
+The ggml rope kernel then REWRITES that mscale for ext_factor != 0
+(ops.cpp rope_yarn, lines 5838-5845):
+
+  mscale *= 1.0 + 0.1*logf(1.0/freq_scale) = 1.0 + 0.1*log(factor)
+          = 1.0199427025
+
+NET TABLE SCALE = yarn_attn_factor * (1 + 0.1*log(factor)) = 1.0199427025.
+The cancellation in llama-context.cpp and the re-fold in the kernel cancel
+against each OTHER; the leftover is get_mscale(factor, 1.0). A naive read
+of only llama-context.cpp (yarn_attn_factor == 1.0) is therefore wrong.
+
+Correctness trap (why the empty GGUF matters): the DeepSeek branch
+(llama-context.cpp:184-200) divides get_mscale(factor, mscale) by
+get_mscale(factor, mscale_all_dim) because DeepSeek's GGUF carries
+rope.scaling.yarn_log_multiplier. DeepSeek models additionally pre-scale the
+attention kq_scale in llama.cpp (deepseek2.cpp:438-446). Qwen3.5 has none
+of that: qwen35moe.cpp:344 keeps kq_scale = 1/sqrt(head_dim) and the only
+magnitude scaling is the 1.0199427025 folded into the rope tables. The
+DeepSeek attention-scale pattern must NOT be copied into qwen3_next.
+
+Section 2 - The rope cache geometry (mrope reduces to neox partial on text)
+
+llama-model.cpp:2726-2732 pins QWEN35/QWEN35MOE to LLAMA_ROPE_TYPE_IMROPE.
+For text batches llama-batch.cpp:781-788 broadcasts the one position to all
+four sections (src_off = batch.token ? 0 : j*n_tokens). In
+ggml_mrope_cache_init (ops.cpp:5866-5929) the four thetas all start at that
+same position and each is advanced by theta_scale = base^(-2/n_dims) per
+cache pair, so the sector selection (ops.cpp:5888-5919) always picks an
+identical theta regardless of section. The claim IMROPE equals NEOX partial
+on text holds for any rot dim because the section bases never differ for
+text; for Qwen3.5 specifically n_rot = 64 = 2 * (11+11+10+0) so the dim
+pairs tile the section cycle exactly. rotate_pairs (ops.cpp:5933-5943)
+rotates dims (p, p + n_dims/2) with the cos/sin built for cache pair p, so
+the value probe below compares one-to-one with new_partial_yarn's table.
+
+corr_dims (ggml.c:4367-4381), with beta_fast = 32, beta_slow = 1:
+  corr_dim(32) = 64*ln(262144/(32*2*pi))/(2*ln(1e7)) = 14.2411 -> low  = 14
+  corr_dim(1)  = 64*ln(262144/(1*2*pi))/(2*ln(1e7))  = 21.1284 -> high = 22
+  mistral.rs new_partial_yarn (layers.rs:2999-3004) matches (clamp to the
+  pair count does not bite for these values).
+
+Section 3 - Value evidence (exact llama.cpp pipeline vs new_partial_yarn)
+
+Reference: /tmp/yarn_ref_llamacpp.py, which executes llama-context.cpp
+get_mscale plus cancellation, ggml.c corr_dims, ops.cpp rope_yarn ramp and
+mscale re-fold, and the shared theta_scale = 1e7^(-2/64). Results:
+
+  corr_dims [14, 22]; theta_scale = 0.6042963902; net mscale = 1.0199427025.
+
+Position 262145 (first beyond native), pair -> (sin, cos):
+  pair  0  llama.cpp (-0.9015606498, -0.4769397353)  mistral (-0.9015606498, -0.4769397353)
+  pair 15  llama.cpp ( 0.8629114077, -0.5437527184)  mistral ( 0.8629114077, -0.5437527184)
+  pair 30  llama.cpp ( 0.0599455498,  1.0181795752)  mistral ( 0.0599455498,  1.0181795752)
+
+The working-tree expectations in yarn_rotary.rs match to the last digit and
+pass. The cos magnitude above 1.0 at pair 30 is the net mscale > 1 acting
+on the table, exactly as in llama.cpp.
+
+Boundary probes (added as yarn_matches_llama_cpp_reference_at_boundary_positions):
+  pos 262144 pair 30: (0.0599453214, 1.0181795887)
+  pos 262145 pair 30: (0.0599455498, 1.0181795752)
+  pos 319999 pair 13: (-0.1119046827, 1.0137852131)
+  pos 319999 pair 30: (0.0731545384, 1.0173158457)
+
+High-frequency pairs (below corr low = 14) are pure extrapolation times the
+net mscale: yarn/plain ratio measured 1.0199427025 for pairs 0, 5, 13 at
+position 262145 - identical to get_mscale(1.220703125, 1.0).
+
+Section 4 - The wrong fix that was reverted
+
+Commit 641c8cd49 (qwen-model session) removed the '* yarn_mscale(factor,
+1.0)' term, setting effective_mscale = 1.0 and correcting the golden
+expectations to (-0.883932644, -0.467614244) and similar. It read
+llama-context.cpp yarn_attn_factor == 1.0 as the final table scale and
+missed the kernel re-fold of (1 + 0.1*log(factor)) in ops.cpp rope_yarn
+(lines 5838-5845). Those expectations match no llama.cpp execution path.
+The commit was dropped (the branch was unpushed) and the original
+cherry-pick code confirmed against the reference.
+
+Section 5 - Verification run (this session)
+
+  cargo test -p mistralrs-core --test yarn_rotary
+    yarn_matches_llama_cpp_reference_at_position_262145         ok
+    yarn_high_frequency_pairs_are_pure_extrapolation_scaled_by_mscale ok
+    yarn_table_extends_to_the_scaled_context                    ok
+    yarn_matches_llama_cpp_reference_at_boundary_positions      ok (added)
+  cargo test -p mistralrs-core --lib qwen35moe_yarn_override
+    qwen35moe_yarn_override_extends_context_and_synthesizes_rope_scaling ok
+    qwen35moe_yarn_override_wins_over_gguf_scaling_metadata             ok
+
+  RopeOverride to apply_rope_override (normal_config.rs:195-237) produces
+  rope_type yarn, factor 1.220703125, original ctx 262144, beta 32/1, and
+  synthesized mscale = 1.0 / mscale_all_dim = 1.0 (no GGUF scaling metadata
+  to read). supports_rope_override accepts Qwen3Next and Qwen3_5
+  (normal_config.rs:167-172). The synthesized mscale pair is what collapses
+  new_partial_yarn's ratio to the single llama.cpp net factor.
+
+Section 6 - Conclusion
+
+No divergence found between mistral.rs new_partial_yarn and the llama.cpp
+YaRN pipeline for the Qwen3.5 synthesized config. Effective table mscale is
+1.0199427025 in both engines; attention stays at 1/sqrt(head_dim) in both.
+Phase A is complete; the next step is Phase B (CUDA rebuild of bin/mistralrs),
+then Phase C (serve at 320000).
+
+Section 7 - Rebuild and serve verification (Phases B-C, 2026-08-16)
+
+Phase B: rebuilt bin/mistralrs with cuda + flash-attn
+(PATH=/usr/local/cuda/bin cargo build --release --bin mistralrs --features
+"cuda flash-attn"; 1m32s, all kernels cached). Copied to bin/ and verified
+the serve subcommand exposes --rope-scaling, --rope-scale, --yarn-orig-ctx,
+--override-ctx, --paged-attn, --pa-context-len, --pa-cache-type. Binary
+reports git revision 5c594e8b2.
+
+Phase C launch on the 12 GB RTX 4070 SUPER (port 8891, log
+/tmp/mistralrs-qwen-yarn.log):
+
+  bin/mistralrs serve -m /home/leandro/models/qwen36-a3b
+    -f /home/leandro/models/qwen36-a3b/Qwen3.6-14B-A3B-FableVibes-Q4_K_M.gguf
+    --port 8891 --host 0.0.0.0 --max-seqs 1
+    --paged-attn on --pa-context-len 320000 --pa-cache-type f4
+    --rope-scaling yarn --rope-scale 1.220703125 --yarn-orig-ctx 262144
+
+Boot markers observed: PagedAttention KV cache type F4 (packed u8);
+10000 GPU blocks, available context length 320000 tokens; 40 layers all on
+cuda[0]; model loaded; /health OK; smoke completion OK.
+
+Context proof (ctx_proof.py, target 320000, incremental turns, block-level
+prefix caching):
+  run 1: served prompts up to ~252k tokens with 99.83% prefix-cache hit
+  rate and 267-272 T/s decode, then the step failed with
+  CUDA_ERROR_OUT_OF_MEMORY (server survived and kept serving). GPU peak
+  11807 MiB of 12282 MiB; cache cost measured 176 KB per 32-token block,
+  i.e. 5.5 KB/token F4. The failing request was short the final ~370 MB
+  of cache blocks. Cause: total VRAM pressure (weights ~9.1 GB + CUDA
+  context + growing F4 cache), not a YaRN bug; positions 262145+ were not
+  reached in run 1.
+  run 2 (after closing Discord/Chrome GPU consumers, +~0.5 GB headroom):
+  reached prompt 275837 / 280261 total on turn 1110 without OOM - past
+  run 1's death point (252k) - then killed by the user before the 320000
+  target and its recall check ran. Reclaiming the ~0.5 GB of non-server
+  GPU memory was enough to cross the earlier ceiling; the F4 cache never
+  overflowed on this run (GPU stayed under ~11.8 GB used).
+
+VRAM arithmetic: the F4 per-token cost measured (5.5 KB/token) matches
+packed U8 storage (16 bytes per 32 values); the 2x budget over-report in
+the startup log is cosmetic (Phase E) - correcting it reallocates no
+actual GPU memory, so it cannot unlock 320000 on this card.
+
+RAM offload, for the record: CPU host layers are supported via an explicit
+--device-layers split (the remainder of layers defaults to CPU,
+device_map/mod.rs), but pipeline/normal.rs:850-856 disables PagedAttention
+when the mapper uses any CPU device, so the F4 cache and CPU offload are
+mutually exclusive by design. Offloaded layers run the standard bf16 KV
+cache in system RAM; context then bounds by RAM instead of VRAM, at a
+large decode-speed cost (MoE experts on CPU).

--- a/mistralrs-cli/src/args/model.rs
+++ b/mistralrs-cli/src/args/model.rs
@@ -3,8 +3,8 @@
 use clap::{Args, ValueEnum};
 use mistralrs_core::{
     AutoDeviceMapParams, IsqOrganization, LoraAdapterSpec, LoraRuntimeConfig, ModelDType,
-    NormalLoaderType, DEFAULT_LORA_MAX_ADAPTERS, DEFAULT_LORA_MAX_BYTES, DEFAULT_LORA_MAX_RANK,
-    MAX_LORA_ALIAS_BYTES,
+    NormalLoaderType, RopeOverride, DEFAULT_LORA_MAX_ADAPTERS, DEFAULT_LORA_MAX_BYTES,
+    DEFAULT_LORA_MAX_RANK, MAX_LORA_ALIAS_BYTES,
 };
 use serde::Deserialize;
 use std::{
@@ -65,13 +65,53 @@ pub struct FormatOptions {
     #[serde(default = "default_gqa")]
     pub gqa: usize,
 
+    /// RoPE scaling mode for long-context extension of GGUF models.
+    /// `yarn` mirrors llama.cpp's `--rope-scaling yarn`.
+    #[arg(long, value_enum)]
+    pub rope_scaling: Option<RopeScalingType>,
+
+    /// YaRN rope scaling factor (e.g. 320000/262144 for a 320k target from a 262144 native context).
+    #[arg(long, default_value_t = 1.0)]
+    #[serde(default)]
+    pub rope_scale: f32,
+
+    /// Original (pretraining) context length for YaRN; defaults to the GGUF context length.
+    #[arg(long)]
+    pub yarn_orig_ctx: Option<usize>,
+
+    /// Force the model's max position embeddings to this context length.
+    #[arg(long)]
+    pub override_ctx: Option<usize>,
+
     #[doc(hidden)]
     #[arg(skip)]
     #[serde(skip)]
     pub direct_file_only: bool,
 }
 
+/// RoPE scaling modes accepted by `--rope-scaling`.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, ValueEnum, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum RopeScalingType {
+    /// YaRN (Yet another RoPE extensioN): interpolation below the correction range,
+    /// extrapolation above it, with the standard 0.1*ln(scale)+1 attention scaling.
+    Yarn,
+    /// Disable rope scaling even if the GGUF carries scaling metadata.
+    None,
+}
+
 impl FormatOptions {
+    pub fn rope_override(&self) -> Option<RopeOverride> {
+        match self.rope_scaling {
+            Some(RopeScalingType::Yarn) => Some(RopeOverride::yarn(
+                self.rope_scale,
+                self.yarn_orig_ctx,
+                self.override_ctx,
+            )),
+            _ => None,
+        }
+    }
+
     pub(crate) fn normalize(&mut self) -> anyhow::Result<()> {
         let mut format = self.format;
         if self.mmproj.is_some() {

--- a/mistralrs-cli/src/args/quantize.rs
+++ b/mistralrs-cli/src/args/quantize.rs
@@ -163,6 +163,10 @@ impl QuantizeFormatOptions {
             tok_model_id: self.tok_model_id.clone(),
             gqa: 1,
             direct_file_only: self.direct_file_only,
+            rope_scaling: None,
+            rope_scale: 1.0,
+            yarn_orig_ctx: None,
+            override_ctx: None,
         }
     }
 

--- a/mistralrs-cli/src/commands/quantize.rs
+++ b/mistralrs-cli/src/commands/quantize.rs
@@ -750,6 +750,7 @@ fn convert_gguf_source(
         hf_cache_path: device.hf_cache.clone(),
         matformer_config_path: None,
         matformer_slice_name: None,
+        rope_override: None,
     })
 }
 

--- a/mistralrs-cli/src/commands/serve.rs
+++ b/mistralrs-cli/src/commands/serve.rs
@@ -657,6 +657,7 @@ fn convert_text_model(
             hf_cache_path: device.hf_cache.clone(),
             matformer_config_path: matformer.config_path.clone(),
             matformer_slice_name: matformer.slice_name.clone(),
+            rope_override: format_opts.rope_override(),
         }),
 
         (ModelFormat::Gguf, false, true, false) => Ok(ModelSelected::LoraGGUF {

--- a/mistralrs-core/src/engine/mod.rs
+++ b/mistralrs-core/src/engine/mod.rs
@@ -1,6 +1,9 @@
 use crate::{
     distributed,
-    paged_attention::block_hash::{adapter_generation_key, compute_block_hashes, BlockHash},
+    paged_attention::{
+        block_hash::{adapter_generation_key, compute_block_hashes, BlockHash},
+        AttentionBackendKind, PagedCacheType,
+    },
     pipeline::{
         llg::{constraint_from_llg_grammar, llg_grammar_from_constraint},
         text_models_inputs_processor::PagedAttentionMeta,
@@ -774,16 +777,30 @@ impl Engine {
                                     block_size,
                                     max_paged_context_len,
                                     sliding_window: pipeline_metadata.sliding_window,
-                                    attention_backend: model_metadata
-                                        .map(|metadata| metadata.attention_backend_kind())
-                                        .unwrap_or(
-                                            crate::paged_attention::AttentionBackendKind::Standard,
-                                        ),
-                                    has_flashinfer_decode_layers: model_metadata
-                                        .is_some_and(|metadata| {
+                                    // F4 caches only exist in the Standard layout/kernels.
+                                    attention_backend: if pipeline_metadata
+                                        .cache_config
+                                        .as_ref()
+                                        .is_some_and(|cfg| {
+                                            cfg.cache_type == PagedCacheType::F4
+                                        })
+                                    {
+                                        AttentionBackendKind::Standard
+                                    } else {
+                                        model_metadata
+                                            .map(|metadata| metadata.attention_backend_kind())
+                                            .unwrap_or(AttentionBackendKind::Standard)
+                                    },
+                                    has_flashinfer_decode_layers: !pipeline_metadata
+                                        .cache_config
+                                        .as_ref()
+                                        .is_some_and(|cfg| {
+                                            cfg.cache_type == PagedCacheType::F4
+                                        })
+                                        && model_metadata.is_some_and(|metadata| {
                                             (0..metadata.num_layers()).any(|layer_idx| {
                                                 metadata.attention_backend_kind_for_layer(layer_idx)
-                                                    == crate::paged_attention::AttentionBackendKind::FlashInfer
+                                                    == AttentionBackendKind::FlashInfer
                                             })
                                         }),
                                     prefill_attention_heads: model_metadata

--- a/mistralrs-core/src/gguf/normal_config.rs
+++ b/mistralrs-core/src/gguf/normal_config.rs
@@ -1,7 +1,7 @@
 use super::normal_registry::{schema_for, CanonicalGgufArchitecture, GgufDescriptor};
 #[cfg(test)]
 use super::normal_registry::{NativeModelAdapter, NORMAL_MODEL_ADAPTERS};
-use crate::{gdn::GDN_V_HEAD_LAYOUT_CONFIG_KEY, NormalLoaderType};
+use crate::{gdn::GDN_V_HEAD_LAYOUT_CONFIG_KEY, NormalLoaderType, RopeOverride};
 use candle_core::quantized::gguf_file::Value as GgufValue;
 use serde_json::{json, Map as JsonMap, Value as JsonValue};
 use std::{collections::HashMap, error::Error, fmt, num::TryFromIntError};
@@ -154,8 +154,9 @@ pub(crate) fn synthesize_normal_config(
     loader: &NormalLoaderType,
     metadata: &HashMap<String, GgufValue>,
     tensor_names: &[String],
+    rope_override: Option<&RopeOverride>,
 ) -> SynthesisResult<String> {
-    let value = synthesize_normal_config_value(loader, metadata, tensor_names)?;
+    let value = synthesize_normal_config_value(loader, metadata, tensor_names, rope_override)?;
     serde_json::to_string(&value).map_err(|error| {
         NormalConfigSynthesisError::new(format!(
             "Failed to serialize synthesized `{loader}` config: {error}"
@@ -163,11 +164,91 @@ pub(crate) fn synthesize_normal_config(
     })
 }
 
+fn supports_rope_override(loader: &NormalLoaderType) -> bool {
+    matches!(
+        loader,
+        NormalLoaderType::Qwen3Next | NormalLoaderType::Qwen3_5
+    )
+}
+
+// A forced YaRN override must win over any scaling metadata the GGUF already
+// carries; the registered builder otherwise rejects the checkpoint.
+fn neutralize_rope_scaling_metadata(
+    metadata: &HashMap<String, GgufValue>,
+) -> HashMap<String, GgufValue> {
+    let mut neutralized = metadata.clone();
+    if let Some(architecture) = metadata
+        .get("general.architecture")
+        .and_then(|value| match value {
+            GgufValue::String(value) => Some(value.clone()),
+            _ => None,
+        })
+    {
+        neutralized.insert(
+            format!("{architecture}.rope.scaling.type"),
+            GgufValue::String("none".to_string()),
+        );
+    }
+    neutralized
+}
+
+fn apply_rope_override(
+    loader: &NormalLoaderType,
+    value: JsonValue,
+    rope_override: Option<&RopeOverride>,
+) -> SynthesisResult<JsonValue> {
+    let Some(rope_override) = rope_override else {
+        return Ok(value);
+    };
+    if !supports_rope_override(loader) {
+        return Ok(value);
+    }
+    let mut object = value.as_object().cloned().ok_or_else(|| {
+        NormalConfigSynthesisError::new(format!(
+            "Synthesized `{loader}` config must be a JSON object"
+        ))
+    })?;
+    let native_ctx = object
+        .get("max_position_embeddings")
+        .and_then(JsonValue::as_u64)
+        .map(|value| value as usize)
+        .ok_or_else(|| {
+            NormalConfigSynthesisError::new(format!(
+                "Synthesized `{loader}` config has no `max_position_embeddings`"
+            ))
+        })?;
+    object.insert(
+        "max_position_embeddings".to_string(),
+        json!(rope_override.resolved_target_ctx(native_ctx)),
+    );
+    object.insert(
+        "rope_scaling".to_string(),
+        json!({
+            "rope_type": "yarn",
+            "factor": rope_override.scale,
+            "original_max_position_embeddings": rope_override.resolved_orig_ctx(native_ctx),
+            "beta_fast": rope_override.beta_fast,
+            "beta_slow": rope_override.beta_slow,
+            "mscale": 1.0,
+            "mscale_all_dim": 1.0,
+        }),
+    );
+    Ok(JsonValue::Object(object))
+}
+
 pub(crate) fn synthesize_normal_config_value(
     loader: &NormalLoaderType,
     metadata: &HashMap<String, GgufValue>,
     tensor_names: &[String],
+    rope_override: Option<&RopeOverride>,
 ) -> SynthesisResult<JsonValue> {
+    let owned_metadata;
+    let metadata = if rope_override.is_some() && supports_rope_override(loader) {
+        owned_metadata = neutralize_rope_scaling_metadata(metadata);
+        &owned_metadata
+    } else {
+        metadata
+    };
     let view = MetadataView::new(loader, metadata, tensor_names)?;
     let builder = NORMAL_CONFIG_BUILDERS
         .iter()
@@ -178,6 +259,7 @@ pub(crate) fn synthesize_normal_config_value(
             ))
         })?;
     let value = (builder.build)(&view)?;
+    let value = apply_rope_override(loader, value, rope_override)?;
     with_reload_identity(loader, value)
 }
 
@@ -2868,7 +2950,7 @@ mod tests {
     fn every_loader_synthesizes_a_native_config() {
         for loader in NormalLoaderType::iter() {
             let (_, metadata, tensors) = default_fixture(&loader);
-            let config = synthesize_normal_config_value(&loader, &metadata, &tensors)
+            let config = synthesize_normal_config_value(&loader, &metadata, &tensors, None)
                 .unwrap_or_else(|error| panic!("failed to synthesize `{loader}` fixture: {error}"));
             assert_eq!(
                 config["architectures"],
@@ -2897,7 +2979,7 @@ mod tests {
         insert_u32(&mut metadata, architecture, "ssm.time_step_rank", 32);
         insert_u32(&mut metadata, architecture, "ssm.inner_size", 4_096);
 
-        let config = synthesize_normal_config_value(&loader, &metadata, &tensors).unwrap();
+        let config = synthesize_normal_config_value(&loader, &metadata, &tensors, None).unwrap();
         assert_eq!(config["intermediate_size"], 512);
         assert_eq!(config["head_dim"], 256);
         assert_eq!(config["partial_rotary_factor"], 0.25);
@@ -2938,7 +3020,7 @@ mod tests {
         insert_u32(&mut metadata, architecture, "ssm.time_step_rank", 32);
         insert_u32(&mut metadata, architecture, "ssm.inner_size", 4_096);
 
-        let config = synthesize_normal_config_value(&loader, &metadata, &tensors).unwrap();
+        let config = synthesize_normal_config_value(&loader, &metadata, &tensors, None).unwrap();
         assert_eq!(config["vocab_size"], 248_320);
         assert_eq!(config["hidden_size"], 2_560);
         assert_eq!(config["intermediate_size"], 9_216);
@@ -2965,7 +3047,7 @@ mod tests {
         let architecture = CanonicalGgufArchitecture::Qwen35;
         let (mut metadata, tensors) = fixture(&loader, architecture);
         insert_u32(&mut metadata, architecture, "full_attention_interval", 0);
-        let error = synthesize_normal_config_value(&loader, &metadata, &tensors).unwrap_err();
+        let error = synthesize_normal_config_value(&loader, &metadata, &tensors, None).unwrap_err();
         assert!(error.to_string().contains("full attention interval"));
 
         insert_u32(&mut metadata, architecture, "full_attention_interval", 4);
@@ -2975,7 +3057,7 @@ mod tests {
             "rope.dimension_sections",
             &[11, 0, 21, 0],
         );
-        let error = synthesize_normal_config_value(&loader, &metadata, &tensors).unwrap_err();
+        let error = synthesize_normal_config_value(&loader, &metadata, &tensors, None).unwrap_err();
         assert!(error.to_string().contains("three non-zero MRoPE sections"));
 
         insert_u32_array(
@@ -2986,7 +3068,7 @@ mod tests {
         );
         insert_u32(&mut metadata, architecture, "ssm.group_count", 3);
         insert_u32(&mut metadata, architecture, "ssm.time_step_rank", 8);
-        let error = synthesize_normal_config_value(&loader, &metadata, &tensors).unwrap_err();
+        let error = synthesize_normal_config_value(&loader, &metadata, &tensors, None).unwrap_err();
         assert!(error.to_string().contains("incompatible GDN head counts"));
     }
 
@@ -3013,7 +3095,7 @@ mod tests {
             let (mut metadata, tensors) = fixture(&loader, architecture);
             metadata.remove(&format!("{}.expert_weights_norm", architecture.as_str()));
 
-            let config = synthesize_normal_config_value(&loader, &metadata, &tensors).unwrap();
+            let config = synthesize_normal_config_value(&loader, &metadata, &tensors, None).unwrap();
             assert_eq!(
                 config["norm_topk_prob"], true,
                 "{loader} with {architecture}"
@@ -3023,18 +3105,83 @@ mod tests {
     }
 
     #[test]
+    fn qwen35moe_yarn_override_extends_context_and_synthesizes_rope_scaling() {
+        let loader = NormalLoaderType::Qwen3Next;
+        let architecture = CanonicalGgufArchitecture::Qwen35Moe;
+        let (mut metadata, tensors) = fixture(&loader, architecture);
+        insert_u32(&mut metadata, architecture, "context_length", 262_144);
+        metadata.remove(&format!("{}.feed_forward_length", architecture.as_str()));
+        insert_u32(&mut metadata, architecture, "attention.key_length", 256);
+        insert_u32(&mut metadata, architecture, "rope.dimension_count", 64);
+        insert_u32(&mut metadata, architecture, "ssm.state_size", 128);
+        insert_u32(&mut metadata, architecture, "ssm.group_count", 16);
+        insert_u32(&mut metadata, architecture, "ssm.time_step_rank", 32);
+        insert_u32(&mut metadata, architecture, "ssm.inner_size", 4_096);
+
+        let scale = 320_000.0 / 262_144.0;
+        let override_ = RopeOverride::yarn(scale, Some(262_144), None);
+        let config = synthesize_normal_config_value(&loader, &metadata, &tensors, Some(&override_))
+            .unwrap();
+        assert_eq!(config["max_position_embeddings"], 320_000);
+        assert_eq!(config["rope_scaling"]["rope_type"], "yarn");
+        assert_eq!(config["rope_scaling"]["factor"], scale);
+        assert_eq!(config["rope_scaling"]["original_max_position_embeddings"], 262_144);
+        assert_eq!(config["rope_scaling"]["beta_fast"], 32.0);
+        assert_eq!(config["rope_scaling"]["beta_slow"], 1.0);
+        let native: models::qwen3_next::Config = serde_json::from_value(config.clone()).unwrap();
+        let scaling = native.rope_scaling.expect("rope_scaling must deserialize");
+        assert_eq!(scaling.rope_type, "yarn");
+        assert_eq!(scaling.factor, scale as f64);
+        assert_eq!(scaling.original_max_position_embeddings, 262_144);
+    }
+
+    #[test]
+    fn qwen35moe_yarn_override_wins_over_gguf_scaling_metadata() {
+        // A checkpoint that already carries scaling metadata must still load when
+        // the user forces --rope-scaling yarn: the rejection is bypassed.
+        let loader = NormalLoaderType::Qwen3Next;
+        let architecture = CanonicalGgufArchitecture::Qwen35Moe;
+        let (mut metadata, tensors) = fixture(&loader, architecture);
+        insert_u32(&mut metadata, architecture, "context_length", 262_144);
+        metadata.remove(&format!("{}.feed_forward_length", architecture.as_str()));
+        insert_u32(&mut metadata, architecture, "attention.key_length", 256);
+        insert_u32(&mut metadata, architecture, "rope.dimension_count", 64);
+        insert_u32(&mut metadata, architecture, "ssm.state_size", 128);
+        insert_u32(&mut metadata, architecture, "ssm.group_count", 16);
+        insert_u32(&mut metadata, architecture, "ssm.time_step_rank", 32);
+        insert_u32(&mut metadata, architecture, "ssm.inner_size", 4_096);
+        insert_string(
+            &mut metadata,
+            architecture,
+            "rope.scaling.type",
+            "yarn",
+        );
+
+        // Without the override the builder rejects the scaled GGUF.
+        let error = synthesize_normal_config_value(&loader, &metadata, &tensors, None)
+            .unwrap_err();
+        assert!(error.to_string().contains("cannot reconstruct"));
+
+        let override_ = RopeOverride::yarn(320_000.0 / 262_144.0, Some(262_144), None);
+        let config = synthesize_normal_config_value(&loader, &metadata, &tensors, Some(&override_))
+            .unwrap();
+        assert_eq!(config["max_position_embeddings"], 320_000);
+        assert_eq!(config["rope_scaling"]["rope_type"], "yarn");
+    }
+
+    #[test]
     fn llama_linear_rope_and_baked_factor_gate_are_explicit() {
         let loader = NormalLoaderType::Llama;
         let (architecture, mut metadata, mut tensors) = default_fixture(&loader);
         insert_string(&mut metadata, architecture, "rope.scaling.type", "linear");
         insert_f32(&mut metadata, architecture, "rope.scaling.factor", 2.0);
-        let config = synthesize_normal_config_value(&loader, &metadata, &tensors).unwrap();
+        let config = synthesize_normal_config_value(&loader, &metadata, &tensors, None).unwrap();
         assert_eq!(config["rope_scaling"]["rope_type"], "linear");
         assert_eq!(config["rope_scaling"]["factor"], 2.0);
         assert_native_config_deserializes(&loader, config);
 
         tensors.push("rope_freqs.weight".to_string());
-        let config = synthesize_normal_config_value(&loader, &metadata, &tensors).unwrap();
+        let config = synthesize_normal_config_value(&loader, &metadata, &tensors, None).unwrap();
         assert!(config["rope_scaling"].is_null());
         assert_native_config_deserializes(&loader, config);
     }
@@ -3058,7 +3205,7 @@ mod tests {
                     .collect(),
             ),
         );
-        let config = synthesize_normal_config_value(&loader, &metadata, &tensors).unwrap();
+        let config = synthesize_normal_config_value(&loader, &metadata, &tensors, None).unwrap();
         assert_eq!(
             config["layer_types"],
             json!([
@@ -3078,7 +3225,8 @@ mod tests {
             "attention.sliding_window",
             1_024,
         );
-        let error = synthesize_normal_config_value(&qwen3, &metadata, &tensors).unwrap_err();
+        let error = synthesize_normal_config_value(&qwen3, &metadata, &tensors, None)
+            .unwrap_err();
         assert!(error.to_string().contains("layer policy"));
     }
 
@@ -3086,7 +3234,7 @@ mod tests {
     fn qwen_moe_inventory_marks_dense_layers() {
         let loader = NormalLoaderType::Qwen3Moe;
         let (_, metadata, tensors) = default_fixture(&loader);
-        let config = synthesize_normal_config_value(&loader, &metadata, &tensors).unwrap();
+        let config = synthesize_normal_config_value(&loader, &metadata, &tensors, None).unwrap();
         assert_eq!(config["mlp_only_layers"], json!([0]));
         assert_eq!(config["num_experts"], 8);
         assert_eq!(config["num_experts_per_tok"], 2);
@@ -3111,7 +3259,7 @@ mod tests {
                 .into_iter()
                 .map(str::to_string),
         );
-        let config = synthesize_normal_config_value(&loader, &metadata, &tensors).unwrap();
+        let config = synthesize_normal_config_value(&loader, &metadata, &tensors, None).unwrap();
         assert_eq!(
             config["layer_types"],
             json!(["attention", "mamba", "attention", "mamba"])
@@ -3123,7 +3271,7 @@ mod tests {
         let loader = NormalLoaderType::Lfm2;
         let (_, metadata, tensors) = default_fixture(&loader);
         assert!(!tensors.iter().any(|tensor| tensor == "output_norm.weight"));
-        let config = synthesize_normal_config_value(&loader, &metadata, &tensors).unwrap();
+        let config = synthesize_normal_config_value(&loader, &metadata, &tensors, None).unwrap();
         assert_eq!(
             config["layer_types"],
             json!(["full_attention", "conv", "full_attention", "conv"])
@@ -3137,14 +3285,14 @@ mod tests {
         let loader = NormalLoaderType::Qwen3Next;
         let (architecture, mut metadata, tensors) = default_fixture(&loader);
         metadata.remove(&format!("{}.ssm.time_step_rank", architecture.as_str()));
-        let error = synthesize_normal_config_value(&loader, &metadata, &tensors).unwrap_err();
+        let error = synthesize_normal_config_value(&loader, &metadata, &tensors, None).unwrap_err();
         assert!(error.to_string().contains("ssm.time_step_rank"));
         assert!(error.to_string().contains("original Hugging Face config"));
 
         let loader = NormalLoaderType::Lfm2;
         let (architecture, mut metadata, tensors) = default_fixture(&loader);
         metadata.remove(&format!("{}.shortconv.l_cache", architecture.as_str()));
-        let error = synthesize_normal_config_value(&loader, &metadata, &tensors).unwrap_err();
+        let error = synthesize_normal_config_value(&loader, &metadata, &tensors, None).unwrap_err();
         assert!(error.to_string().contains("shortconv.l_cache"));
     }
 

--- a/mistralrs-core/src/layers.rs
+++ b/mistralrs-core/src/layers.rs
@@ -2978,6 +2978,70 @@ impl RotaryEmbedding {
             is_gpt_neox,
         })
     }
+
+    /// Partial rotary with YaRN scaling, matching llama.cpp's yarn resolution
+    /// (llama-context.cpp yarn_ext_factor/yarn_attn_factor and rope.cu rope_yarn).
+    pub fn new_partial_yarn(
+        base: f32,
+        rot_dim: usize,
+        max_position_embeddings: usize,
+        original_max_position_embeddings: usize,
+        factor: f32,
+        mscale: f32,
+        mscale_all_dim: f32,
+        beta_fast: f32,
+        beta_slow: f32,
+        device: &Device,
+        dtype: DType,
+    ) -> Result<Self> {
+        let half_dim = rot_dim / 2;
+        // corr_dim(n_rot) = n_dims * log(orig / (n_rot * 2pi)) / (2 * log(base))
+        let corr_dim = |n_rot: f32| {
+            rot_dim as f32 * (original_max_position_embeddings as f32 / (n_rot * 2.0 * std::f32::consts::PI)).ln()
+                / (2.0 * base.ln())
+        };
+        let low = (corr_dim(beta_fast).floor() as i64).clamp(0, half_dim as i64 - 1) as usize;
+        let high = (corr_dim(beta_slow).ceil() as i64).clamp(0, half_dim as i64 - 1) as usize;
+        let inv_freq_extrapolation: Vec<f32> = (0..half_dim)
+            .map(|i| 1f32 / base.powf((2 * i) as f32 / rot_dim as f32))
+            .collect();
+        // Interpolated below the correction range, extrapolated above it, ramped in between.
+        let inv_freq: Vec<f32> = inv_freq_extrapolation
+            .iter()
+            .enumerate()
+            .map(|(i, &extrapolated)| {
+                let range = (high as f32 - low as f32).max(0.001);
+                let ramp = 1.0 - ((i as f32 - low as f32) / range).clamp(0.0, 1.0);
+                let interpolated = extrapolated / factor;
+                interpolated * (1.0 - ramp) + extrapolated * ramp
+            })
+            .collect();
+        // llama.cpp: yarn_attn_factor resolves to get_mscale(f, 1)/get_mscale(f, log_mul)
+        // pre-cancelled against the kernel's 1 + 0.1*ln(scale), netting the product below.
+        let yarn_mscale = |scale: f32, m: f32| {
+            if scale > 1.0 {
+                0.1 * m * scale.ln() + 1.0
+            } else {
+                1.0
+            }
+        };
+        let effective_mscale =
+            yarn_mscale(factor, mscale) / yarn_mscale(factor, mscale_all_dim) * yarn_mscale(factor, 1.0);
+        let inv_freq_len = inv_freq.len();
+        let inv_freq = Tensor::from_vec(inv_freq, (1, inv_freq_len), device)?;
+        let t = Tensor::arange(0u32, max_position_embeddings as u32, device)?
+            .to_dtype(DType::F32)?
+            .reshape((max_position_embeddings, 1))?;
+        let freqs = t.matmul(&inv_freq)?;
+        let sin = (freqs.sin()? * effective_mscale as f64)?.to_dtype(dtype)?;
+        let cos = (freqs.cos()? * effective_mscale as f64)?.to_dtype(dtype)?;
+
+        Ok(Self {
+            cos,
+            sin,
+            is_gpt_neox: true,
+        })
+    }
 }
 
 /// GPT-OSS style rotary embedding with YARN scaling support.

--- a/mistralrs-core/src/lib.rs
+++ b/mistralrs-core/src/lib.rs
@@ -70,6 +70,8 @@ mod search;
 
 mod model_selected;
 pub use model_selected::ModelSelected;
+mod rope_override;
+pub use rope_override::RopeOverride;
 pub use toml_selector::{get_toml_selected_model_device_map_params, get_toml_selected_model_dtype};
 
 mod amoe;

--- a/mistralrs-core/src/model_loader.rs
+++ b/mistralrs-core/src/model_loader.rs
@@ -619,6 +619,7 @@ fn loader_from_model_selected(args: LoaderBuilder) -> anyhow::Result<Box<dyn Loa
             hf_cache_path,
             matformer_config_path,
             matformer_slice_name,
+            rope_override,
             ..
         } => {
             if lora_runtime_config.is_none() && !lora_adapters.is_empty() {
@@ -643,6 +644,7 @@ fn loader_from_model_selected(args: LoaderBuilder) -> anyhow::Result<Box<dyn Loa
                     hf_cache_path,
                     matformer_config_path,
                     matformer_slice_name,
+                    rope_override,
                 },
                 args.no_kv_cache,
                 args.jinja_explicit,

--- a/mistralrs-core/src/model_selected.rs
+++ b/mistralrs-core/src/model_selected.rs
@@ -7,7 +7,8 @@ use crate::{
         AutoDeviceMapParams, EmbeddingLoaderType, IsqOrganization, MultimodalLoaderType,
         NormalLoaderType, UqffWriteConfig,
     },
-    DiffusionLoaderType, LoraAdapterSpec, LoraRuntimeConfig, ModelDType, SpeechLoaderType,
+    DiffusionLoaderType, LoraAdapterSpec, LoraRuntimeConfig, ModelDType, RopeOverride,
+    SpeechLoaderType,
 };
 
 // Default value functions for serde deserialization
@@ -455,6 +456,11 @@ pub enum ModelSelected {
         #[arg(long)]
         #[serde(default)]
         matformer_slice_name: Option<String>,
+
+        /// YaRN rope override for long-context serving (CLI-only, see `--rope-scaling`).
+        #[arg(skip)]
+        #[serde(default)]
+        rope_override: Option<RopeOverride>,
     },
 
     /// Select a GGUF model with X-LoRA.

--- a/mistralrs-core/src/models/qwen3_next.rs
+++ b/mistralrs-core/src/models/qwen3_next.rs
@@ -28,7 +28,10 @@ use crate::{
     },
     layers_masker::PastKvLenCache,
     moe::{MoEExperts, MoEExpertsConfig},
-    paged_attention::{AttentionImplementation, ModelConfigMetadata, PagedAttention},
+    paged_attention::{
+        AttentionImplementation, HybridPagedKvCacheConfig, ModelConfigLike, ModelConfigMetadata,
+        PagedAttention,
+    },
     pipeline::{
         text_models_inputs_processor::{FlashParams, PagedAttentionInputMetadata},
         EitherCache, ForwardMaskCache, IsqModel, KvCache, ModelForwardContext,
@@ -89,6 +92,32 @@ pub struct Config {
     pub quantization_config: Option<QuantizedConfig>,
     #[serde(default, rename = "_mistralrs_gdn_v_head_layout")]
     gdn_v_head_layout: GdnVHeadLayout,
+    #[serde(default)]
+    pub rope_scaling: Option<Qwen35YarnScaling>,
+}
+
+/// YaRN rope scaling for the Qwen3.5-family partial rotary, mirroring
+/// llama.cpp's `--rope-scaling yarn` semantics.
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct Qwen35YarnScaling {
+    #[serde(default = "default_yarn_rope_type")]
+    pub rope_type: String,
+    pub factor: f64,
+    pub original_max_position_embeddings: usize,
+    pub beta_fast: f64,
+    pub beta_slow: f64,
+    #[serde(default = "default_yarn_mscale")]
+    pub mscale: f64,
+    #[serde(default = "default_yarn_mscale")]
+    pub mscale_all_dim: f64,
+}
+
+fn default_yarn_rope_type() -> String {
+    "yarn".to_string()
+}
+
+fn default_yarn_mscale() -> f64 {
+    1.0
 }
 
 #[derive(Debug, Clone)]
@@ -765,14 +794,37 @@ impl Model {
                     .unwrap_or(&normal_loading_metadata.real_device);
                 if let std::collections::hash_map::Entry::Vacant(e) = ropes.entry(device.location())
                 {
-                    let rope = RotaryEmbedding::new_partial(
-                        cfg.rope_theta as f32,
-                        rot_dim,
-                        cfg.max_position_embeddings,
-                        device,
-                        is_gptx,
-                        vb_m.dtype(),
-                    )?;
+                    let rope = match &cfg.rope_scaling {
+                        Some(scaling) if scaling.rope_type == "yarn" => {
+                            RotaryEmbedding::new_partial_yarn(
+                                cfg.rope_theta as f32,
+                                rot_dim,
+                                cfg.max_position_embeddings,
+                                scaling.original_max_position_embeddings,
+                                scaling.factor as f32,
+                                scaling.mscale as f32,
+                                scaling.mscale_all_dim as f32,
+                                scaling.beta_fast as f32,
+                                scaling.beta_slow as f32,
+                                device,
+                                vb_m.dtype(),
+                            )?
+                        }
+                        Some(scaling) => {
+                            candle_core::bail!(
+                                "Unsupported rope scaling type `{}` for Qwen3-Next",
+                                scaling.rope_type
+                            )
+                        }
+                        None => RotaryEmbedding::new_partial(
+                            cfg.rope_theta as f32,
+                            rot_dim,
+                            cfg.max_position_embeddings,
+                            device,
+                            is_gptx,
+                            vb_m.dtype(),
+                        )?,
+                    };
                     e.insert(Arc::new(rope));
                 }
             }
@@ -1197,6 +1249,16 @@ impl NormalModel for Model {
         &self.cfg
     }
 
+    fn model_config(&self) -> Arc<dyn ModelConfigLike + Send + Sync> {
+        Arc::new(HybridPagedKvCacheConfig::new(
+            self.cfg.clone(),
+            self.layer_types
+                .iter()
+                .map(|ty| matches!(ty, LayerType::FullAttention))
+                .collect(),
+        ))
+    }
+
     fn supports_packed_prefill(&self) -> bool {
         true
     }
@@ -1218,7 +1280,7 @@ mod tests {
 
     use super::{
         gdn_input_projection_kind, packed_gdn_segments, validate_packed_gdn_state_rows,
-        GdnInputProjectionKind, PackedGdnSegment,
+        Config, GdnInputProjectionKind, LayerType, PackedGdnSegment,
     };
 
     struct ProjectionWeightSource(HashSet<String>);
@@ -1273,9 +1335,46 @@ mod tests {
             .pp("model.layers.0.linear_attn"))
     }
 
+    fn config_for_test() -> Config {
+        serde_json::from_value(serde_json::json!({
+            "vocab_size": 32000,
+            "hidden_size": 2048,
+            "intermediate_size": 512,
+            "num_hidden_layers": 40,
+            "num_attention_heads": 16,
+            "num_key_value_heads": 2,
+            "hidden_act": "silu",
+            "max_position_embeddings": 262144,
+            "head_dim": 256,
+            "linear_key_head_dim": 128,
+            "linear_value_head_dim": 128,
+            "linear_num_key_heads": 16,
+            "linear_num_value_heads": 32,
+            "moe_intermediate_size": 512,
+            "shared_expert_intermediate_size": 512,
+            "num_experts_per_tok": 8,
+            "num_experts": 90,
+            "full_attention_interval": 4,
+        }))
+        .unwrap()
+    }
+
     #[test]
-    fn gdn_projection_kind_reads_residual_and_weight_source_tensors() -> Result<()> {
-        let split = [
+    fn hybrid_layer_types_mask_only_the_10_full_attention_layers() {
+        let cfg = config_for_test();
+        let types = cfg.layer_types();
+        assert_eq!(types.len(), 40);
+        let full = types
+            .iter()
+            .enumerate()
+            .filter(|(_, ty)| matches!(ty, LayerType::FullAttention))
+            .map(|(idx, _)| idx)
+            .collect::<Vec<_>>();
+        assert_eq!(full, vec![3, 7, 11, 15, 19, 23, 27, 31, 35, 39]);
+    }
+
+    #[test]
+    fn gdn_projection_kind_reads_residual_and_weight_source_tensors() -> Result<()> {        let split = [
             "in_proj_qkv.weight",
             "in_proj_z.weight",
             "in_proj_b.weight",

--- a/mistralrs-core/src/ops.rs
+++ b/mistralrs-core/src/ops.rs
@@ -38,7 +38,7 @@ fn cuda_topk(input: &Tensor, k: usize) -> Result<TopKOutput> {
     use candle_core::cuda_backend::CudaStorageSlice;
     use std::ffi::c_void;
 
-    let input = final_logits_row(input)?;
+    let input = input.contiguous()?;
     let dims = input.dims();
     let ncols = *dims
         .last()

--- a/mistralrs-core/src/paged_attention/cache_engine.rs
+++ b/mistralrs-core/src/paged_attention/cache_engine.rs
@@ -14,12 +14,16 @@ pub enum PagedCacheType {
     #[default]
     Auto,
     F8E4M3,
+    F4,
 }
 
 impl PagedCacheType {
     pub fn to_dtype(&self, act_dtype: DType) -> DType {
         match self {
             PagedCacheType::F8E4M3 => DType::F8E4M3,
+            // Candle has no CUDA storage for sub-byte dtypes; the F4 cache lives
+            // in packed U8 tensors (see F4-KV-STORAGE-ASSESSMENT.md).
+            PagedCacheType::F4 => DType::U8,
             PagedCacheType::Auto => act_dtype,
         }
     }
@@ -31,8 +35,9 @@ impl FromStr for PagedCacheType {
         match s {
             "auto" => Ok(Self::Auto),
             "f8e4m3" => Ok(Self::F8E4M3),
+            "f4" => Ok(Self::F4),
             other => Err(format!(
-                "Unexpected `PagedCacheType`, got `{other}` but expected `auto` and `f8e4m3`."
+                "Unexpected `PagedCacheType`, got `{other}` but expected `auto`, `f8e4m3` and `f4`."
             )),
         }
     }
@@ -102,9 +107,11 @@ impl CacheEngine {
             };
             let requested_kv_cache_layout = model_config.kv_cache_layout_for_layer(layer_idx);
             let kv_cache_layout =
-                if matches!(requested_kv_cache_layout, KvCacheLayout::FlashInferHnd)
-                    && !device.is_cuda()
+                if (matches!(requested_kv_cache_layout, KvCacheLayout::FlashInferHnd)
+                    && !device.is_cuda())
+                    || cache_config.cache_type == PagedCacheType::F4
                 {
+                    // F4 is only implemented for the Standard layout/kernels.
                     KvCacheLayout::Standard
                 } else {
                     requested_kv_cache_layout
@@ -115,11 +122,13 @@ impl CacheEngine {
                         model_config,
                         dtype,
                         cache_config.block_size,
+                        cache_config.cache_type,
                         layer_idx,
                     );
                     let value_block_shape = Self::calculate_value_block_shape(
                         model_config,
                         cache_config.block_size,
+                        cache_config.cache_type,
                         layer_idx,
                     );
                     #[allow(unused)]
@@ -377,26 +386,39 @@ impl CacheEngine {
         model_config: &dyn ModelConfigLike,
         dtype: DType,
         block_size: usize,
+        cache_type: PagedCacheType,
         layer_idx: usize,
     ) -> (usize, usize, usize, usize) {
-        let element_size = dtype.size_in_bytes();
-        let x = 16 / element_size;
+        // F4 packs two values per byte: a 32-value cell row is 16 bytes, so the
+        // trailing shape dim is the byte width, not the value count.
+        let (x, byte_width) = if cache_type == PagedCacheType::F4 {
+            (32, 16)
+        } else {
+            let x = 16 / dtype.size_in_bytes();
+            (x, x)
+        };
         (
             model_config.num_kv_heads_for_layer(layer_idx),
             model_config.k_head_dim_for_layer(layer_idx) / x,
             block_size,
-            x,
+            byte_width,
         )
     }
 
     fn calculate_value_block_shape(
         model_config: &dyn ModelConfigLike,
         block_size: usize,
+        cache_type: PagedCacheType,
         layer_idx: usize,
     ) -> (usize, usize, usize) {
+        let head_bytes = if cache_type == PagedCacheType::F4 {
+            model_config.v_head_dim_for_layer(layer_idx) / 2
+        } else {
+            model_config.v_head_dim_for_layer(layer_idx)
+        };
         (
             model_config.num_kv_heads_for_layer(layer_idx),
-            model_config.v_head_dim_for_layer(layer_idx),
+            head_bytes,
             block_size,
         )
     }

--- a/mistralrs-core/src/paged_attention/layers/paged_attention.rs
+++ b/mistralrs-core/src/paged_attention/layers/paged_attention.rs
@@ -10,6 +10,7 @@ use mistralrs_paged_attn::{kv_scale_update, paged_attention, reshape_and_cache};
 
 const KV_SCALE_UPDATE_ITERATION: i32 = 128;
 use std::sync::atomic::{AtomicI32, Ordering};
+use std::sync::Mutex;
 
 #[cfg(all(feature = "cuda", target_family = "unix"))]
 use crate::attention::sliding_window_left;
@@ -652,8 +653,8 @@ impl PagedForwardCtx<'_> {
 
 pub struct PagedAttention {
     alibi_slopes: Option<Tensor>,
-    k_scale: Option<Tensor>,
-    v_scale: Option<Tensor>,
+    k_scale: Mutex<Option<Tensor>>,
+    v_scale: Mutex<Option<Tensor>>,
     kv_updated_times: AtomicI32,
 }
 
@@ -667,8 +668,8 @@ impl PagedAttention {
         };
         Ok(Self {
             alibi_slopes,
-            k_scale: Some(Tensor::new(1f32, device)?),
-            v_scale: Some(Tensor::new(1f32, device)?),
+            k_scale: Mutex::new(Some(Tensor::new(1f32, device)?)),
+            v_scale: Mutex::new(Some(Tensor::new(1f32, device)?)),
             kv_updated_times: AtomicI32::new(0),
         })
     }
@@ -728,8 +729,8 @@ impl PagedAttention {
         let (k, v) = gather_kv_cache_for_layout(
             key_cache,
             value_cache,
-            self.k_scale.as_ref(),
-            self.v_scale.as_ref(),
+            self.k_scale.lock().expect("kv scale mutex poisoned").as_ref(),
+            self.v_scale.lock().expect("kv scale mutex poisoned").as_ref(),
             &table,
             &cu_kv,
             dtype,
@@ -750,17 +751,49 @@ impl PagedAttention {
         key_cache: Option<&Tensor>,
         write_cache: bool,
     ) -> Result<()> {
-        if write_cache {
-            if let (Some(k_scale), Some(v_scale), Some(key_cache)) =
-                (&self.k_scale, &self.v_scale, key_cache)
+        if !write_cache {
+            return Ok(());
+        }
+        let Some(key_cache) = key_cache else {
+            return Ok(());
+        };
+        match key_cache.dtype() {
+            // F4: the reshape kernel computes and stores per-cell scales inline;
+            // allocate the per-cell scale tensors once, sized from the caches.
+            DType::U8 => {
+                let mut k_scale = self.k_scale.lock().expect("kv scale mutex poisoned");
+                let mut v_scale = self.v_scale.lock().expect("kv scale mutex poisoned");
+                let device = key_cache.device();
+                let (num_blocks, num_kv_heads, _, block_size, _) =
+                    key_cache.shape().dims5()?;
+                let head_size = tensors.value.dim(3)?;
+                let k_shape = (num_blocks, num_kv_heads, head_size / 32, block_size);
+                let v_shape = (num_blocks, num_kv_heads, block_size);
+                // The constructor seeds a 1-element placeholder; replace it with
+                // the real per-cell tensors on first contact with an F4 cache.
+                let need_k = k_scale
+                    .as_ref()
+                    .is_none_or(|t| t.shape().dims() != vec![k_shape.0, k_shape.1, k_shape.2, k_shape.3]);
+                let need_v = v_scale
+                    .as_ref()
+                    .is_none_or(|t| t.shape().dims() != vec![v_shape.0, v_shape.1, v_shape.2]);
+                if need_k || need_v {
+                    *k_scale = Some(Tensor::zeros(k_shape, DType::F32, device)?);
+                    *v_scale = Some(Tensor::zeros(v_shape, DType::F32, device)?);
+                }
+            }
+            DType::F8E4M3
+                if self.kv_updated_times.load(Ordering::Relaxed)
+                    < KV_SCALE_UPDATE_ITERATION =>
             {
-                if self.kv_updated_times.load(Ordering::Relaxed) < KV_SCALE_UPDATE_ITERATION
-                    && key_cache.dtype() == DType::F8E4M3
-                {
+                let k_scale = self.k_scale.lock().expect("kv scale mutex poisoned");
+                let v_scale = self.v_scale.lock().expect("kv scale mutex poisoned");
+                if let (Some(k_scale), Some(v_scale)) = (k_scale.as_ref(), v_scale.as_ref()) {
                     kv_scale_update(tensors.key, tensors.value, k_scale, v_scale)?;
                     self.kv_updated_times.fetch_add(1, Ordering::Relaxed);
                 }
             }
+            _ => {}
         }
         Ok(())
     }
@@ -870,8 +903,8 @@ impl PagedAttention {
             write_kv_cache(
                 &k_flat,
                 &v_flat,
-                self.k_scale.as_ref(),
-                self.v_scale.as_ref(),
+                self.k_scale.lock().expect("kv scale mutex poisoned").as_ref(),
+                self.v_scale.lock().expect("kv scale mutex poisoned").as_ref(),
                 key_cache,
                 value_cache,
                 &ctx.slot_mapping,
@@ -998,8 +1031,8 @@ impl PagedAttention {
         let (k_gathered, v_gathered) = gather_kv_cache_for_layout(
             key_cache.as_ref().unwrap(),
             value_cache.as_ref().unwrap(),
-            self.k_scale.as_ref(),
-            self.v_scale.as_ref(),
+            self.k_scale.lock().expect("kv scale mutex poisoned").as_ref(),
+            self.v_scale.lock().expect("kv scale mutex poisoned").as_ref(),
             block_tables,
             &cu_kv,
             tensors.query.dtype(),
@@ -1344,8 +1377,8 @@ impl PagedAttention {
             write_kv_cache(
                 &key,
                 &value,
-                self.k_scale.as_ref(),
-                self.v_scale.as_ref(),
+                self.k_scale.lock().expect("kv scale mutex poisoned").as_ref(),
+                self.v_scale.lock().expect("kv scale mutex poisoned").as_ref(),
                 key_cache,
                 value_cache,
                 &ctx.slot_mapping,
@@ -1411,8 +1444,8 @@ impl PagedAttention {
             write_kv_cache(
                 key.as_ref().unwrap(),
                 value.as_ref().unwrap(),
-                self.k_scale.as_ref(),
-                self.v_scale.as_ref(),
+                self.k_scale.lock().expect("kv scale mutex poisoned").as_ref(),
+                self.v_scale.lock().expect("kv scale mutex poisoned").as_ref(),
                 key_cache,
                 value_cache,
                 &ctx.slot_mapping,
@@ -1493,8 +1526,8 @@ impl PagedAttention {
         let (k_gathered, v_gathered) = gather_kv_cache_for_layout(
             key_cache,
             value_cache,
-            self.k_scale.as_ref(),
-            self.v_scale.as_ref(),
+            self.k_scale.lock().expect("kv scale mutex poisoned").as_ref(),
+            self.v_scale.lock().expect("kv scale mutex poisoned").as_ref(),
             block_tables,
             &cu_kv,
             query.dtype(),
@@ -1641,18 +1674,17 @@ impl PagedAttention {
     ) -> Result<Tensor> {
         paged_attention(
             query,
-            self.k_scale.as_ref(),
-            self.v_scale.as_ref(),
+            self.k_scale.lock().expect("kv scale mutex poisoned").as_ref(),
+            self.v_scale.lock().expect("kv scale mutex poisoned").as_ref(),
             key_cache,
             value_cache,
             ctx.block_tables(dev).unwrap(),
             ctx.context_lens(dev).unwrap(),
             ctx.alibi_slopes.as_ref(),
-            if ctx.use_full {
-                ctx.input_metadata.full_max_context_len.unwrap()
-            } else {
-                ctx.input_metadata.max_context_len.unwrap()
-            },
+            ctx.input_metadata
+                .full_max_context_len
+                .or(ctx.input_metadata.max_context_len)
+                .unwrap(),
             ctx.sdpa_params.softmax_scale,
             ctx.sdpa_params.softcap.unwrap_or(1.0f32),
             ctx.sdpa_params.sinks.as_ref(),

--- a/mistralrs-core/src/paged_attention/mod.rs
+++ b/mistralrs-core/src/paged_attention/mod.rs
@@ -253,7 +253,11 @@ pub fn calculate_cache_config(
 
     if !silent {
         info!("Allocating {mem_gpu} MB for PagedAttention KV cache per GPU");
-        info!("PagedAttention KV cache type is {dtype:?}");
+        if cache_type == PagedCacheType::F4 {
+            info!("PagedAttention KV cache type is F4 (packed u8)");
+        } else {
+            info!("PagedAttention KV cache type is {dtype:?}");
+        }
         info!("Using PagedAttention with block size {block_size} and {num_gpu_blocks} GPU blocks: available context length is {} tokens", num_gpu_blocks*block_size);
     }
     Ok(CacheConfig {

--- a/mistralrs-core/src/pipeline/gguf.rs
+++ b/mistralrs-core/src/pipeline/gguf.rs
@@ -38,6 +38,7 @@ use crate::kv_cache::FullCacheManager;
 use crate::lora::Ordering;
 use crate::pipeline::chat_template::{calculate_eos_tokens, BeginEndUnkPadTok, GenerationConfig};
 use crate::pipeline::hf::{build_api, get_file, list_repo_files};
+use crate::RopeOverride;
 use crate::pipeline::loaders::{stamp_qk_rope_layout, DeviceMappedModelLoader};
 use crate::pipeline::multimodal::{
     MultimodalLoaderBuilder, MultimodalSpecificConfig, PreparedMultimodalSource,
@@ -174,6 +175,7 @@ pub struct GGUFSpecificConfig {
     pub hf_cache_path: Option<PathBuf>,
     pub matformer_config_path: Option<PathBuf>,
     pub matformer_slice_name: Option<String>,
+    pub rope_override: Option<RopeOverride>,
 }
 
 impl GGUFSpecificConfig {
@@ -652,7 +654,12 @@ impl GGUFLoader {
                 validate_normal_config_tensor_inventory(&config, &tensor_names)?;
                 config
             }
-            None => synthesize_normal_config(&loader_type, archive.metadata(), &tensor_names)?,
+            None => synthesize_normal_config(
+                &loader_type,
+                archive.metadata(),
+                &tensor_names,
+                self.config.rope_override.as_ref(),
+            )?,
         };
         let config = stamp_qk_rope_layout(&config, rope_pairing)?;
         let bindings = build_normal_bindings(&archive, &loader_type, descriptor.architecture)?;

--- a/mistralrs-core/src/pipeline/mod.rs
+++ b/mistralrs-core/src/pipeline/mod.rs
@@ -167,7 +167,7 @@ use self::text_models_inputs_processor::{
     FlashParams, PagedAttentionInputMetadata, PagedAttentionMeta,
 };
 
-pub(crate) const DEFAULT_PAGED_PREFILL_CHUNK_SIZE: usize = 4096;
+pub(crate) const DEFAULT_PAGED_PREFILL_CHUNK_SIZE: usize = 2048;
 
 #[cfg(feature = "cuda")]
 pub(crate) fn synchronize_cuda_contexts(primary: &Device, mapper: &dyn DeviceMapper) -> Result<()> {

--- a/mistralrs-core/src/prefix_cacher.rs
+++ b/mistralrs-core/src/prefix_cacher.rs
@@ -327,6 +327,9 @@ impl PrefixCacheManagerV2 {
 
     /// Add a recurrent-state snapshot for a paged-attention block-hash prefix key.
     /// This is used by hybrid models to restore recurrent states alongside paged KV prefix hits.
+    /// Snapshots are parked in host memory: each one holds every recurrent layer's F32 state
+    /// (~63 MB for Qwen3-Next's 30 GDN layers), so keeping them resident on the GPU would
+    /// accumulate ~1 GB of VRAM per cache fill and starve prefill transients.
     pub fn add_paged_recurrent_prefix(
         &mut self,
         key: Vec<BlockHash>,
@@ -346,6 +349,19 @@ impl PrefixCacheManagerV2 {
                 .paged_recurrent_bytes
                 .saturating_sub(Self::snapshot_bytes(&prev));
         }
+
+        let mut snapshots = snapshots;
+        for snapshot in &mut snapshots {
+            let Ok(conv_state) = snapshot.conv_state.to_device(&Device::Cpu) else {
+                return;
+            };
+            let Ok(recurrent_state) = snapshot.recurrent_state.to_device(&Device::Cpu) else {
+                return;
+            };
+            snapshot.conv_state = conv_state;
+            snapshot.recurrent_state = recurrent_state;
+        }
+
         self.paged_recurrent_bytes += Self::snapshot_bytes(&snapshots);
         self.paged_recurrent_caches.insert(key, snapshots);
 
@@ -365,7 +381,7 @@ impl PrefixCacheManagerV2 {
         {
             self.paged_recurrent_reported = true;
             info!(
-                "Recurrent prefix cache full at {} entries, {} MB. Adjust with `--prefix-cache-n`.",
+                "Recurrent prefix cache full at {} entries, {} MB host RAM. Adjust with `--prefix-cache-n`.",
                 self.paged_recurrent_caches.len(),
                 self.paged_recurrent_bytes / (1024 * 1024),
             );

--- a/mistralrs-core/src/rope_override.rs
+++ b/mistralrs-core/src/rope_override.rs
@@ -1,0 +1,38 @@
+use serde::{Deserialize, Serialize};
+
+/// YaRN rope override applied when synthesizing a GGUF model config.
+///
+/// Mirrors llama.cpp's `--rope-scaling yarn --rope-scale N --yarn-orig-ctx M`
+/// semantics: `scale` is the positional extension factor, `orig_ctx` is the
+/// pretraining context the model was trained with (defaults to the GGUF
+/// `context_length` when unset), and `target_ctx`, when set, forces the
+/// synthesized `max_position_embeddings` instead of `round(orig_ctx * scale)`.
+#[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]
+pub struct RopeOverride {
+    pub scale: f32,
+    pub orig_ctx: Option<usize>,
+    pub beta_fast: f32,
+    pub beta_slow: f32,
+    pub target_ctx: Option<usize>,
+}
+
+impl RopeOverride {
+    pub fn yarn(scale: f32, orig_ctx: Option<usize>, target_ctx: Option<usize>) -> Self {
+        Self {
+            scale,
+            orig_ctx,
+            beta_fast: 32.0,
+            beta_slow: 1.0,
+            target_ctx,
+        }
+    }
+
+    pub fn resolved_orig_ctx(&self, native_ctx: usize) -> usize {
+        self.orig_ctx.unwrap_or(native_ctx)
+    }
+
+    pub fn resolved_target_ctx(&self, native_ctx: usize) -> usize {
+        self.target_ctx
+            .unwrap_or_else(|| (self.resolved_orig_ctx(native_ctx) as f32 * self.scale).round() as usize)
+    }
+}

--- a/mistralrs-core/src/toml_selector.rs
+++ b/mistralrs-core/src/toml_selector.rs
@@ -9,7 +9,7 @@ use crate::{
     GGMLLoaderBuilder, GGMLSpecificConfig, GGUFLoaderBuilder, GGUFSpecificConfig, Loader,
     LoraAdapterSpec, LoraRuntimeConfig, ModelDType, MultimodalLoaderBuilder, MultimodalLoaderType,
     MultimodalSpecificConfig, NormalLoaderBuilder, NormalLoaderType, NormalSpecificConfig,
-    Topology, UqffWriteConfig, GGUF_MULTI_FILE_DELIMITER, UQFF_MULTI_FILE_DELIMITER,
+    RopeOverride, Topology, UqffWriteConfig, GGUF_MULTI_FILE_DELIMITER, UQFF_MULTI_FILE_DELIMITER,
 };
 
 fn default_one() -> usize {
@@ -238,6 +238,10 @@ pub enum TomlModelSelected {
 
         /// Name of the Matryoshka Transformer slice to use.
         matformer_slice_name: Option<String>,
+
+        /// YaRN rope override for long-context serving.
+        #[serde(default)]
+        rope_override: Option<RopeOverride>,
     },
 
     /// Select a GGUF model with X-LoRA.
@@ -943,6 +947,7 @@ fn loader_from_selected(
             hf_cache_path,
             matformer_config_path,
             matformer_slice_name,
+            rope_override,
         } => {
             let mut builder = GGUFLoaderBuilder::new(
                 args.chat_template,
@@ -963,6 +968,7 @@ fn loader_from_selected(
                     hf_cache_path,
                     matformer_config_path,
                     matformer_slice_name,
+                    rope_override,
                 },
                 args.no_kv_cache,
                 args.jinja_explicit,

--- a/mistralrs-core/src/vision_models/qwen3_5/text.rs
+++ b/mistralrs-core/src/vision_models/qwen3_5/text.rs
@@ -29,7 +29,10 @@ use crate::{
     },
     layers::{self, CausalMasker, GemmaRmsNorm, Qwen3VLRotaryEmbedding, Sdpa},
     layers_masker::{CausalMaskConfig, PastKvLenCache},
-    paged_attention::{AttentionImplementation, ModelConfigMetadata, PagedAttention},
+    paged_attention::{
+        AttentionImplementation, HybridPagedKvCacheConfig, ModelConfigLike, ModelConfigMetadata,
+        PagedAttention,
+    },
     pipeline::{
         text_models_inputs_processor::{FlashParams, PagedAttentionInputMetadata},
         EitherCache, ForwardMaskCache, IsqModel, KvCache, ModelForwardContext,
@@ -1213,6 +1216,13 @@ impl NormalModel for Qwen3_5TextModel {
 
     fn config(&self) -> &ModelConfigMetadata {
         &self.cfg
+    }
+
+    fn model_config(&self) -> Arc<dyn ModelConfigLike + Send + Sync> {
+        Arc::new(HybridPagedKvCacheConfig::new(
+            self.cfg.clone(),
+            self.paged_kv_layers(),
+        ))
     }
 
     fn supports_packed_prefill(&self) -> bool {

--- a/mistralrs-core/tests/f4_cache_storage.rs
+++ b/mistralrs-core/tests/f4_cache_storage.rs
@@ -1,0 +1,83 @@
+// Phase 0 evidence: candle DType::F4 (MX4) has no CUDA storage/cast path in the
+// pinned candle-core rev, so the 4-bit KV cache must use packed U8 storage.
+// See F4-KV-STORAGE-ASSESSMENT.md in the repo root.
+use candle_core::DType;
+
+#[cfg(feature = "cuda")]
+use candle_core::{Device, Tensor};
+
+const F4_BLOCK: usize = 32;
+const F4_BIAS: i32 = 8;
+
+fn quantize_q4_block(values: &[f32], block: &mut [u8]) -> f32 {
+    let max_abs = values
+        .iter()
+        .fold(0f32, |acc, v| acc.max(v.abs()))
+        .max(1e-6);
+    let scale = max_abs / (F4_BIAS as f32);
+    for (i, &v) in values.iter().enumerate() {
+        let q = (v / scale).round().clamp(-8.0, 7.0) as i32 + F4_BIAS;
+        let byte = &mut block[i / 2];
+        if i % 2 == 0 {
+            *byte = (*byte & 0xF0) | (q as u8 & 0x0F);
+        } else {
+            *byte = (*byte & 0x0F) | ((q as u8 & 0x0F) << 4);
+        }
+    }
+    scale
+}
+
+fn dequantize_q4_block(values: &[f32], block: &[u8], scale: f32, out: &mut [f32]) {
+    for (i, o) in out.iter_mut().enumerate() {
+        let byte = block[i / 2];
+        let q = if i % 2 == 0 { byte & 0x0F } else { (byte >> 4) & 0x0F };
+        *o = ((q as i32 - F4_BIAS) as f32) * scale;
+    }
+    let _ = values;
+}
+
+#[test]
+fn candle_f4_is_sub_byte() {
+    assert_eq!(DType::F4.size_in_bytes(), 0, "F4 must be sub-byte");
+}
+
+#[test]
+fn q4_pack_unpack_round_trip_closes_to_source() {
+    let values: Vec<f32> = (0..F4_BLOCK)
+        .map(|i| ((i as f32 / F4_BLOCK as f32) - 0.5) * 3.0)
+        .collect();
+    let mut packed = vec![0u8; F4_BLOCK / 2];
+    let scale = quantize_q4_block(&values, &mut packed);
+    let mut out = vec![0f32; F4_BLOCK];
+    dequantize_q4_block(&values, &packed, scale, &mut out);
+    // 4-bit symmetric block format: max error is half a level, scale/2,
+    // where scale = max_abs/8, so the bound is max_abs/16.
+    let max_abs = values.iter().fold(0f32, |acc, v| acc.max(v.abs()));
+    for (a, b) in values.iter().zip(out.iter()) {
+        assert!((a - b).abs() <= max_abs / 16.0 + 1e-6, "value {a} -> {b}");
+    }
+}
+
+#[test]
+fn q4_packed_layout_is_half_byte_per_element() {
+    // 32 f32 values -> 16 bytes of nibbles + one f32 scale.
+    assert_eq!(F4_BLOCK / 2 + std::mem::size_of::<f32>(), 20);
+}
+
+#[cfg(feature = "cuda")]
+#[test]
+fn cuda_rejects_f4_allocation_and_accepts_u8() {
+    let device = Device::Cuda(0);
+    // The cache storage vehicle: F4 allocation must fail with the candle
+    // "Dummy types" error, proving the 4-bit cache needs U8 packing.
+    let err = unsafe { Tensor::empty((1024,), DType::F4, &device) }.unwrap_err();
+    let msg = err.to_string();
+    assert!(
+        msg.contains("Dummy types") || msg.contains("Unsupported"),
+        "unexpected error: {msg}"
+    );
+    // U8 allocation round-trips through the same path CacheEngine uses.
+    let t = unsafe { Tensor::empty((1024,), DType::U8, &device) }.unwrap();
+    assert_eq!(t.dtype(), DType::U8);
+    assert_eq!(t.device(), &device);
+}

--- a/mistralrs-core/tests/f4_kv_layout.rs
+++ b/mistralrs-core/tests/f4_kv_layout.rs
@@ -1,0 +1,171 @@
+// CPU-side verification of the F4 KV cache byte layout and kernel indexing.
+// Mirrors the CUDA kernels exactly (reshape_and_cache_f4_kernel,
+// pagedattention.cuh F4 branches) so indexing bugs are caught without a GPU.
+use candle_core::{Device, Tensor};
+
+const NUM_HEADS: usize = 2;
+const HEAD_SIZE: usize = 256;
+const BLOCK_SIZE: usize = 32;
+const NUM_BLOCKS: usize = 4;
+
+fn quant(v: f32, scale: f32) -> u8 {
+    let s = if scale > 0.0 { scale } else { 1.0 };
+    let q = (v / s).round().clamp(-8.0, 7.0) as i32 + 8;
+    q as u8
+}
+
+fn dequant(nib: u8, scale: f32) -> f32 {
+    ((nib as i32 - 8) as f32) * scale
+}
+
+// K cache: (num_blocks, num_heads, hd/32, block_size, 16) u8; value d of
+// token t, head h, xrow = d/32, xoff = d%32 lives at
+//   ((block*H + h)*8 + xrow)*(BS*16) + t*16 + xoff/2, nibble xoff%2.
+// k_scale: (num_blocks, num_heads, hd/32, block_size) f32, per (h, xrow, t).
+fn write_k_ref(
+    k_cache: &mut [u8],
+    k_scale: &mut [f32],
+    values: &[f32], // [tokens][heads][head_size]
+    slot: &[usize],
+) {
+    for (token, &slot_idx) in slot.iter().enumerate() {
+        let block = slot_idx / BLOCK_SIZE;
+        let t = slot_idx % BLOCK_SIZE;
+        for h in 0..NUM_HEADS {
+            let mut cell_max = [0f32; HEAD_SIZE / 32];
+            for d in 0..HEAD_SIZE {
+                let xrow = d / 32;
+                cell_max[xrow] = cell_max[xrow].max(values[token * NUM_HEADS * HEAD_SIZE + h * HEAD_SIZE + d].abs());
+            }
+            for d in 0..HEAD_SIZE {
+                let xrow = d / 32;
+                let xoff = d % 32;
+                let scale = cell_max[xrow] / 8.0;
+                let byte = ((block * NUM_HEADS + h) * 8 + xrow) * (BLOCK_SIZE * 16) + t * 16 + xoff / 2;
+                let nib = quant(values[token * NUM_HEADS * HEAD_SIZE + h * HEAD_SIZE + d], scale);
+                let pos = if xoff % 2 == 0 {
+                    (nib & 0x0F) | (k_cache[byte] & 0xF0)
+                } else {
+                    ((nib & 0x0F) << 4) | (k_cache[byte] & 0x0F)
+                };
+                k_cache[byte] = pos;
+                if xoff == 0 {
+                    k_scale[((block * NUM_HEADS + h) * 8 + xrow) * BLOCK_SIZE + t] = scale;
+                }
+            }
+        }
+    }
+}
+
+// V cache: (num_blocks, num_heads, hd/2, block_size) u8; value d of token t
+// lives at ((block*H + h)*(hd/2) + d/2)*BS + t, nibble d%2.
+// v_scale: (num_blocks, num_heads, block_size) f32, per (h, t).
+fn write_v_ref(
+    v_cache: &mut [u8],
+    v_scale: &mut [f32],
+    values: &[f32],
+    slot: &[usize],
+) {
+    for (token, &slot_idx) in slot.iter().enumerate() {
+        let block = slot_idx / BLOCK_SIZE;
+        let t = slot_idx % BLOCK_SIZE;
+        for h in 0..NUM_HEADS {
+            let max = (0..HEAD_SIZE)
+                .map(|d| values[token * NUM_HEADS * HEAD_SIZE + h * HEAD_SIZE + d].abs())
+                .fold(0.0f32, f32::max);
+            let scale = max / 8.0;
+            v_scale[(block * NUM_HEADS + h) * BLOCK_SIZE + t] = scale;
+            for d in 0..HEAD_SIZE {
+                let byte = ((block * NUM_HEADS + h) * (HEAD_SIZE / 2) + d / 2) * BLOCK_SIZE + t;
+                let nib = quant(values[token * NUM_HEADS * HEAD_SIZE + h * HEAD_SIZE + d], scale);
+                let pos = if d % 2 == 0 {
+                    (nib & 0x0F) | (v_cache[byte] & 0xF0)
+                } else {
+                    ((nib & 0x0F) << 4) | (v_cache[byte] & 0x0F)
+                };
+                v_cache[byte] = pos;
+            }
+        }
+    }
+}
+
+// Attention-kernel reads.
+fn read_k(k_cache: &[u8], k_scale: &[f32], block: usize, head: usize, token: usize, d: usize) -> f32 {
+    let xrow = d / 32;
+    let xoff = d % 32;
+    let byte = ((block * NUM_HEADS + head) * 8 + xrow) * (BLOCK_SIZE * 16) + token * 16 + xoff / 2;
+    let nib = if xoff % 2 == 0 {
+        k_cache[byte] & 0x0F
+    } else {
+        (k_cache[byte] >> 4) & 0x0F
+    };
+    let scale = k_scale[((block * NUM_HEADS + head) * 8 + xrow) * BLOCK_SIZE + token];
+    dequant(nib, scale)
+}
+
+fn read_v(v_cache: &[u8], v_scale: &[f32], block: usize, head: usize, token: usize, d: usize) -> f32 {
+    let byte = ((block * NUM_HEADS + head) * (HEAD_SIZE / 2) + d / 2) * BLOCK_SIZE + token;
+    let nib = if d % 2 == 0 {
+        v_cache[byte] & 0x0F
+    } else {
+        (v_cache[byte] >> 4) & 0x0F
+    };
+    let scale = v_scale[(block * NUM_HEADS + head) * BLOCK_SIZE + token];
+    dequant(nib, scale)
+}
+
+#[test]
+fn f4_kv_layout_round_trip_close_to_source() {
+    let k_cache = vec![0u8; NUM_BLOCKS * NUM_HEADS * (HEAD_SIZE / 32) * BLOCK_SIZE * 16];
+    let v_cache = vec![0u8; NUM_BLOCKS * NUM_HEADS * (HEAD_SIZE / 2) * BLOCK_SIZE];
+    let k_scale = vec![0f32; NUM_BLOCKS * NUM_HEADS * (HEAD_SIZE / 32) * BLOCK_SIZE];
+    let v_scale = vec![0f32; NUM_BLOCKS * NUM_HEADS * BLOCK_SIZE];
+    let mut k_cache = k_cache;
+    let mut v_cache = v_cache;
+    let mut k_scale = k_scale;
+    let mut v_scale = v_scale;
+
+    // 100 tokens across 4 blocks.
+    let n_tokens = 100;
+    let slot: Vec<usize> = (0..n_tokens).collect();
+    let k_vals: Vec<f32> = (0..n_tokens * NUM_HEADS * HEAD_SIZE)
+        .map(|i| (((i * 7919) % 1000) as f32 / 500.0 - 1.0) * 2.0)
+        .collect();
+    let v_vals: Vec<f32> = (0..n_tokens * NUM_HEADS * HEAD_SIZE)
+        .map(|i| ((i * 104729) % 997) as f32 / 250.0 - 2.0)
+        .collect();
+    write_k_ref(&mut k_cache, &mut k_scale, &k_vals, &slot);
+    write_v_ref(&mut v_cache, &mut v_scale, &v_vals, &slot);
+
+    // Every value round-trips within the 4-bit bound (max_abs/16 per cell).
+    for token in 0..n_tokens {
+        let block = slot[token] / BLOCK_SIZE;
+        let t = slot[token] % BLOCK_SIZE;
+        for h in 0..NUM_HEADS {
+            for d in 0..HEAD_SIZE {
+                let k_orig = k_vals[token * NUM_HEADS * HEAD_SIZE + h * HEAD_SIZE + d];
+                let k_got = read_k(&k_cache, &k_scale, block, h, t, d);
+                let cell_max = (0..32)
+                    .map(|x| k_vals[token * NUM_HEADS * HEAD_SIZE + h * HEAD_SIZE + (d / 32) * 32 + x].abs())
+                    .fold(0.0f32, f32::max);
+                // Worst case: half a step plus the top-level clamp (q4_0-style).
+                let k_bound = cell_max / 8.0;
+                assert!(
+                    (k_orig - k_got).abs() <= k_bound + 1e-4,
+                    "K token {token} h {h} d {d}: {k_orig} -> {k_got}"
+                );
+                let v_orig = v_vals[token * NUM_HEADS * HEAD_SIZE + h * HEAD_SIZE + d];
+                let v_got = read_v(&v_cache, &v_scale, block, h, t, d);
+                let head_max = (0..HEAD_SIZE)
+                    .map(|x| v_vals[token * NUM_HEADS * HEAD_SIZE + h * HEAD_SIZE + x].abs())
+                    .fold(0.0f32, f32::max);
+                let v_bound = head_max / 8.0;
+                assert!(
+                    (v_orig - v_got).abs() <= v_bound + 1e-4,
+                    "V token {token} h {h} d {d}: {v_orig} -> {v_got}"
+                );
+            }
+        }
+    }
+    let _ = (Device::Cpu, Tensor::new(1f32, &Device::Cpu));
+}

--- a/mistralrs-core/tests/yarn_rotary.rs
+++ b/mistralrs-core/tests/yarn_rotary.rs
@@ -1,0 +1,132 @@
+// Golden test for the qwen35 YaRN partial rotary: values at position 262145
+// (the first position beyond the native 262144 window) computed from the exact
+// llama.cpp formulas (ggml.c corr_dims, rope.cu rope_yarn, llama-context.cpp
+// factor resolution). Reference values generated independently in Python.
+use candle_core::{DType, Device, Tensor};
+use mistralrs_core::layers::RotaryEmbedding;
+
+const BASE: f32 = 1e7;
+const ROT_DIM: usize = 64; // rotary dim; head dim is 256 with 64 rotated
+const HEAD_DIM: usize = 256;
+const NATIVE_CTX: usize = 262144;
+const TARGET_CTX: usize = 320000;
+const FACTOR: f32 = 320000.0 / 262144.0;
+
+fn build_yarn() -> RotaryEmbedding {
+    RotaryEmbedding::new_partial_yarn(
+        BASE,
+        ROT_DIM,
+        TARGET_CTX,
+        NATIVE_CTX,
+        FACTOR,
+        1.0,
+        1.0,
+        32.0,
+        1.0,
+        &Device::Cpu,
+        DType::F32,
+    )
+    .unwrap()
+}
+
+// For a neox partial rotary, pair p rotates dims (p, p + ROT_DIM/2); with
+// q[p] = 1, q[p + ROT_DIM/2] = 0, the rotated output is (cos[p], sin[p]).
+fn rotate_pair(rope: &RotaryEmbedding, position: usize, pair: usize) -> (f32, f32) {
+    let mut qv = vec![0f32; HEAD_DIM];
+    qv[pair] = 1.0;
+    let q = Tensor::from_vec(qv, (1, 1, 1, HEAD_DIM), &Device::Cpu).unwrap();
+    let k = Tensor::zeros((1, 1, 1, HEAD_DIM), DType::F32, &Device::Cpu).unwrap();
+    let positions = Tensor::new(&[position as u32], &Device::Cpu).unwrap();
+    let (q_out, _) = rope.forward(&q, &k, &positions).unwrap();
+    let qv = q_out.flatten_all().unwrap().to_vec1::<f32>().unwrap();
+    (qv[pair + ROT_DIM / 2], qv[pair])
+}
+
+#[test]
+fn yarn_matches_llama_cpp_reference_at_position_262145() {
+    let yarn = build_yarn();
+    let position = NATIVE_CTX + 1;
+
+    // (pair, expected_sin, expected_cos) from the reference computation.
+    let cases = [
+        (0usize, -0.901560650f32, -0.476939735f32),
+        (15usize, 0.862911408f32, -0.543752718f32),
+        (30usize, 0.059945550f32, 1.018179575f32),
+    ];
+    for (pair, expected_sin, expected_cos) in cases {
+        let (sin, cos) = rotate_pair(&yarn, position, pair);
+        assert!(
+            (sin - expected_sin).abs() < 1e-4,
+            "pair {pair} sin: got {sin}, expected {expected_sin}"
+        );
+        assert!(
+            (cos - expected_cos).abs() < 1e-4,
+            "pair {pair} cos: got {cos}, expected {expected_cos}"
+        );
+    }
+}
+
+#[test]
+fn yarn_matches_llama_cpp_reference_at_boundary_positions() {
+    // llama.cpp cache values (net mscale 1.0199427) at the last native
+    // position, the first beyond-native position, and the last scaled
+    // position, from the exact ggml.c / ops.cpp / llama-context.cpp chain.
+    let yarn = build_yarn();
+    let cases = [
+        (262144usize, 30usize, 0.0599453214f32, 1.0181795887f32),
+        (262145usize, 0usize, -0.9015606498f32, -0.4769397353f32),
+        (262145usize, 15usize, 0.8629114077f32, -0.5437527184f32),
+        (262145usize, 30usize, 0.0599455498f32, 1.0181795752f32),
+        (319999usize, 13usize, -0.1119046827f32, 1.0137852131f32),
+        (319999usize, 30usize, 0.0731545384f32, 1.0173158457f32),
+    ];
+    for (position, pair, expected_sin, expected_cos) in cases {
+        let (sin, cos) = rotate_pair(&yarn, position, pair);
+        assert!(
+            (sin - expected_sin).abs() < 1e-4,
+            "pos {position} pair {pair} sin: got {sin}, expected {expected_sin}"
+        );
+        assert!(
+            (cos - expected_cos).abs() < 1e-4,
+            "pos {position} pair {pair} cos: got {cos}, expected {expected_cos}"
+        );
+    }
+}
+
+#[test]
+fn yarn_high_frequency_pairs_are_pure_extrapolation_scaled_by_mscale() {
+    // Pairs below the correction range (low = 14) keep the native frequency and
+    // are scaled by mscale = 1 + 0.1*ln(factor); the plain rope is the reference.
+    let yarn = build_yarn();
+    let plain = RotaryEmbedding::new_partial(
+        BASE,
+        ROT_DIM,
+        TARGET_CTX,
+        &Device::Cpu,
+        true,
+        DType::F32,
+    )
+    .unwrap();
+    let mscale = 1.0 + 0.1 * FACTOR.ln();
+    let position = NATIVE_CTX + 1;
+    for pair in [0usize, 5, 13] {
+        let (yarn_sin, yarn_cos) = rotate_pair(&yarn, position, pair);
+        let (plain_sin, plain_cos) = rotate_pair(&plain, position, pair);
+        assert!(
+            (yarn_sin - plain_sin * mscale).abs() < 1e-5,
+            "pair {pair} sin not extrapolation-scaled: {yarn_sin} vs {plain_sin} * {mscale}"
+        );
+        assert!(
+            (yarn_cos - plain_cos * mscale).abs() < 1e-5,
+            "pair {pair} cos not extrapolation-scaled: {yarn_cos} vs {plain_cos} * {mscale}"
+        );
+    }
+}
+
+#[test]
+fn yarn_table_extends_to_the_scaled_context() {
+    let yarn = build_yarn();
+    // The last position of the scaled window must rotate without error.
+    let (sin, cos) = rotate_pair(&yarn, TARGET_CTX - 1, 7);
+    assert!(sin.is_finite() && cos.is_finite());
+}

--- a/mistralrs-paged-attn/src/cuda/attention/dtype_float16.cuh
+++ b/mistralrs-paged-attn/src/cuda/attention/dtype_float16.cuh
@@ -462,6 +462,11 @@ inline __device__ void from_float(uint2& dst, Float4_ src) {
   dst.y = float2_to_half2(src.y);
 }
 
+inline __device__ void from_float(uint4& dst, Float4_ src) {
+  dst.x = float2_to_half2(src.x);
+  dst.y = float2_to_half2(src.y);
+}
+
 inline __device__ void from_float(uint4& dst, Float8_ src) {
   dst.x = float2_to_half2(src.x);
   dst.y = float2_to_half2(src.y);

--- a/mistralrs-paged-attn/src/cuda/attention/dtype_float32.cuh
+++ b/mistralrs-paged-attn/src/cuda/attention/dtype_float32.cuh
@@ -240,6 +240,13 @@ inline __device__ void from_float(float2& dst, float2 src) {
   dst = src;
 }
 
+inline __device__ void from_float(float4& dst, Float4_ src) {
+  dst.x = src.x.x;
+  dst.y = src.x.y;
+  dst.z = src.y.x;
+  dst.w = src.y.y;
+}
+
 inline __device__ void from_float(float4& dst, float4 src) {
   dst = src;
 }

--- a/mistralrs-paged-attn/src/cuda/attention/dtype_fp8.cuh
+++ b/mistralrs-paged-attn/src/cuda/attention/dtype_fp8.cuh
@@ -15,6 +15,7 @@ enum class Fp8KVCacheDataType {
   kAuto = 0,
   kFp8E4M3 = 1,
   kFp8E5M2 = 2,
+  kF4 = 3,
 };
 
 // fp8 vector types for quantization of kv cache

--- a/mistralrs-paged-attn/src/cuda/backend/cache.rs
+++ b/mistralrs-paged-attn/src/cuda/backend/cache.rs
@@ -1,7 +1,9 @@
 use std::{collections::HashMap, iter::zip};
 
 use crate::cuda::backend::slice_ptr;
-use crate::cuda::ffi::{copy_blocks_bf16, copy_blocks_f16, copy_blocks_f32};
+use crate::cuda::ffi::{
+    copy_blocks_bf16, copy_blocks_f16, copy_blocks_f32, copy_blocks_u8,
+};
 use candle_core::backend::BackendDevice;
 use candle_core::cuda_backend::CudaStorageSlice;
 use candle_core::Result;
@@ -85,6 +87,13 @@ pub fn copy_blocks(
                 let (ptr_value, _value_guard) = slice_ptr(slice_value, 0);
                 (ptr_key, ptr_value)
             }
+            // F4 caches are packed U8 tensors; copy raw bytes.
+            (CudaStorageSlice::U8(slice_key), CudaStorageSlice::U8(slice_value)) => {
+                let (ptr_key, _key_guard) = slice_ptr(slice_key, 0);
+                let (ptr_value, _value_guard) = slice_ptr(slice_value, 0);
+                dtype = DType::U8;
+                (ptr_key, ptr_value)
+            }
             _ => {
                 candle_core::bail!("only f32, f16 and bf16 input data type supported!",);
             }
@@ -154,6 +163,18 @@ pub fn copy_blocks(
         },
         candle_core::DType::F32 => unsafe {
             copy_blocks_f32(
+                key_cache_ptr,
+                value_cache_ptr,
+                block_mapping_ptr,
+                num_layers as i32,
+                num_pairs as i32,
+                numel_per_block_key as i32,
+                numel_per_block_value as i32,
+                dev.cuda_stream().cu_stream() as i64,
+            );
+        },
+        candle_core::DType::U8 => unsafe {
+            copy_blocks_u8(
                 key_cache_ptr,
                 value_cache_ptr,
                 block_mapping_ptr,

--- a/mistralrs-paged-attn/src/cuda/backend/gather_kv.rs
+++ b/mistralrs-paged-attn/src/cuda/backend/gather_kv.rs
@@ -55,7 +55,12 @@ pub fn gather_kv_cache(
     let head_size_over_x = k_dims.2;
     let block_size = k_dims.3;
     let x = k_dims.4;
-    let head_size = head_size_over_x * x;
+    // F4 packs 32 values per 16-byte row; the row count is bytes-per-head/32.
+    let head_size = if cache_dtype == DType::U8 {
+        head_size_over_x * 32
+    } else {
+        head_size_over_x * x
+    };
 
     // num_tokens = cu_seq_lens[-1], num_seqs = len(cu_seq_lens) - 1
     let cu_seq_lens_len = cu_seq_lens.dims1()?;
@@ -96,8 +101,10 @@ pub fn gather_kv_cache(
         DType::BF16 => 1,
         DType::F32 => 2,
         DType::F8E4M3 => 3,
+        // F4 lives in packed U8 storage.
+        DType::U8 => 4,
         other => candle_core::bail!(
-            "gather_kv_cache only supports f16, bf16, f32, f8e4m3 cache (got {other:?})"
+            "gather_kv_cache only supports f16, bf16, f32, f8e4m3, f4 cache (got {other:?})"
         ),
     };
 
@@ -117,6 +124,8 @@ pub fn gather_kv_cache(
         // Get cache pointers - handle FP8 vs regular dtype
         let (kc_ptr, _kc_guard) = if cache_dtype_code == 3 {
             slice_ptr(kc_s.as_cuda_slice::<F8E4M3>()?, kc_l.start_offset())
+        } else if cache_dtype_code == 4 {
+            slice_ptr(kc_s.as_cuda_slice::<u8>()?, kc_l.start_offset())
         } else {
             match cache_dtype {
                 DType::F16 => slice_ptr(kc_s.as_cuda_slice::<half::f16>()?, kc_l.start_offset()),
@@ -127,6 +136,8 @@ pub fn gather_kv_cache(
         };
         let (vc_ptr, _vc_guard) = if cache_dtype_code == 3 {
             slice_ptr(vc_s.as_cuda_slice::<F8E4M3>()?, vc_l.start_offset())
+        } else if cache_dtype_code == 4 {
+            slice_ptr(vc_s.as_cuda_slice::<u8>()?, vc_l.start_offset())
         } else {
             match cache_dtype {
                 DType::F16 => slice_ptr(vc_s.as_cuda_slice::<half::f16>()?, vc_l.start_offset()),

--- a/mistralrs-paged-attn/src/cuda/backend/paged_attention.rs
+++ b/mistralrs-paged-attn/src/cuda/backend/paged_attention.rs
@@ -88,6 +88,8 @@ impl PagedAttention {
             DType::BF16 => 1,
             DType::F32 => 2,
             DType::F8E4M3 => 3,
+            // F4 lives in packed U8 storage.
+            DType::U8 => 4,
             dtype => candle::bail!("cache dtype {dtype:?} is not supported"),
         };
 
@@ -147,11 +149,15 @@ impl PagedAttention {
         let q = q.as_cuda_slice::<T>()?;
         let (kc_ptr, _kc_guard) = if cache_dtype == 3 {
             slice_ptr(kc.as_cuda_slice::<F8E4M3>()?, kc_l.start_offset())
+        } else if cache_dtype == 4 {
+            slice_ptr(kc.as_cuda_slice::<u8>()?, kc_l.start_offset())
         } else {
             slice_ptr(kc.as_cuda_slice::<T>()?, kc_l.start_offset())
         };
         let (vc_ptr, _vc_guard) = if cache_dtype == 3 {
             slice_ptr(vc.as_cuda_slice::<F8E4M3>()?, vc_l.start_offset())
+        } else if cache_dtype == 4 {
+            slice_ptr(vc.as_cuda_slice::<u8>()?, vc_l.start_offset())
         } else {
             slice_ptr(vc.as_cuda_slice::<T>()?, vc_l.start_offset())
         };
@@ -240,15 +246,24 @@ impl PagedAttention {
         }
 
         let (num_blocks, num_kv_heads, head_size_kc, block_size, x) = kc_l.shape().dims5()?;
-        if head_size_kc != head_size / x {
+        if cache_dtype == 4 {
+            if head_size_kc != head_size / 32
+                || (num_blocks, num_kv_heads, head_size / 2, block_size)
+                    != vc_l.shape().dims4()?
+            {
+                candle::bail!(
+                    "shape mismatch for F4 caches: key_cache {:?}, value_cache {:?}",
+                    kc_l.shape(),
+                    vc_l.shape()
+                );
+            }
+        } else if head_size_kc != head_size / x {
             candle::bail!(
                 "shape mismatch value_cache {:?}, expected {:?}",
                 vc_l.shape(),
                 (num_blocks, num_kv_heads, head_size / x, block_size, x)
             )
-        }
-
-        if (num_blocks, num_kv_heads, head_size, block_size) != vc_l.shape().dims4()? {
+        } else if (num_blocks, num_kv_heads, head_size, block_size) != vc_l.shape().dims4()? {
             candle::bail!(
                 "shape mismatch key_cache {:?} and value_cache {:?}",
                 kc_l.shape(),
@@ -476,6 +491,8 @@ fn update_cache<
         DType::BF16 => 1,
         DType::F32 => 2,
         DType::F8E4M3 => 3,
+        // F4 lives in packed U8 storage (see F4-KV-STORAGE-ASSESSMENT.md).
+        DType::U8 => 4,
         dtype => candle::bail!("cache dtype {dtype:?} is not supported"),
     };
 
@@ -539,7 +556,7 @@ fn update_cache<
     let v = v.as_cuda_slice::<T>()?;
     let s = s.as_cuda_slice::<i64>()?;
 
-    // For FP8 cache, we need to get as u8 slices instead
+    // For quantized caches, get u8 slices instead
     let ((kc_ptr, _kc_guard), (vc_ptr, _vc_guard)) = if cache_dtype == 3 {
         if !crate::cuda::USE_FP8 {
             candle::bail!("FP8 is not supported on this system.");
@@ -547,6 +564,13 @@ fn update_cache<
 
         let kc = kc.as_cuda_slice::<F8E4M3>()?;
         let vc = vc.as_cuda_slice::<F8E4M3>()?;
+        (
+            slice_ptr(kc, kc_l.start_offset()),
+            slice_ptr(vc, vc_l.start_offset()),
+        )
+    } else if cache_dtype == 4 {
+        let kc = kc.as_cuda_slice::<u8>()?;
+        let vc = vc.as_cuda_slice::<u8>()?;
         (
             slice_ptr(kc, kc_l.start_offset()),
             slice_ptr(vc, vc_l.start_offset()),
@@ -597,20 +621,37 @@ fn update_cache<
     }
 
     let (num_blocks, num_heads_kc, head_size_kc, block_size, x) = kc_l.shape().dims5()?;
-    if num_heads_kc != num_heads || head_size_kc != head_size / x {
-        candle::bail!(
-            "shape mismatch value_cache {:?}, expected {:?}",
-            vc_l.shape(),
-            (num_blocks, num_heads, head_size / x, block_size, x)
-        )
-    }
+    if cache_dtype == 4 {
+        // F4: 32 values per 16-byte cell row; value head dim halved (packed).
+        if num_heads_kc != num_heads
+            || head_size_kc != head_size / 32
+            || (num_blocks, num_heads, head_size / 2, block_size)
+                != vc_l.shape().dims4()?
+        {
+            candle::bail!(
+                "shape mismatch for F4 caches: key_cache {:?}, value_cache {:?}, expected key ({num_blocks}, {num_heads}, {}, {block_size}, 16) and value ({num_blocks}, {num_heads}, {}, {block_size})",
+                kc_l.shape(),
+                vc_l.shape(),
+                head_size / 32,
+                head_size / 2
+            )
+        }
+    } else {
+        if num_heads_kc != num_heads || head_size_kc != head_size / x {
+            candle::bail!(
+                "shape mismatch value_cache {:?}, expected {:?}",
+                vc_l.shape(),
+                (num_blocks, num_heads, head_size / x, block_size, x)
+            )
+        }
 
-    if (num_blocks, num_heads, head_size, block_size) != vc_l.shape().dims4()? {
-        candle::bail!(
-            "shape mismatch key_cache {:?} and value_cache {:?}",
-            kc_l.shape(),
-            vc_l.shape()
-        )
+        if (num_blocks, num_heads, head_size, block_size) != vc_l.shape().dims4()? {
+            candle::bail!(
+                "shape mismatch key_cache {:?} and value_cache {:?}",
+                kc_l.shape(),
+                vc_l.shape()
+            )
+        }
     }
 
     if (num_tokens) != s_l.shape().dims1()? {

--- a/mistralrs-paged-attn/src/cuda/copy_blocks_kernel.cu
+++ b/mistralrs-paged-attn/src/cuda/copy_blocks_kernel.cu
@@ -124,3 +124,33 @@ extern "C" void copy_blocks_bf16(int64_t *key_cache_ptrs,
                                       block_mapping, numel_per_block_key,
                                       numel_per_block_value);
 }
+
+extern "C" __global__ void
+copy_blocks_kernel_u8(int64_t *key_cache_ptrs, int64_t *value_cache_ptrs,
+                      const int64_t *__restrict__ block_mapping,
+                      const int numel_per_block_key,
+                      const int numel_per_block_value) {
+  copy_blocks_internal_kernel<int8_t>(key_cache_ptrs, value_cache_ptrs,
+                                      block_mapping, numel_per_block_key,
+                                      numel_per_block_value);
+}
+
+extern "C" void copy_blocks_u8(int64_t *key_cache_ptrs,
+                               int64_t *value_cache_ptrs,
+                               const int64_t *__restrict__ block_mapping,
+                               const int num_layers, const int num_pairs,
+                               int numel_per_block_key,
+                               int numel_per_block_value, int64_t stream_) {
+  cudaStream_t stream = (cudaStream_t)stream_;
+  int num_threads = numel_per_block_key;
+  if (numel_per_block_value > num_threads) {
+    num_threads = numel_per_block_value;
+  }
+  if (num_threads > 1024) {
+    num_threads = 1024;
+  }
+  copy_blocks_kernel_u8<<<dim3(num_layers, num_pairs, 1), num_threads, 0,
+                          stream>>>(key_cache_ptrs, value_cache_ptrs,
+                                    block_mapping, numel_per_block_key,
+                                    numel_per_block_value);
+}

--- a/mistralrs-paged-attn/src/cuda/ffi.rs
+++ b/mistralrs-paged-attn/src/cuda/ffi.rs
@@ -371,6 +371,17 @@ extern "C" {
         stream: i64,
     );
 
+    pub fn copy_blocks_u8(
+        key_cache_ptrs: *mut c_void,
+        value_cache_ptrs: *mut c_void,
+        block_mapping: *const c_void,
+        num_layers: i32,
+        num_pairs: i32,
+        numel_per_block_key: i32,
+        numel_per_block_value: i32,
+        stream: i64,
+    );
+
     pub fn update_kv_scales_f32(
         k: *const c_void,
         v: *const c_void,

--- a/mistralrs-paged-attn/src/cuda/gather_kv_cache_kernel.cu
+++ b/mistralrs-paged-attn/src/cuda/gather_kv_cache_kernel.cu
@@ -93,21 +93,66 @@ __global__ void gather_kv_cache_kernel(
     const int head_idx = i / head_size;
     const int d = i % head_size;
 
-    // K: [block_id, head_idx, d/x, slot, d%x]
-    const int x_idx = d / x;
-    const int x_offset = d % x;
-    const int64_t k_src_idx = static_cast<int64_t>(block_id) * k_block_stride +
-                              head_idx * k_head_stride +
-                              x_idx * block_size * x + slot * x + x_offset;
+    if constexpr (kv_dt == Fp8KVCacheDataType::kF4) {
+      // F4: K byte layout [block, head, hd/32, bs, 16], V byte layout
+      // [block, head, hd/2, bs]; both caches use a hd*bs/2 block stride.
+      const int64_t f4_block_stride =
+          static_cast<int64_t>(num_kv_heads) * head_size * block_size / 2;
+      const int64_t k_head_stride_f4 =
+          static_cast<int64_t>(head_size / 32) * block_size * 16;
+      const int64_t v_head_stride_f4 =
+          static_cast<int64_t>(head_size / 2) * block_size;
 
-    // V: [block_id, head_idx, d, slot]
-    const int64_t v_src_idx = static_cast<int64_t>(block_id) * v_block_stride +
-                              head_idx * v_head_stride + d * block_size + slot;
+      const int64_t k_byte =
+          static_cast<int64_t>(block_id) * f4_block_stride +
+          head_idx * k_head_stride_f4 + (d / 32) * block_size * 16 +
+          slot * 16 + (d % 32) / 2;
+      const float kscale =
+          k_scale[((static_cast<int64_t>(block_id) * num_kv_heads + head_idx) *
+                       (head_size / 32) +
+                   d / 32) *
+                      block_size +
+                  slot];
+      const uint8_t kb = key_cache[k_byte];
+      const uint8_t knib = (d % 2 == 0) ? (kb & 0x0F) : ((kb >> 4) & 0x0F);
+      k_out[out_base + i] = (out_t)(((float)((int)knib - 8)) * kscale);
 
-    if constexpr (kv_dt == Fp8KVCacheDataType::kAuto) {
+      const int64_t v_byte = static_cast<int64_t>(block_id) * f4_block_stride +
+                             head_idx * v_head_stride_f4 + (d / 2) * block_size +
+                             slot;
+      const float vscale =
+          v_scale[(static_cast<int64_t>(block_id) * num_kv_heads + head_idx) *
+                      block_size +
+                  slot];
+      const uint8_t vb = value_cache[v_byte];
+      const uint8_t vnib = (d % 2 == 0) ? (vb & 0x0F) : ((vb >> 4) & 0x0F);
+      v_out[out_base + i] = (out_t)(((float)((int)vnib - 8)) * vscale);
+    } else if constexpr (kv_dt == Fp8KVCacheDataType::kAuto) {
+      // K: [block_id, head_idx, d/x, slot, d%x]
+      const int x_idx = d / x;
+      const int x_offset = d % x;
+      const int64_t k_src_idx = static_cast<int64_t>(block_id) * k_block_stride +
+                                head_idx * k_head_stride +
+                                x_idx * block_size * x + slot * x + x_offset;
+
+      // V: [block_id, head_idx, d, slot]
+      const int64_t v_src_idx = static_cast<int64_t>(block_id) * v_block_stride +
+                                head_idx * v_head_stride + d * block_size + slot;
+
       k_out[out_base + i] = key_cache[k_src_idx];
       v_out[out_base + i] = value_cache[v_src_idx];
     } else {
+      // K: [block_id, head_idx, d/x, slot, d%x]
+      const int x_idx = d / x;
+      const int x_offset = d % x;
+      const int64_t k_src_idx = static_cast<int64_t>(block_id) * k_block_stride +
+                                head_idx * k_head_stride +
+                                x_idx * block_size * x + slot * x + x_offset;
+
+      // V: [block_id, head_idx, d, slot]
+      const int64_t v_src_idx = static_cast<int64_t>(block_id) * v_block_stride +
+                                head_idx * v_head_stride + d * block_size + slot;
+
       k_out[out_base + i] = fp8::scaled_convert<out_t, cache_t, kv_dt>(
           key_cache[k_src_idx], *k_scale);
       v_out[out_base + i] = fp8::scaled_convert<out_t, cache_t, kv_dt>(
@@ -150,7 +195,17 @@ extern "C" void gather_kv_cache(
   dim3 grid(num_tokens);
   dim3 block(std::min(num_kv_heads * head_size, 512));
 
-  if (cache_dtype == 3) {
+  if (cache_dtype == 4) {
+    // F4 cache -> dequantize to out_dtype
+    if (out_dtype == 0) {
+      CALL_GATHER_KV_CACHE(uint16_t, uint8_t, vllm::Fp8KVCacheDataType::kF4);
+    } else if (out_dtype == 1) {
+      CALL_GATHER_KV_CACHE(__nv_bfloat16, uint8_t,
+                           vllm::Fp8KVCacheDataType::kF4);
+    } else if (out_dtype == 2) {
+      CALL_GATHER_KV_CACHE(float, uint8_t, vllm::Fp8KVCacheDataType::kF4);
+    }
+  } else if (cache_dtype == 3) {
     // FP8 E4M3 cache -> dequantize to out_dtype
     if (out_dtype == 0) {
       CALL_GATHER_KV_CACHE(uint16_t, uint8_t,

--- a/mistralrs-paged-attn/src/cuda/pagedattention.cuh
+++ b/mistralrs-paged-attn/src/cuda/pagedattention.cuh
@@ -55,6 +55,30 @@
 
 namespace vllm {
 
+// Build a packed vector from unpacked floats (F4 dequant path).
+template <typename OutVec, int N>
+__device__ __forceinline__ OutVec f4_vec_from_floats(const float (&vals)[N]) {
+  OutVec out;
+  if constexpr (N == 8) {
+    Float8_ f8;
+    f8.x = make_float2(vals[0], vals[1]);
+    f8.y = make_float2(vals[2], vals[3]);
+    f8.z = make_float2(vals[4], vals[5]);
+    f8.w = make_float2(vals[6], vals[7]);
+    from_float(out, f8);
+  } else if constexpr (N == 4) {
+    Float4_ f4;
+    f4.x = make_float2(vals[0], vals[1]);
+    f4.y = make_float2(vals[2], vals[3]);
+    from_float(out, f4);
+  } else if constexpr (N == 2) {
+    from_float(out, make_float2(vals[0], vals[1]));
+  } else {
+    from_float(out, vals[0]);
+  }
+  return out;
+}
+
 // Utility function for attention softmax.
 template <int NUM_WARPS>
 inline __device__ float block_sum(float *red_smem, float sum) {
@@ -258,6 +282,30 @@ __device__ void paged_attention_kernel(
         if constexpr (kv_dt == vllm::Fp8KVCacheDataType::kAuto) {
           k_vecs[j] = *reinterpret_cast<const K_vec *>(
               k_ptr + offset1 * BLOCK_SIZE * x + offset2);
+        } else if constexpr (kv_dt == vllm::Fp8KVCacheDataType::kF4) {
+          // F4: 2 values per byte; the cell (xrow, token) has one scale. The
+          // cache's last dim is the 16-byte token row (32 values), so byte
+          // offsets are computed from value offsets directly.
+          const int value_off = vec_idx * VEC_SIZE;
+          const int cell_xrow = value_off / 32;
+          const int cell_off = value_off % 32;
+          const float scale =
+              k_scale[((physical_block_number * num_kv_heads + kv_head_idx) *
+                           (HEAD_SIZE / 32) +
+                       cell_xrow) *
+                          BLOCK_SIZE +
+                      physical_block_offset];
+          const int byte_off = cell_xrow * BLOCK_SIZE * 16 + cell_off / 2;
+          // k_ptr is already at this token's 16-byte row (physical_block_offset * x).
+          float vals[VEC_SIZE];
+#pragma unroll
+          for (int v = 0; v < VEC_SIZE; v++) {
+            const uint8_t byte = k_ptr[byte_off + v / 2];
+            const uint8_t nib =
+                (v % 2 == 0) ? (byte & 0x0F) : ((byte >> 4) & 0x0F);
+            vals[v] = ((float)((int)nib - 8)) * scale;
+          }
+          k_vecs[j] = f4_vec_from_floats<K_vec, VEC_SIZE>(vals);
         } else {
           using Cache_K_vec = typename vllm::Vec<cache_t, VEC_SIZE>::Type;
           Cache_K_vec fp8_k_vec = *reinterpret_cast<const Cache_K_vec *>(
@@ -397,6 +445,25 @@ __device__ void paged_attention_kernel(
 
         if constexpr (kv_dt == vllm::Fp8KVCacheDataType::kAuto) {
           v_vec = *reinterpret_cast<const V_vec *>(v_ptr + offset);
+        } else if constexpr (kv_dt == vllm::Fp8KVCacheDataType::kF4) {
+          // F4: values packed along the head axis (2 per byte); one scale per
+          // (head, token). V_VEC_SIZE consecutive tokens live in V_VEC_SIZE
+          // consecutive bytes at (row_idx/2) * BLOCK_SIZE + token.
+          const int byte_off = (row_idx / 2) * BLOCK_SIZE + physical_block_offset;
+          const float *v_s =
+              v_scale + (physical_block_number * num_kv_heads + kv_head_idx) *
+                            BLOCK_SIZE +
+                        physical_block_offset;
+          const bool low_nibble = (row_idx % 2) == 0;
+          float vals[V_VEC_SIZE];
+#pragma unroll
+          for (int j = 0; j < V_VEC_SIZE; j++) {
+            const uint8_t byte = v_ptr[byte_off + j];
+            const uint8_t nib =
+                low_nibble ? (byte & 0x0F) : ((byte >> 4) & 0x0F);
+            vals[j] = ((float)((int)nib - 8)) * v_s[j];
+          }
+          v_vec = f4_vec_from_floats<V_vec, V_VEC_SIZE>(vals);
         } else {
           using Cache_V_vec = typename vllm::Vec<cache_t, V_VEC_SIZE>::Type;
           Cache_V_vec fp8_v_vec =

--- a/mistralrs-paged-attn/src/cuda/pagedattention_v1_bf16.cu
+++ b/mistralrs-paged-attn/src/cuda/pagedattention_v1_bf16.cu
@@ -18,7 +18,11 @@ extern "C" void paged_attention_v1_bf16(
     uint32_t cache_dtype, // 0 => f16; 1 => bf16; 2 => f32; 3 => fp8_e4m3
     float *k_scale, float *v_scale, const float *sinks) {
 
-  if (cache_dtype == 3) {
+  if (cache_dtype == 4) {
+    // F4 cache
+    CALL_V1_LAUNCHER_BLOCK_SIZE(__nv_bfloat16, uint8_t,
+                                vllm::Fp8KVCacheDataType::kF4);
+  } else if (cache_dtype == 3) {
     // FP8 cache
     CALL_V1_LAUNCHER_BLOCK_SIZE(__nv_bfloat16, uint8_t,
                                 vllm::Fp8KVCacheDataType::kFp8E4M3);

--- a/mistralrs-paged-attn/src/cuda/pagedattention_v1_f16.cu
+++ b/mistralrs-paged-attn/src/cuda/pagedattention_v1_f16.cu
@@ -18,7 +18,11 @@ extern "C" void paged_attention_v1_f16(
     uint32_t cache_dtype, // 0 => f16; 1 => bf16; 2 => f32; 3 => fp8_e4m3
     float *k_scale, float *v_scale, const float *sinks) {
 
-  if (cache_dtype == 3) {
+  if (cache_dtype == 4) {
+    // F4 cache
+    CALL_V1_LAUNCHER_BLOCK_SIZE(uint16_t, uint8_t,
+                                vllm::Fp8KVCacheDataType::kF4);
+  } else if (cache_dtype == 3) {
     // FP8 cache
     CALL_V1_LAUNCHER_BLOCK_SIZE(uint16_t, uint8_t,
                                 vllm::Fp8KVCacheDataType::kFp8E4M3);

--- a/mistralrs-paged-attn/src/cuda/pagedattention_v1_f32.cu
+++ b/mistralrs-paged-attn/src/cuda/pagedattention_v1_f32.cu
@@ -18,7 +18,11 @@ extern "C" void paged_attention_v1_f32(
     uint32_t cache_dtype, // 0 => f16; 1 => bf16; 2 => f32; 3 => fp8_e4m3
     float *k_scale, float *v_scale, const float *sinks) {
 
-  if (cache_dtype == 3) {
+  if (cache_dtype == 4) {
+    // F4 cache
+    CALL_V1_LAUNCHER_BLOCK_SIZE(float, uint8_t,
+                                vllm::Fp8KVCacheDataType::kF4);
+  } else if (cache_dtype == 3) {
     // FP8 cache
     CALL_V1_LAUNCHER_BLOCK_SIZE(float, uint8_t,
                                 vllm::Fp8KVCacheDataType::kFp8E4M3);

--- a/mistralrs-paged-attn/src/cuda/pagedattention_v2_bf16.cu
+++ b/mistralrs-paged-attn/src/cuda/pagedattention_v2_bf16.cu
@@ -21,7 +21,11 @@ extern "C" void paged_attention_v2_bf16(
     uint32_t cache_dtype, // 0 => f16; 1 => bf16; 2 => f32; 3 => fp8_e4m3
     float *k_scale, float *v_scale, const float *sinks) {
 
-  if (cache_dtype == 3) {
+  if (cache_dtype == 4) {
+    // F4 cache
+    CALL_V2_LAUNCHER_BLOCK_SIZE(__nv_bfloat16, uint8_t,
+                                vllm::Fp8KVCacheDataType::kF4);
+  } else if (cache_dtype == 3) {
     // FP8 cache
     CALL_V2_LAUNCHER_BLOCK_SIZE(__nv_bfloat16, uint8_t,
                                 vllm::Fp8KVCacheDataType::kFp8E4M3);

--- a/mistralrs-paged-attn/src/cuda/pagedattention_v2_f16.cu
+++ b/mistralrs-paged-attn/src/cuda/pagedattention_v2_f16.cu
@@ -21,7 +21,11 @@ extern "C" void paged_attention_v2_f16(
     uint32_t cache_dtype, // 0 => f16; 1 => bf16; 2 => f32; 3 => fp8_e4m3
     float *k_scale, float *v_scale, const float *sinks) {
 
-  if (cache_dtype == 3) {
+  if (cache_dtype == 4) {
+    // F4 cache
+    CALL_V2_LAUNCHER_BLOCK_SIZE(uint16_t, uint8_t,
+                                vllm::Fp8KVCacheDataType::kF4);
+  } else if (cache_dtype == 3) {
     // FP8 cache
     CALL_V2_LAUNCHER_BLOCK_SIZE(uint16_t, uint8_t,
                                 vllm::Fp8KVCacheDataType::kFp8E4M3);

--- a/mistralrs-paged-attn/src/cuda/pagedattention_v2_f32.cu
+++ b/mistralrs-paged-attn/src/cuda/pagedattention_v2_f32.cu
@@ -22,7 +22,11 @@ extern "C" void paged_attention_v2_f32(
     uint32_t cache_dtype, // 0 => f16; 1 => bf16; 2 => f32; 3 => fp8_e4m3
     float *k_scale, float *v_scale, const float *sinks) {
 
-  if (cache_dtype == 3) {
+  if (cache_dtype == 4) {
+    // F4 cache
+    CALL_V2_LAUNCHER_BLOCK_SIZE(float, uint8_t,
+                                vllm::Fp8KVCacheDataType::kF4);
+  } else if (cache_dtype == 3) {
     // FP8 cache
     CALL_V2_LAUNCHER_BLOCK_SIZE(float, uint8_t,
                                 vllm::Fp8KVCacheDataType::kFp8E4M3);

--- a/mistralrs-paged-attn/src/cuda/reshape_and_cache_kernel.cu
+++ b/mistralrs-paged-attn/src/cuda/reshape_and_cache_kernel.cu
@@ -28,6 +28,38 @@
 
 namespace vllm {
 
+// atomicMax for non-negative floats (abs values), used for per-cell scale maxes.
+__device__ __forceinline__ float atomicMaxFloatShared(float *address, float val) {
+  int *addr_i = reinterpret_cast<int *>(address);
+  int old_i = *addr_i;
+  float old_f = __int_as_float(old_i);
+  while (old_f < val) {
+    int assumed = old_i;
+    int new_i = __float_as_int(val);
+    int prev = atomicCAS(addr_i, assumed, new_i);
+    if (prev == assumed) {
+      return __int_as_float(prev);
+    }
+    old_i = prev;
+    old_f = __int_as_float(old_i);
+  }
+  return old_f;
+}
+
+// f16 keys arrive as raw uint16_t bit patterns; convert like the FP8 path does.
+template <typename scalar_t>
+__device__ __forceinline__ float to_float_val(scalar_t v) {
+  return (float)v;
+}
+template <>
+__device__ __forceinline__ float to_float_val<uint16_t>(uint16_t v) {
+  return __half2float(*reinterpret_cast<__half *>(&v));
+}
+template <>
+__device__ __forceinline__ float to_float_val<__nv_bfloat16>(__nv_bfloat16 v) {
+  return __bfloat162float(v);
+}
+
 template <typename scalar_t, typename cache_t, vllm::Fp8KVCacheDataType kv_dt>
 __global__ void reshape_and_cache_kernel(
     const scalar_t *__restrict__ key,   // [num_tokens, num_heads, head_size]
@@ -94,6 +126,163 @@ __global__ void reshape_and_cache_kernel(
           reinterpret_cast<const float *>(k_scale),                            \
           reinterpret_cast<const float *>(v_scale));
 
+// F4 (4-bit, per-token scales) KV cache write.
+//
+// Layouts (see cache_engine calculate_*_block_shape):
+//   key_cache   [num_blocks, num_heads, head_size/32, block_size, 32] u8,
+//               2 values/byte packed along the x (32-dim cell) axis
+//   value_cache [num_blocks, num_heads, head_size/2, block_size] u8,
+//               2 values/byte packed along the head axis
+//   k_scale     [num_blocks, num_heads, head_size/32, block_size] f32,
+//               one scale per 32-value cell (one token's x-row)
+//   v_scale     [num_blocks, num_heads, block_size] f32,
+//               one scale per token per head (256 values)
+// Values are symmetric 4-bit: q = round(v/scale) clamped to [-8, 7], stored
+// biased by 8 (nibble 0..15); dequant is (nibble - 8) * scale.
+//
+// One block per token: 128 threads, each handling 2 K pairs and 2 V pairs
+// (a pair = (even, odd) head offsets, which always land in the same cell and
+// share one byte), so byte writes are race-free.
+template <typename scalar_t>
+__global__ void reshape_and_cache_f4_kernel(
+    const scalar_t *__restrict__ key,   // [num_tokens, num_heads, head_size]
+    const scalar_t *__restrict__ value, // [num_tokens, num_heads, head_size]
+    uint8_t *__restrict__ key_cache,    // [num_blocks, num_heads, hd/32, bs, 32]
+    uint8_t *__restrict__ value_cache,  // [num_blocks, num_heads, hd/2, bs]
+    float *__restrict__ k_scale,        // [num_blocks, num_heads, hd/32, bs]
+    float *__restrict__ v_scale,        // [num_blocks, num_heads, bs]
+    const int64_t *__restrict__ slot_mapping, // [num_tokens]
+    const int key_stride, const int value_stride, const int num_heads,
+    const int head_size, const int block_size) {
+  constexpr int CELL = 32;            // values per K cell
+  constexpr int K_BYTES_PER_CELL = 16; // 32 values packed into 16 bytes
+  const int64_t token_idx = blockIdx.x;
+  const int64_t slot_idx = slot_mapping[token_idx];
+  if (slot_idx < 0) {
+    return;
+  }
+  const int64_t block_idx = slot_idx / block_size;
+  const int64_t token_offset = slot_idx % block_size;
+
+  const int tid = threadIdx.x;
+  constexpr int THREADS = 128;
+  const int k_pairs_per_head = head_size / 2; // pairs of head offsets
+  const int num_k_pairs = num_heads * k_pairs_per_head; // 2 * 128 = 256
+  const int num_v_pairs = num_heads * k_pairs_per_head; // 256
+
+  // Pair index this thread owns: 2 pairs per thread.
+  const int k_pair0 = tid * 2;
+  const int k_pair1 = tid * 2 + 1;
+  const int v_pair0 = tid * 2;
+  const int v_pair1 = tid * 2 + 1;
+  const bool has_k_pair0 = k_pair0 < num_k_pairs;
+  const bool has_k_pair1 = k_pair1 < num_k_pairs;
+  const bool has_v_pair0 = v_pair0 < num_v_pairs;
+  const bool has_v_pair1 = v_pair1 < num_v_pairs;
+
+  // Per-cell maxes: K cells (head, xrow) and V cells (head), dynamic shared.
+  extern __shared__ float smem[];
+  float *k_cell_max = smem;
+  float *v_cell_max = smem + num_heads * (head_size / CELL);
+  for (int i = tid; i < num_heads * (head_size / CELL); i += THREADS) {
+    k_cell_max[i] = 0.0f;
+  }
+  for (int i = tid; i < num_heads; i += THREADS) {
+    v_cell_max[i] = 0.0f;
+  }
+  __syncthreads();
+
+  const int64_t key_base = token_idx * key_stride;
+  const int64_t value_base = token_idx * value_stride;
+
+  // Phase 1: per-cell abs-max (atomic max into shared memory).
+  auto cell_max_k = [&](int head, int ho) {
+    const int cell = head * (head_size / CELL) + ho / CELL;
+    float av = fabsf(to_float_val(key[key_base + head * head_size + ho]));
+    atomicMaxFloatShared(&k_cell_max[cell], av);
+  };
+  auto cell_max_v = [&](int head, int ho) {
+    float av = fabsf(to_float_val(value[value_base + head * head_size + ho]));
+    atomicMaxFloatShared(&v_cell_max[head], av);
+  };
+  auto handle_pair = [&](int head, int ho, auto fn) {
+    fn(head, ho);
+    fn(head, ho + 1);
+  };
+  if (has_k_pair0) {
+    int head = (k_pair0 * 2) / head_size;
+    int ho = (k_pair0 * 2) % head_size;
+    handle_pair(head, ho, cell_max_k);
+  }
+  if (has_k_pair1) {
+    int head = (k_pair1 * 2) / head_size;
+    int ho = (k_pair1 * 2) % head_size;
+    handle_pair(head, ho, cell_max_k);
+  }
+  if (has_v_pair0) {
+    int head = v_pair0 / k_pairs_per_head;
+    int ho = (v_pair0 % k_pairs_per_head) * 2;
+    handle_pair(head, ho, cell_max_v);
+  }
+  if (has_v_pair1) {
+    int head = v_pair1 / k_pairs_per_head;
+    int ho = (v_pair1 % k_pairs_per_head) * 2;
+    handle_pair(head, ho, cell_max_v);
+  }
+  __syncthreads();
+
+  // Phase 2: quantize and pack.
+  auto quant = [](float v, float scale) -> int {
+    float s = scale > 0.0f ? scale : 1.0f;
+    int q = (int)llrintf(v / s);
+    q = q < -8 ? -8 : (q > 7 ? 7 : q);
+    return q + 8;
+  };
+  auto write_pair_k = [&](int head, int ho) {
+    const int xrow = ho / CELL;
+    const int xoff = ho % CELL;
+    const int64_t cell_byte = ((block_idx * num_heads + head) * (head_size / CELL) + xrow) *
+                                  (block_size * K_BYTES_PER_CELL) +
+                              token_offset * K_BYTES_PER_CELL + xoff / 2;
+    const float scale = k_cell_max[head * (head_size / CELL) + xrow] / 8.0f;
+    const int lo = quant(to_float_val(key[key_base + head * head_size + ho]), scale);
+    const int hi = quant(to_float_val(key[key_base + head * head_size + ho + 1]), scale);
+    key_cache[cell_byte] = (uint8_t)(lo | (hi << 4));
+    k_scale[((block_idx * num_heads + head) * (head_size / CELL) + xrow) * block_size +
+            token_offset] = scale;
+  };
+  auto write_pair_v = [&](int head, int ho) {
+    const int64_t byte = ((block_idx * num_heads + head) * (head_size / 2) + ho / 2) *
+                             block_size +
+                         token_offset;
+    const float scale = v_cell_max[head] / 8.0f;
+    const int lo = quant(to_float_val(value[value_base + head * head_size + ho]), scale);
+    const int hi = quant(to_float_val(value[value_base + head * head_size + ho + 1]), scale);
+    value_cache[byte] = (uint8_t)(lo | (hi << 4));
+    v_scale[(block_idx * num_heads + head) * block_size + token_offset] = scale;
+  };
+  if (has_k_pair0) {
+    int head = (k_pair0 * 2) / head_size;
+    int ho = (k_pair0 * 2) % head_size;
+    write_pair_k(head, ho);
+  }
+  if (has_k_pair1) {
+    int head = (k_pair1 * 2) / head_size;
+    int ho = (k_pair1 * 2) % head_size;
+    write_pair_k(head, ho);
+  }
+  if (has_v_pair0) {
+    int head = v_pair0 / k_pairs_per_head;
+    int ho = (v_pair0 % k_pairs_per_head) * 2;
+    write_pair_v(head, ho);
+  }
+  if (has_v_pair1) {
+    int head = v_pair1 / k_pairs_per_head;
+    int ho = (v_pair1 % k_pairs_per_head) * 2;
+    write_pair_v(head, ho);
+  }
+}
+
 } // namespace vllm
 
 extern "C" void reshape_and_cache(
@@ -113,7 +302,38 @@ extern "C" void reshape_and_cache(
   dim3 grid(num_tokens);
   dim3 block(std::min(num_heads * head_size, 512));
 
-  if (cache_dtype == 3) {
+  if (cache_dtype == 4) {
+    // F4 cache: 128-thread blocks, one per token, dynamic shared for cell maxes.
+    dim3 f4_block(128);
+    int shared_bytes =
+        (num_heads * (head_size / 32) + num_heads) * (int)sizeof(float);
+    if (dtype == 0) {
+      vllm::reshape_and_cache_f4_kernel<uint16_t>
+          <<<grid, f4_block, shared_bytes, stream>>>(
+              reinterpret_cast<uint16_t *>(key), reinterpret_cast<uint16_t *>(value),
+              reinterpret_cast<uint8_t *>(key_cache),
+              reinterpret_cast<uint8_t *>(value_cache), k_scale, v_scale,
+              slot_mapping, key_stride, value_stride, num_heads, head_size,
+              block_size);
+    } else if (dtype == 1) {
+      vllm::reshape_and_cache_f4_kernel<__nv_bfloat16>
+          <<<grid, f4_block, shared_bytes, stream>>>(
+              reinterpret_cast<__nv_bfloat16 *>(key),
+              reinterpret_cast<__nv_bfloat16 *>(value),
+              reinterpret_cast<uint8_t *>(key_cache),
+              reinterpret_cast<uint8_t *>(value_cache), k_scale, v_scale,
+              slot_mapping, key_stride, value_stride, num_heads, head_size,
+              block_size);
+    } else if (dtype == 2) {
+      vllm::reshape_and_cache_f4_kernel<float>
+          <<<grid, f4_block, shared_bytes, stream>>>(
+              reinterpret_cast<float *>(key), reinterpret_cast<float *>(value),
+              reinterpret_cast<uint8_t *>(key_cache),
+              reinterpret_cast<uint8_t *>(value_cache), k_scale, v_scale,
+              slot_mapping, key_stride, value_stride, num_heads, head_size,
+              block_size);
+    }
+  } else if (cache_dtype == 3) {
     // FP8 E4M3 cache
     if (dtype == 0) {
       CALL_RESHAPE_AND_CACHE(uint16_t, uint8_t,

--- a/mistralrs-paged-attn/tests/f4_gpu.rs
+++ b/mistralrs-paged-attn/tests/f4_gpu.rs
@@ -1,0 +1,262 @@
+// GPU test of the F4 KV cache kernels (reshape_and_cache + paged_attention),
+// comparing the kernel round-trip against a CPU reference of the same format.
+#![cfg(all(feature = "cuda", target_family = "unix"))]
+
+use candle_core::{DType, Device, Result, Tensor};
+use half::f16;
+
+const NUM_HEADS: usize = 2;
+const HEAD_SIZE: usize = 64;
+const BLOCK_SIZE: usize = 32;
+const NUM_TOKENS: usize = 48;
+const NUM_BLOCKS: usize = 2;
+
+// llrintf (round half to even), matching the CUDA kernels.
+fn rint_half_even(x: f32) -> f32 {
+    let f = x.floor();
+    let diff = x - f;
+    if diff < 0.5 {
+        f
+    } else if diff > 0.5 {
+        f + 1.0
+    } else if (f as i64) % 2 == 0 {
+        f
+    } else {
+        f + 1.0
+    }
+}
+
+fn quant(v: f32, scale: f32) -> u8 {
+    let s = if scale > 0.0 { scale } else { 1.0 };
+    let q = rint_half_even(v / s).clamp(-8.0, 7.0) as i32 + 8;
+    q as u8
+}
+
+fn dequant(nib: u8, scale: f32) -> f32 {
+    ((nib as i32 - 8) as f32) * scale
+}
+
+fn f16f(v: f32) -> f32 {
+    f16::from_f32(v).to_f32()
+}
+
+fn ref_write(kv: &[f32], slot: &[usize], k_cache: &mut [u8], v_cache: &mut [u8], k_scale: &mut [f32], v_scale: &mut [f32]) {
+    for (token, &slot_idx) in slot.iter().enumerate() {
+        let token_values: Vec<f32> = (0..NUM_HEADS * HEAD_SIZE)
+            .map(|d| f16f(kv[token * NUM_HEADS * HEAD_SIZE + d]))
+            .collect();
+        let block = slot_idx / BLOCK_SIZE;
+        let t = slot_idx % BLOCK_SIZE;
+        for h in 0..NUM_HEADS {
+            for xrow in 0..HEAD_SIZE / 32 {
+                let max = (0..32)
+                    .map(|x| token_values[h * HEAD_SIZE + xrow * 32 + x].abs())
+                    .fold(0.0f32, f32::max);
+                let scale = max / 8.0;
+                k_scale[((block * NUM_HEADS + h) * (HEAD_SIZE / 32) + xrow) * BLOCK_SIZE + t] = scale;
+                for xoff in 0..32 {
+                    let d = xrow * 32 + xoff;
+                    let byte = ((block * NUM_HEADS + h) * (HEAD_SIZE / 32) + xrow) * (BLOCK_SIZE * 16) + t * 16 + xoff / 2;
+                    let nib = quant(token_values[h * HEAD_SIZE + d], scale);
+                    let pos = if xoff % 2 == 0 {
+                        (nib & 0x0F) | (k_cache[byte] & 0xF0)
+                    } else {
+                        ((nib & 0x0F) << 4) | (k_cache[byte] & 0x0F)
+                    };
+                    k_cache[byte] = pos;
+                }
+            }
+            let max = (0..HEAD_SIZE)
+                .map(|d| token_values[h * HEAD_SIZE + d].abs())
+                .fold(0.0f32, f32::max);
+            let scale = max / 8.0;
+            v_scale[(block * NUM_HEADS + h) * BLOCK_SIZE + t] = scale;
+            for d in 0..HEAD_SIZE {
+                let byte = ((block * NUM_HEADS + h) * (HEAD_SIZE / 2) + d / 2) * BLOCK_SIZE + t;
+                let nib = quant(token_values[h * HEAD_SIZE + d], scale);
+                let pos = if d % 2 == 0 {
+                    (nib & 0x0F) | (v_cache[byte] & 0xF0)
+                } else {
+                    ((nib & 0x0F) << 4) | (v_cache[byte] & 0x0F)
+                };
+                v_cache[byte] = pos;
+            }
+        }
+    }
+}
+
+fn ref_attention(
+    q: &[f32],
+    k_cache: &[u8],
+    v_cache: &[u8],
+    k_scale: &[f32],
+    v_scale: &[f32],
+    block_table: &[u32],
+    context_len: usize,
+    softmax_scale: f32,
+) -> Vec<f32> {
+    let mut out = vec![0f32; NUM_HEADS * HEAD_SIZE];
+    for h in 0..NUM_HEADS {
+        let mut scores = vec![0f32; context_len];
+        for t in 0..context_len {
+            let block = (block_table[t / BLOCK_SIZE] as usize) % NUM_BLOCKS;
+            let tt = t % BLOCK_SIZE;
+            let mut dot = 0f32;
+            for d in 0..HEAD_SIZE {
+                let xrow = d / 32;
+                let xoff = d % 32;
+                let byte = ((block * NUM_HEADS + h) * (HEAD_SIZE / 32) + xrow) * (BLOCK_SIZE * 16) + tt * 16 + xoff / 2;
+                let nib = if xoff % 2 == 0 { k_cache[byte] & 0x0F } else { (k_cache[byte] >> 4) & 0x0F };
+                let scale = k_scale[((block * NUM_HEADS + h) * (HEAD_SIZE / 32) + xrow) * BLOCK_SIZE + tt];
+                let k = dequant(nib, scale);
+                dot += q[h * HEAD_SIZE + d] * k;
+            }
+            scores[t] = dot * softmax_scale;
+        }
+        let max = scores.iter().cloned().fold(f32::MIN, f32::max);
+        let mut denom = 0f32;
+        for s in &mut scores {
+            *s = (*s - max).exp();
+            denom += *s;
+        }
+        for t in 0..context_len {
+            let block = (block_table[t / BLOCK_SIZE] as usize) % NUM_BLOCKS;
+            let tt = t % BLOCK_SIZE;
+            let w = scores[t] / denom;
+            for d in 0..HEAD_SIZE {
+                let byte = ((block * NUM_HEADS + h) * (HEAD_SIZE / 2) + d / 2) * BLOCK_SIZE + tt;
+                let nib = if d % 2 == 0 { v_cache[byte] & 0x0F } else { (v_cache[byte] >> 4) & 0x0F };
+                let scale = v_scale[(block * NUM_HEADS + h) * BLOCK_SIZE + tt];
+                out[h * HEAD_SIZE + d] += w * dequant(nib, scale);
+            }
+        }
+    }
+    out
+}
+
+#[test]
+fn f4_kernels_match_cpu_reference() -> Result<()> {
+    let device = Device::new_cuda(0)?;
+    let kv: Vec<f32> = (0..NUM_TOKENS * NUM_HEADS * HEAD_SIZE)
+        .map(|i| (((i as u64 * 2654435761) % 1000) as f32 / 500.0 - 1.0) * 1.5)
+        .collect();
+    let kv_f16: Vec<f16> = kv.iter().map(|&v| f16::from_f32(v)).collect();
+
+    let slot: Vec<i64> = (0..NUM_TOKENS as i64).collect();
+    let block_table: Vec<u32> = (0..NUM_BLOCKS as u32).collect();
+
+    // CPU reference writes.
+    let mut k_cache_ref = vec![0u8; NUM_BLOCKS * NUM_HEADS * (HEAD_SIZE / 32) * BLOCK_SIZE * 16];
+    let mut v_cache_ref = vec![0u8; NUM_BLOCKS * NUM_HEADS * (HEAD_SIZE / 2) * BLOCK_SIZE];
+    let mut k_scale_ref = vec![0f32; NUM_BLOCKS * NUM_HEADS * (HEAD_SIZE / 32) * BLOCK_SIZE];
+    let mut v_scale_ref = vec![0f32; NUM_BLOCKS * NUM_HEADS * BLOCK_SIZE];
+    let slot_us: Vec<usize> = slot.iter().map(|&s| s as usize).collect();
+    ref_write(&kv, &slot_us, &mut k_cache_ref, &mut v_cache_ref, &mut k_scale_ref, &mut v_scale_ref);
+
+    // GPU tensors.
+    let key = Tensor::from_vec(kv_f16.clone(), (NUM_TOKENS, NUM_HEADS, HEAD_SIZE), &device)?;
+    let value = key.clone();
+    let slot_mapping = Tensor::from_vec(slot, NUM_TOKENS, &device)?;
+    let key_cache = unsafe {
+        Tensor::empty(
+            (NUM_BLOCKS, NUM_HEADS, HEAD_SIZE / 32, BLOCK_SIZE, 16),
+            DType::U8,
+            &device,
+        )?
+    };
+    let value_cache = unsafe {
+        Tensor::empty(
+            (NUM_BLOCKS, NUM_HEADS, HEAD_SIZE / 2, BLOCK_SIZE),
+            DType::U8,
+            &device,
+        )?
+    };
+    let k_scale = Tensor::zeros(
+        (NUM_BLOCKS, NUM_HEADS, HEAD_SIZE / 32, BLOCK_SIZE),
+        DType::F32,
+        &device,
+    )?;
+    let v_scale = Tensor::zeros((NUM_BLOCKS, NUM_HEADS, BLOCK_SIZE), DType::F32, &device)?;
+
+    mistralrs_paged_attn::reshape_and_cache(
+        &key,
+        &value,
+        Some(&k_scale),
+        Some(&v_scale),
+        &key_cache,
+        &value_cache,
+        &slot_mapping,
+    )?;
+
+    // The reshape kernel writes scales inline; verify the packed bytes match.
+    let kc_gpu = key_cache.flatten_all()?.to_vec1::<u8>()?;
+    let vc_gpu = value_cache.flatten_all()?.to_vec1::<u8>()?;
+    let ks_gpu = k_scale.flatten_all()?.to_vec1::<f32>()?;
+    let vs_gpu = v_scale.flatten_all()?.to_vec1::<f32>()?;
+    for i in 0..k_cache_ref.len() {
+        assert_eq!(kc_gpu[i], k_cache_ref[i], "K cache byte {i}");
+    }
+    for i in 0..v_cache_ref.len() {
+        assert_eq!(vc_gpu[i], v_cache_ref[i], "V cache byte {i}");
+    }
+    for i in 0..k_scale_ref.len() {
+        assert!(
+            (ks_gpu[i] - k_scale_ref[i]).abs() < 1e-6,
+            "K scale {i}: {} vs {}",
+            ks_gpu[i],
+            k_scale_ref[i]
+        );
+    }
+    for i in 0..v_scale_ref.len() {
+        assert!(
+            (vs_gpu[i] - v_scale_ref[i]).abs() < 1e-6,
+            "V scale {i}: {} vs {}",
+            vs_gpu[i],
+            v_scale_ref[i]
+        );
+    }
+
+    // Decode one token against the full context via the real kernels.
+    let q: Vec<f32> = (0..NUM_HEADS * HEAD_SIZE)
+        .map(|i| ((i * 97) % 50) as f32 / 50.0 - 0.5)
+        .collect();
+    let q_f16: Vec<f16> = q.iter().map(|&v| f16::from_f32(v)).collect();
+    let query = Tensor::from_vec(q_f16, (1, NUM_HEADS, HEAD_SIZE), &device)?;
+    let block_tables = Tensor::from_vec(vec![0u32, 1], (1, NUM_BLOCKS), &device)?;
+    let context_lens = Tensor::from_vec(vec![NUM_TOKENS as u32], 1, &device)?;
+    let out = mistralrs_paged_attn::paged_attention(
+        &query,
+        Some(&k_scale),
+        Some(&v_scale),
+        &key_cache,
+        &value_cache,
+        &block_tables,
+        &context_lens,
+        None,
+        NUM_TOKENS,
+        1.0 / (HEAD_SIZE as f32).sqrt(),
+        1.0,
+        None,
+    )?;
+    let out_gpu = out.to_dtype(DType::F32)?.flatten_all()?.to_vec1::<f32>()?;
+
+    let out_ref = ref_attention(
+        &q,
+        &k_cache_ref,
+        &v_cache_ref,
+        &k_scale_ref,
+        &v_scale_ref,
+        &block_table,
+        NUM_TOKENS,
+        1.0 / (HEAD_SIZE as f32).sqrt(),
+    );
+    for i in 0..out_gpu.len() {
+        assert!(
+            (out_gpu[i] - out_ref[i]).abs() < 1e-2,
+            "attn out {i}: gpu {} vs ref {}",
+            out_gpu[i],
+            out_ref[i]
+        );
+    }
+    Ok(())
+}

--- a/mistralrs/src/anymoe.rs
+++ b/mistralrs/src/anymoe.rs
@@ -124,6 +124,7 @@ impl AnyMoeModelBuilder {
                     hf_cache_path: base.hf_cache_path.clone(),
                     matformer_config_path: base.matformer_config_path.clone(),
                     matformer_slice_name: base.matformer_slice_name.clone(),
+                    rope_override: None,
                 };
 
                 maybe_initialize_logging(base.with_logging);

--- a/mistralrs/src/gguf_lora_model.rs
+++ b/mistralrs/src/gguf_lora_model.rs
@@ -54,6 +54,7 @@ impl GgufLoraModelBuilder {
             hf_cache_path: self.gguf_model.hf_cache_path,
             matformer_config_path: self.gguf_model.matformer_config_path,
             matformer_slice_name: self.gguf_model.matformer_slice_name,
+            rope_override: None,
         };
 
         maybe_initialize_logging(self.gguf_model.with_logging);

--- a/mistralrs/src/gguf_xlora_model.rs
+++ b/mistralrs/src/gguf_xlora_model.rs
@@ -59,6 +59,7 @@ impl GgufXLoraModelBuilder {
             hf_cache_path: self.gguf_model.hf_cache_path,
             matformer_config_path: self.gguf_model.matformer_config_path,
             matformer_slice_name: self.gguf_model.matformer_slice_name,
+            rope_override: None,
         };
 
         maybe_initialize_logging(self.gguf_model.with_logging);

--- a/mistralrs/src/model_builder_trait.rs
+++ b/mistralrs/src/model_builder_trait.rs
@@ -856,6 +856,7 @@ pub async fn build_gguf_pipeline(
         hf_cache_path: builder.hf_cache_path.clone(),
         matformer_config_path: builder.matformer_config_path.clone(),
         matformer_slice_name: builder.matformer_slice_name.clone(),
+        rope_override: None,
     };
 
     maybe_initialize_logging(builder.with_logging);
@@ -985,6 +986,7 @@ pub async fn build_gguf_pipeline(
             hf_cache_path: builder.hf_cache_path.clone(),
             matformer_config_path: builder.matformer_config_path.clone(),
             matformer_slice_name: builder.matformer_slice_name.clone(),
+            rope_override: None,
         },
         token_source: builder.token_source.clone(),
         hf_revision: builder.hf_revision.clone(),


### PR DESCRIPTION
Summary

This PR merges the Qwen3.5-Next long-context serving work back to master. It adds YaRN rope scaling pinned to the llama.cpp reference implementation, a 4-bit F4 packed KV cache for paged attention, hybrid paged-KV allocation that restricts the paged cache to the full-attention layers of the hybrid model, host-memory parking of recurrent prefix snapshots, a halved paged-prefill chunk size for the 262144-token window, a MoE router topk fix on CUDA, and the lockfile security remediation. The target workload is serving the Qwen3.6-14B-A3B Q4_K_M GGUF (qwen35moe, 40 layers, 90 experts, full_attention_interval 4) with up to 320000 tokens of context on a 12 GB consumer GPU.

Origin and included prior work (feat/qwen35-native-context-fix)

Items 2 through 7 below - the F4 cache, the hybrid paged-KV allocation, the recurrent-snapshot host parking, the paged-prefill chunk change, the MoE router topk fix, and the lockfile remediation, with their tests - were developed and verified earlier on the fork branch feat/qwen35-native-context-fix (tip f93428e54, pushed to JLFN/mistral.rs). That branch has no pull request of its own: its 34-file, +1623/-161 diff against master is a strict subset of this PR's 51-file diff, byte-identical in every file except the YaRN additions on top (items 1 and 8 below) and a small extension to f4_cache_storage.rs. The YaRN long-context work (item 1) is the new layer this PR adds over that native-context base, and both together are squashed into the single commit b7f9c9018.

Changes by area

1. YaRN rope scaling for the Qwen3.5 partial rotary (new)

- layers.rs: RotaryEmbedding::new_partial_yarn resolves the rope the same way llama.cpp does: get_mscale cancellation in llama-context.cpp against the 1 + 0.1*ln(scale) re-fold inside the ggml rope_yarn kernel, netting a table scale of 1.0199427025 for factor 1.220703125, with corr_dims low/high ramp from beta_fast 32 / beta_slow 1 exactly as ggml.c computes it.
- models/qwen3_next.rs: Config gains a rope_scaling field (rope_type, factor, original_max_position_embeddings, beta_fast/slow, mscale, mscale_all_dim); the model builds new_partial_yarn when the config carries a yarn entry and bails on unsupported rope types.
- New RopeOverride type (rope_override.rs), threaded from the CLI through ModelSelected, the GGUF loader, and TOML selector into config synthesis.
- gguf/normal_config.rs: synthesizing a config under a forced YaRN override neutralizes any embedded GGUF rope.scaling metadata (which would otherwise make the registered builder reject the checkpoint), then inserts the yarn rope_scaling block and sets max_position_embeddings to the resolved target context.
- CLI: --rope-scaling yarn|none, --rope-scale, --yarn-orig-ctx, --override-ctx on the GGUF model format options of run and serve.
- Golden tests (yarn_rotary.rs) probe positions 262144, 262145 and 319999 against the exact llama.cpp formulas, matching to <= 5e-12.

2. 4-bit F4 KV cache (paged-attn + core)

- candle-core cannot allocate or cast DType::F4 on CUDA in the pinned rev (verified against source; see F4-KV-STORAGE-ASSESSMENT.md), so the cache is stored as packed U8 tensors with custom kernels.
- PagedCacheType::F4 added; cache_engine block-shape math uses 32 values per 16-byte cell row for K and head_dim/2 byte-rows for V.
- reshape_and_cache_f4_kernel writes symmetric 4-bit values (nibble - 8) * scale: one scale per 32-value K cell and one scale per token per V head, with race-free 2-pair-per-thread byte writes.
- The v1/v2 paged_attention kernels dequantize F4 cells inline during attention; gather_kv_cache and copy_blocks gain U8/F4 paths; kv scales become per-cell tensors guarded by a Mutex.
- Storage cost: 5 KB/token for the 10 paged (full-attention) layers vs 20 KB/token for BF16, a 4x reduction; 5.5 KB/token measured at serve.
- Tests: f4_cache_storage.rs (candle F4 limits, pack/unpack tolerance), f4_kv_layout.rs (CPU mirror of the kernel byte indexing), f4_gpu.rs (CUDA kernel round-trip vs CPU reference).

3. Hybrid paged-KV allocation for Qwen3.5-Next

- qwen3_next and the Qwen3.5 vision text model expose model_config via HybridPagedKvCacheConfig; paged KV blocks are allocated only for the 10 full-attention layers of the 40-layer hybrid instead of all 40.
- Test hybrid_layer_types_mask_only_the_10_full_attention_layers pins the mask to layers 3, 7, 11, 15, 19, 23, 27, 31, 35, 39.

4. Recurrent prefix snapshots parked in host memory

- prefix_cacher.rs moves conv_state and recurrent_state of paged recurrent prefix snapshots to Device::Cpu before caching. Each snapshot holds every recurrent layer's F32 state (~63 MB for Qwen3-Next's 30 GDN layers), so GPU residency would accumulate ~1 GB of VRAM per cache fill.

5. Paged prefill chunk halved 4096 to 2048

- pipeline/mod.rs: DEFAULT_PAGED_PREFILL_CHUNK_SIZE is now 2048, sized for the 262144-token window.

6. MoE router CUDA topk fix

- ops.rs: cuda_topk operates on a contiguous copy of the input instead of a final-logits row view, restoring full-row topk for MoE routing on CUDA.

7. Dependency security remediation

- Cargo.lock-only updates (no manifest changes): anyhow, crossbeam-epoch, memmap2, quinn-proto (CVE-2026-25800), rand, tar.
- The remaining 7 vulnerable packages (10 advisories) are recorded as accepted risk in OSV-EVIDENCE.md with per-package reasoning: TLS-path issues in aws-lc-sys not reachable on the plain-HTTP deployment, pyo3 not in the CLI deliverable, and unmaintained build-time/transitive crates with no fix version.

8. Docs

- YARN-SOURCE-VERIFICATION.md: llama.cpp source-line evidence for the rope pipeline (arg parsing, yarn_attn_factor cancellation, ggml rope_yarn re-fold, IMROPE-to-NEOX equivalence, corr_dims) plus the value-level comparison and the Phase B rebuild / Phase C serve evidence.
- F4-KV-STORAGE-ASSESSMENT.md: candle-core storage limits, the chosen packed format, and authoritative per-token cache numbers.
- OSV-EVIDENCE.md: remediation list and accepted-risk set.

Verification

- cargo test -p mistralrs-core --test yarn_rotary: 4 passed (positions 262144, 262145, 319999 match the llama.cpp pipeline to <= 5e-12; a Python reference reproduces llama.cpp to machine precision).
- cargo test -p mistralrs-core --lib qwen35moe_yarn_override: 2 passed (synthesis of the 320000/262144 override including the wins-over-embedded-metadata case).
- F4 tests: f4_cache_storage (CPU + CUDA storage limits), f4_kv_layout (CPU byte-layout mirror), f4_gpu (CUDA kernel vs CPU reference round-trip).
- Binary rebuilt with cuda + flash-attn; serve boot shows the F4 packed u8 cache, the yarn flags honored, and 320000 available context.
- Serve evidence on RTX 4070 SUPER 12 GB with Qwen3.6-14B-A3B Q4_K_M FableVibes: run 1 reached prompt ~252k then CUDA_ERROR_OUT_OF_MEMORY at GPU peak 11807/12282 MiB; run 2, after freeing ~0.5 GB of non-server GPU consumers, reached prompt 275837 (total ~280k tokens) with a 99.83% prefix-cache hit rate, stable F4 cache and no overflow, before being stopped. The full 320000 completion is not yet verified.
- OSV scan at PR time: 800 packages scanned, 7 vulnerable (10 advisories), all the documented accepted-risk set, no new findings.

Known limitations

- The F4 cache exists only in the Standard paged-attention layout/kernels: the engine forces the Standard backend when the cache type is F4 (FlashInfer is disabled), and any CPU-hosted layer in the device map disables paged attention entirely by design, so F4 and host-RAM offloaded KV are mutually exclusive.
- The F4 startup log over-reports the reserved cache budget 2x (blocks are stored packed U8, 16 bytes per 32 values); the correction is cosmetic and frees no real memory.
- F4-vs-BF16 logit equivalence at long context has not been measured; the format's per-value error bound is max_abs/16.
- 320000-token full-window serving on this 12 GB card is bounded by VRAM: the F4 cache ceiling observed is ~275k-280k tokens; the CPU/RAM layer-offload route that would exceed it is a planned follow-up outside this PR.

Commits

One squashed commit (b7f9c9018) ahead of master: the full substantive long-context work condensed into a single conventional commit, 51 files changed, 2182 insertions, 192 deletions. The session-handoff document and the separate CPU-offload experiment branch are intentionally not part of this pull request; the offload work is a planned follow-up.