### PR TITLE
feat(release): verify published artifacts, auto-rerun flakes, pin wheel toolchain

### DIFF
--- a/.github/workflows/release-cache-probe.yml
+++ b/.github/workflows/release-cache-probe.yml
@@ -1,0 +1,76 @@
+name: release-cache-probe
+
+# Measures Namespace cache-volume effectiveness for the CUDA release builds before wiring
+# caching into release.yml. Dispatch twice: the first run seeds the volume (cold), the
+# second measures warm. Also answers whether cache volumes mount inside container jobs.
+# Requires a cache volume enabled on the runner profiles in the Namespace dashboard.
+
+on:
+  workflow_dispatch:
+
+env:
+  CARGO_INCREMENTAL: "0"
+  CARGO_TERM_COLOR: always
+  CARGO_NET_RETRY: "10"
+  CARGO_HTTP_TIMEOUT: "120"
+  CARGO_HTTP_MULTIPLEXING: "false"
+  CARGO_NET_GIT_FETCH_WITH_CLI: "true"
+
+jobs:
+  probe:
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - { sm: "90", runner: namespace-profile-cuda-x86-64, cuda: "13.0.0" }
+          - { sm: "90", runner: namespace-profile-cuda-arm64, cuda: "13.0.0" }
+    container:
+      image: docker.io/nvidia/cuda:${{ matrix.cuda }}-cudnn-devel-ubuntu22.04
+    env:
+      CUDA_COMPUTE_CAP: ${{ matrix.sm }}
+      CUDA_TOOLKIT_PATH: /usr/local/cuda
+      CUDAFORGE_THREADS: "12"
+      RUSTFLAGS: "-C target-cpu=generic"
+    steps:
+      - uses: actions/checkout@v4
+      - name: Mount cache volume
+        uses: namespacelabs/nscloud-cache-action@v1
+        with:
+          path: |
+            target
+            /github/home/.cargo/registry
+            /github/home/.cargo/git
+      - name: Install build dependencies
+        run: |
+          apt-get update
+          apt-get install -y --no-install-recommends \
+            curl ca-certificates build-essential pkg-config libssl-dev patchelf git
+          ldconfig
+          nccl_lib="$(ldconfig -p | awk '$1 == "libnccl.so" { print $NF; exit }')"
+          if [ -z "$nccl_lib" ]; then
+            nccl_runtime="$(ldconfig -p | awk '$1 == "libnccl.so.2" { print $NF; exit }')"
+            if [ -n "$nccl_runtime" ]; then
+              ln -sf "$nccl_runtime" "$(dirname "$nccl_runtime")/libnccl.so"
+            else
+              apt-get install -y --no-install-recommends libnccl-dev
+            fi
+          fi
+          rm -rf /var/lib/apt/lists/*
+      - uses: dtolnay/rust-toolchain@stable
+      - name: Fetch Rust dependencies
+        run: cargo fetch --locked
+      - name: Timed build
+        run: |
+          start=$(date +%s)
+          cargo build --release --locked --offline --features "cuda flash-attn nccl" -p mistralrs-cli
+          end=$(date +%s)
+          echo "BUILD_SECONDS=$((end - start))" | tee -a "$GITHUB_ENV"
+      - name: Report
+        run: |
+          {
+            echo "### cache probe (${{ matrix.runner }}, sm${{ matrix.sm }})"
+            echo "- build: ${BUILD_SECONDS}s"
+            echo "- target: $(du -sh target | cut -f1)"
+            echo "- registry: $(du -sh /github/home/.cargo/registry 2>/dev/null | cut -f1)"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/release-rerun.yml
+++ b/.github/workflows/release-rerun.yml
@@ -1,0 +1,21 @@
+name: release-rerun
+
+# Auto-heals runner flakes: re-runs the failed jobs of a completed release run, which also
+# re-runs the jobs skipped downstream of them. Capped attempts keep a real failure red.
+
+on:
+  workflow_run:
+    workflows: [release]
+    types: [completed]
+
+permissions:
+  actions: write
+
+jobs:
+  rerun-failed:
+    if: ${{ github.event.workflow_run.conclusion == 'failure' && github.event.workflow_run.run_attempt < 3 }}
+    runs-on: ubuntu-latest
+    steps:
+      - env:
+          GH_TOKEN: ${{ github.token }}
+        run: gh run rerun ${{ github.event.workflow_run.id }} --failed -R ${{ github.repository }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -88,13 +88,15 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - { runner: ubuntu-latest, triple: x86_64-unknown-linux-gnu }
-          - { runner: ubuntu-24.04-arm, triple: aarch64-unknown-linux-gnu,
+          # 22.04 runners keep the glibc floor at 2.35; 24.04 binaries need 2.39 and
+          # fail on Debian 12 / RHEL 9 era distros.
+          - { runner: ubuntu-22.04, triple: x86_64-unknown-linux-gnu }
+          - { runner: ubuntu-22.04-arm, triple: aarch64-unknown-linux-gnu,
               # v8.2 floor (Graviton2+, Pi 5, 2018+ phones): recovers autovec perf the
               # runtime-dispatched kernels cannot; the installer probes /proc/cpuinfo
               rustflags: "-C target-cpu=generic -C target-feature=+dotprod,+fp16,+fhm",
               skip_wheel: true }
-          - { runner: ubuntu-24.04-arm, triple: aarch64-unknown-linux-gnu,
+          - { runner: ubuntu-22.04-arm, triple: aarch64-unknown-linux-gnu,
               # ARMv8.0 compat asset and portable manylinux wheel (Pi 4, Graviton1,
               # A72-class SBCs)
               suffix: -v8_0 }
@@ -274,11 +276,14 @@ jobs:
       # tileiras installation.
       # Only mistralrs-pyo3's version is bumped (not the workspace) so the kernel crates already built
       # by the CLI step are reused from target/ instead of recompiling flash-attn's ~90min hdim512 ptxas.
+      # Fails the job on wheel breakage (binary asset is already uploaded above; docker legs
+      # tolerate failed build legs via !cancelled(), so nothing downstream is lost). Pinned
+      # pips: an unpinned auditwheel once raised its patchelf floor above apt's 0.14.3 and
+      # silently dropped every CUDA wheel from a release.
       - name: Build CUDA wheel
-        continue-on-error: true
         run: |
           set -eux
-          pip3 install --quiet maturin auditwheel
+          pip3 install --quiet maturin==1.14.1 auditwheel==6.8.1 patchelf==0.19.1.0
           sed -i 's/^version = "\([^"]*\)"/version = "\1+cuda${{ matrix.cuda_asset }}.sm${{ matrix.sm }}"/' mistralrs-pyo3/Cargo.toml
           # --auditwheel skip: maturin's built-in repair has no --exclude and chokes on libcuda; do
           # our own repair below instead so the driver is excluded rather than bundled.
@@ -355,7 +360,9 @@ jobs:
   # binary is on the release before the image fetches it, avoiding a cross-workflow race.
   docker-cpu:
     needs: linux-cpu
-    if: ${{ !inputs.dry_run }}
+    # !cancelled(): run even when a build leg failed; each docker job fails on its own
+    # only if the specific asset it stages is missing, keeping the blast radius per-image.
+    if: ${{ !inputs.dry_run && !cancelled() }}
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -401,7 +408,7 @@ jobs:
 
   docker-cuda:
     needs: linux-cuda
-    if: ${{ !inputs.dry_run }}
+    if: ${{ !inputs.dry_run && !cancelled() }}
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -502,7 +509,7 @@ jobs:
 
   docker-cuda-manifest:
     needs: docker-cuda
-    if: ${{ !inputs.dry_run }}
+    if: ${{ !inputs.dry_run && !cancelled() }}
     runs-on: ubuntu-latest
     permissions:
       packages: write
@@ -595,3 +602,29 @@ jobs:
       - uses: pypa/gh-action-pypi-publish@release/v1
         with:
           packages-dir: dist
+
+  # The release contract check: every tarball, wheel, image, and (non-rc) PyPI version the
+  # matrices promise must exist, or this fails with the missing list. Job status alone lies
+  # in both directions (soft-failed steps look green, one flaked leg skips whole legs).
+  verify-release:
+    needs: [metal, linux-cpu, windows-cpu, linux-cuda, docker-cpu, docker-cuda, docker-cuda-manifest, pypi-publish]
+    if: ${{ !cancelled() && !inputs.dry_run }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: read
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.tag || github.ref }}
+      - uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Verify published artifacts
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          pip3 install --quiet pyyaml
+          python3 scripts/verify_release_assets.py "${{ inputs.tag || github.ref_name }}"

--- a/scripts/verify_release_assets.py
+++ b/scripts/verify_release_assets.py
@@ -1,0 +1,100 @@
+#!/usr/bin/env python3
+"""Check a tagged release against the artifact contract implied by release.yml.
+
+Expected tarballs, wheels, and Docker tags are derived from the workflow's own
+matrices, so editing the matrix automatically updates the contract. Exits nonzero
+with a list of everything missing. Usage: verify_release_assets.py <tag>
+"""
+
+import json
+import os
+import re
+import subprocess
+import sys
+import urllib.error
+import urllib.request
+
+import yaml
+
+WORKFLOW = ".github/workflows/release.yml"
+FIXED_ASSETS = [
+    "mistralrs-cpu-x86_64-unknown-linux-gnu.tar.gz",
+    "mistralrs-cpu-aarch64-unknown-linux-gnu.tar.gz",
+    "mistralrs-cpu-aarch64-unknown-linux-gnu-v8_0.tar.gz",
+    "mistralrs-cpu-x86_64-pc-windows-msvc.zip",
+    "mistralrs-metal-aarch64-apple-darwin.tar.gz",
+]
+
+
+def main() -> int:
+    tag = sys.argv[1]
+    ver = tag.removeprefix("v")
+    repo = os.environ.get("GITHUB_REPOSITORY", "EricLBuehler/mistral.rs")
+    image = f"ghcr.io/{repo.lower()}"
+
+    jobs = yaml.safe_load(open(WORKFLOW))["jobs"]
+    cuda_rows = jobs["linux-cuda"]["strategy"]["matrix"]["include"]
+    docker_rows = jobs["docker-cuda"]["strategy"]["matrix"]["include"]
+    manifest_rows = jobs["docker-cuda-manifest"]["strategy"]["matrix"]["include"]
+
+    out = subprocess.run(
+        ["gh", "release", "view", tag, "-R", repo, "--json", "assets"],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    assets = {a["name"] for a in json.loads(out.stdout)["assets"]}
+
+    missing = []
+
+    for name in FIXED_ASSETS:
+        if name not in assets:
+            missing.append(f"asset: {name}")
+
+    for row in cuda_rows:
+        tarball = f"mistralrs-cuda{row['cuda_asset']}-sm{row['sm']}-{row['triple']}.tar.gz"
+        if tarball not in assets:
+            missing.append(f"asset: {tarball}")
+        # rc tags PEP440-normalize the base version, so match on the local-version part only
+        plat = row["triple"].split("-")[0]
+        pat = re.compile(
+            rf"mistralrs-.*\+cuda{row['cuda_asset']}\.sm{row['sm']}-.*_{plat}\.whl"
+        )
+        if not any(pat.fullmatch(a) for a in assets):
+            missing.append(f"wheel: +cuda{row['cuda_asset']}.sm{row['sm']} ({plat})")
+
+    docker_tags = [f"{image}:cpu-{ver}"]
+    for row in docker_rows:
+        docker_tags.append(f"{image}:cuda{row['cuda_asset']}-sm{row['sm']}-{ver}-{row['arch']}")
+    for row in manifest_rows:
+        docker_tags.append(f"{image}:cuda{row['cuda_asset']}-sm{row['sm']}-{ver}")
+    for dtag in docker_tags:
+        res = subprocess.run(
+            ["docker", "buildx", "imagetools", "inspect", dtag],
+            capture_output=True,
+            text=True,
+        )
+        if res.returncode != 0:
+            missing.append(f"image: {dtag}")
+
+    if "-" not in tag:
+        url = f"https://pypi.org/pypi/mistralrs/{ver}/json"
+        try:
+            urllib.request.urlopen(url, timeout=30)
+        except urllib.error.HTTPError:
+            missing.append(f"pypi: mistralrs=={ver}")
+
+    expected = len(FIXED_ASSETS) + 2 * len(cuda_rows) + len(docker_tags) + (1 if "-" not in tag else 0)
+    summary = f"{tag}: {expected - len(missing)}/{expected} artifacts published"
+    print(summary)
+    for item in missing:
+        print(f"MISSING {item}")
+    if step_summary := os.environ.get("GITHUB_STEP_SUMMARY"):
+        with open(step_summary, "a") as f:
+            f.write(f"### {summary}\n\n")
+            f.writelines(f"- MISSING {item}\n" for item in missing)
+    return 1 if missing else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Why

v0.9.2 silently published 42 of 143 expected artifacts. Two independent causes:

1. All 36 CUDA wheels were dropped: unpinned `pip3 install auditwheel` picked up a release requiring patchelf >= 0.14.5 while the build container has apt's 0.14.3. `continue-on-error: true` on the wheel step kept every job green.
2. One Namespace arm64 runner lost communication mid-build, which skipped `docker-cuda` and `docker-cuda-manifest` entirely via `needs:` (64 images/manifests), plus the one tarball. Nobody re-ran the failed jobs.

## What

- **`verify-release` job**: derives the expected artifact set (tarballs, wheels, ghcr images and manifests, PyPI version for non-rc tags) from release.yml's own matrices and fails with an explicit missing list. Run against the v0.9.2 release, it reports exactly the 101 missing artifacts.
- **`release-rerun.yml`**: on a failed release run, `gh run rerun --failed` (max 3 attempts). GitHub re-runs failed jobs and their skipped dependents, so runner flakes self-heal.
- **Docker legs decoupled**: `docker-cpu` / `docker-cuda` / `docker-cuda-manifest` now run with `!cancelled()`; each job fails on its own only if the specific asset it stages is missing, so one flaked build leg costs 1-2 images instead of all of them.
- **Wheel step fails loud and is pinned** (`maturin==1.14.1 auditwheel==6.8.1 patchelf==0.19.1.0`); pip's patchelf fixes the actual v0.9.2 break. The binary asset uploads before the wheel step, so nothing downstream is lost when a leg goes red.
- **`linux-cpu` moves to ubuntu-22.04 / ubuntu-22.04-arm**: keeps the CPU tarball glibc floor at 2.35 instead of 2.39. Supersedes #2303.
- **`release-cache-probe.yml`** (workflow_dispatch): builds one x86 and one arm64 CUDA leg with Namespace cache volumes mounted over `target/` and the cargo registry. Dispatch twice (cold seed, then warm) to measure the real cache hit before wiring caching into the 36-leg matrix. Requires cache volumes enabled on the `namespace-profile-cuda-*` profiles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JbqWJ3GXLj28oC3MLUtM8K