### PR TITLE
fix(paged-attn): honor --paged-attn on instead of silently disabling

### DIFF
--- a/docs/src/content/docs/guides/perf/paged-attention.mdx
+++ b/docs/src/content/docs/guides/perf/paged-attention.mdx
@@ -18,7 +18,7 @@ mistralrs serve --paged-attn on --pa-memory-mb 8192 -m Qwen/Qwen3-4B
 mistralrs serve --paged-attn off -m Qwen/Qwen3-4B
 ```
 
-`--paged-attn` accepts `auto` (default), `on`, or `off`. `auto` enables paged attention on CUDA and disables it on Metal and CPU.
+`--paged-attn` accepts `auto` (default), `on`, or `off`. `auto` enables paged attention on CUDA and disables it on Metal and CPU, logging a reason when it stays off. `on` fails closed: if the device, build, or model cannot honor PagedAttention, startup errors instead of silently using eager KV. `off` disables it with no fallback warning.
 
 </TabItem>
 <TabItem label="Python">
@@ -53,7 +53,7 @@ let model = ModelBuilder::new("Qwen/Qwen3-4B")
     .await?;
 ```
 
-`with_paged_attn` is silently ignored on platforms without paged attention support. [Full example](/examples/rust/advanced/paged-attn/).
+`with_paged_attn` is an explicit request. Loading fails if the platform, device, or model cannot honor PagedAttention. [Full example](/examples/rust/advanced/paged-attn/).
 
 </TabItem>
 </Tabs>

