### PR TITLE
perf(mtp): quantized drafter, device verify, stash-based GDN rollback, size-aware n_predict

### DIFF
--- a/mistralrs-core/src/gdn/layer.rs
+++ b/mistralrs-core/src/gdn/layer.rs
@@ -12,6 +12,15 @@ use super::norm::RmsNormGated;
 use super::projection::{GdnInputProjection, GdnProjection};
 use super::weights::{GdnInputProjectionKind, GdnWeightLoadCtx, GdnWeights};
 
+/// Pre-convolution projected inputs of one forward, kept so a speculative rollback can re-advance
+/// the recurrent state over an accepted prefix without re-reading any projection weights.
+#[derive(Clone)]
+pub struct GdnForwardStash {
+    pub mixed_qkv: Tensor,
+    pub b: Tensor,
+    pub a: Tensor,
+}
+
 pub struct GatedDeltaNet {
     pub input_proj: GdnInputProjection,
     pub conv1d_weight: Tensor,
@@ -69,11 +78,28 @@ impl GatedDeltaNet {
         cache: &mut GdnLayerCache,
         batch_kind: RecurrentBatchKind,
     ) -> Result<Tensor> {
+        self.forward_with_stash(x, cache, batch_kind, None)
+    }
+
+    pub fn forward_with_stash(
+        &self,
+        x: &Tensor,
+        cache: &mut GdnLayerCache,
+        batch_kind: RecurrentBatchKind,
+        stash_out: Option<&mut Option<GdnForwardStash>>,
+    ) -> Result<Tensor> {
         let (batch_size, seq_len, _) = x.dims3()?;
         let dtype = x.dtype();
 
         let projected = self.project(x, batch_size, seq_len)?;
         let mixed_qkv = projected.conv_input(&self.dims, batch_size, seq_len)?;
+        if let Some(stash_out) = stash_out {
+            *stash_out = Some(GdnForwardStash {
+                mixed_qkv: mixed_qkv.clone(),
+                b: projected.b.clone(),
+                a: projected.a.clone(),
+            });
+        }
         let mixed_qkv = backend::causal_conv1d(
             &mixed_qkv,
             &self.conv1d_weight,
@@ -97,12 +123,23 @@ impl GatedDeltaNet {
         self.finish_forward(y, projected.z, batch_size, seq_len, dtype)
     }
 
-    /// Advance `cache` over `x` without producing an output; used to replay an accepted prefix
-    /// after speculative verification rejected the tail of a multi-token step.
-    pub fn advance_state(&self, x: &Tensor, cache: &mut GdnLayerCache) -> Result<()> {
-        let (batch_size, seq_len, _) = x.dims3()?;
-        let projected = self.project(x, batch_size, seq_len)?;
-        let mixed_qkv = projected.conv_input(&self.dims, batch_size, seq_len)?;
+    /// Advance `cache` over the first `rows` of a stashed forward's projected inputs; used to replay
+    /// an accepted prefix after speculative verification rejected the tail of a multi-token step.
+    /// Reads no projection weights: only the depthwise conv and the recurrence run.
+    pub fn advance_state_from_stash(
+        &self,
+        stash: &GdnForwardStash,
+        batch_idx: usize,
+        rows: usize,
+        cache: &mut GdnLayerCache,
+    ) -> Result<()> {
+        let mixed_qkv = stash
+            .mixed_qkv
+            .narrow(0, batch_idx, 1)?
+            .narrow(1, 0, rows)?
+            .contiguous()?;
+        let b = stash.b.narrow(0, batch_idx, 1)?.narrow(1, 0, rows)?;
+        let a = stash.a.narrow(0, batch_idx, 1)?.narrow(1, 0, rows)?;
         let mixed_qkv = backend::causal_conv1d(
             &mixed_qkv,
             &self.conv1d_weight,
@@ -112,15 +149,15 @@ impl GatedDeltaNet {
         )?;
         backend::apply_recurrence_from_convolved(
             &mixed_qkv,
-            &projected.b,
-            &projected.a,
+            &b,
+            &a,
             &self.a_log,
             &self.dt_bias,
             &self.dims,
-            batch_size,
-            seq_len,
+            1,
+            rows,
             cache,
-            x.dtype(),
+            stash.mixed_qkv.dtype(),
         )?;
         Ok(())
     }

--- a/mistralrs-core/src/gdn/mod.rs
+++ b/mistralrs-core/src/gdn/mod.rs
@@ -12,5 +12,5 @@ mod weights;
 
 pub use cache::GdnLayerCache;
 pub use config::{GdnConfig, GdnVHeadLayout, GDN_V_HEAD_LAYOUT_CONFIG_KEY};
-pub use layer::GatedDeltaNet;
+pub use layer::{GatedDeltaNet, GdnForwardStash};
 pub use weights::GdnInputProjectionKind;

--- a/mistralrs-core/src/lib.rs
+++ b/mistralrs-core/src/lib.rs
@@ -2714,7 +2714,9 @@ impl MistralRs {
         if let Some(mtp_config) = loader_config.mtp_config.clone() {
             pipeline
                 .blocking_lock()
-                .attach_speculative(SpeculativeConfig::Mtp(mtp_config))
+                .attach_speculative(SpeculativeConfig::Mtp(
+                    mtp_config.with_draft_lm_head_isq(loader_config.isq),
+                ))
                 .map_err(|e| {
                     MistralRsError::ReloadFailed(format!(
                         "Failed to attach MTP speculative decoding: {e}"

--- a/mistralrs-core/src/pipeline/loaders/multimodal_loaders.rs
+++ b/mistralrs-core/src/pipeline/loaders/multimodal_loaders.rs
@@ -6932,6 +6932,10 @@ impl IsqModelLoader for Qwen3_5Loader {
             Regex::new(
                 r"^(language_model\.model|model\.language_model)\.layers\.(\d+)\.mlp\.down_proj\.(weight|bias)$",
             )?,
+            // Built-in MTP head: quantize its projections with the rest of the model
+            Regex::new(r"^mtp\.fc\.weight$")?,
+            Regex::new(r"^mtp\.layers\.(\d+)\.self_attn\.(q|k|v|o)_proj\.(weight|bias)$")?,
+            Regex::new(r"^mtp\.layers\.(\d+)\.mlp\.(gate|up|down)_proj\.(weight|bias)$")?,
         ])
     }
     fn immediate_isq_predicates(&self, config: &str) -> Result<Vec<Regex>> {

--- a/mistralrs-core/src/speculative/config.rs
+++ b/mistralrs-core/src/speculative/config.rs
@@ -18,6 +18,9 @@ pub enum SpeculativeConfig {
 pub struct MtpConfig {
     pub model: Option<String>,
     pub n_predict: Option<usize>,
+    /// ISQ type for a draft-only copy of `lm_head`, so drafting skips the promoted (wider)
+    /// sensitive-tensor type; the target still verifies with the promoted head.
+    pub draft_lm_head_isq: Option<crate::IsqType>,
 }
 
 impl MtpConfig {
@@ -25,6 +28,7 @@ impl MtpConfig {
         Self {
             model: Some(model.into()),
             n_predict,
+            draft_lm_head_isq: None,
         }
     }
 
@@ -32,7 +36,13 @@ impl MtpConfig {
         Self {
             model: None,
             n_predict,
+            draft_lm_head_isq: None,
         }
+    }
+
+    pub fn with_draft_lm_head_isq(mut self, isq: Option<crate::IsqType>) -> Self {
+        self.draft_lm_head_isq = isq;
+        self
     }
 
     pub fn is_builtin(&self) -> bool {

--- a/mistralrs-core/src/speculative/verifier.rs
+++ b/mistralrs-core/src/speculative/verifier.rs
@@ -10,6 +10,61 @@ use crate::prefix_cacher::PrefixCacheManagerV2;
 use crate::sampler::Logprobs;
 use crate::sequence::{Sequence, SequenceRecognizer, SequenceState};
 
+/// One batched argmax + a single D2H for every verify row of a greedy sequence, replacing a
+/// host sampler round trip per draft. None when anything could make the sampler diverge from argmax.
+#[cfg(feature = "cuda")]
+fn greedy_device_verify_tokens(
+    seq: &Sequence,
+    verify_logits: &Tensor,
+    return_logprobs: bool,
+) -> Result<Option<Vec<u32>>> {
+    if !verify_logits.device().is_cuda()
+        || return_logprobs
+        || !matches!(seq.recognizer, SequenceRecognizer::None)
+        || seq.tool_call_state.is_some()
+    {
+        return Ok(None);
+    }
+    let Some(plan) = seq.sampler().cuda_batch_sampling_plan(false) else {
+        return Ok(None);
+    };
+    if !plan.kind.is_argmax() {
+        return Ok(None);
+    }
+    let logits = match *verify_logits.dims() {
+        [1, rows, vocab] => verify_logits.reshape((rows, vocab))?,
+        [_, _] => verify_logits.clone(),
+        _ => return Ok(None),
+    };
+    let logits = logits.to_dtype(DType::F32)?.contiguous()?;
+    let packed = crate::ops::cuda_top1_logits_f32_packed_batched(&logits)?
+        .packed
+        .to_vec2::<f32>()?;
+    let mut tokens = Vec::with_capacity(packed.len());
+    for row in packed {
+        if row.len() != crate::ops::CUDA_TOP1_PACKED_WIDTH
+            || !row[1].is_finite()
+            || row[1] < 0.0
+            || row[1].fract() != 0.0
+        {
+            candle_core::bail!("invalid batched CUDA top-1 verify output");
+        }
+        #[allow(clippy::cast_possible_truncation)]
+        tokens.push(row[1] as u32);
+    }
+    Ok(Some(tokens))
+}
+
+#[cfg(feature = "cuda")]
+fn device_token_logprobs(token: u32) -> Logprobs {
+    Logprobs {
+        token,
+        logprob: 0.0,
+        top_logprobs: None,
+        bytes: None,
+    }
+}
+
 pub struct VerificationOutcome {
     pub accepted_drafts: usize,
     pub proposed_drafts: usize,
@@ -70,22 +125,33 @@ pub async fn finish_verified_step<P: Pipeline>(
         }
     }
 
+    #[cfg(feature = "cuda")]
+    let device_tokens = greedy_device_verify_tokens(seq, &verify_logits, return_logprobs)?;
+    #[cfg(not(feature = "cuda"))]
+    let device_tokens: Option<Vec<u32>> = None;
+
     let mut accepted = 0usize;
     for (idx, draft) in proposal.iter().copied().enumerate() {
-        let row = logit_row(&verify_logits, idx)?;
-        let sampled = sample_sequence(
-            row.clone(),
-            seq,
-            return_logprobs,
-            eos_tok,
-            general_metadata.llg_factory.clone(),
-            general_metadata.max_seq_len,
-            rng.clone(),
-            false,
-            false,
-            false,
-        )
-        .await?;
+        let sampled = match &device_tokens {
+            #[cfg(feature = "cuda")]
+            Some(tokens) => device_token_logprobs(tokens[idx]),
+            _ => {
+                let row = logit_row(&verify_logits, idx)?;
+                sample_sequence(
+                    row.clone(),
+                    seq,
+                    return_logprobs,
+                    eos_tok,
+                    general_metadata.llg_factory.clone(),
+                    general_metadata.max_seq_len,
+                    rng.clone(),
+                    false,
+                    false,
+                    false,
+                )
+                .await?
+            }
+        };
         let sampled_token = sampled.token;
         if sampled_token == draft {
             accepted += 1;
@@ -121,20 +187,26 @@ pub async fn finish_verified_step<P: Pipeline>(
         }
     }
 
-    let row = logit_row(&verify_logits, accepted)?;
-    let continuation = sample_sequence(
-        row.clone(),
-        seq,
-        return_logprobs,
-        eos_tok,
-        general_metadata.llg_factory.clone(),
-        general_metadata.max_seq_len,
-        rng.clone(),
-        false,
-        false,
-        false,
-    )
-    .await?;
+    let continuation = match &device_tokens {
+        #[cfg(feature = "cuda")]
+        Some(tokens) => device_token_logprobs(tokens[accepted]),
+        _ => {
+            let row = logit_row(&verify_logits, accepted)?;
+            sample_sequence(
+                row.clone(),
+                seq,
+                return_logprobs,
+                eos_tok,
+                general_metadata.llg_factory.clone(),
+                general_metadata.max_seq_len,
+                rng.clone(),
+                false,
+                false,
+                false,
+            )
+            .await?
+        }
+    };
     let continuation_token = continuation.token;
     finish_or_add_toks_to_seq(pipeline, prefix_cacher, seq, continuation, eos_tok, true).await?;
 

--- a/mistralrs-core/src/vision_models/qwen3_5/mod.rs
+++ b/mistralrs-core/src/vision_models/qwen3_5/mod.rs
@@ -51,6 +51,8 @@ pub struct Qwen3_5Model {
     encoder_cache: Arc<Mutex<EncoderCacheManager>>,
     // Draft tokens per speculative step; 0 while MTP is not attached
     pub(super) mtp_n_predict: std::sync::atomic::AtomicUsize,
+    // Draft-only lm_head at the base ISQ type; the target verifies with the promoted head
+    pub(super) draft_lm_head: Mutex<Option<std::sync::Arc<dyn mistralrs_quant::QuantMethod>>>,
     pending_prompt_tails: Mutex<std::collections::HashMap<usize, speculative::PendingPromptTail>>,
 }
 
@@ -96,6 +98,7 @@ impl Qwen3_5Model {
             vision_end_token_id: cfg.vision_end_token_id,
             encoder_cache: Arc::new(Mutex::new(EncoderCacheManager::new(32))),
             mtp_n_predict: std::sync::atomic::AtomicUsize::new(0),
+            draft_lm_head: Mutex::new(None),
             pending_prompt_tails: Mutex::new(std::collections::HashMap::new()),
         })
     }

--- a/mistralrs-core/src/vision_models/qwen3_5/speculative.rs
+++ b/mistralrs-core/src/vision_models/qwen3_5/speculative.rs
@@ -164,8 +164,10 @@ impl Qwen3_5Model {
     }
 
     fn draft_logits(&self, normed_hidden: &Tensor) -> Result<Tensor> {
+        let draft_head = self.draft_lm_head.lock().expect("draft lm_head poisoned");
+        let head = draft_head.as_ref().unwrap_or_else(|| self.text.lm_head());
         // [1, rows, hidden] -> [rows, vocab]
-        self.text.lm_head().forward(normed_hidden)?.squeeze(0)
+        head.forward(normed_hidden)?.squeeze(0)
     }
 
     fn mtp_propose(
@@ -462,6 +464,20 @@ impl SpeculativeTargetMixin for Qwen3_5Model {
         }
         self.mtp_n_predict.store(n_predict, Ordering::Relaxed);
         self.text.set_store_spec_hidden(true);
+        // The promoted (sensitive) lm_head is read once per draft; a base-type copy makes the
+        // drafter cheaper without touching what the target verifies with
+        if let Some(ty) = config.draft_lm_head_isq {
+            let head = self.text.lm_head().clone().apply_isq(
+                Some(ty),
+                self.text.device.clone(),
+                &std::sync::atomic::AtomicUsize::new(0),
+                None,
+                mistralrs_quant::QuantizeOntoGuard::new(),
+            )?;
+            *self.draft_lm_head.lock().expect("draft lm_head poisoned") = Some(head);
+        } else {
+            *self.draft_lm_head.lock().expect("draft lm_head poisoned") = None;
+        }
         Ok(Some(SpeculativeAttachInfo::mtp(
             "built-in".to_string(),
             n_predict,

--- a/mistralrs-core/src/vision_models/qwen3_5/speculative.rs
+++ b/mistralrs-core/src/vision_models/qwen3_5/speculative.rs
@@ -31,6 +31,10 @@ use super::{
 
 /// vLLM's documented setting for these single-layer MTP heads.
 pub const DEFAULT_MTP_N_PREDICT: usize = 2;
+// On larger models the verify forward dominates the step, so deeper drafting pays; measured on
+// Qwen3.8-27B: n=3 beats n=2 by ~5% while n=4 over-drafts (acceptance falls under 50%).
+pub const DEFAULT_MTP_N_PREDICT_LARGE: usize = 3;
+const MTP_LARGE_HIDDEN_SIZE: usize = 4096;
 const MROPE_DIMS: usize = 3;
 // Feeds prompt rows whose next token is not known yet; their KV is rewritten before it is ever attended to
 const PLACEHOLDER_TOKEN: u32 = 0;
@@ -458,7 +462,12 @@ impl SpeculativeTargetMixin for Qwen3_5Model {
                 "The built-in MTP head was not loaded; pass `--mtp` when loading the model."
             );
         }
-        let n_predict = config.n_predict.unwrap_or(DEFAULT_MTP_N_PREDICT);
+        let default_n_predict = if self.text.cfg.hidden_size >= MTP_LARGE_HIDDEN_SIZE {
+            DEFAULT_MTP_N_PREDICT_LARGE
+        } else {
+            DEFAULT_MTP_N_PREDICT
+        };
+        let n_predict = config.n_predict.unwrap_or(default_n_predict);
         if n_predict == 0 {
             candle_core::bail!("MTP n_predict must be at least 1.");
         }

--- a/mistralrs-core/src/vision_models/qwen3_5/text.rs
+++ b/mistralrs-core/src/vision_models/qwen3_5/text.rs
@@ -23,7 +23,10 @@ use crate::{
     amoe::AnyMoeBaseModelMixin,
     attention::{AttentionMask, SdpaParams},
     device_map::{DeviceMappedMask, DeviceMapper},
-    gdn::{GatedDeltaNet, GdnConfig, GdnInputProjectionKind, GdnLayerCache, GdnVHeadLayout},
+    gdn::{
+        GatedDeltaNet, GdnConfig, GdnForwardStash, GdnInputProjectionKind, GdnLayerCache,
+        GdnVHeadLayout,
+    },
     kv_cache::{
         HybridCache, HybridCacheConfig, HybridLayerCache, HybridLayerType, RecurrentLayerConfig,
     },
@@ -386,12 +389,13 @@ impl DecoderLayer {
         ffn_out + residual
     }
 
-    fn forward_linear(
+    fn forward_linear_with_stash(
         &self,
         x: &Tensor,
         cache: &mut GdnLayerCache,
         batch_kind: RecurrentBatchKind,
         packed_query_lens: Option<&[usize]>,
+        stash_out: Option<&mut Option<GdnForwardStash>>,
     ) -> Result<Tensor> {
         let gdn = match &self.layer_impl {
             LayerImpl::LinearAttention(gdn) => gdn,
@@ -402,7 +406,7 @@ impl DecoderLayer {
         let gdn_out = if let Some(query_lens) = packed_query_lens {
             forward_packed_gdn(gdn, &x, cache, batch_kind, query_lens)?
         } else {
-            gdn.forward(&x, cache, batch_kind)?
+            gdn.forward_with_stash(&x, cache, batch_kind, stash_out)?
         };
         let x = (gdn_out + residual)?;
         let residual = &x;
@@ -440,7 +444,7 @@ pub(super) struct GdnReplayStash {
 #[derive(Clone)]
 pub(super) struct GdnLayerStash {
     pub(super) layer_idx: usize,
-    pub(super) input: Tensor,
+    pub(super) projected: GdnForwardStash,
     pub(super) conv_state: Tensor,
     pub(super) recurrent_state: Tensor,
 }
@@ -465,7 +469,9 @@ impl crate::speculative::SpeculativeGraphState for SpecGraphState {
         }
         if let Some(stash) = &self.gdn_stash {
             for layer in &stash.layers {
-                out.push(layer.input.clone());
+                out.push(layer.projected.mixed_qkv.clone());
+                out.push(layer.projected.b.clone());
+                out.push(layer.projected.a.clone());
                 out.push(layer.conv_state.clone());
                 out.push(layer.recurrent_state.clone());
             }
@@ -493,7 +499,9 @@ impl crate::speculative::SpeculativeGraphState for SpecGraphState {
         }
         if let Some(stash) = state.gdn_stash.as_mut() {
             for layer in stash.layers.iter_mut() {
-                layer.input = next()?;
+                layer.projected.mixed_qkv = next()?;
+                layer.projected.b = next()?;
+                layer.projected.a = next()?;
                 layer.conv_state = next()?;
                 layer.recurrent_state = next()?;
             }
@@ -813,13 +821,7 @@ impl Qwen3_5TextModel {
                     .contiguous()?,
                 slots: None,
             };
-            let x = layer
-                .input
-                .narrow(0, batch_idx, 1)?
-                .narrow(1, 0, keep_rows)?
-                .contiguous()?;
-            let x = self.layers[layer.layer_idx].input_layernorm.forward(&x)?;
-            gdn.advance_state(&x, &mut cache)?;
+            gdn.advance_state_from_stash(&layer.projected, batch_idx, keep_rows, &mut cache)?;
             snapshots.push(crate::kv_cache::RecurrentStateSnapshot {
                 conv_state: cache.conv_state,
                 recurrent_state: cache.recurrent_state,
@@ -1024,15 +1026,16 @@ impl Qwen3_5TextModel {
                         ))
                     })?;
                     if let Some(HybridLayerCache::Recurrent(pool)) = hybrid_cache.get_mut(i) {
-                        if let Some(stash) = gdn_stash.as_mut() {
-                            // Gathers are fresh copies, untouched by the in-place state kernels
-                            stash.layers.push(GdnLayerStash {
-                                layer_idx: i,
-                                input: xs.clone(),
-                                conv_state: pool.gather_conv_state(&indices)?,
-                                recurrent_state: pool.gather_recurrent_state(&indices)?,
-                            });
-                        }
+                        // Gathers are fresh copies, untouched by the in-place state kernels
+                        let stash_states = gdn_stash
+                            .as_ref()
+                            .map(|_| {
+                                candle_core::Result::Ok((
+                                    pool.gather_conv_state(&indices)?,
+                                    pool.gather_recurrent_state(&indices)?,
+                                ))
+                            })
+                            .transpose()?;
 
                         // Packed prefill slices the gathered rows per logical sequence
                         let mut gdn_cache = if packed_query_lens.is_some() {
@@ -1044,12 +1047,27 @@ impl Qwen3_5TextModel {
                             GdnLayerCache::checkout(pool, &indices)?
                         };
 
-                        xs = layer.forward_linear(
+                        let mut projected_stash = None;
+                        xs = layer.forward_linear_with_stash(
                             &xs,
                             &mut gdn_cache,
                             recurrent_metadata.batch_kind(),
                             packed_query_lens.as_deref(),
+                            stash_states.is_some().then_some(&mut projected_stash),
                         )?;
+                        if let (Some(stash), Some((conv_state, recurrent_state))) =
+                            (gdn_stash.as_mut(), stash_states)
+                        {
+                            let projected = projected_stash.ok_or_else(|| {
+                                candle_core::Error::msg("GDN forward returned no stash")
+                            })?;
+                            stash.layers.push(GdnLayerStash {
+                                layer_idx: i,
+                                projected,
+                                conv_state,
+                                recurrent_state,
+                            });
+                        }
 
                         gdn_cache.commit(
                             pool,

--- a/mistralrs-server-core/src/mistralrs_for_server_builder.rs
+++ b/mistralrs-server-core/src/mistralrs_for_server_builder.rs
@@ -759,7 +759,9 @@ impl MistralRsForServerBuilder {
             pipeline
                 .lock()
                 .await
-                .attach_speculative(mistralrs_core::SpeculativeConfig::Mtp(mtp_config))?;
+                .attach_speculative(mistralrs_core::SpeculativeConfig::Mtp(
+                    mtp_config.with_draft_lm_head_isq(isq),
+                ))?;
         }
 
         let scheduler_config = init_scheduler_config(&cache_config, &pipeline, self.max_seqs).await;
@@ -917,7 +919,9 @@ impl MistralRsForServerBuilder {
             pipeline
                 .lock()
                 .await
-                .attach_speculative(mistralrs_core::SpeculativeConfig::Mtp(mtp_config))?;
+                .attach_speculative(mistralrs_core::SpeculativeConfig::Mtp(
+                    mtp_config.with_draft_lm_head_isq(isq),
+                ))?;
         }
         let first_pipeline_name = pipeline.lock().await.name();
         let first_primary_id = first_model


### PR DESCRIPTION
Four incremental MTP speedups for the built-in Qwen3.5/3.8 head, measured on Qwen3.8-27B `--quant 4 --mtp` (GB10, greedy 300-token prompts, per-request stream timing):

| stage | mean t/s | code prompt |
|---|---|---|
| master | 19.5 | 21.3 |
| quantize the MTP head with the model's ISQ type | 20.9 | 25.1 |
| batched device verify + base-ISQ draft lm_head | 21.8 | 24.3 |
| GDN rollback from stashed projections | 23.2 | 25.7 |
| default n_predict=3 on large models | **24.6** | **29.4** |

- The drafter's projections were missing from the Qwen3.5 ISQ regexes (stayed bf16 under `--quant N`), and it re-read the promoted Q6K lm_head per draft; it now reads a draft-only copy at the base ISQ type. The target always verifies with the promoted head, so drafting precision cannot change accepted outputs.
- Greedy verification does one batched argmax + a single D2H over all verify rows instead of a host sampler round trip per draft.
- A rejected draft used to replay the accepted prefix through every GDN layer's in_proj (~2 GB of quantized weight reads per step); the forward now stashes each GDN layer's pre-conv projected rows (a few MB) and the replay runs only the depthwise conv + recurrence.
- n_predict defaults to 3 when hidden_size >= 4096 (n=4 over-drafts: acceptance falls under 50%); `--mtp-n-predict` still overrides. Small models keep n=2.
