### PR TITLE
fix(ci): green the build for rust 1.98 and metal

### DIFF
--- a/.typos.toml
+++ b/.typos.toml
@@ -2,6 +2,7 @@
 extend-exclude = [
     ".git/",
     "calibration_data/",
+    "*/third_party/",
     "examples/server/phi3_duckduckgo_mistral.rs.ipynb",
     "mistralrs-cli/static/",
     "CLAUDE.md",

--- a/docs/src/content/docs/examples/rust/advanced/perplexity.md
+++ b/docs/src/content/docs/examples/rust/advanced/perplexity.md
@@ -57,10 +57,12 @@ async fn process_chunk(runner: &MistralRs, chunk: Vec<u32>) -> anyhow::Result<(T
             max_len: Some(0),
             ..SamplingParams::deterministic()
         },
+        seed: None,
         response: tx,
         return_logprobs: false,
         is_streaming: false,
         id: 0,
+        queued_at: None,
         constraint: Constraint::None,
         suffix: None,
         tools: None,

--- a/docs/src/content/docs/reference/cli/bench.md
+++ b/docs/src/content/docs/reference/cli/bench.md
@@ -293,3 +293,4 @@ mistralrs bench embedding [OPTIONS] --model-id <MODEL_ID>
 | `--pa-memory-fraction <MEMORY_FRACTION>` |  | GPU memory utilization fraction 0.0-1.0 (alternative to context-len/memory-mb) |
 | `--pa-block-size <BLOCK_SIZE>` |  | Tokens per block (default: 32 on CUDA) |
 | `--pa-cache-type <CACHE_TYPE>` | `auto` | KV cache quantization type |
+

--- a/docs/src/content/docs/reference/cli/run.md
+++ b/docs/src/content/docs/reference/cli/run.md
@@ -56,6 +56,9 @@ mistralrs run [OPTIONS] [COMMAND]
 | `--max-num-images <MAX_NUM_IMAGES>` |  | Maximum number of images per request |
 | `--max-image-length <MAX_IMAGE_LENGTH>` |  | Maximum image dimension for device mapping |
 | `--max-seqs <MAX_SEQS>` | `32` | Maximum concurrent sequences |
+| `--max-num-batched-tokens <MAX_NUM_BATCHED_TOKENS>` | `4096` | Maximum tokens processed in one paged-attention scheduler step |
+| `--max-prefill-chunk-tokens <MAX_PREFILL_CHUNK_TOKENS>` | `512` | Maximum chunkable CUDA text-prompt tokens in one paged-attention scheduler step |
+| `--max-decode-steps-before-prefill <MAX_DECODE_STEPS_BEFORE_PREFILL>` | `8` | Maximum decode steps before a waiting prefill batch is admitted |
 | `--no-kv-cache` | `false` | Disable KV cache entirely |
 | `--prefix-cache-n <PREFIX_CACHE_N>` | `16` | Number of prefix caches to hold (0 to disable) |
 | `-c, --chat-template <CHAT_TEMPLATE>` |  | Custom chat template file (.json or .jinja) |
@@ -318,3 +321,4 @@ mistralrs run embedding [OPTIONS] --model-id <MODEL_ID>
 | `--pa-memory-fraction <MEMORY_FRACTION>` |  | GPU memory utilization fraction 0.0-1.0 (alternative to context-len/memory-mb) |
 | `--pa-block-size <BLOCK_SIZE>` |  | Tokens per block (default: 32 on CUDA) |
 | `--pa-cache-type <CACHE_TYPE>` | `auto` | KV cache quantization type |
+

--- a/docs/src/content/docs/reference/cli/serve.md
+++ b/docs/src/content/docs/reference/cli/serve.md
@@ -67,6 +67,9 @@ mistralrs serve [OPTIONS] [COMMAND]
 | `--disable-request-id-header` | `false` | Disable the x-request-id response header |
 | `--disable-metrics` | `false` | Disable Prometheus HTTP metrics and the metrics recorder |
 | `--max-seqs <MAX_SEQS>` | `32` | Maximum concurrent sequences |
+| `--max-num-batched-tokens <MAX_NUM_BATCHED_TOKENS>` | `4096` | Maximum tokens processed in one paged-attention scheduler step |
+| `--max-prefill-chunk-tokens <MAX_PREFILL_CHUNK_TOKENS>` | `512` | Maximum chunkable CUDA text-prompt tokens in one paged-attention scheduler step |
+| `--max-decode-steps-before-prefill <MAX_DECODE_STEPS_BEFORE_PREFILL>` | `8` | Maximum decode steps before a waiting prefill batch is admitted |
 | `--no-kv-cache` | `false` | Disable KV cache entirely |
 | `--prefix-cache-n <PREFIX_CACHE_N>` | `16` | Number of prefix caches to hold (0 to disable) |
 | `-c, --chat-template <CHAT_TEMPLATE>` |  | Custom chat template file (.json or .jinja) |
@@ -322,3 +325,4 @@ mistralrs serve embedding [OPTIONS] --model-id <MODEL_ID>
 | `--pa-memory-fraction <MEMORY_FRACTION>` |  | GPU memory utilization fraction 0.0-1.0 (alternative to context-len/memory-mb) |
 | `--pa-block-size <BLOCK_SIZE>` |  | Tokens per block (default: 32 on CUDA) |
 | `--pa-cache-type <CACHE_TYPE>` | `auto` | KV cache quantization type |
+

--- a/mistralrs-cli/src/args/mod.rs
+++ b/mistralrs-cli/src/args/mod.rs
@@ -231,7 +231,7 @@ pub enum Command {
 
     /// Update or migrate an install using the installer
     Update {
-        /// Install a specific release tag instead of the latest (e.g. v0.9.1)
+        /// Install a specific release tag instead of the latest (e.g. v0.9.2)
         #[arg(long)]
         tag: Option<String>,
     },

--- a/mistralrs-core/src/adapter/generation.rs
+++ b/mistralrs-core/src/adapter/generation.rs
@@ -61,7 +61,7 @@ impl FromStr for AdapterGenerationId {
             return Err(AdapterGenerationParseError);
         }
         let mut bytes = [0u8; ADAPTER_GENERATION_BYTES];
-        for (index, pair) in value.as_bytes().chunks_exact(2).enumerate() {
+        for (index, pair) in value.as_bytes().as_chunks::<2>().0.iter().enumerate() {
             let high = decode_hex(pair[0]).ok_or(AdapterGenerationParseError)?;
             let low = decode_hex(pair[1]).ok_or(AdapterGenerationParseError)?;
             bytes[index] = high << 4 | low;

--- a/mistralrs-core/src/attention/backends/cpu/full.rs
+++ b/mistralrs-core/src/attention/backends/cpu/full.rs
@@ -46,14 +46,14 @@ fn classify_mask_row(row: &[f32], pivot: usize) -> MaskRowClass {
 
 fn all_zero(values: &[f32]) -> bool {
     let mut mismatch = 0;
-    let mut chunks = values.chunks_exact(4);
-    for chunk in &mut chunks {
+    let (chunks, remainder) = values.as_chunks::<4>();
+    for chunk in chunks {
         mismatch |= chunk[0].to_bits() & F32_MAGNITUDE_BITS;
         mismatch |= chunk[1].to_bits() & F32_MAGNITUDE_BITS;
         mismatch |= chunk[2].to_bits() & F32_MAGNITUDE_BITS;
         mismatch |= chunk[3].to_bits() & F32_MAGNITUDE_BITS;
     }
-    for value in chunks.remainder() {
+    for value in remainder {
         mismatch |= value.to_bits() & F32_MAGNITUDE_BITS;
     }
     mismatch == 0
@@ -61,14 +61,14 @@ fn all_zero(values: &[f32]) -> bool {
 
 fn all_neg_infinity(values: &[f32]) -> bool {
     let mut mismatch = 0;
-    let mut chunks = values.chunks_exact(4);
-    for chunk in &mut chunks {
+    let (chunks, remainder) = values.as_chunks::<4>();
+    for chunk in chunks {
         mismatch |= chunk[0].to_bits() ^ NEG_INFINITY_BITS;
         mismatch |= chunk[1].to_bits() ^ NEG_INFINITY_BITS;
         mismatch |= chunk[2].to_bits() ^ NEG_INFINITY_BITS;
         mismatch |= chunk[3].to_bits() ^ NEG_INFINITY_BITS;
     }
-    for value in chunks.remainder() {
+    for value in remainder {
         mismatch |= value.to_bits() ^ NEG_INFINITY_BITS;
     }
     mismatch == 0

--- a/mistralrs-core/src/engine/logger.rs
+++ b/mistralrs-core/src/engine/logger.rs
@@ -76,11 +76,7 @@ impl IntervalLogger {
         let (shutdown_tx, shutdown_rx) = mpsc::channel();
         let worker = thread::spawn(move || {
             // Start the actual logging
-            loop {
-                match shutdown_rx.recv_timeout(interval) {
-                    Err(RecvTimeoutError::Timeout) => {}
-                    Ok(()) | Err(RecvTimeoutError::Disconnected) => break,
-                }
+            while let Err(RecvTimeoutError::Timeout) = shutdown_rx.recv_timeout(interval) {
                 let num_running = t_num_running.load(Ordering::Relaxed);
                 let num_waiting = t_num_waiting.load(Ordering::Relaxed);
                 metrics::gauge!("mistralrs_sequences_running").set(num_running as f64);
@@ -103,7 +99,8 @@ impl IntervalLogger {
                         .absolute(misses.load(Ordering::Relaxed) as u64);
                 }
                 let tokens_processed = t_tokens_processed.swap(0, Ordering::Relaxed);
-                let prefill_tokens_processed = t_prefill_tokens_processed.swap(0, Ordering::Relaxed);
+                let prefill_tokens_processed =
+                    t_prefill_tokens_processed.swap(0, Ordering::Relaxed);
                 let decode_tokens_processed = t_decode_tokens_processed.swap(0, Ordering::Relaxed);
                 let spec_drafts = t_spec_drafts.swap(0, Ordering::Relaxed);
                 let spec_draft_tokens = t_spec_draft_tokens.swap(0, Ordering::Relaxed);
@@ -206,8 +203,7 @@ impl IntervalLogger {
         self.prefill_tokens_processed
             .fetch_add(num_tokens, Ordering::Relaxed);
         metrics::counter!("mistralrs_tokens_processed_total").increment(num_tokens as u64);
-        metrics::counter!("mistralrs_prefill_tokens_processed_total")
-            .increment(num_tokens as u64);
+        metrics::counter!("mistralrs_prefill_tokens_processed_total").increment(num_tokens as u64);
     }
 
     /// Count generated (decode) tokens through the pipeline. With speculative
@@ -219,8 +215,7 @@ impl IntervalLogger {
         self.decode_tokens_processed
             .fetch_add(num_tokens, Ordering::Relaxed);
         metrics::counter!("mistralrs_tokens_processed_total").increment(num_tokens as u64);
-        metrics::counter!("mistralrs_decode_tokens_processed_total")
-            .increment(num_tokens as u64);
+        metrics::counter!("mistralrs_decode_tokens_processed_total").increment(num_tokens as u64);
     }
 
     /// Record one speculative verification batch (across all its sequences).

--- a/mistralrs-core/src/engine/mod.rs
+++ b/mistralrs-core/src/engine/mod.rs
@@ -1400,7 +1400,8 @@ impl Engine {
                             seq.finish_completion_timing(completion_exec_time);
                         }
 
-                        self.logger.add_decode_tokens_processed(scheduled.completion.len());
+                        self.logger
+                            .add_decode_tokens_processed(scheduled.completion.len());
 
                         last_completion_ids = current_completion_ids;
                     }
@@ -1471,7 +1472,8 @@ impl Engine {
                             .iter()
                             .map(|seq| seq.get_toks().len())
                             .sum();
-                        self.logger.add_prefill_tokens_processed(total_processed_tokens);
+                        self.logger
+                            .add_prefill_tokens_processed(total_processed_tokens);
 
                         for seq in scheduled.prompt.iter_mut() {
                             if !seq.is_finished_paged_attn() {
@@ -2057,9 +2059,11 @@ impl Engine {
 
                         let total_processed_tokens: usize = scheduled_token_counts.iter().sum();
                         if is_prompt {
-                            self.logger.add_prefill_tokens_processed(total_processed_tokens);
+                            self.logger
+                                .add_prefill_tokens_processed(total_processed_tokens);
                         } else {
-                            self.logger.add_decode_tokens_processed(total_processed_tokens);
+                            self.logger
+                                .add_decode_tokens_processed(total_processed_tokens);
                         }
 
                         // Capture recurrent states at full-block boundaries so hybrid models can

--- a/mistralrs-core/src/kv_cache/hybrid_cache.rs
+++ b/mistralrs-core/src/kv_cache/hybrid_cache.rs
@@ -1038,11 +1038,7 @@ impl HybridCache {
         initialization: RecurrentSlotInitialization,
     ) -> Result<usize> {
         self.recurrent_storage_locked = true;
-        if self
-            .slot_owners
-            .iter()
-            .any(|existing| *existing == Some(owner))
-        {
+        if self.slot_owners.contains(&Some(owner)) {
             candle_core::bail!("recurrent slot owner {owner:?} already has an allocation");
         }
         if self.recurrent_capacity() == 0 {
@@ -1732,6 +1728,7 @@ mod tests {
     }
 
     #[test]
+    #[allow(clippy::cast_possible_truncation, clippy::cast_precision_loss)]
     fn checkpoint_batch_maps_logical_slots_and_commits_keep_rows() -> Result<()> {
         let mut cache = HybridCache::new(
             config(vec![HybridLayerType::Recurrent]),
@@ -1783,6 +1780,7 @@ mod tests {
     }
 
     #[test]
+    #[allow(clippy::cast_possible_truncation, clippy::cast_precision_loss)]
     fn checkpoint_snapshot_uses_active_lane_and_restore_canonicalizes() -> Result<()> {
         let mut cache = HybridCache::new(
             config(vec![HybridLayerType::Recurrent]),
@@ -1878,6 +1876,7 @@ mod tests {
     }
 
     #[test]
+    #[allow(clippy::cast_possible_truncation, clippy::cast_precision_loss)]
     fn deferred_recurrent_reservation_requires_initialization_without_resetting() -> Result<()> {
         let mut cache = HybridCache::new(
             config(vec![HybridLayerType::Recurrent]),
@@ -1942,6 +1941,7 @@ mod tests {
     }
 
     #[test]
+    #[allow(clippy::cast_possible_truncation, clippy::cast_precision_loss)]
     fn graph_snapshot_preserves_active_checkpoint_lane() -> Result<()> {
         let mut cache = HybridCache::new(
             config(vec![HybridLayerType::Recurrent]),

--- a/mistralrs-core/src/paged_attention/block_pool.rs
+++ b/mistralrs-core/src/paged_attention/block_pool.rs
@@ -112,9 +112,7 @@ impl PrefixBlockRetentionState {
     }
 
     fn remove_entry(&mut self, id: u64, published_revision: &AtomicU64) -> Option<Vec<BlockHash>> {
-        let Some(entry) = self.entries.shift_remove(&id) else {
-            return None;
-        };
+        let entry = self.entries.shift_remove(&id)?;
         entry.active.store(false, Ordering::Release);
         let mut released_hashes = Vec::new();
         for hash in entry.hashes.into_iter().rev() {
@@ -139,9 +137,7 @@ impl PrefixBlockRetentionState {
     }
 
     fn revoke_oldest(&mut self, published_revision: &AtomicU64) -> Option<Vec<BlockHash>> {
-        let Some(id) = self.entries.first().map(|(id, _)| *id) else {
-            return None;
-        };
+        let id = self.entries.first().map(|(id, _)| *id)?;
         self.remove_entry(id, published_revision)
     }
 

--- a/mistralrs-core/src/paged_attention/layers/paged_attention.rs
+++ b/mistralrs-core/src/paged_attention/layers/paged_attention.rs
@@ -779,6 +779,8 @@ pub struct PagedAttention {
     alibi_slopes: Option<Tensor>,
     fp8_attention_scales: Fp8AttentionScales,
     fp8_attention_scales_calibrated: bool,
+    // read only in the cuda FA3 path
+    #[allow(dead_code)]
     fp8_q_scale: Tensor,
     fp8_k_scale: Tensor,
     fp8_v_scale: Tensor,

--- a/mistralrs-core/src/paged_attention/layers/paged_attention.rs
+++ b/mistralrs-core/src/paged_attention/layers/paged_attention.rs
@@ -1099,6 +1099,18 @@ impl PagedAttention {
             key_cache.as_ref().unwrap(),
             value_cache.as_ref().unwrap(),
         );
+        #[cfg(all(feature = "cuda", target_family = "unix"))]
+        let fa3_supported = fa3_prefill_cache_num_sm(
+            key_cache.as_ref().unwrap(),
+            value_cache.as_ref().unwrap(),
+            ctx.dims.attention_heads,
+            ctx.dims.key_value_heads,
+            ctx.dims.head_size,
+            block_size,
+        )?
+        .is_some();
+        #[cfg(not(all(feature = "cuda", target_family = "unix")))]
+        let fa3_supported = false;
         let prefill_plan_input = PrefixPrefillPlanInput {
             device_is_cuda: tensors.query.device().is_cuda(),
             dtype: tensors.query.dtype(),
@@ -1117,15 +1129,7 @@ impl PagedAttention {
             writes_cache: write_cache,
             is_causal: prefix_causal,
             has_noncausal_mm_context: mm_prefix_ranges.is_some(),
-            fa3_supported: fa3_prefill_cache_num_sm(
-                key_cache.as_ref().unwrap(),
-                value_cache.as_ref().unwrap(),
-                ctx.dims.attention_heads,
-                ctx.dims.key_value_heads,
-                ctx.dims.head_size,
-                block_size,
-            )?
-            .is_some(),
+            fa3_supported,
             block_size,
             attention_backend,
         };

--- a/mistralrs-core/src/paged_attention/plan.rs
+++ b/mistralrs-core/src/paged_attention/plan.rs
@@ -123,6 +123,7 @@ pub(crate) fn fa3_paged_prefill_supported(input: PrefixPrefillPlanInput) -> bool
 }
 
 #[derive(Clone, Copy, Debug)]
+#[allow(dead_code)]
 pub(crate) struct PromptPrefillWorkspaceInput<'a> {
     pub activation_dtype: DType,
     pub cache_dtype: DType,
@@ -141,6 +142,7 @@ pub(crate) struct PromptPrefillWorkspaceInput<'a> {
 }
 
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+#[allow(dead_code)]
 pub(crate) struct PromptPrefillWorkspace {
     pub bytes: usize,
     pub gather_workspace_bytes: usize,
@@ -454,6 +456,7 @@ fn checked_sum(values: &[usize], name: &str) -> Result<usize> {
     })
 }
 
+#[allow(dead_code)]
 pub(crate) fn model_has_donor_paged_cache_layers(
     model: &(dyn ModelConfigLike + Send + Sync),
 ) -> bool {
@@ -462,6 +465,7 @@ pub(crate) fn model_has_donor_paged_cache_layers(
     })
 }
 
+#[allow(dead_code)]
 pub(crate) fn prompt_prefill_workspace(
     model: Option<&(dyn ModelConfigLike + Send + Sync)>,
     input: PromptPrefillWorkspaceInput<'_>,
@@ -587,6 +591,7 @@ pub(crate) fn prompt_prefill_workspace(
     })
 }
 
+#[allow(dead_code)]
 fn prompt_plan_input(
     model: &(dyn ModelConfigLike + Send + Sync),
     layer_idx: usize,

--- a/mistralrs-core/src/paged_attention/scheduler.rs
+++ b/mistralrs-core/src/paged_attention/scheduler.rs
@@ -1508,14 +1508,16 @@ mod tests {
         }
     }
 
+    type TestSequenceMedia = (
+        Option<Vec<image::DynamicImage>>,
+        Option<Vec<AudioInput>>,
+        Option<Vec<VideoInput>>,
+    );
+
     fn test_sequence_with_media_sender_and_group(
         id: usize,
         len: usize,
-        input_media: (
-            Option<Vec<image::DynamicImage>>,
-            Option<Vec<AudioInput>>,
-            Option<Vec<VideoInput>>,
-        ),
+        input_media: TestSequenceMedia,
         tx: tokio::sync::mpsc::Sender<Response>,
         group: Arc<TokioMutex<SequenceGroup>>,
     ) -> Arc<Mutex<Sequence>> {
@@ -2007,7 +2009,7 @@ mod tests {
         assert_eq!(preempted_sequence_ids, vec![10]);
         assert_eq!(output.scheduled.len(), 1);
         assert_eq!(*get_mut_arcmutex!(output.scheduled[0]).id(), 20);
-        assert!(scheduler.waiting_counts.get(&20).is_none());
+        assert!(!scheduler.waiting_counts.contains_key(&20));
     }
 
     #[test]

--- a/mistralrs-core/src/paged_attention/windowed_pool.rs
+++ b/mistralrs-core/src/paged_attention/windowed_pool.rs
@@ -1186,6 +1186,7 @@ mod tests {
             .to_vec1()
     }
 
+    #[allow(clippy::cast_precision_loss)]
     fn fill_slot(
         pool: &mut WindowedKvPool,
         pool_slot: usize,

--- a/mistralrs-core/src/pipeline/amoe.rs
+++ b/mistralrs-core/src/pipeline/amoe.rs
@@ -685,7 +685,7 @@ impl AnyMoePipelineMixin for AnyMoePipeline {
 
             let mut writer = csv::Writer::from_path(path).map_err(candle_core::Error::msg)?;
 
-            let mut header = vec![format!("Step")];
+            let mut header = vec!["Step".to_string()];
             header.extend((0..all_losses[0].len()).map(|i| format!("Gating layer {i}")));
             writer
                 .write_record(&header)

--- a/mistralrs-core/src/pipeline/loaders/checkpoint_inventory.rs
+++ b/mistralrs-core/src/pipeline/loaders/checkpoint_inventory.rs
@@ -156,7 +156,7 @@ pub(crate) fn checkpoint_device_map_sizes(
         }
     }
 
-    if layer_sizes_in_bytes.iter().any(|size| *size == 0) {
+    if layer_sizes_in_bytes.contains(&0) {
         return Ok(None);
     }
     let mapped_size = layer_sizes_in_bytes

--- a/mistralrs-core/src/pipeline/mod.rs
+++ b/mistralrs-core/src/pipeline/mod.rs
@@ -1305,6 +1305,7 @@ pub struct DecodeGraphPrecaptureCtx {
 }
 
 #[derive(Clone)]
+#[allow(clippy::large_enum_variant)]
 pub enum CacheBackendMetadata {
     DefaultInstructions {
         pre_op: CacheInstruction,
@@ -2206,17 +2207,17 @@ pub trait Pipeline:
                                     *seq_idx = active_indices[*seq_idx];
                                 }
                             }
-                            let computed_updates = scheduler_visible_prompt_step
-                                .then(|| {
-                                    active_indices
-                                        .iter()
-                                        .map(|&seq_idx| {
-                                            let chunk = chunk_plans[seq_idx][plan_indices[seq_idx]];
-                                            (seq_idx, chunk.end)
-                                        })
-                                        .collect::<Vec<_>>()
-                                })
-                                .unwrap_or_default();
+                            let computed_updates = if scheduler_visible_prompt_step {
+                                active_indices
+                                    .iter()
+                                    .map(|&seq_idx| {
+                                        let chunk = chunk_plans[seq_idx][plan_indices[seq_idx]];
+                                        (seq_idx, chunk.end)
+                                    })
+                                    .collect::<Vec<_>>()
+                            } else {
+                                Vec::new()
+                            };
                             inputs.push((
                                 processed,
                                 recurrent_boundaries,

--- a/mistralrs-core/src/prefix_cacher.rs
+++ b/mistralrs-core/src/prefix_cacher.rs
@@ -959,6 +959,7 @@ mod tests {
         AdapterGenerationId::from_bytes([value; 32])
     }
 
+    #[allow(clippy::cast_possible_truncation)]
     fn block_hashes(start: u32, len: usize) -> Vec<BlockHash> {
         let tokens = (start..start + len as u32).collect::<Vec<_>>();
         compute_block_hashes(&tokens, 1, &[], &[])

--- a/mistralrs-core/src/sequence.rs
+++ b/mistralrs-core/src/sequence.rs
@@ -1568,9 +1568,11 @@ impl Sequence {
                     .pop_front()
                     .expect("streaming UTF-8 group length must match the queue");
                 emissions.push(StreamingEmission {
-                    text: (idx + 1 == group_len)
-                        .then(|| text.clone())
-                        .unwrap_or_default(),
+                    text: if idx + 1 == group_len {
+                        text.clone()
+                    } else {
+                        String::new()
+                    },
                     bytes: emission.bytes,
                     logprobs: emission.logprobs,
                 });
@@ -2340,6 +2342,7 @@ impl SequenceGroup {
         }
     }
 
+    #[allow(clippy::result_large_err)]
     pub async fn maybe_send_chat_done_response(
         &self,
         response: ChatCompletionResponse,
@@ -2352,6 +2355,7 @@ impl SequenceGroup {
         Ok(())
     }
 
+    #[allow(clippy::result_large_err)]
     pub async fn maybe_send_raw_done_response(
         &self,
         sender: Sender<Response>,
@@ -2370,6 +2374,7 @@ impl SequenceGroup {
         Ok(())
     }
 
+    #[allow(clippy::result_large_err)]
     pub async fn maybe_send_embedding_done_response(
         &self,
         sender: Sender<Response>,
@@ -2391,6 +2396,7 @@ impl SequenceGroup {
         Ok(())
     }
 
+    #[allow(clippy::result_large_err)]
     pub async fn maybe_send_image_gen_response(
         &self,
         response: ImageGenerationResponse,
@@ -2403,6 +2409,7 @@ impl SequenceGroup {
         Ok(())
     }
 
+    #[allow(clippy::result_large_err)]
     pub async fn maybe_send_speech_response(
         &self,
         sender: Sender<Response>,

--- a/mistralrs-core/src/speculative/dflash.rs
+++ b/mistralrs-core/src/speculative/dflash.rs
@@ -2026,6 +2026,16 @@ pub(crate) fn windowed_kv_cache_size_in_bytes(
         .ok_or_else(|| candle_core::Error::msg("DFlash windowed KV byte size overflow"))
 }
 
+pub(crate) struct DFlashGraphProposalInputs<'a> {
+    pub seq_ids: &'a [usize],
+    pub anchors: &'a [u32],
+    pub start_positions: &'a [usize],
+    pub n_predict: usize,
+    pub sampling: Option<DFlashSamplingInputs<'a>>,
+    pub token_embedding: &'a Arc<dyn QuantMethod>,
+    pub lm_head: &'a Arc<dyn QuantMethod>,
+}
+
 impl DFlashDraftModel {
     pub(crate) fn evict_cuda_graphs_lru(&self, max_entries: usize) -> usize {
         #[cfg(all(feature = "cuda", feature = "flash-attn", target_family = "unix"))]
@@ -2426,14 +2436,17 @@ impl DFlashDraftModel {
 
     pub(crate) fn proposals_cuda_graph(
         &self,
-        seq_ids: &[usize],
-        anchors: &[u32],
-        start_positions: &[usize],
-        n_predict: usize,
-        sampling: Option<DFlashSamplingInputs<'_>>,
-        token_embedding: &Arc<dyn QuantMethod>,
-        lm_head: &Arc<dyn QuantMethod>,
+        inputs: &DFlashGraphProposalInputs<'_>,
     ) -> Result<Option<DFlashProposalBatch>> {
+        let DFlashGraphProposalInputs {
+            seq_ids,
+            anchors,
+            start_positions,
+            n_predict,
+            sampling,
+            token_embedding,
+            lm_head,
+        } = inputs;
         #[cfg(all(feature = "cuda", feature = "flash-attn", target_family = "unix"))]
         {
             if !crate::pipeline::cuda_graph::cuda_decode_graphs_enabled()
@@ -3788,6 +3801,7 @@ mod tests {
         Ok(())
     }
 
+    #[allow(clippy::cast_precision_loss)]
     #[test]
     fn context_tap_gather_preserves_flat_row_order() -> Result<()> {
         let device = Device::Cpu;
@@ -3817,6 +3831,7 @@ mod tests {
         Ok(())
     }
 
+    #[allow(clippy::cast_precision_loss)]
     #[test]
     fn context_tap_gather_handles_contiguous_rows_without_reordering() -> Result<()> {
         let device = Device::Cpu;
@@ -3837,6 +3852,7 @@ mod tests {
         assert_eq!(contiguous_row_range(&[]), None);
     }
 
+    #[allow(clippy::cast_precision_loss)]
     #[test]
     fn context_kv_row_selection_handles_narrowed_sources() -> Result<()> {
         let device = Device::Cpu;
@@ -4046,6 +4062,7 @@ mod tests {
         assert!(!dflash_graph_positions_fit(&[100_000], 0));
     }
 
+    #[allow(clippy::cast_precision_loss)]
     #[test]
     fn graph_rope_uses_each_replayed_long_position() -> Result<()> {
         let device = Device::Cpu;

--- a/mistralrs-core/src/speculative/verifier.rs
+++ b/mistralrs-core/src/speculative/verifier.rs
@@ -1215,6 +1215,7 @@ fn normalize_sparse_row(
         if prob == 0.0 {
             continue;
         }
+        #[allow(clippy::cast_possible_truncation)]
         let normalized = (prob as f64 / sum) as f32;
         let token = token as usize;
         if let Some((_, existing)) = entries
@@ -1475,7 +1476,9 @@ fn sample_from_probs_with_uniform(
         })
         .or(last_positive)
         .expect("positive fallback probability was validated");
-    sampler.logprobs_from_probs(token as u32, reporting_probs, return_logprobs)
+    #[allow(clippy::cast_possible_truncation)]
+    let token_id = token as u32;
+    sampler.logprobs_from_probs(token_id, reporting_probs, return_logprobs)
 }
 
 fn valid_uniform(uniform: f32) -> bool {

--- a/mistralrs-core/src/vision_models/llava/llava_next.rs
+++ b/mistralrs-core/src/vision_models/llava/llava_next.rs
@@ -277,8 +277,7 @@ impl Model {
         }
 
         // Per-image caching: each image may have multiple samples (base + tiles).
-        let image_features_vec: Vec<Tensor>;
-        if image_hashes.len() == n_images && n_images > 0 {
+        let image_features_vec = if image_hashes.len() == n_images && n_images > 0 {
             // Compute sample offset ranges per image.
             let mut sample_offsets = vec![0usize; n_images + 1];
             for (i, &ns) in num_image_samples.iter().enumerate() {
@@ -349,7 +348,7 @@ impl Model {
                 }
             }
 
-            image_features_vec = per_image
+            per_image
                 .into_iter()
                 .enumerate()
                 .map(|(index, output)| {
@@ -359,7 +358,7 @@ impl Model {
                         ))
                     })
                 })
-                .collect::<Result<Vec<_>>>()?;
+                .collect::<Result<Vec<_>>>()?
         } else {
             // Fallback: no hashes, encode all at once.
             let image_features = self.encode_images(&images_typed)?;
@@ -375,8 +374,8 @@ impl Model {
                 feats.push(image_features.i(index..index + num_image_sample)?);
                 index += num_image_sample;
             }
-            image_features_vec = feats;
-        }
+            feats
+        };
         let image_features_vec = image_features_vec
             .iter()
             .enumerate()

--- a/mistralrs-core/src/vision_models/qwen3_5/speculative.rs
+++ b/mistralrs-core/src/vision_models/qwen3_5/speculative.rs
@@ -20,8 +20,8 @@ use crate::{
     pipeline::text_models_inputs_processor::FlashParams,
     speculative::{
         dflash::{
-            CtxAppend, DFlashDraftModel, DFlashPreparedContext, DFlashProposalBatch,
-            DFlashSamplingInputs,
+            CtxAppend, DFlashDraftModel, DFlashGraphProposalInputs, DFlashPreparedContext,
+            DFlashProposalBatch, DFlashSamplingInputs,
         },
         paged_rows::make_paged_rows_metadata,
         proposer::sample_draft_rows,
@@ -560,15 +560,15 @@ impl Qwen3_5Model {
             });
         let draft_head = self.draft_lm_head.lock().expect("draft lm_head poisoned");
         let lm_head = draft_head.as_ref().unwrap_or_else(|| self.text.lm_head());
-        let graph_proposals = drafter.proposals_cuda_graph(
-            ctx.seq_ids,
-            ctx.sampled_tokens,
-            ctx.base_lens,
+        let graph_proposals = drafter.proposals_cuda_graph(&DFlashGraphProposalInputs {
+            seq_ids: ctx.seq_ids,
+            anchors: ctx.sampled_tokens,
+            start_positions: ctx.base_lens,
             n_predict,
             sampling,
-            self.text.token_embedding(),
+            token_embedding: self.text.token_embedding(),
             lm_head,
-        )?;
+        })?;
         if let Some(proposals) = graph_proposals {
             return dflash_speculative_batch(proposals).map(Some);
         }

--- a/mistralrs-quant/src/gguf/weight_source.rs
+++ b/mistralrs-quant/src/gguf/weight_source.rs
@@ -471,7 +471,7 @@ impl GgufWeightSource {
         let data = self.archive.tensor_data(name)?;
         let block_count = info.elem_count()? / 32;
         let mut values = Vec::with_capacity(block_count * if scales { 1 } else { 16 });
-        for block in data.bytes().chunks_exact(17) {
+        for block in data.bytes().as_chunks::<17>().0 {
             if scales {
                 values.push(block[0]);
             } else {
@@ -1454,7 +1454,7 @@ mod tests {
 
     fn native_mxfp4_blocks(data: &[u8]) -> Vec<u8> {
         let mut blocks = Vec::new();
-        for block in data.chunks_exact(17) {
+        for block in data.as_chunks::<17>().0 {
             for index in (0..32).step_by(2) {
                 let nibble = |index: usize| {
                     if index < 16 {
@@ -1940,11 +1940,15 @@ mod tests {
         let expected_gate_blocks = native_mxfp4_blocks(&gate_data);
         let expected_up_blocks = native_mxfp4_blocks(&up_data);
         let expected_gate_scales = gate_data
-            .chunks_exact(17)
+            .as_chunks::<17>()
+            .0
+            .iter()
             .map(|block| block[0])
             .collect::<Vec<_>>();
         let expected_up_scales = up_data
-            .chunks_exact(17)
+            .as_chunks::<17>()
+            .0
+            .iter()
             .map(|block| block[0])
             .collect::<Vec<_>>();
 
@@ -1969,7 +1973,7 @@ mod tests {
             -6.0,
         ];
         let mut expected_dequantized = Vec::new();
-        for block in gate_data.chunks_exact(17) {
+        for block in gate_data.as_chunks::<17>().0 {
             let scale = f32::from_bits(u32::from(block[0]) << 23);
             for packed in &block[1..] {
                 expected_dequantized.push(fp4[(packed & 0x0f) as usize] * scale);

--- a/mistralrs-quant/src/uqff/report.rs
+++ b/mistralrs-quant/src/uqff/report.rs
@@ -1525,8 +1525,10 @@ fn scalar_u32_vec(meta: &TensorMeta) -> Option<Vec<usize>> {
         return None;
     }
     Some(
-        data.chunks_exact(4)
-            .map(|chunk| u32::from_le_bytes(chunk.try_into().expect("chunk is 4 bytes")) as usize)
+        data.as_chunks::<4>()
+            .0
+            .iter()
+            .map(|chunk| u32::from_le_bytes(*chunk) as usize)
             .collect(),
     )
 }

--- a/mistralrs-quant/src/uqff/tensor.rs
+++ b/mistralrs-quant/src/uqff/tensor.rs
@@ -99,10 +99,10 @@ impl UqffTensor {
         }
         Ok(self
             .data
-            .chunks_exact(4)
-            .map(|chunk| {
-                u32::from_le_bytes(chunk.try_into().expect("chunk is four bytes")) as usize
-            })
+            .as_chunks::<4>()
+            .0
+            .iter()
+            .map(|chunk| u32::from_le_bytes(*chunk) as usize)
             .collect())
     }
 

--- a/mistralrs-server-core/src/metrics.rs
+++ b/mistralrs-server-core/src/metrics.rs
@@ -571,6 +571,7 @@ fn request_id(req: &mut Request) -> String {
 #[derive(Clone, Debug)]
 pub struct RequestId(pub String);
 
+#[allow(clippy::result_large_err)]
 async fn extract_model(
     req: Request,
     route: &str,


### PR DESCRIPTION
CI went red when rust 1.98.0 (2026-08-18) hit the unpinned `stable` toolchain, and a few red PRs merged on top, stacking up failures that now block every open PR.

## Fixes

- **Check (metal)**: real compile bug - `fa3_prefill_cache_num_sm` is cuda-only but was called unconditionally in the paged prefill plan, breaking `cargo check --features metal` with E0425. Now computed under the existing paired cfg gates (`fa3_supported = false` off-cuda).
- **Clippy**: 7x new 1.98 `chunks_exact_to_as_chunks` lints in `mistralrs-quant`, plus ~38 latent lints in `mistralrs-core`/`mistralrs-server-core` that CI never saw because clippy stopped at quant first (casts, while-let, contains, result_large_err, ...). The 8-arg `proposals_cuda_graph` is wrapped in a `DFlashGraphProposalInputs` struct.
- **Rustfmt**: the unformatted prefill/decode logging from the recent metrics work.
- **Typos**: exclude vendored `third_party/` code (upstream typos in flash-attention headers, PTX `setp.eq.u32` mnemonics in deepgemm).
- **Docs `generated` job**: regenerate CLI/example references - 3 paged-scheduler flags were missing from run/serve docs, examples inline the new completions request fields, and the `update --tag` example now points at v0.9.2 (the source doc-comment was stale, which is what made the job red).
- **Metal dead code**: scoped `#[allow(dead_code)]` on the fp8 q-scale field and the cuda prompt-preflight plan types that only cuda code reads (editor warnings; the metal CI job does not deny warnings).

## Verification (local, rust 1.98.0)

- cargo fmt --all -- --check
- cargo clippy --workspace --tests --examples -- -D warnings
- cargo check --workspace (plain and --features metal, 0 warnings)
- cargo test -p mistralrs-core -p mistralrs-quant -p mistralrs-vision (1501 passed)
- cd docs && npm run generate (no drift)
- typos, cargo doc

Merge first, then open PRs need their branches updated to re-run against green master.
