### PR TITLE
fix(cuda): restore GB10 builds with cudaforge 0.1.6

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1250,9 +1250,9 @@ dependencies = [
 
 [[package]]
 name = "cudaforge"
-version = "0.1.4"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ac9cd50bed6f024583322f1a5b8027eabef203086ccceb27aac1b0b58515a32"
+checksum = "8d475ff95b9e4096878f47fe0ca5dbad0e23849a79fc225305ea06c2f25771cd"
 dependencies = [
  "anyhow",
  "fs2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -181,7 +181,7 @@ http = "1.4.0"
 http-body = "1.0.1"
 hyper = "1.8.1"
 rust-mcp-schema = { version = "0.9.5", default-features = false, features = ["schema_utils", "latest"] }
-cudaforge = "0.1.2"
+cudaforge = "=0.1.6"
 rubato = "0.16.2"
 rustfft = "6.4.1"
 hound = "3.5.1"

--- a/mistralrs-core/build.rs
+++ b/mistralrs-core/build.rs
@@ -177,6 +177,7 @@ fn main() {
                     "https://github.com/flashinfer-ai/flashinfer.git",
                     FLASHINFER_GDN_COMMIT,
                     vec!["include"],
+                    vec![],
                     false,
                 );
             if let Some(cuda_nvcc_flags_env) = CUDA_NVCC_FLAGS {


### PR DESCRIPTION
Fixes #2414.

Cargo install resolves workspace dependencies without relying on the repository lockfile. The existing cudaforge range therefore selected 0.1.6, while mistralrs-core still called its old five-argument API.

This updates the call for the extra sparse-checkout paths argument and pins 0.1.6 exactly. Keeping 0.1.6 matters for GB10 because it adds SM121f architecture handling; the exact pin also prevents another incompatible 0.1.x patch from breaking unlocked installs.

Validation:

- RTX 4050 CUDA build compiled and ran the mistralrs-core build script without the reported E0061. I stopped the later full GDN kernel compilation after about seven minutes.
- Cargo metadata with the lockfile passes.
- The CUDA feature graph resolves cudaforge 0.1.6.
- Changed Rust file formatting and git diff checks pass.

The reporter's GB10 is still the best place to confirm the complete original cargo install command.
