### PR TITLE
docs: refresh generated reference artifacts

### DIFF
--- a/docs/src/content/docs/reference/cli/run.md
+++ b/docs/src/content/docs/reference/cli/run.md
@@ -203,6 +203,7 @@ mistralrs run text [OPTIONS] --model-id <MODEL_ID>
 | `--pa-memory-fraction <MEMORY_FRACTION>` |  | GPU memory utilization fraction 0.0-1.0 (alternative to context-len/memory-mb) |
 | `--pa-block-size <BLOCK_SIZE>` |  | Tokens per block (default: 32 on CUDA) |
 | `--pa-cache-type <CACHE_TYPE>` | `auto` | KV cache quantization type |
+
 ## mistralrs run multimodal
 
 Multimodal model
@@ -337,3 +338,4 @@ mistralrs run embedding [OPTIONS] --model-id <MODEL_ID>
 | `--pa-memory-fraction <MEMORY_FRACTION>` |  | GPU memory utilization fraction 0.0-1.0 (alternative to context-len/memory-mb) |
 | `--pa-block-size <BLOCK_SIZE>` |  | Tokens per block (default: 32 on CUDA) |
 | `--pa-cache-type <CACHE_TYPE>` | `auto` | KV cache quantization type |
+

--- a/docs/src/content/docs/reference/cli/serve.md
+++ b/docs/src/content/docs/reference/cli/serve.md
@@ -207,6 +207,7 @@ mistralrs serve text [OPTIONS] --model-id <MODEL_ID>
 | `--pa-memory-fraction <MEMORY_FRACTION>` |  | GPU memory utilization fraction 0.0-1.0 (alternative to context-len/memory-mb) |
 | `--pa-block-size <BLOCK_SIZE>` |  | Tokens per block (default: 32 on CUDA) |
 | `--pa-cache-type <CACHE_TYPE>` | `auto` | KV cache quantization type |
+
 ## mistralrs serve multimodal
 
 Multimodal model
@@ -341,3 +342,4 @@ mistralrs serve embedding [OPTIONS] --model-id <MODEL_ID>
 | `--pa-memory-fraction <MEMORY_FRACTION>` |  | GPU memory utilization fraction 0.0-1.0 (alternative to context-len/memory-mb) |
 | `--pa-block-size <BLOCK_SIZE>` |  | Tokens per block (default: 32 on CUDA) |
 | `--pa-cache-type <CACHE_TYPE>` | `auto` | KV cache quantization type |
+

--- a/docs/src/content/docs/reference/python/which.md
+++ b/docs/src/content/docs/reference/python/which.md
@@ -121,6 +121,7 @@ Pass `in_situ_quant` to `Runner` to requantize compatible GGUF weights while loa
 | `hf_cache_path` | `str \| None` | `None (keyword-only)` |
 | `matformer_config_path` | `str \| None` | `None (keyword-only)` |
 | `matformer_slice_name` | `str \| None` | `None (keyword-only)` |
+| `encoder_cache_memory_bytes` | `int \| None` | `None (keyword-only)` |
 
 ### `Which.XLoraGGUF`
 
@@ -218,6 +219,7 @@ For dynamic adapters on a supported GGUF, pass `adapters` to `Which.GGUF`.
 | `matformer_config_path` | `str \| None` | `None` |
 | `matformer_slice_name` | `str \| None` | `None` |
 | `organization` | `IsqOrganization \| None` | `None` |
+| `encoder_cache_memory_bytes` | `int \| None` | `None` |
 
 ### `Which.DiffusionPlain`
 


### PR DESCRIPTION
## Summary

- preserve the section spacing emitted by the CLI reference generator
- include `encoder_cache_memory_bytes` in the generated Python `Which` reference

## Context

PR #2400 was merged before its generated-artifacts check completed. That check found three stale reference files from the updated upstream base. This follow-up contains only the generator output.

## Validation

- `cd docs && npm run generate`