--- a/docs/src/content/docs/reference/cli-toml-config.md
+++ b/docs/src/content/docs/reference/cli-toml-config.md
@@ -97,7 +97,7 @@ The MCP *client* configuration (`mcp_config`) lives under `[runtime]`, not `[ser
 
 | Field | CLI flag | Default | Purpose |
 |---|---|---|---|
-| `mode` | `--paged-attn` | `auto` | `auto` (on for CUDA, off for Metal/CPU), `on`, or `off`. |
+| `mode` | `--paged-attn` | `auto` | `auto` (on for CUDA, off for Metal/CPU), `on` (fail closed if PagedAttention cannot be enabled), or `off`. |
 | `context_len` | `--pa-context-len` | not set | Allocate KV cache for this context length. |
 | `memory_mb` | `--pa-memory-mb` | not set | KV cache budget in MB. Conflicts with `context_len`. |
 | `memory_fraction` | `--pa-memory-fraction` | not set | KV cache budget as fraction of VRAM (0.0 to 1.0). Conflicts with `context_len` and `memory_mb`. |

--- a/docs/src/content/docs/reference/cli/bench.md
+++ b/docs/src/content/docs/reference/cli/bench.md
@@ -48,7 +48,7 @@ mistralrs bench [OPTIONS] [COMMAND]
 | `--hf-cache <HF_CACHE>` |  | Custom Hugging Face cache directory |
 | `--max-seq-len <MAX_SEQ_LEN>` | `4096` | Max sequence length for automatic device mapping |
 | `--max-batch-size <MAX_BATCH_SIZE>` | `1` | Max batch size for automatic device mapping |
-| `--paged-attn <MODE>` | `auto` | PagedAttention mode - auto: enabled on CUDA, disabled on Metal/CPU (default) - on: force enable (fails if unsupported) - off: force disable. Possible values: `auto`, `on`, `off`. |
+| `--paged-attn <MODE>` | `auto` | PagedAttention mode - auto: enabled on CUDA, disabled on Metal/CPU (default) - on: force enable; error if the device, build, or model cannot honor it - off: force disable. Possible values: `auto`, `on`, `off`. |
 | `--pa-context-len <CONTEXT_LEN>` |  | Allocate KV cache for this context length. If not specified, defaults to using 90% of available VRAM |
 | `--pa-memory-mb <MEMORY_MB>` |  | GPU memory to allocate in MBs (alternative to context-len) |
 | `--pa-memory-fraction <MEMORY_FRACTION>` |  | GPU memory utilization fraction 0.0-1.0 (alternative to context-len/memory-mb) |
@@ -115,7 +115,7 @@ mistralrs bench auto [OPTIONS] --model-id <MODEL_ID>
 | `--hf-cache <HF_CACHE>` |  | Custom Hugging Face cache directory |
 | `--max-seq-len <MAX_SEQ_LEN>` | `4096` | Max sequence length for automatic device mapping |
 | `--max-batch-size <MAX_BATCH_SIZE>` | `1` | Max batch size for automatic device mapping |
-| `--paged-attn <MODE>` | `auto` | PagedAttention mode - auto: enabled on CUDA, disabled on Metal/CPU (default) - on: force enable (fails if unsupported) - off: force disable. Possible values: `auto`, `on`, `off`. |
+| `--paged-attn <MODE>` | `auto` | PagedAttention mode - auto: enabled on CUDA, disabled on Metal/CPU (default) - on: force enable; error if the device, build, or model cannot honor it - off: force disable. Possible values: `auto`, `on`, `off`. |
 | `--pa-context-len <CONTEXT_LEN>` |  | Allocate KV cache for this context length. If not specified, defaults to using 90% of available VRAM |
 | `--pa-memory-mb <MEMORY_MB>` |  | GPU memory to allocate in MBs (alternative to context-len) |
 | `--pa-memory-fraction <MEMORY_FRACTION>` |  | GPU memory utilization fraction 0.0-1.0 (alternative to context-len/memory-mb) |
@@ -169,7 +169,7 @@ mistralrs bench text [OPTIONS] --model-id <MODEL_ID>
 | `--hf-cache <HF_CACHE>` |  | Custom Hugging Face cache directory |
 | `--max-seq-len <MAX_SEQ_LEN>` | `4096` | Max sequence length for automatic device mapping |
 | `--max-batch-size <MAX_BATCH_SIZE>` | `1` | Max batch size for automatic device mapping |
-| `--paged-attn <MODE>` | `auto` | PagedAttention mode - auto: enabled on CUDA, disabled on Metal/CPU (default) - on: force enable (fails if unsupported) - off: force disable. Possible values: `auto`, `on`, `off`. |
+| `--paged-attn <MODE>` | `auto` | PagedAttention mode - auto: enabled on CUDA, disabled on Metal/CPU (default) - on: force enable; error if the device, build, or model cannot honor it - off: force disable. Possible values: `auto`, `on`, `off`. |
 | `--pa-context-len <CONTEXT_LEN>` |  | Allocate KV cache for this context length. If not specified, defaults to using 90% of available VRAM |
 | `--pa-memory-mb <MEMORY_MB>` |  | GPU memory to allocate in MBs (alternative to context-len) |
 | `--pa-memory-fraction <MEMORY_FRACTION>` |  | GPU memory utilization fraction 0.0-1.0 (alternative to context-len/memory-mb) |
@@ -214,7 +214,7 @@ mistralrs bench multimodal [OPTIONS] --model-id <MODEL_ID>
 | `--hf-cache <HF_CACHE>` |  | Custom Hugging Face cache directory |
 | `--max-seq-len <MAX_SEQ_LEN>` | `4096` | Max sequence length for automatic device mapping |
 | `--max-batch-size <MAX_BATCH_SIZE>` | `1` | Max batch size for automatic device mapping |
-| `--paged-attn <MODE>` | `auto` | PagedAttention mode - auto: enabled on CUDA, disabled on Metal/CPU (default) - on: force enable (fails if unsupported) - off: force disable. Possible values: `auto`, `on`, `off`. |
+| `--paged-attn <MODE>` | `auto` | PagedAttention mode - auto: enabled on CUDA, disabled on Metal/CPU (default) - on: force enable; error if the device, build, or model cannot honor it - off: force disable. Possible values: `auto`, `on`, `off`. |
 | `--pa-context-len <CONTEXT_LEN>` |  | Allocate KV cache for this context length. If not specified, defaults to using 90% of available VRAM |
 | `--pa-memory-mb <MEMORY_MB>` |  | GPU memory to allocate in MBs (alternative to context-len) |
 | `--pa-memory-fraction <MEMORY_FRACTION>` |  | GPU memory utilization fraction 0.0-1.0 (alternative to context-len/memory-mb) |
@@ -304,7 +304,7 @@ mistralrs bench embedding [OPTIONS] --model-id <MODEL_ID>
 | `--hf-cache <HF_CACHE>` |  | Custom Hugging Face cache directory |
 | `--max-seq-len <MAX_SEQ_LEN>` | `4096` | Max sequence length for automatic device mapping |
 | `--max-batch-size <MAX_BATCH_SIZE>` | `1` | Max batch size for automatic device mapping |
-| `--paged-attn <MODE>` | `auto` | PagedAttention mode - auto: enabled on CUDA, disabled on Metal/CPU (default) - on: force enable (fails if unsupported) - off: force disable. Possible values: `auto`, `on`, `off`. |
+| `--paged-attn <MODE>` | `auto` | PagedAttention mode - auto: enabled on CUDA, disabled on Metal/CPU (default) - on: force enable; error if the device, build, or model cannot honor it - off: force disable. Possible values: `auto`, `on`, `off`. |
 | `--pa-context-len <CONTEXT_LEN>` |  | Allocate KV cache for this context length. If not specified, defaults to using 90% of available VRAM |
 | `--pa-memory-mb <MEMORY_MB>` |  | GPU memory to allocate in MBs (alternative to context-len) |
 | `--pa-memory-fraction <MEMORY_FRACTION>` |  | GPU memory utilization fraction 0.0-1.0 (alternative to context-len/memory-mb) |

--- a/docs/src/content/docs/reference/cli/run.md
+++ b/docs/src/content/docs/reference/cli/run.md
@@ -48,7 +48,7 @@ mistralrs run [OPTIONS] [COMMAND]
 | `--hf-cache <HF_CACHE>` |  | Custom Hugging Face cache directory |
 | `--max-seq-len <MAX_SEQ_LEN>` | `4096` | Max sequence length for automatic device mapping |
 | `--max-batch-size <MAX_BATCH_SIZE>` | `1` | Max batch size for automatic device mapping |
-| `--paged-attn <MODE>` | `auto` | PagedAttention mode - auto: enabled on CUDA, disabled on Metal/CPU (default) - on: force enable (fails if unsupported) - off: force disable. Possible values: `auto`, `on`, `off`. |
+| `--paged-attn <MODE>` | `auto` | PagedAttention mode - auto: enabled on CUDA, disabled on Metal/CPU (default) - on: force enable; error if the device, build, or model cannot honor it - off: force disable. Possible values: `auto`, `on`, `off`. |
 | `--pa-context-len <CONTEXT_LEN>` |  | Allocate KV cache for this context length. If not specified, defaults to using 90% of available VRAM |
 | `--pa-memory-mb <MEMORY_MB>` |  | GPU memory to allocate in MBs (alternative to context-len) |
 | `--pa-memory-fraction <MEMORY_FRACTION>` |  | GPU memory utilization fraction 0.0-1.0 (alternative to context-len/memory-mb) |
@@ -143,7 +143,7 @@ mistralrs run auto [OPTIONS] --model-id <MODEL_ID>
 | `--hf-cache <HF_CACHE>` |  | Custom Hugging Face cache directory |
 | `--max-seq-len <MAX_SEQ_LEN>` | `4096` | Max sequence length for automatic device mapping |
 | `--max-batch-size <MAX_BATCH_SIZE>` | `1` | Max batch size for automatic device mapping |
-| `--paged-attn <MODE>` | `auto` | PagedAttention mode - auto: enabled on CUDA, disabled on Metal/CPU (default) - on: force enable (fails if unsupported) - off: force disable. Possible values: `auto`, `on`, `off`. |
+| `--paged-attn <MODE>` | `auto` | PagedAttention mode - auto: enabled on CUDA, disabled on Metal/CPU (default) - on: force enable; error if the device, build, or model cannot honor it - off: force disable. Possible values: `auto`, `on`, `off`. |
 | `--pa-context-len <CONTEXT_LEN>` |  | Allocate KV cache for this context length. If not specified, defaults to using 90% of available VRAM |
 | `--pa-memory-mb <MEMORY_MB>` |  | GPU memory to allocate in MBs (alternative to context-len) |
 | `--pa-memory-fraction <MEMORY_FRACTION>` |  | GPU memory utilization fraction 0.0-1.0 (alternative to context-len/memory-mb) |
@@ -197,7 +197,7 @@ mistralrs run text [OPTIONS] --model-id <MODEL_ID>
 | `--hf-cache <HF_CACHE>` |  | Custom Hugging Face cache directory |
 | `--max-seq-len <MAX_SEQ_LEN>` | `4096` | Max sequence length for automatic device mapping |
 | `--max-batch-size <MAX_BATCH_SIZE>` | `1` | Max batch size for automatic device mapping |
-| `--paged-attn <MODE>` | `auto` | PagedAttention mode - auto: enabled on CUDA, disabled on Metal/CPU (default) - on: force enable (fails if unsupported) - off: force disable. Possible values: `auto`, `on`, `off`. |
+| `--paged-attn <MODE>` | `auto` | PagedAttention mode - auto: enabled on CUDA, disabled on Metal/CPU (default) - on: force enable; error if the device, build, or model cannot honor it - off: force disable. Possible values: `auto`, `on`, `off`. |
 | `--pa-context-len <CONTEXT_LEN>` |  | Allocate KV cache for this context length. If not specified, defaults to using 90% of available VRAM |
 | `--pa-memory-mb <MEMORY_MB>` |  | GPU memory to allocate in MBs (alternative to context-len) |
 | `--pa-memory-fraction <MEMORY_FRACTION>` |  | GPU memory utilization fraction 0.0-1.0 (alternative to context-len/memory-mb) |
@@ -242,7 +242,7 @@ mistralrs run multimodal [OPTIONS] --model-id <MODEL_ID>
 | `--hf-cache <HF_CACHE>` |  | Custom Hugging Face cache directory |
 | `--max-seq-len <MAX_SEQ_LEN>` | `4096` | Max sequence length for automatic device mapping |
 | `--max-batch-size <MAX_BATCH_SIZE>` | `1` | Max batch size for automatic device mapping |
-| `--paged-attn <MODE>` | `auto` | PagedAttention mode - auto: enabled on CUDA, disabled on Metal/CPU (default) - on: force enable (fails if unsupported) - off: force disable. Possible values: `auto`, `on`, `off`. |
+| `--paged-attn <MODE>` | `auto` | PagedAttention mode - auto: enabled on CUDA, disabled on Metal/CPU (default) - on: force enable; error if the device, build, or model cannot honor it - off: force disable. Possible values: `auto`, `on`, `off`. |
 | `--pa-context-len <CONTEXT_LEN>` |  | Allocate KV cache for this context length. If not specified, defaults to using 90% of available VRAM |
 | `--pa-memory-mb <MEMORY_MB>` |  | GPU memory to allocate in MBs (alternative to context-len) |
 | `--pa-memory-fraction <MEMORY_FRACTION>` |  | GPU memory utilization fraction 0.0-1.0 (alternative to context-len/memory-mb) |
@@ -332,7 +332,7 @@ mistralrs run embedding [OPTIONS] --model-id <MODEL_ID>
 | `--hf-cache <HF_CACHE>` |  | Custom Hugging Face cache directory |
 | `--max-seq-len <MAX_SEQ_LEN>` | `4096` | Max sequence length for automatic device mapping |
 | `--max-batch-size <MAX_BATCH_SIZE>` | `1` | Max batch size for automatic device mapping |
-| `--paged-attn <MODE>` | `auto` | PagedAttention mode - auto: enabled on CUDA, disabled on Metal/CPU (default) - on: force enable (fails if unsupported) - off: force disable. Possible values: `auto`, `on`, `off`. |
+| `--paged-attn <MODE>` | `auto` | PagedAttention mode - auto: enabled on CUDA, disabled on Metal/CPU (default) - on: force enable; error if the device, build, or model cannot honor it - off: force disable. Possible values: `auto`, `on`, `off`. |
 | `--pa-context-len <CONTEXT_LEN>` |  | Allocate KV cache for this context length. If not specified, defaults to using 90% of available VRAM |
 | `--pa-memory-mb <MEMORY_MB>` |  | GPU memory to allocate in MBs (alternative to context-len) |
 | `--pa-memory-fraction <MEMORY_FRACTION>` |  | GPU memory utilization fraction 0.0-1.0 (alternative to context-len/memory-mb) |

--- a/docs/src/content/docs/reference/cli/serve.md
+++ b/docs/src/content/docs/reference/cli/serve.md
@@ -48,7 +48,7 @@ mistralrs serve [OPTIONS] [COMMAND]
 | `--hf-cache <HF_CACHE>` |  | Custom Hugging Face cache directory |
 | `--max-seq-len <MAX_SEQ_LEN>` | `4096` | Max sequence length for automatic device mapping |
 | `--max-batch-size <MAX_BATCH_SIZE>` | `1` | Max batch size for automatic device mapping |
-| `--paged-attn <MODE>` | `auto` | PagedAttention mode - auto: enabled on CUDA, disabled on Metal/CPU (default) - on: force enable (fails if unsupported) - off: force disable. Possible values: `auto`, `on`, `off`. |
+| `--paged-attn <MODE>` | `auto` | PagedAttention mode - auto: enabled on CUDA, disabled on Metal/CPU (default) - on: force enable; error if the device, build, or model cannot honor it - off: force disable. Possible values: `auto`, `on`, `off`. |
 | `--pa-context-len <CONTEXT_LEN>` |  | Allocate KV cache for this context length. If not specified, defaults to using 90% of available VRAM |
 | `--pa-memory-mb <MEMORY_MB>` |  | GPU memory to allocate in MBs (alternative to context-len) |
 | `--pa-memory-fraction <MEMORY_FRACTION>` |  | GPU memory utilization fraction 0.0-1.0 (alternative to context-len/memory-mb) |
@@ -147,7 +147,7 @@ mistralrs serve auto [OPTIONS] --model-id <MODEL_ID>
 | `--hf-cache <HF_CACHE>` |  | Custom Hugging Face cache directory |
 | `--max-seq-len <MAX_SEQ_LEN>` | `4096` | Max sequence length for automatic device mapping |
 | `--max-batch-size <MAX_BATCH_SIZE>` | `1` | Max batch size for automatic device mapping |
-| `--paged-attn <MODE>` | `auto` | PagedAttention mode - auto: enabled on CUDA, disabled on Metal/CPU (default) - on: force enable (fails if unsupported) - off: force disable. Possible values: `auto`, `on`, `off`. |
+| `--paged-attn <MODE>` | `auto` | PagedAttention mode - auto: enabled on CUDA, disabled on Metal/CPU (default) - on: force enable; error if the device, build, or model cannot honor it - off: force disable. Possible values: `auto`, `on`, `off`. |
 | `--pa-context-len <CONTEXT_LEN>` |  | Allocate KV cache for this context length. If not specified, defaults to using 90% of available VRAM |
 | `--pa-memory-mb <MEMORY_MB>` |  | GPU memory to allocate in MBs (alternative to context-len) |
 | `--pa-memory-fraction <MEMORY_FRACTION>` |  | GPU memory utilization fraction 0.0-1.0 (alternative to context-len/memory-mb) |
@@ -201,7 +201,7 @@ mistralrs serve text [OPTIONS] --model-id <MODEL_ID>
 | `--hf-cache <HF_CACHE>` |  | Custom Hugging Face cache directory |
 | `--max-seq-len <MAX_SEQ_LEN>` | `4096` | Max sequence length for automatic device mapping |
 | `--max-batch-size <MAX_BATCH_SIZE>` | `1` | Max batch size for automatic device mapping |
-| `--paged-attn <MODE>` | `auto` | PagedAttention mode - auto: enabled on CUDA, disabled on Metal/CPU (default) - on: force enable (fails if unsupported) - off: force disable. Possible values: `auto`, `on`, `off`. |
+| `--paged-attn <MODE>` | `auto` | PagedAttention mode - auto: enabled on CUDA, disabled on Metal/CPU (default) - on: force enable; error if the device, build, or model cannot honor it - off: force disable. Possible values: `auto`, `on`, `off`. |
 | `--pa-context-len <CONTEXT_LEN>` |  | Allocate KV cache for this context length. If not specified, defaults to using 90% of available VRAM |
 | `--pa-memory-mb <MEMORY_MB>` |  | GPU memory to allocate in MBs (alternative to context-len) |
 | `--pa-memory-fraction <MEMORY_FRACTION>` |  | GPU memory utilization fraction 0.0-1.0 (alternative to context-len/memory-mb) |
@@ -246,7 +246,7 @@ mistralrs serve multimodal [OPTIONS] --model-id <MODEL_ID>
 | `--hf-cache <HF_CACHE>` |  | Custom Hugging Face cache directory |
 | `--max-seq-len <MAX_SEQ_LEN>` | `4096` | Max sequence length for automatic device mapping |
 | `--max-batch-size <MAX_BATCH_SIZE>` | `1` | Max batch size for automatic device mapping |
-| `--paged-attn <MODE>` | `auto` | PagedAttention mode - auto: enabled on CUDA, disabled on Metal/CPU (default) - on: force enable (fails if unsupported) - off: force disable. Possible values: `auto`, `on`, `off`. |
+| `--paged-attn <MODE>` | `auto` | PagedAttention mode - auto: enabled on CUDA, disabled on Metal/CPU (default) - on: force enable; error if the device, build, or model cannot honor it - off: force disable. Possible values: `auto`, `on`, `off`. |
 | `--pa-context-len <CONTEXT_LEN>` |  | Allocate KV cache for this context length. If not specified, defaults to using 90% of available VRAM |
 | `--pa-memory-mb <MEMORY_MB>` |  | GPU memory to allocate in MBs (alternative to context-len) |
 | `--pa-memory-fraction <MEMORY_FRACTION>` |  | GPU memory utilization fraction 0.0-1.0 (alternative to context-len/memory-mb) |
@@ -336,7 +336,7 @@ mistralrs serve embedding [OPTIONS] --model-id <MODEL_ID>
 | `--hf-cache <HF_CACHE>` |  | Custom Hugging Face cache directory |
 | `--max-seq-len <MAX_SEQ_LEN>` | `4096` | Max sequence length for automatic device mapping |
 | `--max-batch-size <MAX_BATCH_SIZE>` | `1` | Max batch size for automatic device mapping |
-| `--paged-attn <MODE>` | `auto` | PagedAttention mode - auto: enabled on CUDA, disabled on Metal/CPU (default) - on: force enable (fails if unsupported) - off: force disable. Possible values: `auto`, `on`, `off`. |
+| `--paged-attn <MODE>` | `auto` | PagedAttention mode - auto: enabled on CUDA, disabled on Metal/CPU (default) - on: force enable; error if the device, build, or model cannot honor it - off: force disable. Possible values: `auto`, `on`, `off`. |
 | `--pa-context-len <CONTEXT_LEN>` |  | Allocate KV cache for this context length. If not specified, defaults to using 90% of available VRAM |
 | `--pa-memory-mb <MEMORY_MB>` |  | GPU memory to allocate in MBs (alternative to context-len) |
 | `--pa-memory-fraction <MEMORY_FRACTION>` |  | GPU memory utilization fraction 0.0-1.0 (alternative to context-len/memory-mb) |

--- a/docs/src/content/docs/reference/cli/tune.md
+++ b/docs/src/content/docs/reference/cli/tune.md
@@ -48,7 +48,7 @@ mistralrs tune [OPTIONS] [COMMAND]
 | `--hf-cache <HF_CACHE>` |  | Custom Hugging Face cache directory |
 | `--max-seq-len <MAX_SEQ_LEN>` | `4096` | Max sequence length for automatic device mapping |
 | `--max-batch-size <MAX_BATCH_SIZE>` | `1` | Max batch size for automatic device mapping |
-| `--paged-attn <MODE>` | `auto` | PagedAttention mode - auto: enabled on CUDA, disabled on Metal/CPU (default) - on: force enable (fails if unsupported) - off: force disable. Possible values: `auto`, `on`, `off`. |
+| `--paged-attn <MODE>` | `auto` | PagedAttention mode - auto: enabled on CUDA, disabled on Metal/CPU (default) - on: force enable; error if the device, build, or model cannot honor it - off: force disable. Possible values: `auto`, `on`, `off`. |
 | `--pa-context-len <CONTEXT_LEN>` |  | Allocate KV cache for this context length. If not specified, defaults to using 90% of available VRAM |
 | `--pa-memory-mb <MEMORY_MB>` |  | GPU memory to allocate in MBs (alternative to context-len) |
 | `--pa-memory-fraction <MEMORY_FRACTION>` |  | GPU memory utilization fraction 0.0-1.0 (alternative to context-len/memory-mb) |
@@ -105,7 +105,7 @@ mistralrs tune auto [OPTIONS] --model-id <MODEL_ID>
 | `--hf-cache <HF_CACHE>` |  | Custom Hugging Face cache directory |
 | `--max-seq-len <MAX_SEQ_LEN>` | `4096` | Max sequence length for automatic device mapping |
 | `--max-batch-size <MAX_BATCH_SIZE>` | `1` | Max batch size for automatic device mapping |
-| `--paged-attn <MODE>` | `auto` | PagedAttention mode - auto: enabled on CUDA, disabled on Metal/CPU (default) - on: force enable (fails if unsupported) - off: force disable. Possible values: `auto`, `on`, `off`. |
+| `--paged-attn <MODE>` | `auto` | PagedAttention mode - auto: enabled on CUDA, disabled on Metal/CPU (default) - on: force enable; error if the device, build, or model cannot honor it - off: force disable. Possible values: `auto`, `on`, `off`. |
 | `--pa-context-len <CONTEXT_LEN>` |  | Allocate KV cache for this context length. If not specified, defaults to using 90% of available VRAM |
 | `--pa-memory-mb <MEMORY_MB>` |  | GPU memory to allocate in MBs (alternative to context-len) |
 | `--pa-memory-fraction <MEMORY_FRACTION>` |  | GPU memory utilization fraction 0.0-1.0 (alternative to context-len/memory-mb) |
@@ -159,7 +159,7 @@ mistralrs tune text [OPTIONS] --model-id <MODEL_ID>
 | `--hf-cache <HF_CACHE>` |  | Custom Hugging Face cache directory |
 | `--max-seq-len <MAX_SEQ_LEN>` | `4096` | Max sequence length for automatic device mapping |
 | `--max-batch-size <MAX_BATCH_SIZE>` | `1` | Max batch size for automatic device mapping |
-| `--paged-attn <MODE>` | `auto` | PagedAttention mode - auto: enabled on CUDA, disabled on Metal/CPU (default) - on: force enable (fails if unsupported) - off: force disable. Possible values: `auto`, `on`, `off`. |
+| `--paged-attn <MODE>` | `auto` | PagedAttention mode - auto: enabled on CUDA, disabled on Metal/CPU (default) - on: force enable; error if the device, build, or model cannot honor it - off: force disable. Possible values: `auto`, `on`, `off`. |
 | `--pa-context-len <CONTEXT_LEN>` |  | Allocate KV cache for this context length. If not specified, defaults to using 90% of available VRAM |
 | `--pa-memory-mb <MEMORY_MB>` |  | GPU memory to allocate in MBs (alternative to context-len) |
 | `--pa-memory-fraction <MEMORY_FRACTION>` |  | GPU memory utilization fraction 0.0-1.0 (alternative to context-len/memory-mb) |
@@ -204,7 +204,7 @@ mistralrs tune multimodal [OPTIONS] --model-id <MODEL_ID>
 | `--hf-cache <HF_CACHE>` |  | Custom Hugging Face cache directory |
 | `--max-seq-len <MAX_SEQ_LEN>` | `4096` | Max sequence length for automatic device mapping |
 | `--max-batch-size <MAX_BATCH_SIZE>` | `1` | Max batch size for automatic device mapping |
-| `--paged-attn <MODE>` | `auto` | PagedAttention mode - auto: enabled on CUDA, disabled on Metal/CPU (default) - on: force enable (fails if unsupported) - off: force disable. Possible values: `auto`, `on`, `off`. |
+| `--paged-attn <MODE>` | `auto` | PagedAttention mode - auto: enabled on CUDA, disabled on Metal/CPU (default) - on: force enable; error if the device, build, or model cannot honor it - off: force disable. Possible values: `auto`, `on`, `off`. |
 | `--pa-context-len <CONTEXT_LEN>` |  | Allocate KV cache for this context length. If not specified, defaults to using 90% of available VRAM |
 | `--pa-memory-mb <MEMORY_MB>` |  | GPU memory to allocate in MBs (alternative to context-len) |
 | `--pa-memory-fraction <MEMORY_FRACTION>` |  | GPU memory utilization fraction 0.0-1.0 (alternative to context-len/memory-mb) |
@@ -294,7 +294,7 @@ mistralrs tune embedding [OPTIONS] --model-id <MODEL_ID>
 | `--hf-cache <HF_CACHE>` |  | Custom Hugging Face cache directory |
 | `--max-seq-len <MAX_SEQ_LEN>` | `4096` | Max sequence length for automatic device mapping |
 | `--max-batch-size <MAX_BATCH_SIZE>` | `1` | Max batch size for automatic device mapping |
-| `--paged-attn <MODE>` | `auto` | PagedAttention mode - auto: enabled on CUDA, disabled on Metal/CPU (default) - on: force enable (fails if unsupported) - off: force disable. Possible values: `auto`, `on`, `off`. |
+| `--paged-attn <MODE>` | `auto` | PagedAttention mode - auto: enabled on CUDA, disabled on Metal/CPU (default) - on: force enable; error if the device, build, or model cannot honor it - off: force disable. Possible values: `auto`, `on`, `off`. |
 | `--pa-context-len <CONTEXT_LEN>` |  | Allocate KV cache for this context length. If not specified, defaults to using 90% of available VRAM |
 | `--pa-memory-mb <MEMORY_MB>` |  | GPU memory to allocate in MBs (alternative to context-len) |
 | `--pa-memory-fraction <MEMORY_FRACTION>` |  | GPU memory utilization fraction 0.0-1.0 (alternative to context-len/memory-mb) |

--- a/mistralrs-cli/src/args/paged_attn.rs
+++ b/mistralrs-cli/src/args/paged_attn.rs
@@ -18,7 +18,7 @@ pub struct CacheOptions {
 pub struct PagedAttentionOptions {
     /// PagedAttention mode
     /// - auto: enabled on CUDA, disabled on Metal/CPU (default)
-    /// - on: force enable (fails if unsupported)
+    /// - on: force enable; error if the device, build, or model cannot honor it
     /// - off: force disable
     #[arg(long = "paged-attn", default_value = "auto", value_enum)]
     #[serde(default)]
@@ -67,7 +67,7 @@ pub enum PagedAttnMode {
     /// Automatic: enabled on CUDA, disabled on Metal/CPU
     #[default]
     Auto,
-    /// Force enable (error if device doesn't support it)
+    /// Force enable; error if the device, build, or model cannot honor it
     On,
     /// Force disable
     Off,
@@ -106,3 +106,23 @@ pub type PagedAttnBuilderFlags = (
     Option<usize>,  // block_size
     PagedCacheType, // cache_type
 );
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn flags_for(mode: PagedAttnMode) -> PagedAttnBuilderFlags {
+        PagedAttentionOptions {
+            mode,
+            ..Default::default()
+        }
+        .into_builder_flags()
+    }
+
+    #[test]
+    fn into_builder_flags_preserves_auto_on_off_intent() {
+        assert_eq!(flags_for(PagedAttnMode::Auto).0, None);
+        assert_eq!(flags_for(PagedAttnMode::On).0, Some(true));
+        assert_eq!(flags_for(PagedAttnMode::Off).0, Some(false));
+    }
+}

--- a/mistralrs-core/src/lib.rs
+++ b/mistralrs-core/src/lib.rs
@@ -159,7 +159,10 @@ pub use mistralrs_mcp::{
 };
 pub use mistralrs_quant::{IsqBits, IsqType};
 pub use mistralrs_sandbox::{NetworkMode, SandboxPolicy};
-pub use paged_attention::{MemoryGpuConfig, PagedAttentionConfig, PagedCacheType};
+pub use paged_attention::{
+    disable_paged_attention, required_paged_attention_error, MemoryGpuConfig, PagedAttentionConfig,
+    PagedCacheType,
+};
 pub use pipeline::hf::{
     get_model_file, hf_home_dir, hf_hub_cache_dir, hf_token_path, is_hf_hub_offline,
     list_model_files, probe_hf_repo_files, read_model_file_range, try_get_model_file,
@@ -199,8 +202,9 @@ pub use sampler::{
     TopLogprob,
 };
 pub use scheduler::{
-    DefaultSchedulerMethod, SchedulerConfig, DEFAULT_MAX_DECODE_STEPS_BEFORE_PREFILL,
-    DEFAULT_MAX_NUM_BATCHED_TOKENS, DEFAULT_MAX_PREFILL_CHUNK_TOKENS,
+    scheduler_config_for_paged_attention, DefaultSchedulerMethod, SchedulerConfig,
+    DEFAULT_MAX_DECODE_STEPS_BEFORE_PREFILL, DEFAULT_MAX_NUM_BATCHED_TOKENS,
+    DEFAULT_MAX_PREFILL_CHUNK_TOKENS,
 };
 pub use search::{SearchCallback, SearchFunctionParameters, SearchResult};
 use serde::Serialize;

--- a/mistralrs-core/src/paged_attention/mod.rs
+++ b/mistralrs-core/src/paged_attention/mod.rs
@@ -40,7 +40,7 @@ pub use scheduler::{
 };
 
 use crate::MemoryUsage;
-use tracing::info;
+use tracing::{info, warn};
 
 pub const DEFAULT_PAGED_ATTENTION_BLOCK_SIZE: usize = 32;
 const GPU_RESERVE_FRACTION: f64 = 0.02;
@@ -188,6 +188,60 @@ mod tests {
         );
         Ok(())
     }
+
+    fn sample_config() -> anyhow::Result<super::PagedAttentionConfig> {
+        super::PagedAttentionConfig::new(
+            Some(32),
+            MemoryGpuConfig::Utilization(0.9),
+            PagedCacheType::Auto,
+        )
+    }
+
+    #[test]
+    fn new_paged_attention_config_is_not_required() -> anyhow::Result<()> {
+        assert!(!sample_config()?.required);
+        assert!(!sample_config()?.is_required());
+        Ok(())
+    }
+
+    #[test]
+    fn with_required_marks_explicit_paged_attention_intent() -> anyhow::Result<()> {
+        let config = sample_config()?.with_required();
+        assert!(config.required);
+        assert!(config.is_required());
+        Ok(())
+    }
+
+    #[test]
+    fn disable_paged_attention_is_noop_when_already_disabled() -> anyhow::Result<()> {
+        let mut config = None;
+        super::disable_paged_attention(&mut config, "this model does not support PagedAttention")?;
+        assert!(config.is_none());
+        Ok(())
+    }
+
+    #[test]
+    fn disable_paged_attention_clears_optional_config() -> anyhow::Result<()> {
+        let mut config = Some(sample_config()?);
+        super::disable_paged_attention(&mut config, "this model does not support PagedAttention")?;
+        assert!(config.is_none());
+        Ok(())
+    }
+
+    #[test]
+    fn disable_paged_attention_errors_when_required() -> anyhow::Result<()> {
+        let mut config = Some(sample_config()?.with_required());
+        let error = super::disable_paged_attention(
+            &mut config,
+            "this model does not support PagedAttention",
+        )
+        .expect_err("required PagedAttention must fail closed");
+        let message = error.to_string();
+        assert!(message.contains("--paged-attn on"));
+        assert!(message.contains("this model does not support PagedAttention"));
+        assert!(config.is_some());
+        Ok(())
+    }
 }
 
 /// All memory counts in MB. Default for block size is 32.
@@ -203,6 +257,7 @@ pub struct PagedAttentionConfig {
     pub(crate) recurrent_checkpoint_lanes: usize,
     pub(crate) recurrent_prefix_capacity: usize,
     pub(crate) resolve_memory_utilization_after_load: bool,
+    pub(crate) required: bool,
 }
 
 #[derive(Clone, Copy, Debug, Default)]
@@ -228,7 +283,17 @@ impl PagedAttentionConfig {
             recurrent_checkpoint_lanes: 1,
             recurrent_prefix_capacity: 0,
             resolve_memory_utilization_after_load: true,
+            required: false,
         })
+    }
+
+    pub fn with_required(mut self) -> Self {
+        self.required = true;
+        self
+    }
+
+    pub fn is_required(&self) -> bool {
+        self.required
     }
 
     pub fn with_serving_capacity(mut self, serving_capacity: usize) -> anyhow::Result<Self> {
@@ -283,6 +348,25 @@ impl PagedAttentionConfig {
             primary_device_bytes,
             secondary_device_bytes: self.mapped_activation_memory_reservation_bytes,
         })
+    }
+}
+
+pub fn required_paged_attention_error(reason: impl std::fmt::Display) -> anyhow::Error {
+    anyhow::anyhow!("PagedAttention was explicitly requested (--paged-attn on), but {reason}")
+}
+
+pub fn disable_paged_attention(
+    config: &mut Option<PagedAttentionConfig>,
+    reason: impl std::fmt::Display,
+) -> anyhow::Result<()> {
+    match config {
+        None => Ok(()),
+        Some(cfg) if cfg.required => Err(required_paged_attention_error(reason)),
+        Some(_) => {
+            warn!("PagedAttention disabled: {reason}");
+            *config = None;
+            Ok(())
+        }
     }
 }
 
@@ -371,6 +455,8 @@ fn fit_post_load_cache_budget(
 /// Unlike CUDA with dedicated VRAM where unused memory is wasted, Metal's wired buffers
 /// compete with the OS and CPU for the same physical RAM. On CUDA this is ignored.
 /// If `None` on Metal, falls back to `config.max_seq_len()`.
+///
+/// `required`: true when PagedAttention was explicitly requested (`--paged-attn on`).
 #[allow(clippy::too_many_arguments)]
 pub fn calculate_cache_config(
     mem_gpu: MemoryGpuConfig,
@@ -384,6 +470,7 @@ pub fn calculate_cache_config(
     silent: bool,
     model_weight_size_in_bytes: Option<usize>,
     max_num_tokens: Option<usize>,
+    required: bool,
 ) -> anyhow::Result<CacheConfig> {
     let block_size = block_size.unwrap_or(DEFAULT_PAGED_ATTENTION_BLOCK_SIZE);
     if !SUPPORTED_BLOCK_SIZE.contains(&block_size) {
@@ -542,7 +629,8 @@ pub fn calculate_cache_config(
         let available_context_tokens = num_gpu_blocks.saturating_sub(1) * block_size;
         info!("Allocating {mem_gpu} MB for PagedAttention KV cache per GPU");
         info!("PagedAttention KV cache type is {dtype:?}");
-        info!("Using PagedAttention with block size {block_size} and {num_gpu_blocks} GPU blocks: available context length is {available_context_tokens} tokens");
+        let mode = if required { "on" } else { "auto" };
+        info!("Using PagedAttention with block size {block_size} and {num_gpu_blocks} GPU blocks: available context length is {available_context_tokens} tokens (mode={mode})");
     }
     Ok(CacheConfig {
         block_size,

--- a/mistralrs-core/src/pipeline/amoe.rs
+++ b/mistralrs-core/src/pipeline/amoe.rs
@@ -15,8 +15,9 @@ use indexmap::IndexMap;
 use mistralrs_quant::IsqType;
 use rand::{rng, seq::SliceRandom};
 use rand_isaac::Isaac64Rng;
-use tracing::{info, warn};
+use tracing::info;
 
+use crate::paged_attention::disable_paged_attention;
 use crate::{
     amoe::{AnyMoeConfig, AnyMoeTrainingInputRow, AnyMoeTrainingInputs, AnyMoeTrainingResult},
     device_map::DeviceMapper,
@@ -63,12 +64,11 @@ impl Loader for AnyMoeLoader {
         paged_attn_config: Option<PagedAttentionConfig>,
     ) -> anyhow::Result<Arc<tokio::sync::Mutex<dyn Pipeline + Send + Sync>>> {
         let _progress_guard = ProgressScopeGuard::new(silent);
-        let paged_attn_config = if paged_attn_config.is_some() {
-            warn!("AnyMoE does not currently support PagedAttention, running without");
-            None
-        } else {
-            paged_attn_config
-        };
+        let mut paged_attn_config = paged_attn_config;
+        disable_paged_attention(
+            &mut paged_attn_config,
+            "AnyMoE models do not support PagedAttention",
+        )?;
 
         let target = self.target.load_model_from_hf(
             revision.clone(),
@@ -106,12 +106,11 @@ impl Loader for AnyMoeLoader {
         paged_attn_config: Option<PagedAttentionConfig>,
     ) -> anyhow::Result<Arc<tokio::sync::Mutex<dyn Pipeline + Send + Sync>>> {
         let _progress_guard = ProgressScopeGuard::new(silent);
-        let paged_attn_config = if paged_attn_config.is_some() {
-            warn!("AnyMoE does not currently support PagedAttention, running without");
-            None
-        } else {
-            paged_attn_config
-        };
+        let mut paged_attn_config = paged_attn_config;
+        disable_paged_attention(
+            &mut paged_attn_config,
+            "AnyMoE models do not support PagedAttention",
+        )?;
 
         let target = self.target.load_model_from_path(
             paths,

--- a/mistralrs-core/src/pipeline/diffusion.rs
+++ b/mistralrs-core/src/pipeline/diffusion.rs
@@ -8,7 +8,7 @@ use super::{
 use crate::device_map::{self, DeviceMapper};
 use crate::diffusion_models::processor::{DiffusionProcessor, ModelInputs};
 use crate::distributed::{self, use_ring, WorkerTransferData};
-use crate::paged_attention::AttentionImplementation;
+use crate::paged_attention::{disable_paged_attention, AttentionImplementation};
 use crate::pipeline::{ChatTemplate, Modalities, SupportedModality};
 use crate::prefix_cacher::PrefixCacheManagerV2;
 use crate::sequence::Sequence;
@@ -31,7 +31,6 @@ use std::sync::Arc;
 use std::{env, io};
 use tokenizers::Tokenizer;
 use tokio::sync::Mutex;
-use tracing::warn;
 
 pub struct DiffusionPipeline {
     model: Box<dyn DiffusionModel + Send + Sync>,
@@ -145,11 +144,10 @@ impl Loader for DiffusionLoader {
             anyhow::bail!("ISQ is not supported for Diffusion models.");
         }
 
-        if paged_attn_config.is_some() {
-            warn!("PagedAttention is not supported for Diffusion models, disabling it.");
-
-            paged_attn_config = None;
-        }
+        disable_paged_attention(
+            &mut paged_attn_config,
+            "diffusion models do not support PagedAttention",
+        )?;
 
         if crate::using_flash_attn() {
             once_log_info("FlashAttention is enabled.");

--- a/mistralrs-core/src/pipeline/embedding.rs
+++ b/mistralrs-core/src/pipeline/embedding.rs
@@ -15,6 +15,7 @@ use crate::embedding_models::{Dense, DenseActivation, Normalize, Pooling};
 use crate::embedding_normal_model_loader;
 use crate::embedding_normal_model_loader_sharded;
 use crate::get_embedding_paths;
+use crate::paged_attention::disable_paged_attention;
 use crate::paged_attention::AttentionImplementation;
 use crate::pipeline::loaders::auto_device_map;
 use crate::pipeline::loaders::{AutoDeviceMapQuantization, QuantizationConfigShim};
@@ -55,7 +56,7 @@ use std::str::FromStr;
 use std::sync::{Arc, RwLock};
 use tokenizers::Tokenizer;
 use tokio::sync::Mutex;
-use tracing::{debug, info, trace, warn};
+use tracing::{debug, info, trace};
 
 pub struct EmbeddingPipeline {
     model: Box<dyn EmbeddingModel + Send + Sync>,
@@ -238,10 +239,10 @@ impl Loader for EmbeddingLoader {
             config
         };
 
-        if paged_attn_config.is_some() {
-            warn!("PagedAttention is not supported for embedding models, disabling it.");
-            paged_attn_config = None;
-        }
+        disable_paged_attention(
+            &mut paged_attn_config,
+            "embedding models do not support PagedAttention",
+        )?;
 
         debug!("Prompt chunk size is {ATTENTION_CHUNK_SIZE}.");
 

--- a/mistralrs-core/src/pipeline/ggml.rs
+++ b/mistralrs-core/src/pipeline/ggml.rs
@@ -11,6 +11,7 @@ use crate::attention::ATTENTION_CHUNK_SIZE;
 use crate::device_map::DeviceMapper;
 use crate::kv_cache::FullCacheManager;
 use crate::lora::Ordering;
+use crate::paged_attention::disable_paged_attention;
 use crate::pipeline::chat_template::{calculate_eos_tokens, GenerationConfig};
 use crate::pipeline::sampling::sample_and_add_toks;
 use crate::pipeline::{get_chat_template, Modalities, SupportedModality};
@@ -40,7 +41,7 @@ use std::str::FromStr;
 use std::sync::Arc;
 use tokenizers::Tokenizer;
 use tokio::sync::Mutex;
-use tracing::{debug, info, trace, warn};
+use tracing::{debug, info, trace};
 
 enum Model {
     Llama(Box<QLlama>),
@@ -257,11 +258,11 @@ impl Loader for GGMLLoader {
             anyhow::bail!("Device mapping is not supported for diffusion models.")
         }
 
-        if paged_attn_config.is_some() {
-            warn!("PagedAttention is not supported for GGML models, disabling it.");
-
-            paged_attn_config = None;
-        }
+        disable_paged_attention(
+            &mut paged_attn_config,
+            "GGML models do not support PagedAttention",
+        )?;
+        let _ = paged_attn_config;
 
         debug!("Prompt chunk size is {ATTENTION_CHUNK_SIZE}.");
 
@@ -298,13 +299,6 @@ impl Loader for GGMLLoader {
 
             info!("Debug is enabled, wrote the names and information about each tensor to `mistralrs_ggml_tensors.txt`.");
         }
-
-        let _ = if paged_attn_config.is_none() {
-            warn!("GGML does not currently support PagedAttention, running without");
-            None
-        } else {
-            paged_attn_config
-        };
 
         let has_adapter = self.kind.is_adapted();
         let is_xlora = self.kind.is_adapted_and(|a| a.is_x_lora());

--- a/mistralrs-core/src/pipeline/gguf.rs
+++ b/mistralrs-core/src/pipeline/gguf.rs
@@ -36,6 +36,7 @@ use crate::gguf::{
 use crate::gguf::{Content, GGUFArchitecture};
 use crate::kv_cache::FullCacheManager;
 use crate::lora::Ordering;
+use crate::paged_attention::disable_paged_attention;
 use crate::pipeline::chat_template::{calculate_eos_tokens, BeginEndUnkPadTok, GenerationConfig};
 use crate::pipeline::hf::{build_api, get_file, list_repo_files};
 use crate::pipeline::loaders::{stamp_qk_rope_layout, DeviceMappedModelLoader};
@@ -1197,7 +1198,7 @@ impl Loader for GGUFLoader {
         silent: bool,
         mut mapper: DeviceMapSetting,
         in_situ_quant: Option<IsqType>,
-        paged_attn_config: Option<PagedAttentionConfig>,
+        mut paged_attn_config: Option<PagedAttentionConfig>,
     ) -> Result<Arc<Mutex<dyn Pipeline + Send + Sync>>> {
         let _progress_guard = ProgressScopeGuard::new(silent);
         if matches!(self.kind, ModelKind::GgufQuantized { .. }) || self.dynamic_lora.is_some() {
@@ -1218,9 +1219,11 @@ impl Loader for GGUFLoader {
         {
             bail!("ISQ conversion is only supported by the native GGUF loading path");
         }
-        if paged_attn_config.is_some() {
-            warn!("Adapter models do not currently support PagedAttention, running without");
-        }
+        disable_paged_attention(
+            &mut paged_attn_config,
+            "adapter models do not support PagedAttention",
+        )?;
+        let _ = paged_attn_config;
 
         let mut readers = Vec::new();
         for filename in paths.get_weight_filenames() {

--- a/mistralrs-core/src/pipeline/loaders/auto_device_map.rs
+++ b/mistralrs-core/src/pipeline/loaders/auto_device_map.rs
@@ -317,6 +317,7 @@ pub fn get_device_layers(
                 true,
                 Some(total_model_size_in_bytes),
                 Some(max_seq_len * max_batch_size),
+                cfg.required,
             )?;
             let key_shape = calculate_key_block_shape(&*model_cfg, dtype, cache.block_size);
             let key_sz =

--- a/mistralrs-core/src/pipeline/multimodal.rs
+++ b/mistralrs-core/src/pipeline/multimodal.rs
@@ -48,6 +48,7 @@ struct CudaDecodeGraphForwardInput<'a> {
     model_specific_args: &'a dyn Any,
     recurrent_batch_kind: RecurrentBatchKind,
 }
+use crate::paged_attention::disable_paged_attention;
 use crate::paged_attention::{calculate_cache_config, AttentionImplementation, CacheEngine};
 use crate::pipeline::chat_template::{
     calculate_eos_tokens, BeginEndUnkPadTok, ChatTemplateValue, GenerationConfig,
@@ -463,7 +464,10 @@ impl Loader for MultimodalLoader {
             .runtime_config(&config, self.config.max_model_len)?;
 
         if !self.inner.supports_paged_attention(&config) {
-            paged_attn_config = None;
+            disable_paged_attention(
+                &mut paged_attn_config,
+                "this model does not support PagedAttention",
+            )?;
         }
         let supports_encoder_cache = self.inner.supports_encoder_cache(&config);
         if self.encoder_cache_memory_bytes.is_some() && !supports_encoder_cache {
@@ -872,9 +876,11 @@ impl Loader for MultimodalLoader {
         // TODO: PagedAttention is not supported with CPU for now.
         // This check is not really necessary because `get_device_layers` should prevent it.
         let mapping_uses_cpu = mapper.get_unique_devices().iter().any(Device::is_cpu);
-        if mapping_uses_cpu && paged_attn_config.is_some() {
-            warn!("Device mapping contains a mix of GPU and CPU. There is no CPU support for PagedAttention, disabling PagedAttention.");
-            paged_attn_config = None;
+        if mapping_uses_cpu {
+            disable_paged_attention(
+                &mut paged_attn_config,
+                "device mapping includes CPU, and PagedAttention has no CPU KV cache",
+            )?;
         }
 
         trace!("Model config: {:?}", self.inner.get_config_repr(&config)?);
@@ -1347,6 +1353,7 @@ impl Loader for MultimodalLoader {
                 silent,
                 None,
                 max_kv_tokens,
+                paged_attn_config.required,
             )?;
             let cache_engine = CacheEngine::new(
                 model_metadata.as_ref(),

--- a/mistralrs-core/src/pipeline/normal.rs
+++ b/mistralrs-core/src/pipeline/normal.rs
@@ -30,6 +30,7 @@ type SeqRecurrentCheckpointSnapshots = Vec<(usize, RecurrentCheckpointStateSnaps
 type HybridStateIndicesSnapshot = (Option<Tensor>, Option<Vec<u32>>);
 use crate::kv_cache::{FullCacheManager, HybridCacheManager, NormalCacheManager};
 use crate::lora::Ordering;
+use crate::paged_attention::disable_paged_attention;
 use crate::paged_attention::{calculate_cache_config, AttentionImplementation, CacheEngine};
 use crate::pipeline::chat_template::{calculate_eos_tokens, BeginEndUnkPadTok, GenerationConfig};
 #[cfg(feature = "cuda")]
@@ -202,6 +203,7 @@ pub(crate) fn build_normal_pipeline(
             silent,
             None,
             max_kv_tokens,
+            paged_attn_config.required,
         )?;
         let layer_devices = (0..num_hidden_layers)
             .map(|layer| mapper.device_for(layer, false).cloned())
@@ -639,7 +641,10 @@ impl Loader for NormalLoader {
         )?;
 
         if !self.inner.supports_paged_attention(&config)? {
-            paged_attn_config = None;
+            disable_paged_attention(
+                &mut paged_attn_config,
+                "this model does not support PagedAttention",
+            )?;
         }
 
         debug!("Prompt chunk size is {ATTENTION_CHUNK_SIZE}.");
@@ -925,9 +930,11 @@ impl Loader for NormalLoader {
         // TODO: PagedAttention is not supported with CPU for now.
         // This check is not really necessary because `get_device_layers` should prevent it.
         let mapping_uses_cpu = mapper.get_unique_devices().iter().any(Device::is_cpu);
-        if mapping_uses_cpu && paged_attn_config.is_some() {
-            warn!("Device mapping contains a mix of GPU and CPU. There is no CPU support for PagedAttention, disabling PagedAttention.");
-            paged_attn_config = None;
+        if mapping_uses_cpu {
+            disable_paged_attention(
+                &mut paged_attn_config,
+                "device mapping includes CPU, and PagedAttention has no CPU KV cache",
+            )?;
         }
 
         trace!("Model config: {:?}", self.inner.get_config_repr(&config)?);
@@ -1394,19 +1401,17 @@ impl Loader for NormalLoader {
             })?;
         }
 
-        let paged_attn_config = if matches!(
+        if matches!(
             self.kind,
             ModelKind::Adapter {
                 adapter: AdapterKind::XLora
             }
         ) {
-            warn!(
-                "Adapter parallel_models do not currently support PagedAttention, running without"
-            );
-            None
-        } else {
-            paged_attn_config
-        };
+            disable_paged_attention(
+                &mut paged_attn_config,
+                "X-LoRA adapter parallel_models do not support PagedAttention",
+            )?;
+        }
 
         if plan.immediate_isq_installed {
             for module in tracker.get().clone() {

--- a/mistralrs-core/src/pipeline/speech.rs
+++ b/mistralrs-core/src/pipeline/speech.rs
@@ -7,6 +7,7 @@ use super::{
 };
 use crate::device_map::{self, DeviceMapper};
 use crate::distributed::{use_ring, WorkerTransferData};
+use crate::paged_attention::disable_paged_attention;
 use crate::pipeline::{ChatTemplate, EmbeddingModulePaths, Modalities, SupportedModality};
 use crate::prefix_cacher::PrefixCacheManagerV2;
 use crate::sequence::Sequence;
@@ -243,13 +244,19 @@ impl Loader for SpeechLoader {
         silent: bool,
         mapper: DeviceMapSetting,
         in_situ_quant: Option<IsqType>,
-        _paged_attn_config: Option<PagedAttentionConfig>,
+        mut paged_attn_config: Option<PagedAttentionConfig>,
     ) -> Result<Arc<Mutex<dyn Pipeline + Send + Sync>>> {
         let _progress_guard = ProgressScopeGuard::new(silent);
         let paths = paths
             .as_any()
             .downcast_ref::<SpeechModelPaths>()
             .expect("Path downcast failed.");
+
+        disable_paged_attention(
+            &mut paged_attn_config,
+            "speech models do not support PagedAttention",
+        )?;
+        let _ = paged_attn_config;
 
         if matches!(mapper, DeviceMapSetting::Map(_)) {
             anyhow::bail!("Device mapping is not supported for speech models.")

--- a/mistralrs-core/src/scheduler/mod.rs
+++ b/mistralrs-core/src/scheduler/mod.rs
@@ -9,8 +9,8 @@ use crate::{
     engine::IntervalLogger,
     paged_attention::{
         block_hash::{BlockHash, MultimodalKind},
-        CacheConfig, KVCacheManager, PagedAttentionScheduler, PagedAttentionSchedulerConfig,
-        PagedAttentionSchedulerOutput,
+        required_paged_attention_error, CacheConfig, KVCacheManager, PagedAttentionConfig,
+        PagedAttentionScheduler, PagedAttentionSchedulerConfig, PagedAttentionSchedulerOutput,
     },
     sequence::Sequence,
     speculative::SpeculativePrefixCheckpointPolicy,
@@ -64,6 +64,46 @@ pub enum SchedulerConfig {
         max_decode_steps_before_prefill: usize,
         config: CacheConfig,
     },
+}
+
+const PAGED_ATTENTION_SCHEDULER_FALLBACK_REASON: &str =
+    "the pipeline did not install a PagedAttention cache (scheduler would fall back to eager KV)";
+
+pub fn scheduler_config_for_paged_attention(
+    requested: &Option<PagedAttentionConfig>,
+    realized: Option<&CacheConfig>,
+    max_num_seqs: usize,
+    max_num_batched_tokens: usize,
+    max_prefill_chunk_tokens: usize,
+    max_decode_steps_before_prefill: usize,
+) -> anyhow::Result<SchedulerConfig> {
+    if let Some(config) = realized {
+        return Ok(SchedulerConfig::PagedAttentionMeta {
+            max_num_seqs,
+            max_num_batched_tokens,
+            max_prefill_chunk_tokens,
+            max_decode_steps_before_prefill,
+            config: config.clone(),
+        });
+    }
+
+    if requested.is_some_and(|config| config.required) {
+        return Err(required_paged_attention_error(
+            PAGED_ATTENTION_SCHEDULER_FALLBACK_REASON,
+        ));
+    }
+
+    if requested.is_some() {
+        tracing::warn!("PagedAttention disabled: {PAGED_ATTENTION_SCHEDULER_FALLBACK_REASON}");
+    }
+
+    Ok(SchedulerConfig::DefaultScheduler {
+        method: DefaultSchedulerMethod::Fixed(
+            max_num_seqs
+                .try_into()
+                .map_err(|_| anyhow::anyhow!("max_num_seqs must be nonzero"))?,
+        ),
+    })
 }
 
 impl SchedulerConfig {
@@ -292,5 +332,71 @@ mod tests {
             config: cache_config(128),
         };
         assert!(scheduler.refresh_paged_cache_config(None).is_err());
+    }
+
+    fn sample_paged_attn_config(required: bool) -> anyhow::Result<PagedAttentionConfig> {
+        let config = PagedAttentionConfig::new(
+            Some(32),
+            crate::MemoryGpuConfig::Utilization(0.9),
+            PagedCacheType::Auto,
+        )?;
+        Ok(if required {
+            config.with_required()
+        } else {
+            config
+        })
+    }
+
+    #[test]
+    fn required_paged_attention_cannot_fall_back_to_default_scheduler() -> anyhow::Result<()> {
+        let requested = Some(sample_paged_attn_config(true)?);
+        let Err(error) = scheduler_config_for_paged_attention(&requested, None, 1, 4096, 512, 8)
+        else {
+            panic!("required PagedAttention must not become DefaultScheduler");
+        };
+        let message = error.to_string();
+        assert!(message.contains("--paged-attn on"));
+        assert!(message.contains("pipeline did not install"));
+        Ok(())
+    }
+
+    #[test]
+    fn optional_paged_attention_falls_back_to_default_scheduler() -> anyhow::Result<()> {
+        let requested = Some(sample_paged_attn_config(false)?);
+        let scheduler = scheduler_config_for_paged_attention(&requested, None, 4, 4096, 512, 8)?;
+        assert!(matches!(
+            scheduler,
+            SchedulerConfig::DefaultScheduler { .. }
+        ));
+        Ok(())
+    }
+
+    #[test]
+    fn realized_cache_config_selects_paged_attention_scheduler() -> anyhow::Result<()> {
+        let requested = Some(sample_paged_attn_config(true)?);
+        let realized = cache_config(8);
+        let scheduler =
+            scheduler_config_for_paged_attention(&requested, Some(&realized), 4, 4096, 512, 8)?;
+        let SchedulerConfig::PagedAttentionMeta {
+            max_num_seqs,
+            config,
+            ..
+        } = scheduler
+        else {
+            panic!("expected PagedAttention scheduler")
+        };
+        assert_eq!(max_num_seqs, 4);
+        assert_eq!(config.num_gpu_blocks, 8);
+        Ok(())
+    }
+
+    #[test]
+    fn disabled_paged_attention_uses_default_scheduler_quietly() -> anyhow::Result<()> {
+        let scheduler = scheduler_config_for_paged_attention(&None, None, 2, 4096, 512, 8)?;
+        assert!(matches!(
+            scheduler,
+            SchedulerConfig::DefaultScheduler { .. }
+        ));
+        Ok(())
     }
 }

--- a/mistralrs-server-core/src/mistralrs_for_server_builder.rs
+++ b/mistralrs-server-core/src/mistralrs_for_server_builder.rs
@@ -6,8 +6,9 @@ use anyhow::{Context, Result};
 use candle_core::Device;
 use mistralrs_core::{
     get_auto_device_map_params, get_model_dtype, get_tgt_non_granular_index, paged_attn_supported,
-    parse_isq_value, plan_paged_kv, reserve_external_mtp_memory_with_runtime, AutoDeviceMapParams,
-    DefaultSchedulerMethod, DeviceLayerMapMetadata, DeviceMapMetadata, DeviceMapSetting,
+    parse_isq_value, plan_paged_kv, required_paged_attention_error,
+    reserve_external_mtp_memory_with_runtime, scheduler_config_for_paged_attention,
+    AutoDeviceMapParams, DeviceLayerMapMetadata, DeviceMapMetadata, DeviceMapSetting,
     HfConfigOverrides, Loader, LoaderBuilder, McpClientConfig, MemoryGpuConfig, MistralRsBuilder,
     ModelLoaderConfig, ModelSelected, MtpConfig, MtpRuntimeConfig, PagedAttentionConfig,
     PagedCacheType, PagedKvModelRequest, SchedulerConfig, SearchCallback, SearchEmbeddingModel,
@@ -624,7 +625,7 @@ impl MistralRsForServerBuilder {
     /// and `Some(false)` have different implications.
     ///
     /// `None`: default behavior for target device (e.g. enable for CUDA, disable for Metal)
-    /// `Some(true)`: enable (if supported by target device)
+    /// `Some(true)`: require PagedAttention; fail if the device, build, or model cannot honor it
     /// `Some(false)`: disable
     pub fn set_paged_attn(mut self, paged_attn: Option<bool>) -> Self {
         self.paged_attn = paged_attn;
@@ -832,7 +833,7 @@ impl MistralRsForServerBuilder {
         };
 
         let mapper = init_mapper(&self.num_device_layers, &auto_device_map_params);
-        let paged_attn = configure_paged_attn(&device, self.paged_attn);
+        let paged_attn = configure_paged_attn(&device, self.paged_attn)?;
 
         let cache_config = reserve_external_mtp_memory_with_runtime(
             init_cache_config(
@@ -841,7 +842,8 @@ impl MistralRsForServerBuilder {
                 self.paged_attn_gpu_mem_usage,
                 self.paged_ctxt_len,
                 self.paged_cache_type,
-                !paged_attn,
+                !paged_attn.enabled,
+                paged_attn.required,
             )?
             .map(|config| config.with_serving_capacity(self.max_seqs))
             .transpose()?
@@ -906,7 +908,7 @@ impl MistralRsForServerBuilder {
             self.max_prefill_chunk_tokens.get(),
             self.max_decode_steps_before_prefill.get(),
         )
-        .await;
+        .await?;
 
         let search_embedding_model =
             get_search_embedding_model(self.enable_search, self.search_embedding_model);
@@ -1029,7 +1031,7 @@ impl MistralRsForServerBuilder {
             &auto_device_map_params,
         );
         let mapper_for_config = mapper.clone();
-        let paged_attn = configure_paged_attn(&device, self.paged_attn);
+        let paged_attn = configure_paged_attn(&device, self.paged_attn)?;
 
         let requested_cache_config = init_cache_config(
             self.paged_attn_block_size,
@@ -1037,7 +1039,8 @@ impl MistralRsForServerBuilder {
             self.paged_attn_gpu_mem_usage,
             self.paged_ctxt_len,
             self.paged_cache_type,
-            !paged_attn,
+            !paged_attn.enabled,
+            paged_attn.required,
         )?
         .map(|config| config.with_serving_capacity(self.max_seqs))
         .transpose()?
@@ -1125,7 +1128,7 @@ impl MistralRsForServerBuilder {
             self.max_prefill_chunk_tokens.get(),
             self.max_decode_steps_before_prefill.get(),
         )
-        .await;
+        .await?;
         let search_embedding_model =
             get_search_embedding_model(self.enable_search, self.search_embedding_model);
         let first_loader_config = ModelLoaderConfig {
@@ -1261,7 +1264,7 @@ impl MistralRsForServerBuilder {
                 self.max_prefill_chunk_tokens.get(),
                 self.max_decode_steps_before_prefill.get(),
             )
-            .await;
+            .await?;
 
             // Use the pipeline's name() as the canonical ID, but allow an alias.
             let pipeline_name = pipeline.lock().await.name();
@@ -1464,22 +1467,84 @@ fn mistralrs_instance_info(loader: &dyn Loader) {
     debug!("Model kind is: {}", loader.get_kind().to_string());
 }
 
-/// Determines whether paged attention should be enabled based on device type and preferences.
-fn configure_paged_attn(device: &Device, paged_attn: Option<bool>) -> bool {
-    if mistralrs_core::distributed::use_nccl() {
-        paged_attn.unwrap_or(defaults::PAGED_ATTN_CUDA)
-    } else if device.is_cpu() {
-        if paged_attn == Some(true) {
-            warn!("Paged attention is not supported on CPU.");
-        }
+/// Device-level PagedAttention enablement. `reason` is set only for auto fallback.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct PagedAttentionDeviceDecision {
+    enabled: bool,
+    required: bool,
+    reason: Option<&'static str>,
+}
 
-        defaults::PAGED_ATTN_CPU
+/// Determines whether paged attention should be enabled based on device type and preferences.
+fn configure_paged_attn(
+    device: &Device,
+    paged_attn: Option<bool>,
+) -> Result<PagedAttentionDeviceDecision> {
+    let required = paged_attn == Some(true);
+
+    let decision = if mistralrs_core::distributed::use_nccl() {
+        PagedAttentionDeviceDecision {
+            enabled: paged_attn.unwrap_or(defaults::PAGED_ATTN_CUDA),
+            required,
+            reason: None,
+        }
+    } else if device.is_cpu() {
+        if required {
+            return Err(required_paged_attention_error("it is not supported on CPU"));
+        }
+        let reason = match paged_attn {
+            Some(false) => None,
+            _ => Some("it is not supported on CPU"),
+        };
+        PagedAttentionDeviceDecision {
+            enabled: defaults::PAGED_ATTN_CPU,
+            required: false,
+            reason,
+        }
     } else if device.is_cuda() {
-        paged_attn.unwrap_or(defaults::PAGED_ATTN_CUDA)
+        PagedAttentionDeviceDecision {
+            enabled: paged_attn.unwrap_or(defaults::PAGED_ATTN_CUDA),
+            required,
+            reason: None,
+        }
     } else if device.is_metal() {
-        paged_attn.unwrap_or(defaults::PAGED_ATTN_METAL)
+        let enabled = paged_attn.unwrap_or(defaults::PAGED_ATTN_METAL);
+        let reason = if !enabled && paged_attn.is_none() {
+            Some("it is disabled by default on Metal")
+        } else {
+            None
+        };
+        PagedAttentionDeviceDecision {
+            enabled,
+            required,
+            reason,
+        }
+    } else if required {
+        return Err(required_paged_attention_error(
+            "it is not supported on this device",
+        ));
     } else {
-        false
+        PagedAttentionDeviceDecision {
+            enabled: false,
+            required: false,
+            reason: None,
+        }
+    };
+
+    if let Some(reason) = decision.reason {
+        info!("PagedAttention not enabled: {reason}");
+    }
+    Ok(decision)
+}
+
+fn apply_paged_attention_required(
+    config: PagedAttentionConfig,
+    required: bool,
+) -> PagedAttentionConfig {
+    if required {
+        config.with_required()
+    } else {
+        config
     }
 }
 
@@ -1491,62 +1556,84 @@ fn init_cache_config(
     paged_ctxt_len: Option<usize>,
     cache_type: PagedCacheType,
     no_paged_attn: bool,
+    required: bool,
 ) -> Result<Option<PagedAttentionConfig>> {
+    if no_paged_attn {
+        if required {
+            return Err(required_paged_attention_error(
+                "it could not be enabled for this device",
+            ));
+        }
+        return Ok(None);
+    }
+
+    if !paged_attn_supported() {
+        let reason =
+            "this build was compiled without PagedAttention (needs the cuda feature on Unix, or metal)";
+        if required {
+            return Err(required_paged_attention_error(reason));
+        }
+        warn!("PagedAttention disabled: {reason}");
+        return Ok(None);
+    }
+
     match (
         paged_attn_block_size,
         paged_attn_gpu_mem,
         paged_attn_gpu_mem_usage,
         paged_ctxt_len,
-        paged_attn_supported(),
-        no_paged_attn,
     ) {
-        (block_size, None, None, None, true, false) => Ok(Some(PagedAttentionConfig::new(
-            block_size,
-            MemoryGpuConfig::Utilization(0.9),
-            cache_type,
-        )?)),
-        (block_size, None, None, Some(ctxt), true, false) => Ok(Some(PagedAttentionConfig::new(
-            block_size,
-            MemoryGpuConfig::ContextSize(ctxt),
-            cache_type,
-        )?)),
-        (block_size, None, Some(f), None, true, false) => Ok(Some(PagedAttentionConfig::new(
-            block_size,
-            MemoryGpuConfig::Utilization(f),
-            cache_type,
-        )?)),
-        (block_size, Some(m), None, None, true, false) => Ok(Some(PagedAttentionConfig::new(
-            block_size,
-            MemoryGpuConfig::MbAmount(m),
-            cache_type,
-        )?)),
-        (block_size, Some(_m), Some(f), None, true, false) => {
+        (block_size, None, None, None) => Ok(Some(apply_paged_attention_required(
+            PagedAttentionConfig::new(block_size, MemoryGpuConfig::Utilization(0.9), cache_type)?,
+            required,
+        ))),
+        (block_size, None, None, Some(ctxt)) => Ok(Some(apply_paged_attention_required(
+            PagedAttentionConfig::new(block_size, MemoryGpuConfig::ContextSize(ctxt), cache_type)?,
+            required,
+        ))),
+        (block_size, None, Some(f), None) => Ok(Some(apply_paged_attention_required(
+            PagedAttentionConfig::new(block_size, MemoryGpuConfig::Utilization(f), cache_type)?,
+            required,
+        ))),
+        (block_size, Some(m), None, None) => Ok(Some(apply_paged_attention_required(
+            PagedAttentionConfig::new(block_size, MemoryGpuConfig::MbAmount(m), cache_type)?,
+            required,
+        ))),
+        (block_size, Some(_m), Some(f), None) => {
             warn!("Both memory size and usage were specified, defaulting to the usage value.");
-            Ok(Some(PagedAttentionConfig::new(
-                block_size,
-                MemoryGpuConfig::Utilization(f),
-                cache_type,
-            )?))
+            Ok(Some(apply_paged_attention_required(
+                PagedAttentionConfig::new(block_size, MemoryGpuConfig::Utilization(f), cache_type)?,
+                required,
+            )))
         }
-        (block_size, Some(_m), None, Some(ctxt), true, false) => {
+        (block_size, Some(_m), None, Some(ctxt)) => {
             warn!(
                 "Both memory size and context length were specified, defaulting to context length."
             );
-            Ok(Some(PagedAttentionConfig::new(
-                block_size,
-                MemoryGpuConfig::ContextSize(ctxt),
-                cache_type,
-            )?))
+            Ok(Some(apply_paged_attention_required(
+                PagedAttentionConfig::new(
+                    block_size,
+                    MemoryGpuConfig::ContextSize(ctxt),
+                    cache_type,
+                )?,
+                required,
+            )))
         }
-        (block_size, None, Some(f), Some(_ctxt), true, false) => {
+        (block_size, None, Some(f), Some(_ctxt)) => {
             warn!("Both context length and usage were specified, defaulting to the usage value.");
-            Ok(Some(PagedAttentionConfig::new(
-                block_size,
-                MemoryGpuConfig::Utilization(f),
-                cache_type,
-            )?))
+            Ok(Some(apply_paged_attention_required(
+                PagedAttentionConfig::new(block_size, MemoryGpuConfig::Utilization(f), cache_type)?,
+                required,
+            )))
         }
-        (_, _, _, _, _, _) => Ok(None),
+        (_, _, _, _) => {
+            if required {
+                return Err(required_paged_attention_error(
+                    "a valid KV cache configuration could not be created",
+                ));
+            }
+            Ok(None)
+        }
     }
 }
 
@@ -1558,27 +1645,16 @@ async fn init_scheduler_config(
     max_num_batched_tokens: usize,
     max_prefill_chunk_tokens: usize,
     max_decode_steps_before_prefill: usize,
-) -> SchedulerConfig {
-    if cache_config.is_some() {
-        // Handle case where we may have device mapping
-        if let Some(ref cache_config) = pipeline.lock().await.get_metadata().cache_config {
-            SchedulerConfig::PagedAttentionMeta {
-                max_num_seqs: args_max_seqs,
-                max_num_batched_tokens,
-                max_prefill_chunk_tokens,
-                max_decode_steps_before_prefill,
-                config: cache_config.clone(),
-            }
-        } else {
-            SchedulerConfig::DefaultScheduler {
-                method: DefaultSchedulerMethod::Fixed(args_max_seqs.try_into().unwrap()),
-            }
-        }
-    } else {
-        SchedulerConfig::DefaultScheduler {
-            method: DefaultSchedulerMethod::Fixed(args_max_seqs.try_into().unwrap()),
-        }
-    }
+) -> Result<SchedulerConfig> {
+    let realized = pipeline.lock().await.get_metadata().cache_config.clone();
+    scheduler_config_for_paged_attention(
+        cache_config,
+        realized.as_ref(),
+        args_max_seqs,
+        max_num_batched_tokens,
+        max_prefill_chunk_tokens,
+        max_decode_steps_before_prefill,
+    )
 }
 
 /// Configures PagedAttention based on two flags.
@@ -1608,5 +1684,85 @@ pub fn get_search_embedding_model(
         Some(search_embedding_model.unwrap_or_default())
     } else {
         None
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn empty_cache_config(
+        no_paged_attn: bool,
+        required: bool,
+    ) -> Result<Option<PagedAttentionConfig>> {
+        init_cache_config(
+            None,
+            None,
+            None,
+            None,
+            PagedCacheType::Auto,
+            no_paged_attn,
+            required,
+        )
+    }
+
+    #[test]
+    fn explicit_on_cpu_is_an_error() {
+        let error = configure_paged_attn(&Device::Cpu, Some(true))
+            .expect_err("CPU --paged-attn on must fail closed");
+        let message = error.to_string();
+        assert!(message.contains("--paged-attn on"));
+        assert!(message.contains("CPU"));
+    }
+
+    #[test]
+    fn auto_cpu_stays_disabled_with_reason() {
+        let decision =
+            configure_paged_attn(&Device::Cpu, None).expect("CPU auto must not be an error");
+        assert!(!decision.enabled);
+        assert!(!decision.required);
+        assert_eq!(decision.reason, Some("it is not supported on CPU"));
+    }
+
+    #[test]
+    fn off_cpu_stays_disabled_quietly() {
+        let decision = configure_paged_attn(&Device::Cpu, Some(false))
+            .expect("CPU --paged-attn off must not be an error");
+        assert!(!decision.enabled);
+        assert!(!decision.required);
+        assert_eq!(decision.reason, None);
+    }
+
+    #[test]
+    fn off_cache_config_is_none() -> Result<()> {
+        assert!(empty_cache_config(true, false)?.is_none());
+        Ok(())
+    }
+
+    #[test]
+    fn required_cache_config_fails_when_paged_attention_is_unsupported() {
+        if paged_attn_supported() {
+            let config = empty_cache_config(false, true)
+                .expect("supported builds can create a required config");
+            assert!(config.is_some_and(|config| config.is_required()));
+            return;
+        }
+
+        let error = empty_cache_config(false, true)
+            .expect_err("required PagedAttention must fail on unsupported builds");
+        let message = error.to_string();
+        assert!(message.contains("--paged-attn on"));
+        assert!(message.contains("cuda feature on Unix"));
+    }
+
+    #[test]
+    fn auto_cache_config_is_none_when_paged_attention_is_unsupported() -> Result<()> {
+        if paged_attn_supported() {
+            let config = empty_cache_config(false, false)?;
+            assert!(config.is_some_and(|config| !config.is_required()));
+        } else {
+            assert!(empty_cache_config(false, false)?.is_none());
+        }
+        Ok(())
     }
 }

--- a/mistralrs/src/builder_macros.rs
+++ b/mistralrs/src/builder_macros.rs
@@ -162,8 +162,8 @@ macro_rules! common_builder_methods {
             self
         }
 
-        /// Enable PagedAttention. If PagedAttention is not supported on this platform,
-        /// the configuration is silently ignored.
+        /// Enable PagedAttention. This stores an explicit request; loading fails if the
+        /// device, build, or model cannot honor it.
         ///
         /// Configure with a [`PagedAttentionConfig`] object, which can be created with
         /// sensible defaults via [`crate::PagedAttentionMetaBuilder`]:
@@ -177,9 +177,7 @@ macro_rules! common_builder_methods {
         /// # }
         /// ```
         pub fn with_paged_attn(mut self, paged_attn_cfg: PagedAttentionConfig) -> Self {
-            if paged_attn_supported() {
-                self.paged_attn_cfg = Some(paged_attn_cfg);
-            }
+            self.paged_attn_cfg = Some(paged_attn_cfg.with_required());
             self
         }
 

