### PR TITLE
perf(gguf): sparse per-expert MoE forward on CPU, no full dequantize

### DIFF
--- a/mistralrs-quant/src/gguf/cpu.rs
+++ b/mistralrs-quant/src/gguf/cpu.rs
@@ -3,13 +3,86 @@
 //! This dequantizes the weights and delegates to UnquantLinear's gather_forward.
 
 use candle_core::{
-    quantized::{QMatMul, QTensor},
-    Result, Tensor,
+    quantized::{QMatMul, QStorage, QTensor},
+    DType, Module, Result, Tensor,
 };
 use candle_nn::Linear;
+use std::borrow::Cow;
 use std::sync::Arc;
 
 use crate::{QuantMethod, QuantMethodConfig, UnquantLinear};
+
+/// Per-expert quantized matmul: route each (token, slot) pair to its expert's slice of
+/// the stacked [num_experts, n, k] QTensor without dequantizing the unused experts.
+/// Returns None for layouts this path cannot serve.
+fn sparse_indexed_moe(qtensor: &Arc<QTensor>, x: &Tensor, ids: &Tensor) -> Result<Option<Tensor>> {
+    if !x.device().is_cpu() || !qtensor.device().is_cpu() {
+        return Ok(None);
+    }
+    let Ok((n_experts, n, k)) = qtensor.shape().dims3() else {
+        return Ok(None);
+    };
+    let Ok((batch, x_t, xk)) = x.dims3() else {
+        return Ok(None);
+    };
+    let Ok((ids_b, topk)) = ids.dims2() else {
+        return Ok(None);
+    };
+    if xk != k || ids_b != batch || (x_t != 1 && x_t != topk) {
+        return Ok(None);
+    }
+    let in_dtype = x.dtype();
+    let x = match in_dtype {
+        DType::F32 => x.clone(),
+        DType::F16 | DType::BF16 => x.to_dtype(DType::F32)?,
+        _ => return Ok(None),
+    };
+    if !x.is_contiguous() {
+        return Ok(None);
+    }
+    let ids_v: Vec<u32> = ids.to_dtype(DType::U32)?.flatten_all()?.to_vec1::<u32>()?;
+    if ids_v.iter().any(|&e| e as usize >= n_experts) {
+        candle_core::bail!("expert index out of range");
+    }
+    let n_pairs = ids_v.len();
+    let mut buckets: Vec<Vec<usize>> = vec![Vec::new(); n_experts];
+    for (pair, &e) in ids_v.iter().enumerate() {
+        buckets[e as usize].push(pair);
+    }
+    let n_rows = batch * x_t;
+    let x_flat = x.reshape((n_rows, k))?;
+    let bytes = qtensor.data()?;
+    let total = qtensor.storage_size_in_bytes();
+    if !total.is_multiple_of(n_experts) || bytes.len() < total {
+        return Ok(None);
+    }
+    let per_expert = total / n_experts;
+    let dtype = qtensor.dtype();
+    let mut dst = vec![0f32; n_pairs * n];
+    for (e, bucket) in buckets.iter().enumerate() {
+        if bucket.is_empty() {
+            continue;
+        }
+        let row_idx: Vec<u32> = bucket
+            .iter()
+            .map(|&pair| if n_rows == n_pairs { pair } else { pair / topk } as u32)
+            .collect();
+        let rows = x_flat.index_select(&Tensor::from_vec(row_idx, bucket.len(), x.device())?, 0)?;
+        let storage = dtype.from_data(Cow::Borrowed(&bytes[e * per_expert..(e + 1) * per_expert]));
+        let expert = QMatMul::from_qtensor(QTensor::new(QStorage::Cpu(storage), (n, k))?)?;
+        let out = expert.forward(&rows)?.reshape((bucket.len() * n,))?;
+        let out_v: Vec<f32> = out.to_vec1()?;
+        for (i, &pair) in bucket.iter().enumerate() {
+            dst[pair * n..(pair + 1) * n].copy_from_slice(&out_v[i * n..(i + 1) * n]);
+        }
+    }
+    let out = Tensor::from_vec(dst, (batch, topk, n), x.device())?;
+    let out = match in_dtype {
+        DType::F32 => out,
+        other => out.to_dtype(other)?,
+    };
+    Ok(Some(out))
+}
 
 /// Perform indexed MoE forward pass on a QTensor by dequantizing and using UnquantLinear.
 ///
@@ -69,6 +142,10 @@ pub fn qtensor_indexed_moe_forward(
         }
     }
 
+    if let Some(out) = sparse_indexed_moe(qtensor, x, ids)? {
+        return Ok(out);
+    }
+
     let device = x.device();
 
     // Dequantize all weights to f32
