### PR TITLE
fix(multimodal): keep Qwen media work out of decode

### DIFF
--- a/mistralrs-core/src/vision_models/qwen2_5_vl/inputs_processor.rs
+++ b/mistralrs-core/src/vision_models/qwen2_5_vl/inputs_processor.rs
@@ -2,6 +2,7 @@ use crate::paged_attention::block_hash::MultimodalKind;
 use crate::{
     device_map::DeviceMapper,
     pipeline::{
+        recurrent_batch_kind_for_input,
         text_models_inputs_processor::{
             self, get_completion_input, get_prompt_input, PagedAttentionMeta,
         },
@@ -13,9 +14,10 @@ use crate::{
         image_processor::{ImagePreProcessor, PreprocessedImages},
         preprocessor_config::{PreProcessorConfig, ToFilter},
         qwen2vl::{
-            expand_media_placeholders, media_data_cached_offset, packed_layout, prompt_mrope,
-            select_media_batch, select_media_view, shift_media_spans, split_media_pixels,
-            validate_qwen_media_dimensions, validated_mm_features, video_hashes, PromptMropeConfig,
+            apply_mrope_position_deltas, expand_media_placeholders, media_data_cached_offset,
+            packed_layout, prompt_mrope, select_media_batch, select_media_view, shift_media_spans,
+            split_media_pixels, validate_qwen_media_dimensions, validated_mm_features,
+            video_hashes, PromptMropeConfig,
         },
         ModelInputs,
     },
@@ -30,6 +32,24 @@ use std::{any::Any, sync::Arc};
 use tokenizers::Tokenizer;
 
 use super::Qwen2_5VLVisionSpecificArgs;
+
+fn qwen2_5_decode_args(input_ids: &Tensor, seqlens: Vec<usize>) -> Qwen2_5VLVisionSpecificArgs {
+    Qwen2_5VLVisionSpecificArgs {
+        input_ids_full: input_ids.clone(),
+        pixel_values_videos: None,
+        image_grid_thw: None,
+        video_grid_thw: None,
+        rope_img_grid_thw: None,
+        rope_vid_grid_thw: None,
+        seqlens,
+        continuous_img_pad: Vec::new(),
+        continuous_vid_pad: Vec::new(),
+        image_hashes: Vec::new(),
+        video_hashes: Vec::new(),
+        packed_layout: None,
+        prompt_position_ids: None,
+    }
+}
 
 // Input processor
 struct Qwen2_5VLImageProcessor {
@@ -352,6 +372,56 @@ impl InputsProcessor for Qwen2_5VLImageProcessor {
         if no_kv_cache {
             return Err(anyhow::Error::msg("Vision model must have kv cache."));
         }
+        if !is_prompt {
+            let text_models_inputs_processor::InnerInputProcessorOutput {
+                inputs:
+                    text_models_inputs_processor::InputMetadata {
+                        input,
+                        positions,
+                        context_lens,
+                        position_ids,
+                        paged_attn_meta,
+                        flash_meta,
+                    },
+                seq_indices,
+            } = get_completion_input(
+                input_seqs
+                    .iter()
+                    .map(|seq| seq.get_toks())
+                    .collect::<Vec<_>>(),
+                input_seqs,
+                device,
+                no_kv_cache,
+                last_n_context_len,
+                return_raw_logits,
+                paged_attn_metadata.as_mut(),
+                mapper,
+                sliding_window,
+            )
+            .unwrap();
+            let position_ids = apply_mrope_position_deltas(position_ids, input_seqs)?;
+            let args =
+                qwen2_5_decode_args(&input, input_seqs.iter().map(|seq| seq.len()).collect());
+            let inputs: Box<dyn Any> = Box::new(ModelInputs {
+                input_ids: input,
+                seqlen_offsets: positions,
+                context_lens,
+                position_ids,
+                pixel_values: None,
+                model_specific_args: Box::new(args),
+                paged_attn_meta,
+                flash_meta,
+                recurrent_batch_kind: recurrent_batch_kind_for_input(
+                    false,
+                    crate::speculative::staging::staged_batch_width(input_seqs).is_some(),
+                ),
+                adapter_leases: crate::vision_models::adapter_leases(input_seqs, &seq_indices),
+            });
+            return Ok(InputProcessorOutput {
+                inputs,
+                seq_indices,
+            });
+        }
         let Some(tokenizer) = tokenizer else {
             return Err(anyhow::Error::msg(
                 "MLlamaInputProcessor requires a specified tokenizer.",
@@ -364,6 +434,13 @@ impl InputsProcessor for Qwen2_5VLImageProcessor {
         let has_media = input_seqs
             .iter()
             .any(|seq| seq.has_images() || seq.has_videos());
+        for seq in input_seqs.iter_mut() {
+            if seq.multimodal.rope_img_grid_thw.is_none()
+                && seq.multimodal.rope_vid_grid_thw.is_none()
+            {
+                seq.multimodal.mrope_position_delta = None;
+            }
+        }
         let mut image_item_counts = vec![0usize; input_seqs.len()];
         let mut video_item_counts = vec![0usize; input_seqs.len()];
 
@@ -859,7 +936,6 @@ impl InputsProcessor for Qwen2_5VLImageProcessor {
         } else {
             None
         };
-
         let inputs: Box<dyn Any> = Box::new(ModelInputs {
             input_ids: input,
             seqlen_offsets: positions,
@@ -1124,6 +1200,30 @@ impl ImagePreProcessor for Qwen2_5VLImageProcessor {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn decode_args_only_retain_current_tokens() -> Result<()> {
+        let input_ids = Tensor::new(&[[7u32], [9]], &Device::Cpu)?;
+        let args = qwen2_5_decode_args(&input_ids, vec![100, 200]);
+
+        assert_eq!(
+            args.input_ids_full.to_vec2::<u32>()?,
+            vec![vec![7], vec![9]]
+        );
+        assert_eq!(args.seqlens, vec![100, 200]);
+        assert!(args.pixel_values_videos.is_none());
+        assert!(args.image_grid_thw.is_none());
+        assert!(args.video_grid_thw.is_none());
+        assert!(args.rope_img_grid_thw.is_none());
+        assert!(args.rope_vid_grid_thw.is_none());
+        assert!(args.continuous_img_pad.is_empty());
+        assert!(args.continuous_vid_pad.is_empty());
+        assert!(args.image_hashes.is_empty());
+        assert!(args.video_hashes.is_empty());
+        assert!(args.packed_layout.is_none());
+        assert!(args.prompt_position_ids.is_none());
+        Ok(())
+    }
 
     #[test]
     fn split_pixels_rejects_grid_mismatch() -> Result<()> {

--- a/mistralrs-core/src/vision_models/qwen2_5_vl/mod.rs
+++ b/mistralrs-core/src/vision_models/qwen2_5_vl/mod.rs
@@ -306,8 +306,15 @@ impl Qwen2_5VLModel {
             self.text.embed_tokens(input_ids)?
         };
 
+        let decode_position_ids = if rope_img_grid_thw.is_none() && rope_vid_grid_thw.is_none() {
+            crate::vision_models::text_decode_mrope_position_ids_from_context(input_ids, ctx)?
+        } else {
+            None
+        };
         let position_ids = if let Some(position_ids) = prompt_position_ids {
             position_ids.clone()
+        } else if let Some(position_ids) = decode_position_ids {
+            position_ids
         } else {
             let mut ropeidx_attn_mask_bs = Vec::new();
             let max_seqlens = *seqlens.iter().max().unwrap();

--- a/mistralrs-core/src/vision_models/qwen2vl/inputs_processor.rs
+++ b/mistralrs-core/src/vision_models/qwen2vl/inputs_processor.rs
@@ -21,6 +21,7 @@ use crate::{
     attention::AttentionMask,
     device_map::DeviceMapper,
     pipeline::{
+        recurrent_batch_kind_for_input,
         text_models_inputs_processor::{
             self, get_completion_input, get_prompt_input, PagedAttentionMeta,
         },
@@ -474,7 +475,7 @@ impl<'a> PromptMropeConfig<'a> {
 }
 
 pub(crate) fn prompt_mrope(
-    input_seqs: &[&mut Sequence],
+    input_seqs: &mut [&mut Sequence],
     query_ranges: &[Range<usize>],
     config: PromptMropeConfig<'_>,
 ) -> Result<Tensor> {
@@ -490,7 +491,7 @@ pub(crate) fn prompt_mrope(
         anyhow::bail!("Qwen MRoPE query count does not match sequence count");
     }
     let mut sources = Vec::with_capacity(input_seqs.len());
-    for seq in input_seqs {
+    for seq in input_seqs.iter_mut() {
         let image_grid = completed_media_grid(
             seq,
             MultimodalKind::Image,
@@ -511,10 +512,12 @@ pub(crate) fn prompt_mrope(
             image_token_id,
             video_token_id,
         )?;
-        sources.push(MropePositionSource {
+        let source = MropePositionSource {
             position_ids: positions,
             delta: deltas.flatten_all()?.to_vec1::<i64>()?[0],
-        });
+        };
+        seq.multimodal.mrope_position_delta = Some(source.delta);
+        sources.push(source);
     }
     if packed {
         return Ok(gather_packed_mrope_positions(
@@ -548,6 +551,52 @@ pub(crate) fn prompt_mrope(
         rows.push(positions);
     }
     Ok(Tensor::stack(&rows, 1)?)
+}
+
+pub(crate) fn apply_mrope_position_deltas(
+    position_ids: Vec<usize>,
+    input_seqs: &[&mut Sequence],
+) -> Result<Vec<usize>> {
+    if position_ids.len() != input_seqs.len() {
+        anyhow::bail!(
+            "Qwen MRoPE position count {} does not match sequence count {}",
+            position_ids.len(),
+            input_seqs.len()
+        );
+    }
+    position_ids
+        .into_iter()
+        .zip(input_seqs)
+        .map(|(position, seq)| {
+            apply_mrope_position_delta(position, seq.multimodal.mrope_position_delta.unwrap_or(0))
+        })
+        .collect()
+}
+
+fn apply_mrope_position_delta(position: usize, delta: i64) -> Result<usize> {
+    let position = i64::try_from(position)?;
+    let position = position
+        .checked_add(delta)
+        .ok_or_else(|| anyhow::anyhow!("Qwen MRoPE position overflow"))?;
+    usize::try_from(position).map_err(anyhow::Error::from)
+}
+
+fn qwen2_decode_args(input_ids: &Tensor, seqlens: Vec<usize>) -> Qwen2VLVisionSpecificArgs {
+    Qwen2VLVisionSpecificArgs {
+        input_ids_full: input_ids.clone(),
+        pixel_values_videos: None,
+        image_grid_thw: None,
+        video_grid_thw: None,
+        rope_img_grid_thw: None,
+        rope_vid_grid_thw: None,
+        seqlens,
+        continuous_img_pad: Vec::new(),
+        continuous_vid_pad: Vec::new(),
+        image_hashes: Vec::new(),
+        video_hashes: Vec::new(),
+        packed_layout: None,
+        prompt_position_ids: None,
+    }
 }
 
 pub(crate) fn packed_layout(
@@ -889,6 +938,55 @@ impl InputsProcessor for Qwen2VLImageProcessor {
         if no_kv_cache {
             return Err(anyhow::Error::msg("Vision model must have kv cache."));
         }
+        if !is_prompt {
+            let text_models_inputs_processor::InnerInputProcessorOutput {
+                inputs:
+                    text_models_inputs_processor::InputMetadata {
+                        input,
+                        positions,
+                        context_lens,
+                        position_ids,
+                        paged_attn_meta,
+                        flash_meta,
+                    },
+                seq_indices,
+            } = get_completion_input(
+                input_seqs
+                    .iter()
+                    .map(|seq| seq.get_toks())
+                    .collect::<Vec<_>>(),
+                input_seqs,
+                device,
+                no_kv_cache,
+                last_n_context_len,
+                return_raw_logits,
+                paged_attn_metadata.as_mut(),
+                mapper,
+                sliding_window,
+            )
+            .unwrap();
+            let position_ids = apply_mrope_position_deltas(position_ids, input_seqs)?;
+            let args = qwen2_decode_args(&input, input_seqs.iter().map(|seq| seq.len()).collect());
+            let inputs: Box<dyn Any> = Box::new(ModelInputs {
+                input_ids: input,
+                seqlen_offsets: positions,
+                context_lens,
+                position_ids,
+                pixel_values: None,
+                model_specific_args: Box::new(args),
+                paged_attn_meta,
+                flash_meta,
+                recurrent_batch_kind: recurrent_batch_kind_for_input(
+                    false,
+                    crate::speculative::staging::staged_batch_width(input_seqs).is_some(),
+                ),
+                adapter_leases: crate::vision_models::adapter_leases(input_seqs, &seq_indices),
+            });
+            return Ok(InputProcessorOutput {
+                inputs,
+                seq_indices,
+            });
+        }
         let Some(tokenizer) = tokenizer else {
             return Err(anyhow::Error::msg(
                 "MLlamaInputProcessor requires a specified tokenizer.",
@@ -944,6 +1042,13 @@ impl InputsProcessor for Qwen2VLImageProcessor {
         let has_media = input_seqs
             .iter()
             .any(|seq| seq.has_images() || seq.has_videos());
+        for seq in input_seqs.iter_mut() {
+            if seq.multimodal.rope_img_grid_thw.is_none()
+                && seq.multimodal.rope_vid_grid_thw.is_none()
+            {
+                seq.multimodal.mrope_position_delta = None;
+            }
+        }
         let mut image_item_counts = vec![0usize; input_seqs.len()];
         let mut video_item_counts = vec![0usize; input_seqs.len()];
 
@@ -1396,7 +1501,6 @@ impl InputsProcessor for Qwen2VLImageProcessor {
         } else {
             None
         };
-
         let inputs: Box<dyn Any> = Box::new(ModelInputs {
             input_ids: input,
             seqlen_offsets: positions,
@@ -1661,6 +1765,39 @@ impl ImagePreProcessor for Qwen2VLImageProcessor {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn decode_position_ends_apply_mrope_delta() -> Result<()> {
+        assert_eq!(apply_mrope_position_delta(20, -7)?, 13);
+        assert_eq!(apply_mrope_position_delta(30, 2)?, 32);
+        assert_eq!(apply_mrope_position_delta(100, 0)?, 100);
+        assert!(apply_mrope_position_delta(3, -4).is_err());
+        Ok(())
+    }
+
+    #[test]
+    fn decode_args_only_retain_current_tokens() -> Result<()> {
+        let input_ids = Tensor::new(&[[7u32], [9]], &Device::Cpu)?;
+        let args = qwen2_decode_args(&input_ids, vec![100, 200]);
+
+        assert_eq!(
+            args.input_ids_full.to_vec2::<u32>()?,
+            vec![vec![7], vec![9]]
+        );
+        assert_eq!(args.seqlens, vec![100, 200]);
+        assert!(args.pixel_values_videos.is_none());
+        assert!(args.image_grid_thw.is_none());
+        assert!(args.video_grid_thw.is_none());
+        assert!(args.rope_img_grid_thw.is_none());
+        assert!(args.rope_vid_grid_thw.is_none());
+        assert!(args.continuous_img_pad.is_empty());
+        assert!(args.continuous_vid_pad.is_empty());
+        assert!(args.image_hashes.is_empty());
+        assert!(args.video_hashes.is_empty());
+        assert!(args.packed_layout.is_none());
+        assert!(args.prompt_position_ids.is_none());
+        Ok(())
+    }
 
     #[test]
     fn media_expansion_requires_exact_placeholder_grid_and_media_counts() -> Result<()> {

--- a/mistralrs-core/src/vision_models/qwen2vl/mod.rs
+++ b/mistralrs-core/src/vision_models/qwen2vl/mod.rs
@@ -38,10 +38,10 @@ mod vision;
 
 pub(crate) use config::Config;
 pub(crate) use inputs_processor::{
-    expand_media_placeholders, media_data_cached_offset, packed_layout, prompt_mrope,
-    replace_first_occurrence, select_media_batch, select_media_view, shift_media_spans,
-    split_media_pixels, validate_qwen_media_dimensions, validated_mm_features, video_hashes,
-    PromptMropeConfig, Qwen2VLProcessor,
+    apply_mrope_position_deltas, expand_media_placeholders, media_data_cached_offset,
+    packed_layout, prompt_mrope, replace_first_occurrence, select_media_batch, select_media_view,
+    shift_media_spans, split_media_pixels, validate_qwen_media_dimensions, validated_mm_features,
+    video_hashes, PromptMropeConfig, Qwen2VLProcessor,
 };
 
 pub struct Qwen2VLModel {
@@ -463,8 +463,15 @@ impl Qwen2VLModel {
             self.text.embed_tokens(input_ids)?
         };
 
+        let decode_position_ids = if rope_img_grid_thw.is_none() && rope_vid_grid_thw.is_none() {
+            crate::vision_models::text_decode_mrope_position_ids_from_context(input_ids, ctx)?
+        } else {
+            None
+        };
         let position_ids = if let Some(position_ids) = prompt_position_ids {
             position_ids.clone()
+        } else if let Some(position_ids) = decode_position_ids {
+            position_ids
         } else {
             let mut ropeidx_attn_mask_bs = Vec::new();
             let max_seqlens = *seqlens.iter().max().unwrap();

--- a/mistralrs-core/src/vision_models/qwen3_vl/inputs_processor.rs
+++ b/mistralrs-core/src/vision_models/qwen3_vl/inputs_processor.rs
@@ -750,6 +750,24 @@ fn apply_mrope_position_delta(position: usize, delta: i64) -> Result<usize> {
     usize::try_from(position).map_err(anyhow::Error::from)
 }
 
+fn qwen3_decode_args(input_ids: &Tensor, seqlens: Vec<usize>) -> Qwen3VLVisionSpecificArgs {
+    Qwen3VLVisionSpecificArgs {
+        input_ids_full: input_ids.clone(),
+        pixel_values_videos: None,
+        image_grid_thw: None,
+        video_grid_thw: None,
+        rope_img_grid_thw: None,
+        rope_vid_grid_thw: None,
+        seqlens,
+        continuous_img_pad: Vec::new(),
+        continuous_vid_pad: Vec::new(),
+        image_hashes: Vec::new(),
+        video_hashes: Vec::new(),
+        packed_layout: None,
+        prompt_position_ids: None,
+    }
+}
+
 impl InputsProcessor for Qwen3VLImageProcessor {
     fn get_type(&self) -> InputsProcessorType {
         InputsProcessorType::Vision
@@ -1020,6 +1038,55 @@ impl InputsProcessor for Qwen3VLImageProcessor {
         }
         if no_kv_cache {
             return Err(anyhow::Error::msg("Vision model must have kv cache."));
+        }
+        if !is_prompt {
+            let text_models_inputs_processor::InnerInputProcessorOutput {
+                inputs:
+                    text_models_inputs_processor::InputMetadata {
+                        input,
+                        positions,
+                        context_lens,
+                        position_ids,
+                        paged_attn_meta,
+                        flash_meta,
+                    },
+                seq_indices,
+            } = get_completion_input(
+                input_seqs
+                    .iter()
+                    .map(|seq| seq.get_toks())
+                    .collect::<Vec<_>>(),
+                input_seqs,
+                device,
+                no_kv_cache,
+                last_n_context_len,
+                return_raw_logits,
+                paged_attn_metadata.as_mut(),
+                mapper,
+                sliding_window,
+            )
+            .unwrap();
+            let position_ids = apply_mrope_position_deltas(position_ids, input_seqs)?;
+            let args = qwen3_decode_args(&input, input_seqs.iter().map(|seq| seq.len()).collect());
+            let inputs: Box<dyn Any> = Box::new(ModelInputs {
+                input_ids: input,
+                seqlen_offsets: positions,
+                context_lens,
+                position_ids,
+                pixel_values: None,
+                model_specific_args: Box::new(args),
+                paged_attn_meta,
+                flash_meta,
+                recurrent_batch_kind: recurrent_batch_kind_for_input(
+                    false,
+                    crate::speculative::staging::staged_batch_width(input_seqs).is_some(),
+                ),
+                adapter_leases: crate::vision_models::adapter_leases(input_seqs, &seq_indices),
+            });
+            return Ok(InputProcessorOutput {
+                inputs,
+                seq_indices,
+            });
         }
         let Some(tokenizer) = tokenizer else {
             return Err(anyhow::Error::msg(
@@ -1986,6 +2053,77 @@ mod tests {
         assert_eq!(apply_mrope_position_delta(100, 0)?, 100);
         assert_eq!(apply_mrope_position_delta(100, -48)?, 52);
         assert!(apply_mrope_position_delta(3, -4).is_err());
+        Ok(())
+    }
+
+    #[test]
+    fn decode_args_only_retain_current_tokens() -> Result<()> {
+        let input_ids = Tensor::new(&[[7u32], [9]], &Device::Cpu)?;
+        let args = qwen3_decode_args(&input_ids, vec![100, 200]);
+
+        assert_eq!(
+            args.input_ids_full.to_vec2::<u32>()?,
+            vec![vec![7], vec![9]]
+        );
+        assert_eq!(args.seqlens, vec![100, 200]);
+        assert!(args.pixel_values_videos.is_none());
+        assert!(args.image_grid_thw.is_none());
+        assert!(args.video_grid_thw.is_none());
+        assert!(args.rope_img_grid_thw.is_none());
+        assert!(args.rope_vid_grid_thw.is_none());
+        assert!(args.continuous_img_pad.is_empty());
+        assert!(args.continuous_vid_pad.is_empty());
+        assert!(args.image_hashes.is_empty());
+        assert!(args.video_hashes.is_empty());
+        assert!(args.packed_layout.is_none());
+        assert!(args.prompt_position_ids.is_none());
+        Ok(())
+    }
+
+    #[test]
+    fn cached_decode_positions_match_full_history_mrope() -> Result<()> {
+        let config = QwenMropeConfig {
+            spatial_merge_size: 2,
+            image_token_id: 100,
+            video_token_id: 101,
+            vision_start_token_id: 102,
+            vision_end_token_id: 103,
+        };
+        let image_grid = Tensor::new(&[[1u32, 4, 4]], &Device::Cpu)?;
+        let cases = [
+            (
+                vec![10, 102, 100, 100, 100, 100, 103, 11],
+                Some(&image_grid),
+            ),
+            (vec![20, 21, 22, 23, 24], None),
+        ];
+        let deltas = cases
+            .iter()
+            .map(|(prompt, grid)| {
+                qwen3_mrope_position_source(prompt, *grid, None, &config, &Device::Cpu)
+                    .map(|source| source.delta)
+            })
+            .collect::<Result<Vec<_>>>()?;
+
+        assert_ne!(deltas[0], deltas[1]);
+        for query_len in [1, 8] {
+            for ((prompt, grid), delta) in cases.iter().zip(&deltas) {
+                let mut full_history = prompt.clone();
+                full_history.extend((0..query_len).map(|token| 30 + token as u32));
+                let legacy =
+                    qwen3_mrope_position_source(&full_history, *grid, None, &config, &Device::Cpu)?;
+                let actual = legacy
+                    .position_ids
+                    .i((.., 0, prompt.len()..full_history.len()))?
+                    .to_vec2::<i64>()?;
+                let adjusted_end = apply_mrope_position_delta(full_history.len(), *delta)?;
+                let expected_row = (adjusted_end - query_len..adjusted_end)
+                    .map(|position| position as i64)
+                    .collect::<Vec<_>>();
+
+                assert_eq!(actual, vec![expected_row; 3]);
+            }
+        }
         Ok(())
     }
 

--- a/mistralrs-core/src/vision_models/qwen3_vl/mod.rs
+++ b/mistralrs-core/src/vision_models/qwen3_vl/mod.rs
@@ -855,7 +855,14 @@ impl Qwen3VLModel {
             (legacy_visual_pos_masks, legacy_deepstack_visual_embeds)
         };
 
-        let position_ids = if let Some(position_ids) = prompt_position_ids {
+        let decode_position_ids = if rope_img_grid_thw.is_none() && rope_vid_grid_thw.is_none() {
+            crate::vision_models::text_decode_mrope_position_ids_from_context(input_ids, ctx)?
+        } else {
+            None
+        };
+        let position_ids = if let Some(position_ids) = decode_position_ids {
+            position_ids
+        } else if let Some(position_ids) = prompt_position_ids {
             position_ids.clone()
         } else {
             let mut ropeidx_attn_mask_bs = Vec::new();

--- a/mistralrs-core/src/vision_models/qwen3_vl_moe/mod.rs
+++ b/mistralrs-core/src/vision_models/qwen3_vl_moe/mod.rs
@@ -393,7 +393,14 @@ impl Qwen3VLMoEModel {
             (legacy_visual_pos_masks, legacy_deepstack_visual_embeds)
         };
 
-        let position_ids = if let Some(position_ids) = prompt_position_ids {
+        let decode_position_ids = if rope_img_grid_thw.is_none() && rope_vid_grid_thw.is_none() {
+            crate::vision_models::text_decode_mrope_position_ids_from_context(input_ids, ctx)?
+        } else {
+            None
+        };
+        let position_ids = if let Some(position_ids) = decode_position_ids {
+            position_ids
+        } else if let Some(position_ids) = prompt_position_ids {
             position_ids.clone()
         } else {
             let mut ropeidx_attn_mask_bs = Vec::new();


### PR DESCRIPTION
## Summary

- return lightweight, media-free inputs before tokenizer, configuration, and media processing on Qwen VL decode
- cache each sequence MRoPE delta during prompt processing and derive ordinary and speculative decode positions from forward context
- cover Qwen2-VL, Qwen2.5-VL, Qwen3-VL, Qwen3-VL-MoE, and the Qwen3.5 dense/MoE models that share the Qwen3-VL processor

## Why

Media-bearing sequences were retaining prompt-side metadata and re-entering full-history position/media preparation during decode. That made decode after an image substantially slower even though the vision encoder had already finished. The decode path now carries only current tokens and persistent sequence state.

## Validation

- 52 Qwen-family CPU tests pass
- cached MRoPE decode positions match full-history reconstruction for single-token and speculative-width inputs
- all-target `mistralrs-core` checks pass with the default and FlashAttention feature sets
- post-image serving behavior manually confirmed on the affected model path