--- a/mistralrs/src/gguf.rs
+++ b/mistralrs/src/gguf.rs
@@ -400,13 +400,11 @@ impl GgufModelBuilder {
     /// Enable PagedAttention. Configure PagedAttention with a [`PagedAttentionConfig`] object, which
     /// can be created with sensible values with a [`PagedAttentionMetaBuilder`].
     ///
-    /// If PagedAttention is not supported (query with [`paged_attn_supported`]), this will do nothing.
+    /// This stores an explicit request; loading fails if the device, build, or model cannot honor it.
     ///
     /// [`PagedAttentionMetaBuilder`]: crate::PagedAttentionMetaBuilder
     pub fn with_paged_attn(mut self, paged_attn_cfg: PagedAttentionConfig) -> Self {
-        if paged_attn_supported() {
-            self.paged_attn_cfg = Some(paged_attn_cfg);
-        }
+        self.paged_attn_cfg = Some(paged_attn_cfg.with_required());
         self
     }
 

--- a/mistralrs/src/model_builder_trait.rs
+++ b/mistralrs/src/model_builder_trait.rs
@@ -2,9 +2,9 @@
 
 use candle_core::Device;
 use mistralrs_core::{
-    plan_paged_kv, AddModelConfig, DefaultSchedulerMethod, EngineConfig, IsqType,
-    PagedAttentionConfig, PagedKvModelRequest, Pipeline, SchedulerConfig, SearchCallback,
-    SearchEmbeddingModel, ToolCallbackWithTool,
+    plan_paged_kv, scheduler_config_for_paged_attention, AddModelConfig, DefaultSchedulerMethod,
+    EngineConfig, IsqType, PagedAttentionConfig, PagedKvModelRequest, Pipeline, SchedulerConfig,
+    SearchCallback, SearchEmbeddingModel, ToolCallbackWithTool,
 };
 use std::{collections::HashMap, path::PathBuf, sync::Arc};
 use tokio::sync::Mutex;
@@ -367,33 +367,21 @@ fn paged_attn_with_serving_capacity(
 
 pub(crate) async fn scheduler_config_from_pipeline<P>(
     pipeline: &Arc<Mutex<P>>,
-    paged_attn_requested: bool,
+    paged_attn_cfg: &Option<PagedAttentionConfig>,
     max_num_seqs: usize,
 ) -> anyhow::Result<SchedulerConfig>
 where
     P: ?Sized + Pipeline,
 {
-    if paged_attn_requested {
-        if let Some(config) = pipeline
-            .lock()
-            .await
-            .get_metadata()
-            .cache_config
-            .as_ref()
-            .cloned()
-        {
-            return Ok(SchedulerConfig::PagedAttentionMeta {
-                max_num_seqs,
-                max_num_batched_tokens: mistralrs_core::DEFAULT_MAX_NUM_BATCHED_TOKENS,
-                max_prefill_chunk_tokens: mistralrs_core::DEFAULT_MAX_PREFILL_CHUNK_TOKENS,
-                max_decode_steps_before_prefill:
-                    mistralrs_core::DEFAULT_MAX_DECODE_STEPS_BEFORE_PREFILL,
-                config,
-            });
-        }
-    }
-
-    default_scheduler_config(max_num_seqs)
+    let realized = pipeline.lock().await.get_metadata().cache_config.clone();
+    scheduler_config_for_paged_attention(
+        paged_attn_cfg,
+        realized.as_ref(),
+        max_num_seqs,
+        mistralrs_core::DEFAULT_MAX_NUM_BATCHED_TOKENS,
+        mistralrs_core::DEFAULT_MAX_PREFILL_CHUNK_TOKENS,
+        mistralrs_core::DEFAULT_MAX_DECODE_STEPS_BEFORE_PREFILL,
+    )
 }
 
 pub(crate) fn build_engine_config(
@@ -465,7 +453,6 @@ pub(crate) async fn build_pipeline_from_text_loader(
             .unwrap_or(mistralrs_core::DeviceMapSetting::Auto(
                 mistralrs_core::AutoDeviceMapParams::default_text(),
             ));
-    let paged_attn_requested = builder.paged_attn_cfg.is_some();
 
     let pipeline = loader.load_model_from_hf(
         builder.hf_revision,
@@ -485,7 +472,7 @@ pub(crate) async fn build_pipeline_from_text_loader(
     }
 
     let scheduler_config =
-        scheduler_config_from_pipeline(&pipeline, paged_attn_requested, builder.max_num_seqs)
+        scheduler_config_from_pipeline(&pipeline, &builder.paged_attn_cfg, builder.max_num_seqs)
             .await?;
 
     let add_model_config = AddModelConfig {
@@ -538,7 +525,6 @@ pub(crate) async fn build_pipeline_from_gguf_loader(
         .device_mapping
         .clone()
         .unwrap_or(DeviceMapSetting::Auto(default_device_map));
-    let paged_attn_requested = builder.paged_attn_cfg.is_some();
     let isq_type = resolve_isq_type(builder.isq.as_ref(), &device)?;
 
     let pipeline = loader.load_model_from_hf(
@@ -559,7 +545,7 @@ pub(crate) async fn build_pipeline_from_gguf_loader(
     }
 
     let scheduler_config =
-        scheduler_config_from_pipeline(&pipeline, paged_attn_requested, builder.max_num_seqs)
+        scheduler_config_from_pipeline(&pipeline, &builder.paged_attn_cfg, builder.max_num_seqs)
             .await?;
 
     let add_model_config = AddModelConfig {
@@ -696,12 +682,9 @@ pub async fn build_text_pipeline(
             .attach_speculative_with_runtime(SpeculativeConfig::Mtp(mtp_config), mtp_runtime)?;
     }
 
-    let scheduler_config = scheduler_config_from_pipeline(
-        &pipeline,
-        builder.paged_attn_cfg.is_some(),
-        builder.max_num_seqs,
-    )
-    .await?;
+    let scheduler_config =
+        scheduler_config_from_pipeline(&pipeline, &builder.paged_attn_cfg, builder.max_num_seqs)
+            .await?;
 
     let engine_config = build_engine_config(
         builder.throughput_logging,
@@ -846,12 +829,9 @@ pub async fn build_multimodal_pipeline(
             .attach_speculative_with_runtime(SpeculativeConfig::Mtp(mtp_config), mtp_runtime)?;
     }
 
-    let scheduler_config = scheduler_config_from_pipeline(
-        &pipeline,
-        builder.paged_attn_cfg.is_some(),
-        builder.max_num_seqs,
-    )
-    .await?;
+    let scheduler_config =
+        scheduler_config_from_pipeline(&pipeline, &builder.paged_attn_cfg, builder.max_num_seqs)
+            .await?;
 
     let engine_config = build_engine_config(
         builder.throughput_logging,
@@ -1007,12 +987,9 @@ pub async fn build_gguf_pipeline(
             .attach_speculative_with_runtime(SpeculativeConfig::Mtp(mtp_config), mtp_runtime)?;
     }
 
-    let scheduler_config = scheduler_config_from_pipeline(
-        &pipeline,
-        builder.paged_attn_cfg.is_some(),
-        builder.max_num_seqs,
-    )
-    .await?;
+    let scheduler_config =
+        scheduler_config_from_pipeline(&pipeline, &builder.paged_attn_cfg, builder.max_num_seqs)
+            .await?;
 
     let engine_config = build_engine_config(
         builder.throughput_logging,
@@ -1451,12 +1428,9 @@ pub async fn build_auto_pipeline(
             .attach_speculative_with_runtime(SpeculativeConfig::Mtp(mtp_config), mtp_runtime)?;
     }
 
-    let scheduler_config = scheduler_config_from_pipeline(
-        &pipeline,
-        builder.paged_attn_cfg.is_some(),
-        builder.max_num_seqs,
-    )
-    .await?;
+    let scheduler_config =
+        scheduler_config_from_pipeline(&pipeline, &builder.paged_attn_cfg, builder.max_num_seqs)
+            .await?;
 
     let engine_config = build_engine_config(
         builder.throughput_logging,


### PR DESCRIPTION
## Summary
- `--paged-attn on` is now fail-closed: if the device, build, or model cannot honor PagedAttention, startup errors with an actionable `--paged-attn on` message instead of silently switching to eager KV / `DefaultScheduler`.
- `auto` keeps existing defaults (CUDA on, Metal/CPU off) and logs a reason when it falls back. `off` stays quiet.
- Intent is stamped on `PagedAttentionConfig.required`. Shared `disable_paged_attention` and `scheduler_config_for_paged_attention` helpers are used by the server builder, pipeline loaders, and Rust SDK `with_paged_attn`.

Python bindings are unchanged and still use the previous optional path. NCCL PagedAttention and the engine `no_kv_cache` scheduler remap are also unchanged.