@@ -100,5 +177,77 @@ pub fn cpu_indexed_moe_forward(qmatmul: &QMatMul, x: &Tensor, ids: &Tensor) -> R
                 UnquantLinear::new(QuantMethodConfig::Unquantized(Linear::new(t.clone(), None)))?;
             unquant.gather_forward(x, ids)
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use candle_core::quantized::GgmlDType;
+    use candle_core::{Device, Tensor};
+
+    #[test]
+    fn sparse_indexed_moe_matches_dequantize_gather() -> Result<()> {
+        let dev = Device::Cpu;
+        let (e, n, k) = (8, 64, 128);
+        let w = Tensor::randn(0f32, 1.0, (e, n, k), &dev)?;
+        let qt = Arc::new(QTensor::quantize(&w, GgmlDType::F32)?);
+
+        let (batch, topk) = (3, 2);
+        let x = Tensor::randn(0f32, 1.0, (batch, 1, k), &dev)?;
+        let ids = Tensor::from_vec(vec![0u32, 5, 7, 1, 3, 3], (batch, topk), &dev)?;
+
+        let sparse = sparse_indexed_moe(&qt, &x, &ids)?.expect("sparse path should serve this");
+        let weights = qt.dequantize(&dev)?;
+        let unquant =
+            UnquantLinear::new(QuantMethodConfig::Unquantized(Linear::new(weights, None)))?;
+        let reference = unquant.gather_forward(&x, &ids)?;
+
+        let diff = (sparse - reference)?
+            .abs()?
+            .max(0)?
+            .max(0)?
+            .max(0)?
+            .to_scalar::<f32>()?;
+        assert!(diff < 1e-5, "max abs diff {diff}");
+        Ok(())
+    }
+
+    #[test]
+    fn sparse_indexed_moe_quantized_close_to_dequantize_gather() -> Result<()> {
+        let dev = Device::Cpu;
+        let (e, n, k) = (8, 64, 128);
+        let w = Tensor::randn(0f32, 1.0, (e, n, k), &dev)?;
+        let qt = Arc::new(QTensor::quantize(&w, GgmlDType::Q8_0)?);
+
+        let (batch, topk) = (3, 2);
+        let x = Tensor::randn(0f32, 1.0, (batch, 1, k), &dev)?;
+        let ids = Tensor::from_vec(vec![0u32, 5, 7, 1, 3, 3], (batch, topk), &dev)?;
+
+        let sparse = sparse_indexed_moe(&qt, &x, &ids)?.expect("sparse path should serve this");
+        let weights = qt.dequantize(&dev)?;
+        let unquant =
+            UnquantLinear::new(QuantMethodConfig::Unquantized(Linear::new(weights, None)))?;
+        let reference = unquant.gather_forward(&x, &ids)?;
+
+        // quantized activation dot (ggml-style vec_dot) vs plain f32 matmul: allow
+        // quantization noise, catch routing/indexing errors which are O(1) magnitude
+        let diff = (sparse - &reference)?
+            .abs()?
+            .max(0)?
+            .max(0)?
+            .max(0)?
+            .to_scalar::<f32>()?;
+        let scale = reference
+            .abs()?
+            .max(0)?
+            .max(0)?
+            .max(0)?
+            .to_scalar::<f32>()?;
+        assert!(
+            diff < 0.05 * scale,
+            "max abs diff {diff} vs output scale {scale}"
+        );
+        Ok(())
     }
 }


### PR DESCRIPTION
## Problem

On x86_64, `QTensor::indexed_gemv` returns `None` (the repacked per-expert GEMV path is aarch64-only), so `qtensor_indexed_moe_forward` falls back to **dequantizing the entire stacked expert tensor to f32** and then doing gather+matmul via `UnquantLinear`.

For MoE GGUF models this is catastrophic on CPU: e.g. Qwen3.6-35B-A3B (256 experts) dequantizes ~380MB of Q3_K weights **per MoE layer per token**, resulting in ~1 token/min decode on a modern x86 CPU.

## Fix

Add `sparse_indexed_moe` in `mistralrs-quant/src/gguf/cpu.rs`: slice the stacked `[n_experts, n, k]` QTensor's raw byte storage per expert (GGUF quantized blocks are uniform size), construct a per-expert `QMatMul`, and run quantized matmul **only for the experts actually routed to** (top-k per token). Unused experts are never touched — no dequantization of irrelevant weights.

Falls back to the existing dequantize-and-gather path for layouts it cannot serve (non-CPU, unexpected shapes/dtypes), so behavior is unchanged where the new path doesn't apply.

## Result

~200x decode speedup on x86_64 CPU for Qwen3.6-35B-A3B Q3_K_M (~1 tok/min → ~3.4 tok/s, measured in a multi-device layer-split setup).

## Tests

Two new unit tests in `gguf/cpu.rs`:
- `sparse_indexed_moe_matches_dequantize_gather`: F32 weights — bit-exact match (<1e-5) vs the dequantize+gather reference.
- `sparse_indexed_moe_quantized_close_to_dequantize_gather`: Q8_0 weights — output within 5% of output scale vs reference (covers ggml quantized-activation dot noise; catches routing/indexing errors).

`cargo check`, `cargo test -p mistralrs-quant`, `cargo fmt --check`, `cargo clippy` all clean.