### PR TITLE
feat(gdn): in-place pooled recurrent state kernels, fused MLP, f32 gate params

### DIFF
--- a/mistralrs-core/src/cuda/ffi.rs
+++ b/mistralrs-core/src/cuda/ffi.rs
@@ -625,6 +625,8 @@ extern "C" {
         seq_len: i32,
         k_dim: i32,
         v_dim: i32,
+        slot_indices: *const i32,
+        num_heads: i32,
         stream: i64,
     );
     pub(crate) fn warp_gated_delta_rule_recurrence(
@@ -639,6 +641,8 @@ extern "C" {
         seq_len: i32,
         k_dim: i32,
         v_dim: i32,
+        slot_indices: *const i32,
+        num_heads: i32,
         stream: i64,
     );
     // Chunked GDN recurrence for prefill (processes tokens in BT=64 chunks)
@@ -654,6 +658,8 @@ extern "C" {
         seq_len: i32,
         k_dim: i32,
         v_dim: i32,
+        slot_indices: *const i32,
+        num_heads: i32,
         stream: i64,
     );
     pub(crate) fn causal_conv1d_update(
@@ -664,6 +670,7 @@ extern "C" {
         batch_size: i32,
         conv_dim: i32,
         kernel_size: i32,
+        slot_indices: *const i32,
         dtype: i32,
         stream: i64,
     );
@@ -677,6 +684,7 @@ extern "C" {
         conv_dim: i32,
         seq_len: i32,
         kernel_size: i32,
+        slot_indices: *const i32,
         dtype: i32,
         stream: i64,
     );
@@ -732,13 +740,14 @@ extern "C" {
         a_log: *const f32,
         dt_bias: *const f32,
         state: *mut f32,
-        output: *mut f32,
+        output: *mut c_void,
         batch_size: i32,
         num_k_heads: i32,
         num_v_heads: i32,
         head_k_dim: i32,
         head_v_dim: i32,
         tiled_v_heads: i32,
+        slot_indices: *const i32,
         dtype: i32,
         stream: i64,
     );

--- a/mistralrs-core/src/cuda/gdn.cu
+++ b/mistralrs-core/src/cuda/gdn.cu
@@ -4,6 +4,14 @@
 #include <cstdint>
 #include <cuda_runtime.h>
 
+// (batch, head) -> row of the state buffer: identity on a gathered [B*H, ...] copy, or through the
+// per-batch slot table when a kernel updates the recurrent state pool in place
+__device__ __forceinline__ size_t gdn_state_row(const int32_t *__restrict__ slot_indices,
+                                                int bidx, int h, int num_heads) {
+  const size_t slot = slot_indices ? (size_t)slot_indices[bidx] : (size_t)bidx;
+  return slot * num_heads + h;
+}
+
 // ============================================================================
 // Kernel 1: gated_delta_rule_recurrence (optimized)
 //
@@ -30,9 +38,10 @@ __global__ void gated_delta_rule_recurrence_kernel_tiled(
     const float *__restrict__ v,    // [BH, S, V]
     const float *__restrict__ g,    // [BH, S]
     const float *__restrict__ beta, // [BH, S]
-    float *__restrict__ state,      // [BH, K, V]
+    float *__restrict__ state,      // [BH, K, V] or the pool with slot_indices
     float *__restrict__ output,     // [BH, S, V]
-    int seq_len, int v_dim) {
+    int seq_len, int v_dim, const int32_t *__restrict__ slot_indices,
+    int num_heads) {
 
   const int v_tile = blockIdx.x;       // which V-tile
   const int bh = blockIdx.y;           // batch*head index
@@ -48,7 +57,8 @@ __global__ void gated_delta_rule_recurrence_kernel_tiled(
   const float *v_bh = v + (size_t)bh * seq_len * v_dim;
   const float *g_bh = g + (size_t)bh * seq_len;
   const float *beta_bh = beta + (size_t)bh * seq_len;
-  float *state_bh = state + bh * BK * v_dim;
+  float *state_bh =
+      state + gdn_state_row(slot_indices, bh / num_heads, bh % num_heads, num_heads) * BK * v_dim;
   float *out_bh = output + (size_t)bh * seq_len * v_dim;
 
   // Shared memory: k_buf[BK] + q_buf[BK]
@@ -121,7 +131,8 @@ __global__ void gated_delta_rule_recurrence_kernel_fallback(
     const float *__restrict__ q, const float *__restrict__ k,
     const float *__restrict__ v, const float *__restrict__ g,
     const float *__restrict__ beta, float *__restrict__ state,
-    float *__restrict__ output, int seq_len, int k_dim, int v_dim) {
+    float *__restrict__ output, int seq_len, int k_dim, int v_dim,
+    const int32_t *__restrict__ slot_indices, int num_heads) {
 
   const int v_tile = blockIdx.x;
   const int bh = blockIdx.y;
@@ -136,7 +147,8 @@ __global__ void gated_delta_rule_recurrence_kernel_fallback(
   const float *v_bh = v + (size_t)bh * seq_len * v_dim;
   const float *g_bh = g + (size_t)bh * seq_len;
   const float *beta_bh = beta + (size_t)bh * seq_len;
-  float *state_bh = state + bh * k_dim * v_dim;
+  float *state_bh =
+      state + gdn_state_row(slot_indices, bh / num_heads, bh % num_heads, num_heads) * k_dim * v_dim;
   float *out_bh = output + (size_t)bh * seq_len * v_dim;
 
   extern __shared__ float shared[];
@@ -192,7 +204,8 @@ extern "C" void gated_delta_rule_recurrence(const float *q, const float *k,
                                             const float *beta, float *state,
                                             float *output, int bh, int seq_len,
                                             int k_dim, int v_dim,
-                                            int64_t stream) {
+                                            const int32_t *slot_indices,
+                                            int num_heads, int64_t stream) {
 
   const cudaStream_t custream = (cudaStream_t)stream;
 
@@ -204,7 +217,7 @@ extern "C" void gated_delta_rule_recurrence(const float *q, const float *k,
     dim3 block(BV);
     gated_delta_rule_recurrence_kernel_tiled<BK, BV>
         <<<grid, block, 0, custream>>>(q, k, v, g, beta, state, output, seq_len,
-                                       v_dim);
+                                       v_dim, slot_indices, num_heads);
   } else if (k_dim == 64) {
     // Fast path for models with k_dim=64
     constexpr int BK = 64;
@@ -213,7 +226,7 @@ extern "C" void gated_delta_rule_recurrence(const float *q, const float *k,
     dim3 block(BV);
     gated_delta_rule_recurrence_kernel_tiled<BK, BV>
         <<<grid, block, 0, custream>>>(q, k, v, g, beta, state, output, seq_len,
-                                       v_dim);
+                                       v_dim, slot_indices, num_heads);
   } else {
     // Fallback for other k_dim values (runtime loop, still V-tiled)
     constexpr int BV = 64;
@@ -223,7 +236,8 @@ extern "C" void gated_delta_rule_recurrence(const float *q, const float *k,
     size_t smem = 2 * k_dim * sizeof(float);
     gated_delta_rule_recurrence_kernel_fallback<BV, MAX_K>
         <<<grid, block, smem, custream>>>(q, k, v, g, beta, state, output,
-                                          seq_len, k_dim, v_dim);
+                                          seq_len, k_dim, v_dim, slot_indices,
+                                          num_heads);
   }
 }
 
@@ -247,7 +261,9 @@ __global__ __launch_bounds__(
                                                         *__restrict__ beta,
                                                     float *__restrict__ state,
                                                     float *__restrict__ output,
-                                                    int seq_len, int v_dim) {
+                                                    int seq_len, int v_dim,
+                                                    const int32_t *__restrict__ slot_indices,
+                                                    int num_heads) {
 
   constexpr int WARP_SIZE = 32;
   static_assert(BK % WARP_SIZE == 0, "BK must be a multiple of warp size");
@@ -267,7 +283,8 @@ __global__ __launch_bounds__(
   const float *v_bh = v + (size_t)bh * seq_len * v_dim;
   const float *g_bh = g + (size_t)bh * seq_len;
   const float *beta_bh = beta + (size_t)bh * seq_len;
-  float *state_bh = state + bh * BK * v_dim;
+  float *state_bh =
+      state + gdn_state_row(slot_indices, bh / num_heads, bh % num_heads, num_heads) * BK * v_dim;
   float *out_bh = output + (size_t)bh * seq_len * v_dim;
 
   float s[ROWS_PER_LANE];
@@ -322,7 +339,9 @@ extern "C" void warp_gated_delta_rule_recurrence(const float *q, const float *k,
                                                  const float *beta,
                                                  float *state, float *output,
                                                  int bh, int seq_len, int k_dim,
-                                                 int v_dim, int64_t stream) {
+                                                 int v_dim,
+                                                 const int32_t *slot_indices,
+                                                 int num_heads, int64_t stream) {
 
   const cudaStream_t custream = (cudaStream_t)stream;
   constexpr int NUM_WARPS = 4;
@@ -332,14 +351,14 @@ extern "C" void warp_gated_delta_rule_recurrence(const float *q, const float *k,
   if (k_dim == 128) {
     gated_delta_rule_recurrence_kernel_warp<128, NUM_WARPS>
         <<<grid, block, 0, custream>>>(q, k, v, g, beta, state, output, seq_len,
-                                       v_dim);
+                                       v_dim, slot_indices, num_heads);
   } else if (k_dim == 64) {
     gated_delta_rule_recurrence_kernel_warp<64, NUM_WARPS>
         <<<grid, block, 0, custream>>>(q, k, v, g, beta, state, output, seq_len,
-                                       v_dim);
+                                       v_dim, slot_indices, num_heads);
   } else {
     gated_delta_rule_recurrence(q, k, v, g, beta, state, output, bh, seq_len,
-                                k_dim, v_dim, stream);
+                                k_dim, v_dim, slot_indices, num_heads, stream);
   }
 }
 
@@ -372,9 +391,11 @@ chunked_gated_delta_rule_kernel(const float *__restrict__ q,    // [BH, S, K]
                                 const float *__restrict__ v,    // [BH, S, V]
                                 const float *__restrict__ g,    // [BH, S]
                                 const float *__restrict__ beta, // [BH, S]
-                                float *__restrict__ state,      // [BH, K, V]
+                                float *__restrict__ state,      // [BH, K, V] or pool
                                 float *__restrict__ output,     // [BH, S, V]
-                                int seq_len, int v_dim) {
+                                int seq_len, int v_dim,
+                                const int32_t *__restrict__ slot_indices,
+                                int num_heads) {
 
   const int v_tile = blockIdx.x;
   const int bh = blockIdx.y;
@@ -392,7 +413,8 @@ chunked_gated_delta_rule_kernel(const float *__restrict__ q,    // [BH, S, K]
   const float *v_bh = v + (size_t)bh * seq_len * v_dim;
   const float *g_bh = g + (size_t)bh * seq_len;
   const float *beta_bh = beta + (size_t)bh * seq_len;
-  float *state_bh = state + bh * BK * v_dim;
+  float *state_bh =
+      state + gdn_state_row(slot_indices, bh / num_heads, bh % num_heads, num_heads) * BK * v_dim;
   float *out_bh = output + (size_t)bh * seq_len * v_dim;
 
   // Dynamic shared memory layout
@@ -534,7 +556,8 @@ chunked_gated_delta_rule_kernel(const float *__restrict__ q,    // [BH, S, K]
 extern "C" void chunked_gated_delta_rule_recurrence(
     const float *q, const float *k, const float *v, const float *g,
     const float *beta, float *state, float *output, int bh, int seq_len,
-    int k_dim, int v_dim, int64_t stream) {
+    int k_dim, int v_dim, const int32_t *slot_indices, int num_heads,
+    int64_t stream) {
 
   const cudaStream_t custream = (cudaStream_t)stream;
 
@@ -553,7 +576,8 @@ extern "C" void chunked_gated_delta_rule_recurrence(
     dim3 grid((v_dim + BV - 1) / BV, bh);
     dim3 block(BV);
     kernel<<<grid, block, smem, custream>>>(q, k, v, g, beta, state, output,
-                                            seq_len, v_dim);
+                                            seq_len, v_dim, slot_indices,
+                                            num_heads);
   } else if (k_dim == 64) {
     constexpr int BT = 64;
     constexpr int BK = 64;
@@ -567,11 +591,12 @@ extern "C" void chunked_gated_delta_rule_recurrence(
     dim3 grid((v_dim + BV - 1) / BV, bh);
     dim3 block(BV);
     kernel<<<grid, block, smem, custream>>>(q, k, v, g, beta, state, output,
-                                            seq_len, v_dim);
+                                            seq_len, v_dim, slot_indices,
+                                            num_heads);
   } else {
     // Fallback: use the sequential kernel for unsupported k_dim
     gated_delta_rule_recurrence(q, k, v, g, beta, state, output, bh, seq_len,
-                                k_dim, v_dim, stream);
+                                k_dim, v_dim, slot_indices, num_heads, stream);
   }
 }
 
@@ -592,7 +617,8 @@ __global__ void causal_conv1d_update_kernel(
     const T *__restrict__ weight, // [conv_dim, kernel_size]
     T *__restrict__ conv_state,   // [B, conv_dim, kernel_size]
     T *__restrict__ output,       // [B, conv_dim, 1]
-    int batch_size, int conv_dim, int kernel_size) {
+    int batch_size, int conv_dim, int kernel_size,
+    const int32_t *__restrict__ slot_indices) {
 
   const int ch = blockIdx.x * blockDim.x + threadIdx.x;
   const int b = blockIdx.y;
@@ -601,7 +627,7 @@ __global__ void causal_conv1d_update_kernel(
     return;
 
   // Pointer to this batch/channel's conv state
-  T *cs = conv_state + (b * conv_dim + ch) * kernel_size;
+  T *cs = conv_state + (gdn_state_row(slot_indices, b, 0, 1) * conv_dim + ch) * kernel_size;
   const T *w = weight + ch * kernel_size;
 
   // Shift state left by 1
@@ -627,7 +653,8 @@ __global__ void causal_conv1d_update_kernel(
 extern "C" void causal_conv1d_update(const void *x, const void *weight,
                                      void *conv_state, void *output,
                                      int batch_size, int conv_dim,
-                                     int kernel_size, int dtype,
+                                     int kernel_size,
+                                     const int32_t *slot_indices, int dtype,
                                      int64_t stream) {
   const cudaStream_t custream = (cudaStream_t)stream;
   dim3 block(256);
@@ -637,13 +664,13 @@ extern "C" void causal_conv1d_update(const void *x, const void *weight,
     // f16
     causal_conv1d_update_kernel<__half><<<grid, block, 0, custream>>>(
         (const __half *)x, (const __half *)weight, (__half *)conv_state,
-        (__half *)output, batch_size, conv_dim, kernel_size);
+        (__half *)output, batch_size, conv_dim, kernel_size, slot_indices);
   } else {
     // bf16
     causal_conv1d_update_kernel<__nv_bfloat16><<<grid, block, 0, custream>>>(
         (const __nv_bfloat16 *)x, (const __nv_bfloat16 *)weight,
         (__nv_bfloat16 *)conv_state, (__nv_bfloat16 *)output, batch_size,
-        conv_dim, kernel_size);
+        conv_dim, kernel_size, slot_indices);
   }
 }
 
@@ -663,7 +690,8 @@ __global__ void causal_conv1d_full_kernel(
     const T *__restrict__ weight, // [conv_dim, kernel_size]
     const T *__restrict__ conv_state,
     T *__restrict__ output, // [B, conv_dim, S]
-    int batch_size, int conv_dim, int seq_len, int kernel_size) {
+    int batch_size, int conv_dim, int seq_len, int kernel_size,
+    const int32_t *__restrict__ slot_indices) {
 
   // Flat (channel, position) index: keeps long prompts inside grid limits and coalesces along S
   const size_t idx = (size_t)blockIdx.x * blockDim.x + threadIdx.x;
@@ -678,7 +706,8 @@ __global__ void causal_conv1d_full_kernel(
 
   const T *x_bch = x + ((size_t)b * conv_dim + ch) * seq_len;
   const T *w = weight + (size_t)ch * kernel_size;
-  const T *cs = conv_state + ((size_t)b * conv_dim + ch) * kernel_size;
+  const T *cs =
+      conv_state + (gdn_state_row(slot_indices, b, 0, 1) * conv_dim + ch) * kernel_size;
 
   float acc = 0.0f;
   for (int i = 0; i < kernel_size; i++) {
@@ -698,9 +727,11 @@ __global__ void causal_conv1d_full_kernel(
 template <typename T>
 __global__ void save_conv_state_kernel(
     const T *__restrict__ x, // [B, conv_dim, S]
-    const T *__restrict__ conv_state_in,
-    T *__restrict__ conv_state_out, // [B, conv_dim, kernel_size]
-    int batch_size, int conv_dim, int seq_len, int kernel_size) {
+    // May alias conv_state_out (pooled in-place update): every read is ahead of the write position
+    const T *conv_state_in,
+    T *conv_state_out, // [B, conv_dim, kernel_size]
+    int batch_size, int conv_dim, int seq_len, int kernel_size,
+    const int32_t *__restrict__ slot_indices) {
 
   const int ch = blockIdx.x * blockDim.x + threadIdx.x;
   const int b = blockIdx.y;
@@ -709,8 +740,9 @@ __global__ void save_conv_state_kernel(
     return;
 
   const T *x_bch = x + ((size_t)b * conv_dim + ch) * seq_len;
-  const T *prior = conv_state_in + (b * conv_dim + ch) * kernel_size;
-  T *cs = conv_state_out + (b * conv_dim + ch) * kernel_size;
+  const size_t row = gdn_state_row(slot_indices, b, 0, 1);
+  const T *prior = conv_state_in + (row * conv_dim + ch) * kernel_size;
+  T *cs = conv_state_out + (row * conv_dim + ch) * kernel_size;
 
   int pad = kernel_size - seq_len;
   for (int i = 0; i < kernel_size; i++) {
@@ -726,7 +758,8 @@ extern "C" void causal_conv1d_full(const void *x, const void *weight,
                                    const void *conv_state_in,
                                    void *conv_state_out, void *output,
                                    int batch_size, int conv_dim, int seq_len,
-                                   int kernel_size, int dtype, int64_t stream) {
+                                   int kernel_size, const int32_t *slot_indices,
+                                   int dtype, int64_t stream) {
   const cudaStream_t custream = (cudaStream_t)stream;
 
   // Main convolution kernel
@@ -738,21 +771,22 @@ extern "C" void causal_conv1d_full(const void *x, const void *weight,
     causal_conv1d_full_kernel<__half><<<grid, block, 0, custream>>>(
         (const __half *)x, (const __half *)weight,
         (const __half *)conv_state_in, (__half *)output, batch_size, conv_dim,
-        seq_len, kernel_size);
+        seq_len, kernel_size, slot_indices);
     dim3 grid2((conv_dim + 255) / 256, batch_size);
     save_conv_state_kernel<__half><<<grid2, block, 0, custream>>>(
         (const __half *)x, (const __half *)conv_state_in,
-        (__half *)conv_state_out, batch_size, conv_dim, seq_len, kernel_size);
+        (__half *)conv_state_out, batch_size, conv_dim, seq_len, kernel_size,
+        slot_indices);
   } else {
     causal_conv1d_full_kernel<__nv_bfloat16><<<grid, block, 0, custream>>>(
         (const __nv_bfloat16 *)x, (const __nv_bfloat16 *)weight,
         (const __nv_bfloat16 *)conv_state_in, (__nv_bfloat16 *)output,
-        batch_size, conv_dim, seq_len, kernel_size);
+        batch_size, conv_dim, seq_len, kernel_size, slot_indices);
     dim3 grid2((conv_dim + 255) / 256, batch_size);
     save_conv_state_kernel<__nv_bfloat16><<<grid2, block, 0, custream>>>(
         (const __nv_bfloat16 *)x, (const __nv_bfloat16 *)conv_state_in,
         (__nv_bfloat16 *)conv_state_out, batch_size, conv_dim, seq_len,
-        kernel_size);
+        kernel_size, slot_indices);
   }
 }
 
@@ -873,8 +907,9 @@ __global__ void gdn_decode_recurrence_kernel(
     const T *__restrict__ mixed_qkv, const T *__restrict__ b,
     const T *__restrict__ a, const float *__restrict__ a_log,
     const float *__restrict__ dt_bias, float *__restrict__ state,
-    float *__restrict__ output, int batch_size, int num_k_heads,
-    int num_v_heads, int head_v_dim, int tiled_v_heads) {
+    T *__restrict__ output, int batch_size, int num_k_heads,
+    int num_v_heads, int head_v_dim, int tiled_v_heads,
+    const int32_t *__restrict__ slot_indices) {
   const int v_tile = blockIdx.x;
   const int bh = blockIdx.y;
   const int tid = threadIdx.x;
@@ -894,8 +929,8 @@ __global__ void gdn_decode_recurrence_kernel(
   const T *row = mixed_qkv + bidx * conv_dim;
   const T *b_row = b + bidx * num_v_heads;
   const T *a_row = a + bidx * num_v_heads;
-  float *state_bh = state + bh * BK * head_v_dim;
-  float *out_bh = output + bh * head_v_dim;
+  float *state_bh = state + gdn_state_row(slot_indices, bidx, hv, num_v_heads) * BK * head_v_dim;
+  T *out_bh = output + bh * head_v_dim;
 
   __shared__ float red_q[BV];
   __shared__ float red_k[BV];
@@ -975,7 +1010,7 @@ __global__ void gdn_decode_recurrence_kernel(
   for (int j = 0; j < BK; j++) {
     state_bh[j * head_v_dim + v_idx] = s[j];
   }
-  out_bh[v_idx] = y_t;
+  out_bh[v_idx] = (T)y_t;
 }
 
 template <typename T, int BV, int MAX_K>
@@ -983,8 +1018,9 @@ __global__ void gdn_decode_recurrence_kernel_fallback(
     const T *__restrict__ mixed_qkv, const T *__restrict__ b,
     const T *__restrict__ a, const float *__restrict__ a_log,
     const float *__restrict__ dt_bias, float *__restrict__ state,
-    float *__restrict__ output, int batch_size, int num_k_heads,
-    int num_v_heads, int head_k_dim, int head_v_dim, int tiled_v_heads) {
+    T *__restrict__ output, int batch_size, int num_k_heads,
+    int num_v_heads, int head_k_dim, int head_v_dim, int tiled_v_heads,
+    const int32_t *__restrict__ slot_indices) {
   const int v_tile = blockIdx.x;
   const int bh = blockIdx.y;
   const int tid = threadIdx.x;
@@ -1004,8 +1040,9 @@ __global__ void gdn_decode_recurrence_kernel_fallback(
   const T *row = mixed_qkv + bidx * conv_dim;
   const T *b_row = b + bidx * num_v_heads;
   const T *a_row = a + bidx * num_v_heads;
-  float *state_bh = state + bh * head_k_dim * head_v_dim;
-  float *out_bh = output + bh * head_v_dim;
+  float *state_bh =
+      state + gdn_state_row(slot_indices, bidx, hv, num_v_heads) * head_k_dim * head_v_dim;
+  T *out_bh = output + bh * head_v_dim;
 
   extern __shared__ float shared[];
   float *red_q = shared;
@@ -1083,15 +1120,16 @@ __global__ void gdn_decode_recurrence_kernel_fallback(
   for (int j = 0; j < head_k_dim; j++) {
     state_bh[j * head_v_dim + v_idx] = s[j];
   }
-  out_bh[v_idx] = y_t;
+  out_bh[v_idx] = (T)y_t;
 }
 
 extern "C" void
 gdn_decode_recurrence(const void *mixed_qkv, const void *b, const void *a,
                       const float *a_log, const float *dt_bias, float *state,
-                      float *output, int batch_size, int num_k_heads,
+                      void *output, int batch_size, int num_k_heads,
                       int num_v_heads, int head_k_dim, int head_v_dim,
-                      int tiled_v_heads, int dtype, int64_t stream) {
+                      int tiled_v_heads, const int32_t *slot_indices, int dtype,
+                      int64_t stream) {
   const cudaStream_t custream = (cudaStream_t)stream;
   constexpr int BV = 64;
   dim3 grid((head_v_dim + BV - 1) / BV, batch_size * num_v_heads);
@@ -1102,28 +1140,30 @@ gdn_decode_recurrence(const void *mixed_qkv, const void *b, const void *a,
       gdn_decode_recurrence_kernel<__half, 128, BV>
           <<<grid, block, 0, custream>>>(
               (const __half *)mixed_qkv, (const __half *)b, (const __half *)a,
-              a_log, dt_bias, state, output, batch_size, num_k_heads,
-              num_v_heads, head_v_dim, tiled_v_heads);
+              a_log, dt_bias, state, (__half *)output, batch_size, num_k_heads,
+              num_v_heads, head_v_dim, tiled_v_heads, slot_indices);
     } else {
       gdn_decode_recurrence_kernel<__nv_bfloat16, 128, BV>
           <<<grid, block, 0, custream>>>(
               (const __nv_bfloat16 *)mixed_qkv, (const __nv_bfloat16 *)b,
-              (const __nv_bfloat16 *)a, a_log, dt_bias, state, output,
-              batch_size, num_k_heads, num_v_heads, head_v_dim, tiled_v_heads);
+              (const __nv_bfloat16 *)a, a_log, dt_bias, state, (__nv_bfloat16 *)output,
+              batch_size, num_k_heads, num_v_heads, head_v_dim, tiled_v_heads,
+              slot_indices);
     }
   } else if (head_k_dim == 64) {
     if (dtype == 0) {
       gdn_decode_recurrence_kernel<__half, 64, BV>
           <<<grid, block, 0, custream>>>(
               (const __half *)mixed_qkv, (const __half *)b, (const __half *)a,
-              a_log, dt_bias, state, output, batch_size, num_k_heads,
-              num_v_heads, head_v_dim, tiled_v_heads);
+              a_log, dt_bias, state, (__half *)output, batch_size, num_k_heads,
+              num_v_heads, head_v_dim, tiled_v_heads, slot_indices);
     } else {
       gdn_decode_recurrence_kernel<__nv_bfloat16, 64, BV>
           <<<grid, block, 0, custream>>>(
               (const __nv_bfloat16 *)mixed_qkv, (const __nv_bfloat16 *)b,
-              (const __nv_bfloat16 *)a, a_log, dt_bias, state, output,
-              batch_size, num_k_heads, num_v_heads, head_v_dim, tiled_v_heads);
+              (const __nv_bfloat16 *)a, a_log, dt_bias, state, (__nv_bfloat16 *)output,
+              batch_size, num_k_heads, num_v_heads, head_v_dim, tiled_v_heads,
+              slot_indices);
     }
   } else {
     constexpr int MAX_K = 256;
@@ -1132,15 +1172,15 @@ gdn_decode_recurrence(const void *mixed_qkv, const void *b, const void *a,
       gdn_decode_recurrence_kernel_fallback<__half, BV, MAX_K>
           <<<grid, block, smem, custream>>>(
               (const __half *)mixed_qkv, (const __half *)b, (const __half *)a,
-              a_log, dt_bias, state, output, batch_size, num_k_heads,
-              num_v_heads, head_k_dim, head_v_dim, tiled_v_heads);
+              a_log, dt_bias, state, (__half *)output, batch_size, num_k_heads,
+              num_v_heads, head_k_dim, head_v_dim, tiled_v_heads, slot_indices);
     } else {
       gdn_decode_recurrence_kernel_fallback<__nv_bfloat16, BV, MAX_K>
           <<<grid, block, smem, custream>>>(
               (const __nv_bfloat16 *)mixed_qkv, (const __nv_bfloat16 *)b,
-              (const __nv_bfloat16 *)a, a_log, dt_bias, state, output,
+              (const __nv_bfloat16 *)a, a_log, dt_bias, state, (__nv_bfloat16 *)output,
               batch_size, num_k_heads, num_v_heads, head_k_dim, head_v_dim,
-              tiled_v_heads);
+              tiled_v_heads, slot_indices);
     }
   }
 }

--- a/mistralrs-core/src/cuda/gdn.rs
+++ b/mistralrs-core/src/cuda/gdn.rs
@@ -5,95 +5,129 @@ use candle_core::{Result, Tensor};
 #[cfg(feature = "cuda")]
 use candle_core::DType;
 
-/// CUDA-accelerated gated delta rule recurrence.
-///
-/// Inputs (all contiguous, f32):
-///   q, k: [BH, S, K]  v: [BH, S, V]  g, beta: [BH, S]
-///   state: [BH, K, V] (mutated in place)
-///
-/// Returns: output [BH, S, V]
+/// Which rows of the recurrent state a GDN kernel reads and writes. `Gathered` means the state is a
+/// `[B*H, ...]` copy addressed by batch row; `Pooled` addresses the whole pool `[cap, H, ...]`
+/// through a `[B]` u32 slot table, so the kernels update it in place without gather/scatter copies.
+#[derive(Clone, Copy)]
+pub enum GdnStateSlots<'a> {
+    Gathered,
+    Pooled(&'a Tensor),
+}
+
+impl<'a> GdnStateSlots<'a> {
+    pub fn from_option(slots: Option<&'a Tensor>) -> Self {
+        match slots {
+            Some(slots) => Self::Pooled(slots),
+            None => Self::Gathered,
+        }
+    }
+}
+
 #[cfg(feature = "cuda")]
-pub fn gated_delta_rule_recurrence_cuda(
-    q: &Tensor,
-    k: &Tensor,
-    v: &Tensor,
-    g: &Tensor,
-    beta: &Tensor,
+fn with_slot_indices<T>(
+    slots: GdnStateSlots<'_>,
+    f: impl FnOnce(*const i32, usize) -> Result<T>,
+) -> Result<T> {
+    use candle_core::cuda_backend::cudarc::driver::DevicePtr;
+    match slots {
+        GdnStateSlots::Gathered => f(std::ptr::null(), 0),
+        GdnStateSlots::Pooled(slots) => {
+            let batch = slots.dim(0)?;
+            let (s, l) = slots.storage_and_layout();
+            let s = match &*s {
+                candle_core::Storage::Cuda(c) => c.as_cuda_slice::<u32>()?,
+                _ => candle_core::bail!("slot indices must be a cuda tensor"),
+            };
+            let ptr = s.slice(l.start_offset()..).device_ptr(s.stream()).0 as *const i32;
+            f(ptr, batch)
+        }
+    }
+}
+
+/// Contiguous f32 recurrence inputs: q, k `[BH, S, K]`, v `[BH, S, V]`, g, beta `[BH, S]`.
+#[derive(Clone, Copy)]
+pub struct RecurrenceInputs<'a> {
+    pub q: &'a Tensor,
+    pub k: &'a Tensor,
+    pub v: &'a Tensor,
+    pub g: &'a Tensor,
+    pub beta: &'a Tensor,
+}
+
+#[cfg(feature = "cuda")]
+#[derive(Clone, Copy)]
+enum RecurrenceKernel {
+    Scalar,
+    Warp,
+    Chunked,
+}
+
+/// `state` is `[BH, K, V]` (gathered) or the `[cap, H, K, V]` pool (pooled), mutated in place.
+/// Returns output `[BH, S, V]`.
+#[cfg(feature = "cuda")]
+fn launch_recurrence(
+    kernel: RecurrenceKernel,
+    inputs: RecurrenceInputs<'_>,
     state: &mut Tensor,
+    slots: GdnStateSlots<'_>,
 ) -> Result<Tensor> {
     use candle::cuda_backend::cudarc::driver::DevicePtr;
     use candle_core as candle;
 
+    let RecurrenceInputs { q, k, v, g, beta } = inputs;
     let (bh, seq_len, k_dim) = q.dims3()?;
     let v_dim = v.dim(2)?;
-
     let dev = q.device().as_cuda_device()?;
 
-    let (q_s, q_l) = q.storage_and_layout();
-    let q_s = match &*q_s {
-        candle::Storage::Cuda(c) => c.as_cuda_slice::<f32>()?,
-        _ => candle::bail!("q must be a cuda tensor"),
-    };
-    let q_offset = q_l.start_offset();
-
-    let (k_s, k_l) = k.storage_and_layout();
-    let k_s = match &*k_s {
-        candle::Storage::Cuda(c) => c.as_cuda_slice::<f32>()?,
-        _ => candle::bail!("k must be a cuda tensor"),
-    };
-    let k_offset = k_l.start_offset();
-
-    let (v_s, v_l) = v.storage_and_layout();
-    let v_s = match &*v_s {
-        candle::Storage::Cuda(c) => c.as_cuda_slice::<f32>()?,
-        _ => candle::bail!("v must be a cuda tensor"),
-    };
-    let v_offset = v_l.start_offset();
-
-    let (g_s, g_l) = g.storage_and_layout();
-    let g_s = match &*g_s {
-        candle::Storage::Cuda(c) => c.as_cuda_slice::<f32>()?,
-        _ => candle::bail!("g must be a cuda tensor"),
-    };
-    let g_offset = g_l.start_offset();
-
-    let (beta_s, beta_l) = beta.storage_and_layout();
-    let beta_s = match &*beta_s {
-        candle::Storage::Cuda(c) => c.as_cuda_slice::<f32>()?,
-        _ => candle::bail!("beta must be a cuda tensor"),
-    };
-    let beta_offset = beta_l.start_offset();
-
-    let (state_s, state_l) = state.storage_and_layout();
-    let state_s = match &*state_s {
-        candle::Storage::Cuda(c) => c.as_cuda_slice::<f32>()?,
-        _ => candle::bail!("state must be a cuda tensor"),
-    };
-    let state_offset = state_l.start_offset();
+    macro_rules! f32_ptr {
+        ($t:expr, $name:literal) => {{
+            let (s, l) = $t.storage_and_layout();
+            let offset = l.start_offset();
+            let s = match &*s {
+                candle::Storage::Cuda(c) => c.as_cuda_slice::<f32>()?,
+                _ => candle::bail!(concat!($name, " must be a cuda tensor")),
+            };
+            let ptr = s.slice(offset..).device_ptr(s.stream()).0 as *mut f32;
+            ptr
+        }};
+    }
+    let q_ptr = f32_ptr!(q, "q");
+    let k_ptr = f32_ptr!(k, "k");
+    let v_ptr = f32_ptr!(v, "v");
+    let g_ptr = f32_ptr!(g, "g");
+    let beta_ptr = f32_ptr!(beta, "beta");
+    let state_ptr = f32_ptr!(state, "state");
 
     let output_buf = unsafe { dev.alloc::<f32>(bh * seq_len * v_dim) }?;
-
     let stream = dev.cuda_stream().cu_stream() as i64;
 
-    unsafe {
-        crate::cuda::ffi::gated_delta_rule_recurrence(
-            q_s.slice(q_offset..).device_ptr(q_s.stream()).0 as *const f32,
-            k_s.slice(k_offset..).device_ptr(k_s.stream()).0 as *const f32,
-            v_s.slice(v_offset..).device_ptr(v_s.stream()).0 as *const f32,
-            g_s.slice(g_offset..).device_ptr(g_s.stream()).0 as *const f32,
-            beta_s.slice(beta_offset..).device_ptr(beta_s.stream()).0 as *const f32,
-            state_s.slice(state_offset..).device_ptr(state_s.stream()).0 as *mut f32,
-            output_buf.device_ptr(output_buf.stream()).0 as *mut f32,
-            bh as i32,
-            seq_len as i32,
-            k_dim as i32,
-            v_dim as i32,
-            stream,
-        );
-    }
-
-    // The kernel wrote state in-place via the raw pointer; rewrap
-    // (state tensor's underlying CudaSlice was modified directly)
+    with_slot_indices(slots, |slot_ptr, batch| {
+        let num_heads = bh.checked_div(batch).unwrap_or(1);
+        let launcher = match kernel {
+            RecurrenceKernel::Scalar => crate::cuda::ffi::gated_delta_rule_recurrence,
+            RecurrenceKernel::Warp => crate::cuda::ffi::warp_gated_delta_rule_recurrence,
+            RecurrenceKernel::Chunked => crate::cuda::ffi::chunked_gated_delta_rule_recurrence,
+        };
+        unsafe {
+            launcher(
+                q_ptr,
+                k_ptr,
+                v_ptr,
+                g_ptr,
+                beta_ptr,
+                state_ptr,
+                output_buf.device_ptr(output_buf.stream()).0 as *mut f32,
+                bh as i32,
+                seq_len as i32,
+                k_dim as i32,
+                v_dim as i32,
+                slot_ptr,
+                num_heads as i32,
+                stream,
+            );
+        }
+        Ok(())
+    })?;
 
     let output_storage = candle::CudaStorage::wrap_cuda_slice(output_buf, dev.clone());
     Ok(Tensor::from((
@@ -102,238 +136,72 @@ pub fn gated_delta_rule_recurrence_cuda(
     )))
 }
 
+/// Sequential (one token at a time) gated delta rule recurrence; see `launch_recurrence`.
+#[cfg(feature = "cuda")]
+pub fn gated_delta_rule_recurrence_cuda(
+    inputs: RecurrenceInputs<'_>,
+    state: &mut Tensor,
+    slots: GdnStateSlots<'_>,
+) -> Result<Tensor> {
+    launch_recurrence(RecurrenceKernel::Scalar, inputs, state, slots)
+}
+
+/// Prefill recurrence in 64-token chunks; see `launch_recurrence`.
+#[cfg(feature = "cuda")]
+pub fn chunked_gated_delta_rule_recurrence_cuda(
+    inputs: RecurrenceInputs<'_>,
+    state: &mut Tensor,
+    slots: GdnStateSlots<'_>,
+) -> Result<Tensor> {
+    launch_recurrence(RecurrenceKernel::Chunked, inputs, state, slots)
+}
+
+/// Warp-per-value-column prefill recurrence; see `launch_recurrence`.
+#[cfg(feature = "cuda")]
+pub fn warp_gated_delta_rule_recurrence_cuda(
+    inputs: RecurrenceInputs<'_>,
+    state: &mut Tensor,
+    slots: GdnStateSlots<'_>,
+) -> Result<Tensor> {
+    launch_recurrence(RecurrenceKernel::Warp, inputs, state, slots)
+}
+
 #[cfg(not(feature = "cuda"))]
 #[allow(unused)]
 pub fn gated_delta_rule_recurrence_cuda(
-    _q: &Tensor,
-    _k: &Tensor,
-    _v: &Tensor,
-    _g: &Tensor,
-    _beta: &Tensor,
+    _inputs: RecurrenceInputs<'_>,
     _state: &mut Tensor,
+    _slots: GdnStateSlots<'_>,
 ) -> Result<Tensor> {
     candle_core::bail!("gated_delta_rule_recurrence_cuda requires the cuda feature")
 }
 
-/// CUDA-accelerated chunked gated delta rule recurrence (prefill optimization).
-///
-/// Processes prefill tokens in 64-token chunks instead of one at a time.
-/// Same interface as `gated_delta_rule_recurrence_cuda`.
-///
-/// Inputs (all contiguous, f32):
-///   q, k: [BH, S, K]  v: [BH, S, V]  g, beta: [BH, S]
-///   state: [BH, K, V] (mutated in place)
-///
-/// Returns: output [BH, S, V]
-#[cfg(feature = "cuda")]
-pub fn chunked_gated_delta_rule_recurrence_cuda(
-    q: &Tensor,
-    k: &Tensor,
-    v: &Tensor,
-    g: &Tensor,
-    beta: &Tensor,
-    state: &mut Tensor,
-) -> Result<Tensor> {
-    use candle::cuda_backend::cudarc::driver::DevicePtr;
-    use candle_core as candle;
-
-    let (bh, seq_len, k_dim) = q.dims3()?;
-    let v_dim = v.dim(2)?;
-
-    let dev = q.device().as_cuda_device()?;
-
-    let (q_s, q_l) = q.storage_and_layout();
-    let q_s = match &*q_s {
-        candle::Storage::Cuda(c) => c.as_cuda_slice::<f32>()?,
-        _ => candle::bail!("q must be a cuda tensor"),
-    };
-    let q_offset = q_l.start_offset();
-
-    let (k_s, k_l) = k.storage_and_layout();
-    let k_s = match &*k_s {
-        candle::Storage::Cuda(c) => c.as_cuda_slice::<f32>()?,
-        _ => candle::bail!("k must be a cuda tensor"),
-    };
-    let k_offset = k_l.start_offset();
-
-    let (v_s, v_l) = v.storage_and_layout();
-    let v_s = match &*v_s {
-        candle::Storage::Cuda(c) => c.as_cuda_slice::<f32>()?,
-        _ => candle::bail!("v must be a cuda tensor"),
-    };
-    let v_offset = v_l.start_offset();
-
-    let (g_s, g_l) = g.storage_and_layout();
-    let g_s = match &*g_s {
-        candle::Storage::Cuda(c) => c.as_cuda_slice::<f32>()?,
-        _ => candle::bail!("g must be a cuda tensor"),
-    };
-    let g_offset = g_l.start_offset();
-
-    let (beta_s, beta_l) = beta.storage_and_layout();
-    let beta_s = match &*beta_s {
-        candle::Storage::Cuda(c) => c.as_cuda_slice::<f32>()?,
-        _ => candle::bail!("beta must be a cuda tensor"),
-    };
-    let beta_offset = beta_l.start_offset();
-
-    let (state_s, state_l) = state.storage_and_layout();
-    let state_s = match &*state_s {
-        candle::Storage::Cuda(c) => c.as_cuda_slice::<f32>()?,
-        _ => candle::bail!("state must be a cuda tensor"),
-    };
-    let state_offset = state_l.start_offset();
-
-    let output_buf = unsafe { dev.alloc::<f32>(bh * seq_len * v_dim) }?;
-
-    let stream = dev.cuda_stream().cu_stream() as i64;
-
-    unsafe {
-        crate::cuda::ffi::chunked_gated_delta_rule_recurrence(
-            q_s.slice(q_offset..).device_ptr(q_s.stream()).0 as *const f32,
-            k_s.slice(k_offset..).device_ptr(k_s.stream()).0 as *const f32,
-            v_s.slice(v_offset..).device_ptr(v_s.stream()).0 as *const f32,
-            g_s.slice(g_offset..).device_ptr(g_s.stream()).0 as *const f32,
-            beta_s.slice(beta_offset..).device_ptr(beta_s.stream()).0 as *const f32,
-            state_s.slice(state_offset..).device_ptr(state_s.stream()).0 as *mut f32,
-            output_buf.device_ptr(output_buf.stream()).0 as *mut f32,
-            bh as i32,
-            seq_len as i32,
-            k_dim as i32,
-            v_dim as i32,
-            stream,
-        );
-    }
-
-    let output_storage = candle::CudaStorage::wrap_cuda_slice(output_buf, dev.clone());
-    Ok(Tensor::from((
-        candle::Storage::Cuda(output_storage),
-        (bh, seq_len, v_dim),
-    )))
-}
-
 #[cfg(not(feature = "cuda"))]
 #[allow(unused)]
 pub fn chunked_gated_delta_rule_recurrence_cuda(
-    _q: &Tensor,
-    _k: &Tensor,
-    _v: &Tensor,
-    _g: &Tensor,
-    _beta: &Tensor,
+    _inputs: RecurrenceInputs<'_>,
     _state: &mut Tensor,
+    _slots: GdnStateSlots<'_>,
 ) -> Result<Tensor> {
     candle_core::bail!("chunked_gated_delta_rule_recurrence_cuda requires the cuda feature")
 }
 
-#[cfg(feature = "cuda")]
-pub fn warp_gated_delta_rule_recurrence_cuda(
-    q: &Tensor,
-    k: &Tensor,
-    v: &Tensor,
-    g: &Tensor,
-    beta: &Tensor,
-    state: &mut Tensor,
-) -> Result<Tensor> {
-    use candle::cuda_backend::cudarc::driver::DevicePtr;
-    use candle_core as candle;
-
-    let (bh, seq_len, k_dim) = q.dims3()?;
-    let v_dim = v.dim(2)?;
-
-    let dev = q.device().as_cuda_device()?;
-
-    let (q_s, q_l) = q.storage_and_layout();
-    let q_s = match &*q_s {
-        candle::Storage::Cuda(c) => c.as_cuda_slice::<f32>()?,
-        _ => candle::bail!("q must be a cuda tensor"),
-    };
-    let q_offset = q_l.start_offset();
-
-    let (k_s, k_l) = k.storage_and_layout();
-    let k_s = match &*k_s {
-        candle::Storage::Cuda(c) => c.as_cuda_slice::<f32>()?,
-        _ => candle::bail!("k must be a cuda tensor"),
-    };
-    let k_offset = k_l.start_offset();
-
-    let (v_s, v_l) = v.storage_and_layout();
-    let v_s = match &*v_s {
-        candle::Storage::Cuda(c) => c.as_cuda_slice::<f32>()?,
-        _ => candle::bail!("v must be a cuda tensor"),
-    };
-    let v_offset = v_l.start_offset();
-
-    let (g_s, g_l) = g.storage_and_layout();
-    let g_s = match &*g_s {
-        candle::Storage::Cuda(c) => c.as_cuda_slice::<f32>()?,
-        _ => candle::bail!("g must be a cuda tensor"),
-    };
-    let g_offset = g_l.start_offset();
-
-    let (beta_s, beta_l) = beta.storage_and_layout();
-    let beta_s = match &*beta_s {
-        candle::Storage::Cuda(c) => c.as_cuda_slice::<f32>()?,
-        _ => candle::bail!("beta must be a cuda tensor"),
-    };
-    let beta_offset = beta_l.start_offset();
-
-    let (state_s, state_l) = state.storage_and_layout();
-    let state_s = match &*state_s {
-        candle::Storage::Cuda(c) => c.as_cuda_slice::<f32>()?,
-        _ => candle::bail!("state must be a cuda tensor"),
-    };
-    let state_offset = state_l.start_offset();
-
-    let output_buf = unsafe { dev.alloc::<f32>(bh * seq_len * v_dim) }?;
-    let stream = dev.cuda_stream().cu_stream() as i64;
-
-    unsafe {
-        crate::cuda::ffi::warp_gated_delta_rule_recurrence(
-            q_s.slice(q_offset..).device_ptr(q_s.stream()).0 as *const f32,
-            k_s.slice(k_offset..).device_ptr(k_s.stream()).0 as *const f32,
-            v_s.slice(v_offset..).device_ptr(v_s.stream()).0 as *const f32,
-            g_s.slice(g_offset..).device_ptr(g_s.stream()).0 as *const f32,
-            beta_s.slice(beta_offset..).device_ptr(beta_s.stream()).0 as *const f32,
-            state_s.slice(state_offset..).device_ptr(state_s.stream()).0 as *mut f32,
-            output_buf.device_ptr(output_buf.stream()).0 as *mut f32,
-            bh as i32,
-            seq_len as i32,
-            k_dim as i32,
-            v_dim as i32,
-            stream,
-        );
-    }
-
-    let output_storage = candle::CudaStorage::wrap_cuda_slice(output_buf, dev.clone());
-    Ok(Tensor::from((
-        candle::Storage::Cuda(output_storage),
-        (bh, seq_len, v_dim),
-    )))
-}
-
 #[cfg(not(feature = "cuda"))]
 #[allow(unused)]
 pub fn warp_gated_delta_rule_recurrence_cuda(
-    _q: &Tensor,
-    _k: &Tensor,
-    _v: &Tensor,
-    _g: &Tensor,
-    _beta: &Tensor,
+    _inputs: RecurrenceInputs<'_>,
     _state: &mut Tensor,
+    _slots: GdnStateSlots<'_>,
 ) -> Result<Tensor> {
     candle_core::bail!("warp_gated_delta_rule_recurrence_cuda requires the cuda feature")
 }
 
 /// CUDA-accelerated causal conv1d (both update and full paths).
 ///
-/// For update (is_update=true):
-///   x: [B, conv_dim, 1]  weight: [conv_dim, kernel_size]
-///   conv_state: [B, conv_dim, kernel_size] (mutated in place for update)
-///   Returns: (output [B, conv_dim, 1], updated conv_state)
-///
-/// For full (is_update=false):
-///   x: [B, conv_dim, S]  weight: [conv_dim, kernel_size]
-///   Returns: (output [B, conv_dim, S], new conv_state [B, conv_dim, kernel_size])
+/// x: [B, conv_dim, S] (S=1 for update)  weight: [conv_dim, kernel_size]
+/// conv_state: [B, conv_dim, kernel_size], or the [cap, conv_dim, kernel_size] pool with `Pooled` slots.
+/// Update mutates `conv_state` in place; full writes a fresh state (gathered) or the pool rows (pooled).
+/// Returns (output [B, conv_dim, S], conv_state after the step).
 #[cfg(feature = "cuda")]
 pub fn causal_conv1d_cuda(
     x: &Tensor,
@@ -341,6 +209,7 @@ pub fn causal_conv1d_cuda(
     conv_state: &Tensor,
     kernel_size: usize,
     is_update: bool,
+    slots: GdnStateSlots<'_>,
 ) -> Result<(Tensor, Tensor)> {
     use candle::cuda_backend::cudarc::driver::DevicePtr;
     use candle_core as candle;
@@ -353,10 +222,12 @@ pub fn causal_conv1d_cuda(
         conv_state: &Tensor,
         kernel_size: usize,
         is_update: bool,
+        slots: GdnStateSlots<'_>,
         dtype_code: i32,
     ) -> Result<(Tensor, Tensor)> {
         let dev = x.device().as_cuda_device()?;
         let (batch_size, conv_dim, seq_len) = x.dims3()?;
+        let pooled = matches!(slots, GdnStateSlots::Pooled(_));
 
         let (x_s, x_l) = x.storage_and_layout();
         let x_s = match &*x_s {
@@ -389,19 +260,23 @@ pub fn causal_conv1d_cuda(
                 };
                 let cs_offset = cs_l.start_offset();
 
-                unsafe {
-                    crate::cuda::ffi::causal_conv1d_update(
-                        x_s.slice(x_offset..).device_ptr(x_s.stream()).0 as *const c_void,
-                        w_s.slice(w_offset..).device_ptr(w_s.stream()).0 as *const c_void,
-                        cs_s.slice(cs_offset..).device_ptr(cs_s.stream()).0 as *mut c_void,
-                        output_buf.device_ptr(output_buf.stream()).0 as *mut c_void,
-                        batch_size as i32,
-                        conv_dim as i32,
-                        kernel_size as i32,
-                        dtype_code,
-                        stream,
-                    );
-                }
+                with_slot_indices(slots, |slot_ptr, _| {
+                    unsafe {
+                        crate::cuda::ffi::causal_conv1d_update(
+                            x_s.slice(x_offset..).device_ptr(x_s.stream()).0 as *const c_void,
+                            w_s.slice(w_offset..).device_ptr(w_s.stream()).0 as *const c_void,
+                            cs_s.slice(cs_offset..).device_ptr(cs_s.stream()).0 as *mut c_void,
+                            output_buf.device_ptr(output_buf.stream()).0 as *mut c_void,
+                            batch_size as i32,
+                            conv_dim as i32,
+                            kernel_size as i32,
+                            slot_ptr,
+                            dtype_code,
+                            stream,
+                        );
+                    }
+                    Ok(())
+                })?;
             }
 
             let output_storage = candle::CudaStorage::wrap_cuda_slice(output_buf, dev.clone());
@@ -413,29 +288,43 @@ pub fn causal_conv1d_cuda(
             Ok((output, conv_state_new))
         } else {
             let output_buf = unsafe { dev.alloc::<T>(batch_size * conv_dim * seq_len) }?;
-            let cs_buf = unsafe { dev.alloc::<T>(batch_size * conv_dim * kernel_size) }?;
+            // Pooled: the save kernel rewrites the pool rows in place (it reads ahead of every write)
+            let cs_buf = if pooled {
+                None
+            } else {
+                Some(unsafe { dev.alloc::<T>(batch_size * conv_dim * kernel_size) }?)
+            };
             let (cs_s, cs_l) = conv_state.storage_and_layout();
             let cs_s = match &*cs_s {
                 candle::Storage::Cuda(c) => c.as_cuda_slice::<T>()?,
                 _ => candle::bail!("conv_state must be a cuda tensor"),
             };
             let cs_offset = cs_l.start_offset();
+            let cs_in_ptr = cs_s.slice(cs_offset..).device_ptr(cs_s.stream()).0;
+            let cs_out_ptr = match &cs_buf {
+                Some(buf) => buf.device_ptr(buf.stream()).0,
+                None => cs_in_ptr,
+            };
 
-            unsafe {
-                crate::cuda::ffi::causal_conv1d_full(
-                    x_s.slice(x_offset..).device_ptr(x_s.stream()).0 as *const c_void,
-                    w_s.slice(w_offset..).device_ptr(w_s.stream()).0 as *const c_void,
-                    cs_s.slice(cs_offset..).device_ptr(cs_s.stream()).0 as *const c_void,
-                    cs_buf.device_ptr(cs_buf.stream()).0 as *mut c_void,
-                    output_buf.device_ptr(output_buf.stream()).0 as *mut c_void,
-                    batch_size as i32,
-                    conv_dim as i32,
-                    seq_len as i32,
-                    kernel_size as i32,
-                    dtype_code,
-                    stream,
-                );
-            }
+            with_slot_indices(slots, |slot_ptr, _| {
+                unsafe {
+                    crate::cuda::ffi::causal_conv1d_full(
+                        x_s.slice(x_offset..).device_ptr(x_s.stream()).0 as *const c_void,
+                        w_s.slice(w_offset..).device_ptr(w_s.stream()).0 as *const c_void,
+                        cs_in_ptr as *const c_void,
+                        cs_out_ptr as *mut c_void,
+                        output_buf.device_ptr(output_buf.stream()).0 as *mut c_void,
+                        batch_size as i32,
+                        conv_dim as i32,
+                        seq_len as i32,
+                        kernel_size as i32,
+                        slot_ptr,
+                        dtype_code,
+                        stream,
+                    );
+                }
+                Ok(())
+            })?;
 
             let output_storage = candle::CudaStorage::wrap_cuda_slice(output_buf, dev.clone());
             let output = Tensor::from((
@@ -443,11 +332,16 @@ pub fn causal_conv1d_cuda(
                 (batch_size, conv_dim, seq_len),
             ));
 
-            let cs_storage = candle::CudaStorage::wrap_cuda_slice(cs_buf, dev.clone());
-            let new_conv_state = Tensor::from((
-                candle::Storage::Cuda(cs_storage),
-                (batch_size, conv_dim, kernel_size),
-            ));
+            let new_conv_state = match cs_buf {
+                Some(cs_buf) => Tensor::from((
+                    candle::Storage::Cuda(candle::CudaStorage::wrap_cuda_slice(
+                        cs_buf,
+                        dev.clone(),
+                    )),
+                    (batch_size, conv_dim, kernel_size),
+                )),
+                None => conv_state.clone(),
+            };
 
             Ok((output, new_conv_state))
         }
@@ -455,10 +349,17 @@ pub fn causal_conv1d_cuda(
 
     let x = x.contiguous()?;
     let weight = weight.contiguous()?;
+    if matches!(slots, GdnStateSlots::Pooled(_)) && !conv_state.is_contiguous() {
+        candle_core::bail!("pooled conv state must be contiguous");
+    }
     let conv_state = conv_state.contiguous()?;
     match x.dtype() {
-        DType::F16 => cuda_fwd::<half::f16>(&x, &weight, &conv_state, kernel_size, is_update, 0),
-        DType::BF16 => cuda_fwd::<half::bf16>(&x, &weight, &conv_state, kernel_size, is_update, 1),
+        DType::F16 => {
+            cuda_fwd::<half::f16>(&x, &weight, &conv_state, kernel_size, is_update, slots, 0)
+        }
+        DType::BF16 => {
+            cuda_fwd::<half::bf16>(&x, &weight, &conv_state, kernel_size, is_update, slots, 1)
+        }
         other => candle_core::bail!("causal_conv1d_cuda only supports f16/bf16, got {:?}", other),
     }
 }
@@ -471,6 +372,7 @@ pub fn causal_conv1d_cuda(
     _conv_state: &Tensor,
     _kernel_size: usize,
     _is_update: bool,
+    _slots: GdnStateSlots<'_>,
 ) -> Result<(Tensor, Tensor)> {
     candle_core::bail!("causal_conv1d_cuda requires the cuda feature")
 }
@@ -678,6 +580,7 @@ pub fn fused_decode_recurrence_cuda(
     head_k_dim: usize,
     head_v_dim: usize,
     tiled_v_heads: bool,
+    slots: GdnStateSlots<'_>,
 ) -> Result<Tensor> {
     use candle::cuda_backend::cudarc::driver::DevicePtr;
     use candle_core as candle;
@@ -698,6 +601,7 @@ pub fn fused_decode_recurrence_cuda(
         head_k_dim: usize,
         head_v_dim: usize,
         tiled_v_heads: bool,
+        slots: GdnStateSlots<'_>,
         dtype_code: i32,
     ) -> Result<Tensor> {
         let dev = mixed_qkv.device().as_cuda_device()?;
@@ -745,28 +649,32 @@ pub fn fused_decode_recurrence_cuda(
         let state_offset = state_l.start_offset();
 
         let bh = batch_size * num_v_heads;
-        let output_buf = unsafe { dev.alloc::<f32>(bh * head_v_dim) }?;
+        let output_buf = unsafe { dev.alloc::<T>(bh * head_v_dim) }?;
         let stream = dev.cuda_stream().cu_stream() as i64;
 
-        unsafe {
-            crate::cuda::ffi::gdn_decode_recurrence(
-                mixed_s.slice(mixed_offset..).device_ptr(mixed_s.stream()).0 as *const c_void,
-                b_s.slice(b_offset..).device_ptr(b_s.stream()).0 as *const c_void,
-                a_s.slice(a_offset..).device_ptr(a_s.stream()).0 as *const c_void,
-                alog_s.slice(alog_offset..).device_ptr(alog_s.stream()).0 as *const f32,
-                dtb_s.slice(dtb_offset..).device_ptr(dtb_s.stream()).0 as *const f32,
-                state_s.slice(state_offset..).device_ptr(state_s.stream()).0 as *mut f32,
-                output_buf.device_ptr(output_buf.stream()).0 as *mut f32,
-                batch_size as i32,
-                num_k_heads as i32,
-                num_v_heads as i32,
-                head_k_dim as i32,
-                head_v_dim as i32,
-                i32::from(tiled_v_heads),
-                dtype_code,
-                stream,
-            );
-        }
+        with_slot_indices(slots, |slot_ptr, _| {
+            unsafe {
+                crate::cuda::ffi::gdn_decode_recurrence(
+                    mixed_s.slice(mixed_offset..).device_ptr(mixed_s.stream()).0 as *const c_void,
+                    b_s.slice(b_offset..).device_ptr(b_s.stream()).0 as *const c_void,
+                    a_s.slice(a_offset..).device_ptr(a_s.stream()).0 as *const c_void,
+                    alog_s.slice(alog_offset..).device_ptr(alog_s.stream()).0 as *const f32,
+                    dtb_s.slice(dtb_offset..).device_ptr(dtb_s.stream()).0 as *const f32,
+                    state_s.slice(state_offset..).device_ptr(state_s.stream()).0 as *mut f32,
+                    output_buf.device_ptr(output_buf.stream()).0 as *mut c_void,
+                    batch_size as i32,
+                    num_k_heads as i32,
+                    num_v_heads as i32,
+                    head_k_dim as i32,
+                    head_v_dim as i32,
+                    i32::from(tiled_v_heads),
+                    slot_ptr,
+                    dtype_code,
+                    stream,
+                );
+            }
+            Ok(())
+        })?;
 
         Ok(Tensor::from((
             candle::Storage::Cuda(candle::CudaStorage::wrap_cuda_slice(
@@ -791,6 +699,7 @@ pub fn fused_decode_recurrence_cuda(
             head_k_dim,
             head_v_dim,
             tiled_v_heads,
+            slots,
             0,
         ),
         DType::BF16 => cuda_fwd::<half::bf16>(
@@ -806,6 +715,7 @@ pub fn fused_decode_recurrence_cuda(
             head_k_dim,
             head_v_dim,
             tiled_v_heads,
+            slots,
             1,
         ),
         other => candle_core::bail!(
@@ -830,6 +740,7 @@ pub fn fused_decode_recurrence_cuda(
     _head_k_dim: usize,
     _head_v_dim: usize,
     _tiled_v_heads: bool,
+    _slots: GdnStateSlots<'_>,
 ) -> Result<Tensor> {
     candle_core::bail!("fused_decode_recurrence_cuda requires the cuda feature")
 }
@@ -1124,12 +1035,41 @@ mod tests {
         let state = patterned(case.bh * case.k_dim * case.v_dim, 6, 0.01, 0.0);
 
         let mut state_scalar = tensor3(state.clone(), (case.bh, case.k_dim, case.v_dim), dev)?;
-        let scalar = gated_delta_rule_recurrence_cuda(&q, &k, &v, &g, &beta, &mut state_scalar)?;
+        let scalar = gated_delta_rule_recurrence_cuda(
+            RecurrenceInputs {
+                q: &q,
+                k: &k,
+                v: &v,
+                g: &g,
+                beta: &beta,
+            },
+            &mut state_scalar,
+            GdnStateSlots::Gathered,
+        )?;
         let mut state_chunked = tensor3(state.clone(), (case.bh, case.k_dim, case.v_dim), dev)?;
-        let chunked =
-            chunked_gated_delta_rule_recurrence_cuda(&q, &k, &v, &g, &beta, &mut state_chunked)?;
+        let chunked = chunked_gated_delta_rule_recurrence_cuda(
+            RecurrenceInputs {
+                q: &q,
+                k: &k,
+                v: &v,
+                g: &g,
+                beta: &beta,
+            },
+            &mut state_chunked,
+            GdnStateSlots::Gathered,
+        )?;
         let mut state_warp = tensor3(state, (case.bh, case.k_dim, case.v_dim), dev)?;
-        let warp = warp_gated_delta_rule_recurrence_cuda(&q, &k, &v, &g, &beta, &mut state_warp)?;
+        let warp = warp_gated_delta_rule_recurrence_cuda(
+            RecurrenceInputs {
+                q: &q,
+                k: &k,
+                v: &v,
+                g: &g,
+                beta: &beta,
+            },
+            &mut state_warp,
+            GdnStateSlots::Gathered,
+        )?;
 
         let scalar_flat = flat(&scalar)?;
         let scalar_state_flat = flat(&state_scalar)?;
@@ -1238,14 +1178,21 @@ mod tests {
         )?
         .to_dtype(DType::F16)?;
 
-        let (one_shot, one_shot_state) =
-            causal_conv1d_cuda(&x, &weight, &initial_state, kernel_size, false)?;
+        let (one_shot, one_shot_state) = causal_conv1d_cuda(
+            &x,
+            &weight,
+            &initial_state,
+            kernel_size,
+            false,
+            GdnStateSlots::Gathered,
+        )?;
         let (first, first_state) = causal_conv1d_cuda(
             &x.narrow(2, 0, split)?,
             &weight,
             &initial_state,
             kernel_size,
             false,
+            GdnStateSlots::Gathered,
         )?;
         let (second, chunked_state) = causal_conv1d_cuda(
             &x.narrow(2, split, seq_len - split)?,
@@ -1253,6 +1200,7 @@ mod tests {
             &first_state,
             kernel_size,
             false,
+            GdnStateSlots::Gathered,
         )?;
         let chunked = Tensor::cat(&[first, second], 2)?;
 
@@ -1268,6 +1216,147 @@ mod tests {
             &flat(&chunked_state.to_dtype(DType::F32)?)?,
             2.0e-3,
         );
+        Ok(())
+    }
+
+    // Pooled kernels addressed through a permuted slot table must match the gathered kernels on
+    // the same rows and leave every other pool row untouched.
+    #[test]
+    #[ignore = "requires a CUDA device"]
+    fn pooled_state_kernels_match_gathered_cuda() -> Result<()> {
+        let dev = Device::new_cuda(0)?;
+        let capacity = 6usize;
+        let batch = 3usize;
+        let slots_host: Vec<u32> = vec![4, 1, 5];
+        let slots = Tensor::from_vec(slots_host.clone(), (batch,), &dev)?;
+        let num_heads = 4usize;
+        let k_dim = 128usize;
+        let v_dim = 64usize;
+        let conv_dim = 3 * num_heads * k_dim;
+        let kernel_size = 4usize;
+
+        let pool_rec_host = patterned(capacity * num_heads * k_dim * v_dim, 30, 0.01, 0.0);
+        let pool_rec = Tensor::from_vec(
+            pool_rec_host.clone(),
+            (capacity, num_heads, k_dim, v_dim),
+            &dev,
+        )?;
+        let pool_conv_host = patterned(capacity * conv_dim * kernel_size, 31, 0.03, 0.0);
+        let pool_conv = Tensor::from_vec(pool_conv_host, (capacity, conv_dim, kernel_size), &dev)?
+            .to_dtype(DType::BF16)?;
+        let gathered_rec = pool_rec.index_select(&slots, 0)?.contiguous()?;
+        let gathered_conv = pool_conv.index_select(&slots, 0)?.contiguous()?;
+
+        for seq_len in [1usize, 3, 70] {
+            let bh = batch * num_heads;
+            let q = tensor3(
+                patterned(bh * seq_len * k_dim, 1, 0.02, 0.0),
+                (bh, seq_len, k_dim),
+                &dev,
+            )?;
+            let k = tensor3(
+                patterned(bh * seq_len * k_dim, 2, 0.02, 0.0),
+                (bh, seq_len, k_dim),
+                &dev,
+            )?;
+            let v = tensor3(
+                patterned(bh * seq_len * v_dim, 3, 0.05, 0.0),
+                (bh, seq_len, v_dim),
+                &dev,
+            )?;
+            let g = tensor2(patterned(bh * seq_len, 4, 0.03, -0.08), (bh, seq_len), &dev)?;
+            let beta = tensor2(patterned(bh * seq_len, 5, 0.15, 0.5), (bh, seq_len), &dev)?;
+
+            let inputs = RecurrenceInputs {
+                q: &q,
+                k: &k,
+                v: &v,
+                g: &g,
+                beta: &beta,
+            };
+            let mut state_gathered = gathered_rec.reshape((bh, k_dim, v_dim))?.copy()?;
+            let mut state_pooled = pool_rec.copy()?;
+            for kernel in [
+                RecurrenceKernel::Scalar,
+                RecurrenceKernel::Warp,
+                RecurrenceKernel::Chunked,
+            ] {
+                let mut sg = state_gathered.copy()?;
+                let mut sp = state_pooled.copy()?;
+                let out_g = launch_recurrence(kernel, inputs, &mut sg, GdnStateSlots::Gathered)?;
+                let out_p =
+                    launch_recurrence(kernel, inputs, &mut sp, GdnStateSlots::Pooled(&slots))?;
+                assert_close(
+                    "pooled recurrence output",
+                    &flat(&out_g)?,
+                    &flat(&out_p)?,
+                    1.0e-6,
+                );
+                let sp_rows = sp.index_select(&slots, 0)?.reshape((bh, k_dim, v_dim))?;
+                assert_close(
+                    "pooled recurrence state",
+                    &flat(&sg)?,
+                    &flat(&sp_rows)?,
+                    1.0e-6,
+                );
+                let untouched = flat(&sp)?;
+                for row in (0..capacity).filter(|r| !slots_host.contains(&(*r as u32))) {
+                    let span = num_heads * k_dim * v_dim;
+                    assert_close(
+                        "pooled recurrence untouched row",
+                        &untouched[row * span..(row + 1) * span],
+                        &pool_rec_host[row * span..(row + 1) * span],
+                        0.0,
+                    );
+                }
+                state_gathered = sg;
+                state_pooled = sp;
+            }
+
+            let x = tensor3(
+                patterned(batch * conv_dim * seq_len, 20, 0.08, 0.01),
+                (batch, conv_dim, seq_len),
+                &dev,
+            )?
+            .to_dtype(DType::BF16)?;
+            let weight = tensor2(
+                patterned(conv_dim * kernel_size, 21, 0.05, -0.01),
+                (conv_dim, kernel_size),
+                &dev,
+            )?
+            .to_dtype(DType::BF16)?;
+            let is_update = seq_len == 1;
+            let (out_g, cs_g) = causal_conv1d_cuda(
+                &x,
+                &weight,
+                &gathered_conv.copy()?,
+                kernel_size,
+                is_update,
+                GdnStateSlots::Gathered,
+            )?;
+            let pool_copy = pool_conv.copy()?;
+            let (out_p, cs_p) = causal_conv1d_cuda(
+                &x,
+                &weight,
+                &pool_copy,
+                kernel_size,
+                is_update,
+                GdnStateSlots::Pooled(&slots),
+            )?;
+            assert_close(
+                "pooled conv output",
+                &flat(&out_g.to_dtype(DType::F32)?)?,
+                &flat(&out_p.to_dtype(DType::F32)?)?,
+                0.0,
+            );
+            let cs_p_rows = cs_p.index_select(&slots, 0)?;
+            assert_close(
+                "pooled conv state",
+                &flat(&cs_g.to_dtype(DType::F32)?)?,
+                &flat(&cs_p_rows.to_dtype(DType::F32)?)?,
+                0.0,
+            );
+        }
         Ok(())
     }
 }

--- a/mistralrs-core/src/cuda/gdn.rs
+++ b/mistralrs-core/src/cuda/gdn.rs
@@ -8,12 +8,14 @@ use candle_core::DType;
 /// Which rows of the recurrent state a GDN kernel reads and writes. `Gathered` means the state is a
 /// `[B*H, ...]` copy addressed by batch row; `Pooled` addresses the whole pool `[cap, H, ...]`
 /// through a `[B]` u32 slot table, so the kernels update it in place without gather/scatter copies.
+#[cfg_attr(not(feature = "cuda"), allow(dead_code))]
 #[derive(Clone, Copy)]
 pub enum GdnStateSlots<'a> {
     Gathered,
     Pooled(&'a Tensor),
 }
 
+#[cfg_attr(not(feature = "cuda"), allow(dead_code))]
 impl<'a> GdnStateSlots<'a> {
     pub fn from_option(slots: Option<&'a Tensor>) -> Self {
         match slots {
@@ -45,6 +47,7 @@ fn with_slot_indices<T>(
 }
 
 /// Contiguous f32 recurrence inputs: q, k `[BH, S, K]`, v `[BH, S, V]`, g, beta `[BH, S]`.
+#[cfg_attr(not(feature = "cuda"), allow(dead_code))]
 #[derive(Clone, Copy)]
 pub struct RecurrenceInputs<'a> {
     pub q: &'a Tensor,

--- a/mistralrs-core/src/gdn/backend.rs
+++ b/mistralrs-core/src/gdn/backend.rs
@@ -3,6 +3,8 @@ use rayon::prelude::*;
 
 use super::cache::GdnLayerCache;
 use super::config::{GdnDims, GdnVHeadLayout};
+#[cfg(feature = "cuda")]
+use crate::cuda::gdn::{GdnStateSlots, RecurrenceInputs};
 use crate::pipeline::RecurrentBatchKind;
 
 #[cfg(any(feature = "cuda", feature = "metal"))]
@@ -415,6 +417,7 @@ fn recurrence_cuda_from_convolved(
     let a_log = a_log.to_dtype(DType::F32)?.contiguous()?;
     let dt_bias = dt_bias.to_dtype(DType::F32)?.contiguous()?;
     let mut state_flat = prepare_state_for_backend(cache, dims, batch_size)?;
+    let slots = GdnStateSlots::from_option(cache.slots.as_ref());
 
     let out_bh = if seq_len == 1 {
         crate::cuda::gdn::fused_decode_recurrence_cuda(
@@ -430,6 +433,7 @@ fn recurrence_cuda_from_convolved(
             dims.head_k_dim,
             dims.head_v_dim,
             dims.v_head_layout == GdnVHeadLayout::Tiled,
+            slots,
         )?
     } else {
         let (q_bh, k_bh, v_bh, g_bh, beta_bh) = crate::cuda::gdn::prepare_recurrence_inputs_cuda(
@@ -446,33 +450,23 @@ fn recurrence_cuda_from_convolved(
             dims.head_v_dim,
             dims.v_head_layout == GdnVHeadLayout::Tiled,
         )?;
+        let inputs = RecurrenceInputs {
+            q: &q_bh,
+            k: &k_bh,
+            v: &v_bh,
+            g: &g_bh,
+            beta: &beta_bh,
+        };
         if seq_len >= RECURRENCE_CHUNK_THRESHOLD && use_warp_prefill_recurrence(dims) {
-            crate::cuda::gdn::warp_gated_delta_rule_recurrence_cuda(
-                &q_bh,
-                &k_bh,
-                &v_bh,
-                &g_bh,
-                &beta_bh,
-                &mut state_flat,
-            )?
+            crate::cuda::gdn::warp_gated_delta_rule_recurrence_cuda(inputs, &mut state_flat, slots)?
         } else if seq_len >= RECURRENCE_CHUNK_THRESHOLD {
             crate::cuda::gdn::chunked_gated_delta_rule_recurrence_cuda(
-                &q_bh,
-                &k_bh,
-                &v_bh,
-                &g_bh,
-                &beta_bh,
+                inputs,
                 &mut state_flat,
+                slots,
             )?
         } else {
-            crate::cuda::gdn::gated_delta_rule_recurrence_cuda(
-                &q_bh,
-                &k_bh,
-                &v_bh,
-                &g_bh,
-                &beta_bh,
-                &mut state_flat,
-            )?
+            crate::cuda::gdn::gated_delta_rule_recurrence_cuda(inputs, &mut state_flat, slots)?
         }
     };
 
@@ -526,34 +520,21 @@ fn recurrence_cuda(
     let g_bh = prepare_gate_for_backend(g, dims, batch_size, seq_len)?;
     let beta_bh = prepare_gate_for_backend(beta, dims, batch_size, seq_len)?;
     let mut state_flat = prepare_state_for_backend(cache, dims, batch_size)?;
+    let slots = GdnStateSlots::from_option(cache.slots.as_ref());
+    let inputs = RecurrenceInputs {
+        q: &q_bh,
+        k: &k_bh,
+        v: &v_bh,
+        g: &g_bh,
+        beta: &beta_bh,
+    };
 
     let out_bh = if seq_len >= RECURRENCE_CHUNK_THRESHOLD && use_warp_prefill_recurrence(dims) {
-        crate::cuda::gdn::warp_gated_delta_rule_recurrence_cuda(
-            &q_bh,
-            &k_bh,
-            &v_bh,
-            &g_bh,
-            &beta_bh,
-            &mut state_flat,
-        )?
+        crate::cuda::gdn::warp_gated_delta_rule_recurrence_cuda(inputs, &mut state_flat, slots)?
     } else if seq_len >= RECURRENCE_CHUNK_THRESHOLD {
-        crate::cuda::gdn::chunked_gated_delta_rule_recurrence_cuda(
-            &q_bh,
-            &k_bh,
-            &v_bh,
-            &g_bh,
-            &beta_bh,
-            &mut state_flat,
-        )?
+        crate::cuda::gdn::chunked_gated_delta_rule_recurrence_cuda(inputs, &mut state_flat, slots)?
     } else {
-        crate::cuda::gdn::gated_delta_rule_recurrence_cuda(
-            &q_bh,
-            &k_bh,
-            &v_bh,
-            &g_bh,
-            &beta_bh,
-            &mut state_flat,
-        )?
+        crate::cuda::gdn::gated_delta_rule_recurrence_cuda(inputs, &mut state_flat, slots)?
     };
 
     finish_recurrence(out_bh, state_flat, dims, batch_size, seq_len, cache, dtype)
@@ -651,6 +632,10 @@ fn prepare_state_for_backend(
     dims: &GdnDims,
     batch_size: usize,
 ) -> Result<Tensor> {
+    if cache.slots.is_some() {
+        // The pool is f32 and contiguous by construction; kernels address rows through the slot table
+        return Ok(cache.recurrent_state.clone());
+    }
     cache
         .recurrent_state
         .to_dtype(DType::F32)?
@@ -672,14 +657,16 @@ fn finish_recurrence(
     cache: &mut GdnLayerCache,
     dtype: DType,
 ) -> Result<Tensor> {
-    cache.recurrent_state = state_flat
-        .reshape((
-            batch_size,
-            dims.num_v_heads,
-            dims.head_k_dim,
-            dims.head_v_dim,
-        ))?
-        .to_dtype(cache.recurrent_state.dtype())?;
+    if cache.slots.is_none() {
+        cache.recurrent_state = state_flat
+            .reshape((
+                batch_size,
+                dims.num_v_heads,
+                dims.head_k_dim,
+                dims.head_v_dim,
+            ))?
+            .to_dtype(cache.recurrent_state.dtype())?;
+    }
 
     out_bh
         .reshape((batch_size, dims.num_v_heads, seq_len, dims.head_v_dim))?
@@ -733,6 +720,7 @@ fn causal_conv1d_update(
             &conv_state,
             dims.conv_kernel_size,
             true,
+            GdnStateSlots::from_option(cache.slots.as_ref()),
         )?;
         cache.conv_state = new_conv_state;
         return output.transpose(1, 2);
@@ -853,6 +841,7 @@ fn causal_conv1d_full(
             &cache.conv_state,
             dims.conv_kernel_size,
             false,
+            GdnStateSlots::from_option(cache.slots.as_ref()),
         )?;
         cache.conv_state = new_conv_state;
         return output.transpose(1, 2);
@@ -1211,6 +1200,7 @@ mod tests {
         let mut fast_cache = GdnLayerCache {
             conv_state: conv_state.clone(),
             recurrent_state: initial_state.clone(),
+            slots: None,
         };
         let fast = decode_recurrence_cpu_from_convolved(
             &mixed,
@@ -1238,6 +1228,7 @@ mod tests {
         let mut reference_cache = GdnLayerCache {
             conv_state,
             recurrent_state: initial_state,
+            slots: None,
         };
         let reference = gated_delta_rule_recurrence(
             &q,
@@ -1407,6 +1398,7 @@ mod tests {
         let mut grouped_cache = GdnLayerCache {
             conv_state: conv_state_grouped.clone(),
             recurrent_state: recurrent_state_grouped.clone(),
+            slots: None,
         };
         let mut tiled_cache = GdnLayerCache {
             conv_state: runtime_from_grouped(&conv_state_grouped, 1, &conv_runtime_to_grouped)?,
@@ -1415,6 +1407,7 @@ mod tests {
                 1,
                 &head_runtime_to_grouped,
             )?,
+            slots: None,
         };
 
         let prefill_mixed_grouped = Tensor::from_vec(
@@ -1693,10 +1686,12 @@ mod tests {
         let mut fast_cache = GdnLayerCache {
             conv_state: initial_state.clone(),
             recurrent_state: recurrent_state.clone(),
+            slots: None,
         };
         let mut reference_cache = GdnLayerCache {
             conv_state: initial_state,
             recurrent_state,
+            slots: None,
         };
 
         let fast = causal_conv1d_update_cpu(&x, &weight, &dims, &mut fast_cache)?;
@@ -1746,10 +1741,12 @@ mod tests {
         let mut one_shot_cache = GdnLayerCache {
             conv_state: conv_state.clone(),
             recurrent_state: recurrent_state.clone(),
+            slots: None,
         };
         let mut chunked_cache = GdnLayerCache {
             conv_state,
             recurrent_state,
+            slots: None,
         };
 
         let one_shot = causal_conv1d_full(&x, &weight, &dims, &mut one_shot_cache)?;

--- a/mistralrs-core/src/gdn/cache.rs
+++ b/mistralrs-core/src/gdn/cache.rs
@@ -1,11 +1,17 @@
 use candle_core::{DType, Device, Result, Tensor};
 
+use crate::kv_cache::RecurrentStatePool;
+
 use super::config::{GdnConfig, GdnDims};
 
+/// Per-layer GDN state handed to the kernels. Gathered: `conv_state` `[B, conv_dim, k]` and
+/// `recurrent_state` `[B, H, K, V]` hold this batch's rows. Pooled (`slots` set): they are the whole
+/// recurrent state pool and `slots` is the `[B]` u32 row table, so CUDA kernels update it in place.
 #[derive(Debug)]
 pub struct GdnLayerCache {
     pub conv_state: Tensor,
     pub recurrent_state: Tensor,
+    pub slots: Option<Tensor>,
 }
 
 #[allow(dead_code)]
@@ -18,10 +24,52 @@ impl GdnLayerCache {
             DType::F32,
             device,
         )?;
-        Ok(Self {
+        Ok(Self::gathered(conv_state, recurrent_state))
+    }
+
+    pub fn gathered(conv_state: Tensor, recurrent_state: Tensor) -> Self {
+        Self {
             conv_state,
             recurrent_state,
-        })
+            slots: None,
+        }
+    }
+
+    pub fn pooled(conv_state: Tensor, recurrent_state: Tensor, slots: Tensor) -> Self {
+        Self {
+            conv_state,
+            recurrent_state,
+            slots: Some(slots),
+        }
+    }
+
+    /// Check out the rows `indices` of `pool` for one layer forward. On CUDA the kernels update the
+    /// pool in place through the slot table; elsewhere this is a gathered copy that `commit` scatters back.
+    pub fn checkout(pool: &RecurrentStatePool, indices: &Tensor) -> Result<Self> {
+        if pool.device().is_cuda() {
+            return Ok(Self::pooled(
+                pool.conv_state.clone(),
+                pool.recurrent_state.clone(),
+                indices.clone(),
+            ));
+        }
+        Ok(Self::gathered(
+            pool.gather_conv_state(indices)?,
+            pool.gather_recurrent_state(indices)?,
+        ))
+    }
+
+    pub fn commit(
+        self,
+        pool: &mut RecurrentStatePool,
+        indices: &Tensor,
+        host_indices: Option<&[u32]>,
+    ) -> Result<()> {
+        if self.slots.is_some() {
+            return Ok(());
+        }
+        pool.scatter_conv_state_with_host_indices(indices, host_indices, &self.conv_state)?;
+        pool.scatter_recurrent_state_with_host_indices(indices, host_indices, &self.recurrent_state)
     }
 
     pub fn reset(&mut self) -> Result<()> {
@@ -36,6 +84,7 @@ impl Clone for GdnLayerCache {
         Self {
             conv_state: self.conv_state.clone(),
             recurrent_state: self.recurrent_state.clone(),
+            slots: self.slots.clone(),
         }
     }
 }

--- a/mistralrs-core/src/gdn/projection.rs
+++ b/mistralrs-core/src/gdn/projection.rs
@@ -77,6 +77,8 @@ pub struct GdnProjection {
     pub z: Tensor,
     pub b: Tensor,
     pub a: Tensor,
+    // Set when the projection already produced `[q | k | v]` contiguously, so the conv needs no copy
+    conv_src: Option<Tensor>,
 }
 
 impl GdnProjection {
@@ -112,6 +114,7 @@ impl GdnProjection {
             z: z.reshape((batch_size, seq_len, dims.num_v_heads, dims.head_v_dim))?,
             b: b.reshape((batch_size, seq_len, dims.num_v_heads))?,
             a: a.reshape((batch_size, seq_len, dims.num_v_heads))?,
+            conv_src: None,
         })
     }
 
@@ -127,6 +130,10 @@ impl GdnProjection {
         let q = mixed_qkv.narrow(D::Minus1, 0, dims.key_dim)?;
         let k = mixed_qkv.narrow(D::Minus1, dims.key_dim, dims.key_dim)?;
         let v = mixed_qkv.narrow(D::Minus1, dims.key_dim * 2, dims.value_dim)?;
+        let conv_src = mixed_qkv
+            .is_contiguous()
+            .then(|| mixed_qkv.reshape((batch_size, seq_len, dims.conv_dim)))
+            .transpose()?;
 
         Ok(Self {
             q: q.reshape((batch_size, seq_len, dims.num_k_heads, dims.head_k_dim))?,
@@ -135,6 +142,7 @@ impl GdnProjection {
             z: mixed_z.reshape((batch_size, seq_len, dims.num_v_heads, dims.head_v_dim))?,
             b: mixed_b.reshape((batch_size, seq_len, dims.num_v_heads))?,
             a: mixed_a.reshape((batch_size, seq_len, dims.num_v_heads))?,
+            conv_src,
         })
     }
 
@@ -160,6 +168,9 @@ impl GdnProjection {
     }
 
     pub fn conv_input(&self, dims: &GdnDims, batch_size: usize, seq_len: usize) -> Result<Tensor> {
+        if let Some(src) = &self.conv_src {
+            return Ok(src.clone());
+        }
         let q = self.q.reshape((batch_size, seq_len, dims.key_dim))?;
         let k = self.k.reshape((batch_size, seq_len, dims.key_dim))?;
         let v = self.v.reshape((batch_size, seq_len, dims.value_dim))?;

--- a/mistralrs-core/src/gdn/weights.rs
+++ b/mistralrs-core/src/gdn/weights.rs
@@ -1,4 +1,4 @@
-use candle_core::{Device, Result, Tensor};
+use candle_core::{DType, Device, Result, Tensor};
 use mistralrs_quant::{
     Comm, LoraLinearSpec, QuantMethod, ReplicatedLayer, RowParallelLayer, Shard, ShardedVarBuilder,
 };
@@ -272,12 +272,14 @@ impl GdnWeights {
             vb_la.get((dims.conv_dim, 1, dims.conv_kernel_size), "conv1d.weight")?,
             isq_target_device.as_ref(),
         )?;
+        // The recurrence consumes these in f32 every step; A_log is f32 in the checkpoint anyway
+        let vb_f32 = vb_la.clone().set_dtype(DType::F32);
         let dt_bias = move_to_target(
-            vb_la.get(dims.num_v_heads, "dt_bias")?,
+            vb_f32.get(dims.num_v_heads, "dt_bias")?,
             isq_target_device.as_ref(),
         )?;
         let a_log = move_to_target(
-            vb_la.get(dims.num_v_heads, "A_log")?,
+            vb_f32.get(dims.num_v_heads, "A_log")?,
             isq_target_device.as_ref(),
         )?;
 

--- a/mistralrs-core/src/kv_cache/hybrid_cache.rs
+++ b/mistralrs-core/src/kv_cache/hybrid_cache.rs
@@ -16,9 +16,9 @@ use crate::layers_masker::PastKvLenCache;
 ///
 /// Works for both Mamba SSM and GDN (Gated Delta Net) recurrent layers.
 /// Instead of dynamically sized state tensors, we maintain a pool of
-/// state slots that grows dynamically. Each sequence is assigned a slot index,
-/// and the forward pass uses `index_select` (gather) and index assignment (scatter)
-/// to access the correct states.
+/// state slots that grows dynamically. Each sequence is assigned a slot index; CUDA GDN kernels
+/// address the pool rows in place through the batch's slot table, other backends gather the rows
+/// with `index_select` and scatter them back after the layer.
 #[derive(Debug)]
 pub struct RecurrentStatePool {
     /// Convolution state pool: (capacity, conv_dim, conv_width)

--- a/mistralrs-core/src/kv_cache/mod.rs
+++ b/mistralrs-core/src/kv_cache/mod.rs
@@ -17,7 +17,7 @@ mod single_cache;
 pub use full_cache::{EitherCache, LayerCaches};
 pub use hybrid_cache::{
     HybridCache, HybridCacheConfig, HybridLayerCache, HybridLayerType, RecurrentLayerConfig,
-    RecurrentStateSnapshot,
+    RecurrentStatePool, RecurrentStateSnapshot,
 };
 pub use rotating_cache::{RotatingCache, RotatingCacheSnapshot};
 pub use single_cache::{SingleCache, SingleCacheSnapshot};

--- a/mistralrs-core/src/models/qwen3_next.rs
+++ b/mistralrs-core/src/models/qwen3_next.rs
@@ -659,6 +659,7 @@ impl DecoderLayer {
                 let mut segment_cache = GdnLayerCache {
                     conv_state: cache.conv_state.narrow(0, segment.state_index, 1)?,
                     recurrent_state: cache.recurrent_state.narrow(0, segment.state_index, 1)?,
+                    slots: None,
                 };
                 outputs.push(mistralrs_quant::with_lora_execution_row_range(
                     segment.token_range.clone(),
@@ -1058,12 +1059,14 @@ impl Model {
                         })?;
                     if let Some(HybridLayerCache::Recurrent(pool)) = hybrid_cache.get_mut(layer_idx)
                     {
-                        let conv_state = pool.gather_conv_state(&indices)?;
-                        let recurrent_state = pool.gather_recurrent_state(&indices)?;
-
-                        let mut gdn_cache = GdnLayerCache {
-                            conv_state,
-                            recurrent_state,
+                        // Packed prefill slices the gathered rows per logical sequence
+                        let mut gdn_cache = if packed_query_lens.is_some() {
+                            GdnLayerCache::gathered(
+                                pool.gather_conv_state(&indices)?,
+                                pool.gather_recurrent_state(&indices)?,
+                            )
+                        } else {
+                            GdnLayerCache::checkout(pool, &indices)?
                         };
 
                         x = layer.forward_linear(
@@ -1073,15 +1076,10 @@ impl Model {
                             packed_query_lens.as_deref(),
                         )?;
 
-                        pool.scatter_conv_state_with_host_indices(
+                        gdn_cache.commit(
+                            pool,
                             &indices,
                             recurrent_metadata.state_indices_host(),
-                            &gdn_cache.conv_state,
-                        )?;
-                        pool.scatter_recurrent_state_with_host_indices(
-                            &indices,
-                            recurrent_metadata.state_indices_host(),
-                            &gdn_cache.recurrent_state,
                         )?;
                     } else {
                         candle_core::bail!(

--- a/mistralrs-core/src/vision_models/qwen3_5/packed_gdn.rs
+++ b/mistralrs-core/src/vision_models/qwen3_5/packed_gdn.rs
@@ -148,6 +148,7 @@ pub(crate) fn forward_packed_gdn(
         let mut segment_cache = GdnLayerCache {
             conv_state: cache.conv_state.narrow(0, segment.state_index, 1)?,
             recurrent_state: cache.recurrent_state.narrow(0, segment.state_index, 1)?,
+            slots: None,
         };
         outputs.push(mistralrs_quant::with_lora_execution_row_range(
             segment.token_range.clone(),

--- a/mistralrs-core/src/vision_models/qwen3_5/text.rs
+++ b/mistralrs-core/src/vision_models/qwen3_5/text.rs
@@ -27,7 +27,7 @@ use crate::{
     kv_cache::{
         HybridCache, HybridCacheConfig, HybridLayerCache, HybridLayerType, RecurrentLayerConfig,
     },
-    layers::{self, CausalMasker, GemmaRmsNorm, Qwen3VLRotaryEmbedding, Sdpa},
+    layers::{self, CausalMasker, GemmaRmsNorm, Mlp, Qwen3VLRotaryEmbedding, Sdpa},
     layers_masker::{CausalMaskConfig, PastKvLenCache},
     paged_attention::{AttentionImplementation, ModelConfigMetadata, PagedAttention},
     pipeline::{
@@ -285,66 +285,6 @@ impl FullAttention {
         y = y.broadcast_mul(&gate)?;
 
         let res = self.o_proj.forward(&y)?;
-        Ok(res)
-    }
-}
-
-// ====================== Dense MLP ======================
-
-#[derive(Clone)]
-struct Mlp {
-    gate_proj: Arc<dyn QuantMethod>,
-    up_proj: Arc<dyn QuantMethod>,
-    down_proj: Arc<dyn QuantMethod>,
-    act_fn: crate::layers::Activation,
-}
-
-impl Mlp {
-    fn new(
-        vb: ShardedVarBuilder,
-        hidden_size: usize,
-        intermediate_size: usize,
-        quant_config: &Option<mistralrs_quant::QuantizedConfig>,
-        act_fn: crate::layers::Activation,
-        comm: &Arc<mistralrs_quant::Comm>,
-    ) -> Result<Self> {
-        let gate_proj = ColumnParallelLayer::new(
-            hidden_size,
-            intermediate_size,
-            quant_config,
-            false,
-            comm,
-            vb.pp("gate_proj"),
-        )?;
-        let up_proj = ColumnParallelLayer::new(
-            hidden_size,
-            intermediate_size,
-            quant_config,
-            false,
-            comm,
-            vb.pp("up_proj"),
-        )?;
-        let down_proj = RowParallelLayer::new(
-            intermediate_size,
-            hidden_size,
-            quant_config,
-            false,
-            comm,
-            vb.pp("down_proj"),
-        )?;
-        Ok(Self {
-            gate_proj,
-            up_proj,
-            down_proj,
-            act_fn,
-        })
-    }
-
-    fn forward(&self, xs: &Tensor) -> Result<Tensor> {
-        let gate = self.gate_proj.forward(xs)?;
-        let up = self.up_proj.forward(xs)?;
-        let activated = crate::ops::mul_and_act(&gate, &up, self.act_fn)?;
-        let res = self.down_proj.forward(&activated)?;
         Ok(res)
     }
 }
@@ -871,6 +811,7 @@ impl Qwen3_5TextModel {
                     .recurrent_state
                     .narrow(0, batch_idx, 1)?
                     .contiguous()?,
+                slots: None,
             };
             let x = layer
                 .input
@@ -1075,21 +1016,24 @@ impl Qwen3_5TextModel {
                         ))
                     })?;
                     if let Some(HybridLayerCache::Recurrent(pool)) = hybrid_cache.get_mut(i) {
-                        let conv_state = pool.gather_conv_state(&indices)?;
-                        let recurrent_state = pool.gather_recurrent_state(&indices)?;
                         if let Some(stash) = gdn_stash.as_mut() {
-                            // The recurrence kernels update the state buffers in place, so keep real copies
+                            // Gathers are fresh copies, untouched by the in-place state kernels
                             stash.layers.push(GdnLayerStash {
                                 layer_idx: i,
                                 input: xs.clone(),
-                                conv_state: conv_state.copy()?,
-                                recurrent_state: recurrent_state.copy()?,
+                                conv_state: pool.gather_conv_state(&indices)?,
+                                recurrent_state: pool.gather_recurrent_state(&indices)?,
                             });
                         }
 
-                        let mut gdn_cache = GdnLayerCache {
-                            conv_state,
-                            recurrent_state,
+                        // Packed prefill slices the gathered rows per logical sequence
+                        let mut gdn_cache = if packed_query_lens.is_some() {
+                            GdnLayerCache::gathered(
+                                pool.gather_conv_state(&indices)?,
+                                pool.gather_recurrent_state(&indices)?,
+                            )
+                        } else {
+                            GdnLayerCache::checkout(pool, &indices)?
                         };
 
                         xs = layer.forward_linear(
@@ -1099,15 +1043,10 @@ impl Qwen3_5TextModel {
                             packed_query_lens.as_deref(),
                         )?;
 
-                        pool.scatter_conv_state_with_host_indices(
+                        gdn_cache.commit(
+                            pool,
                             &indices,
                             recurrent_metadata.state_indices_host(),
-                            &gdn_cache.conv_state,
-                        )?;
-                        pool.scatter_recurrent_state_with_host_indices(
-                            &indices,
-                            recurrent_metadata.state_indices_host(),
-                            &gdn_cache.recurrent_state,
                         )?;
                     } else {
                         candle_core::bail!(

--- a/mistralrs-core/src/vision_models/qwen3_5_moe/text.rs
+++ b/mistralrs-core/src/vision_models/qwen3_5_moe/text.rs
@@ -820,12 +820,14 @@ impl Qwen3_5MoeTextModel {
                         ))
                     })?;
                     if let Some(HybridLayerCache::Recurrent(pool)) = hybrid_cache.get_mut(i) {
-                        let conv_state = pool.gather_conv_state(&indices)?;
-                        let recurrent_state = pool.gather_recurrent_state(&indices)?;
-
-                        let mut gdn_cache = GdnLayerCache {
-                            conv_state,
-                            recurrent_state,
+                        // Packed prefill slices the gathered rows per logical sequence
+                        let mut gdn_cache = if packed_query_lens.is_some() {
+                            GdnLayerCache::gathered(
+                                pool.gather_conv_state(&indices)?,
+                                pool.gather_recurrent_state(&indices)?,
+                            )
+                        } else {
+                            GdnLayerCache::checkout(pool, &indices)?
                         };
 
                         xs = layer.forward_linear(
@@ -835,15 +837,10 @@ impl Qwen3_5MoeTextModel {
                             packed_query_lens.as_deref(),
                         )?;
 
-                        pool.scatter_conv_state_with_host_indices(
+                        gdn_cache.commit(
+                            pool,
                             &indices,
                             recurrent_metadata.state_indices_host(),
-                            &gdn_cache.conv_state,
-                        )?;
-                        pool.scatter_recurrent_state_with_host_indices(
-                            &indices,
-                            recurrent_metadata.state_indices_host(),
-                            &gdn_cache.recurrent_state,
                         )?;
                     } else {
                         candle_core::bail!(


### PR DESCRIPTION
GDN CUDA kernels (decode recurrence, scalar/warp/chunked prefill recurrence, causal conv update/full) now take an optional per-batch slot table and update the recurrent state pool in place, replacing the per-layer gather/scatter round trips. GdnLayerCache gains a pooled mode (checkout/commit), the MTP replay stash keeps gathered copies, packed prefill stays gathered. Also: load A_log/dt_bias as f32, reuse the contiguous split projection as conv input, and route the Qwen3.5 dense MLP through the shared fused layers::Mlp.

Qwen3.5-4B ISQ8 on GB10: decode 43.4 -> 45.9 t/s (short), 40.4 -> 42.5 t/s (@8k); concurrency 8 aggregate 138.5 -> 163.5 t/s.