### PR TITLE
feat(core): report cached prompt tokens in usage

### DIFF
--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -3675,6 +3675,16 @@
             "type": "integer",
             "minimum": 0
           },
+          "prompt_tokens_details": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/PromptTokensDetailsResponse"
+              }
+            ]
+          },
           "total_completion_time_sec": {
             "type": "number",
             "format": "float"
@@ -6739,6 +6749,19 @@
               "null"
             ],
             "description": "Text tokens",
+            "minimum": 0
+          }
+        }
+      },
+      "PromptTokensDetailsResponse": {
+        "type": "object",
+        "required": [
+          "cached_tokens"
+        ],
+        "properties": {
+          "cached_tokens": {
+            "type": "integer",
+            "description": "Prompt tokens served from the prefix cache, not recomputed.",
             "minimum": 0
           }
         }

--- a/mistralrs-core/src/engine/agentic_loop.rs
+++ b/mistralrs-core/src/engine/agentic_loop.rs
@@ -397,6 +397,7 @@ impl AgenticUsageAccumulator {
                 completion_tokens: self.completion_tokens,
                 prompt_tokens: self.prompt_tokens,
                 total_tokens,
+                prompt_tokens_details: None,
                 avg_tok_per_sec: tps(total_tokens, total_time_sec),
                 avg_prompt_tok_per_sec: tps(self.prompt_tokens, self.total_prompt_time_sec),
                 avg_compl_tok_per_sec: tps(self.completion_tokens, self.total_completion_time_sec),

--- a/mistralrs-core/src/response.rs
+++ b/mistralrs-core/src/response.rs
@@ -122,11 +122,25 @@ generate_repr!(CompletionChunkChoice);
 #[cfg_attr(feature = "pyo3_macros", pyclass)]
 #[cfg_attr(feature = "pyo3_macros", pyo3(get_all))]
 #[derive(Debug, Clone, Serialize)]
+/// OpenAI compatible prompt token breakdown.
+pub struct PromptTokensDetails {
+    /// Prompt tokens served from the prefix cache, not recomputed.
+    pub cached_tokens: usize,
+}
+
+generate_repr!(PromptTokensDetails);
+
+#[cfg_attr(feature = "pyo3_macros", pyclass)]
+#[cfg_attr(feature = "pyo3_macros", pyo3(get_all))]
+#[derive(Debug, Clone, Serialize)]
 /// OpenAI compatible (superset) usage during a request.
 pub struct Usage {
     pub completion_tokens: usize,
     pub prompt_tokens: usize,
     pub total_tokens: usize,
+    /// Present when some prompt tokens were served from the prefix cache.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub prompt_tokens_details: Option<PromptTokensDetails>,
     pub avg_tok_per_sec: f32,
     pub avg_prompt_tok_per_sec: f32,
     pub avg_compl_tok_per_sec: f32,

--- a/mistralrs-core/src/sequence.rs
+++ b/mistralrs-core/src/sequence.rs
@@ -6,7 +6,8 @@ use crate::{
     response::{ChatCompletionChunkResponse, Choice, ChunkChoice, Response, SYSTEM_FINGERPRINT},
     sampler::{Logprobs, Sampler},
     speculative::{SpeculativeProposalDistribution, SpeculativeTokens},
-    AdapterGenerationId, AdapterLease, AudioInput, ChatCompletionResponse, Usage, VideoInput,
+    AdapterGenerationId, AdapterLease, AudioInput, ChatCompletionResponse, PromptTokensDetails,
+    Usage, VideoInput,
 };
 use crate::{
     pipeline::{DiffusionGenerationParams, KvCache},
@@ -1880,6 +1881,7 @@ impl Sequence {
         group.total_completion_time = completion_time_ms;
         group.total_time = prompt_time_ms.saturating_add(completion_time_ms);
         group.total_prompt_toks = self.prompt_len;
+        group.total_cached_toks = self.prefix_cache_len();
         group.total_toks = self.len();
     }
 
@@ -2232,6 +2234,7 @@ pub struct SequenceGroup {
     n_choices: usize, // The target number of choices to return. Can be decreased if an error is thrown.
     best_of: Option<usize>, // Top n seqs based on cumulative logprobs.
     pub total_prompt_toks: usize,
+    pub total_cached_toks: usize,
     pub total_toks: usize,
     pub total_prompt_time: u128,
     pub total_time: u128,
@@ -2266,6 +2269,7 @@ impl SequenceGroup {
             completion_choices: Vec::new(),
             n_choices,
             total_prompt_toks: 0,
+            total_cached_toks: 0,
             total_toks: 0,
             total_prompt_time: 0,
             total_time: 0,
@@ -2319,6 +2323,13 @@ impl SequenceGroup {
             completion_tokens: self.total_toks.saturating_sub(self.total_prompt_toks),
             prompt_tokens: self.total_prompt_toks,
             total_tokens: self.total_toks,
+            prompt_tokens_details: if self.total_cached_toks > 0 {
+                Some(PromptTokensDetails {
+                    cached_tokens: self.total_cached_toks,
+                })
+            } else {
+                None
+            },
             avg_tok_per_sec: if self.total_time > 0 {
                 (self.total_toks as f32 / self.total_time as f32) * 1000.
             } else {
@@ -2574,6 +2585,7 @@ mod tests {
             completion_tokens: 0,
             prompt_tokens: 0,
             total_tokens: 0,
+            prompt_tokens_details: None,
             avg_tok_per_sec: 0.0,
             avg_prompt_tok_per_sec: 0.0,
             avg_compl_tok_per_sec: 0.0,
@@ -3189,6 +3201,30 @@ mod tests {
             0
         );
         assert_eq!(seq.count_prefix_cached_mm_items(), 0);
+    }
+
+    #[test]
+    fn usage_reports_cached_prompt_tokens() {
+        let seq = make_test_sequence();
+        let seq = seq.prefill_v2_normal(vec![], vec![7, 8], 4);
+        seq.update_time_info();
+        let usage = seq.get_mut_group().get_usage();
+        assert_eq!(
+            usage.prompt_tokens_details.map(|d| d.cached_tokens),
+            Some(4)
+        );
+    }
+
+    #[test]
+    fn usage_omits_prompt_details_without_prefix_cache() {
+        let seq = make_test_sequence();
+        let seq = seq.prefill_v2_normal(vec![], vec![7, 8], 0);
+        seq.update_time_info();
+        assert!(seq
+            .get_mut_group()
+            .get_usage()
+            .prompt_tokens_details
+            .is_none());
     }
 
     #[test]

--- a/mistralrs-server-core/src/openai.rs
+++ b/mistralrs-server-core/src/openai.rs
@@ -1321,10 +1321,17 @@ pub struct ModelObjects {
 }
 
 #[derive(Debug, ToSchema)]
+pub struct PromptTokensDetailsResponse {
+    /// Prompt tokens served from the prefix cache, not recomputed.
+    pub cached_tokens: usize,
+}
+
+#[derive(Debug, ToSchema)]
 pub struct CompletionUsageResponse {
     pub completion_tokens: usize,
     pub prompt_tokens: usize,
     pub total_tokens: usize,
+    pub prompt_tokens_details: Option<PromptTokensDetailsResponse>,
     pub avg_tok_per_sec: f32,
     pub avg_prompt_tok_per_sec: f32,
     pub avg_compl_tok_per_sec: f32,

--- a/mistralrs-server-core/src/responses.rs
+++ b/mistralrs-server-core/src/responses.rs
@@ -55,7 +55,7 @@ use crate::{
         enums::{ItemStatus, ResponseStatus},
         events::StreamingState,
         items::{InputItem, MessageContentParam, OutputItem, ShellCallOutputPart},
-        resource::{ResponseError, ResponseResource, ResponseUsage},
+        resource::{InputTokensDetails, ResponseError, ResponseResource, ResponseUsage},
     },
     skills::SkillStore,
     streaming::{get_keep_alive_interval, observe_response, DoneState, StreamOutcomeHandle},
@@ -1481,10 +1481,17 @@ impl futures::Stream for OpenResponsesStreamer {
 
                             // Add usage from chunk if available
                             if let Some(usage) = &chat_chunk.usage {
-                                response.usage = Some(ResponseUsage::new(
+                                let mut resp_usage = ResponseUsage::new(
                                     usage.prompt_tokens,
                                     usage.completion_tokens,
-                                ));
+                                );
+                                if let Some(details) = &usage.prompt_tokens_details {
+                                    resp_usage.input_tokens_details = Some(InputTokensDetails {
+                                        cached_tokens: Some(details.cached_tokens),
+                                        ..Default::default()
+                                    });
+                                }
+                                response.usage = Some(resp_usage);
                             }
 
                             events_to_emit.push(OpenResponsesStreamEvent::ResponseCompleted {
@@ -1791,10 +1798,17 @@ fn chat_response_to_response_resource(
     } else {
         Some(reasoning_parts.join(""))
     };
-    resource.usage = Some(ResponseUsage::new(
+    let mut resp_usage = ResponseUsage::new(
         chat_resp.usage.prompt_tokens,
         chat_resp.usage.completion_tokens,
-    ));
+    );
+    if let Some(details) = &chat_resp.usage.prompt_tokens_details {
+        resp_usage.input_tokens_details = Some(InputTokensDetails {
+            cached_tokens: Some(details.cached_tokens),
+            ..Default::default()
+        });
+    }
+    resource.usage = Some(resp_usage);
     resource.metadata = metadata;
     resource.completed_at = Some(
         SystemTime::now()
@@ -2681,6 +2695,7 @@ mod tests {
                 completion_tokens: 0,
                 prompt_tokens: 0,
                 total_tokens: 0,
+                prompt_tokens_details: None,
                 avg_tok_per_sec: 0.0,
                 avg_prompt_tok_per_sec: 0.0,
                 avg_compl_tok_per_sec: 0.0,

--- a/mistralrs/src/agent.rs
+++ b/mistralrs/src/agent.rs
@@ -283,6 +283,7 @@ impl<'a> AgentStream<'a> {
                                                         completion_tokens: 0,
                                                         prompt_tokens: 0,
                                                         total_tokens: 0,
+                                                        prompt_tokens_details: None,
                                                         avg_tok_per_sec: 0.0,
                                                         avg_prompt_tok_per_sec: 0.0,
                                                         avg_compl_tok_per_sec: 0.0,


### PR DESCRIPTION
Adds usage.prompt_tokens_details.cached_tokens (chat/completions) and input_tokens_details.cached_tokens (responses) - prompt tokens served from the prefix cache instead of recomputed. Based on fix/ci-green-rust-198, so it includes those commits until that PR merges.