### PR TITLE
fix: bump sysinfo to 0.38.4 so macOS CPU available memory is usable

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2857,7 +2857,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core",
+ "windows-core 0.61.2",
 ]
 
 [[package]]
@@ -6680,9 +6680,9 @@ dependencies = [
 
 [[package]]
 name = "sysinfo"
-version = "0.36.1"
+version = "0.38.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "252800745060e7b9ffb7b2badbd8b31cfa4aa2e61af879d0a3bf2a317c20217d"
+checksum = "92ab6a2f8bfe508deb3c6406578252e491d299cbbf3bc0529ecc3313aee4a52f"
 dependencies = [
  "libc",
  "memchr",
@@ -7861,24 +7861,23 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows"
-version = "0.61.3"
+version = "0.62.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9babd3a767a4c1aef6900409f85f5d53ce2544ccdfaa86dad48c91782c6d6893"
+checksum = "527fadee13e0c05939a6a05d5bd6eec6cd2e3dbd648b9f8e447c6518133d8580"
 dependencies = [
  "windows-collections",
- "windows-core",
+ "windows-core 0.62.2",
  "windows-future",
- "windows-link 0.1.3",
  "windows-numerics",
 ]
 
 [[package]]
 name = "windows-collections"
-version = "0.2.0"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3beeceb5e5cfd9eb1d76b381630e82c4241ccd0d27f1a39ed41b2760b255c5e8"
+checksum = "23b2d95af1a8a14a3c7367e1ed4fc9c20e0a26e79551b1454d72583c97cc6610"
 dependencies = [
- "windows-core",
+ "windows-core 0.62.2",
 ]
 
 [[package]]
@@ -7895,13 +7894,26 @@ dependencies = [
 ]
 
 [[package]]
-name = "windows-future"
-version = "0.2.1"
+name = "windows-core"
+version = "0.62.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc6a41e98427b19fe4b73c550f060b59fa592d7d686537eebf9385621bfbad8e"
+checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
 dependencies = [
- "windows-core",
- "windows-link 0.1.3",
+ "windows-implement",
+ "windows-interface",
+ "windows-link 0.2.1",
+ "windows-result 0.4.1",
+ "windows-strings 0.5.1",
+]
+
+[[package]]
+name = "windows-future"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1d6f90251fe18a279739e78025bd6ddc52a7e22f921070ccdc67dde84c605cb"
+dependencies = [
+ "windows-core 0.62.2",
+ "windows-link 0.2.1",
  "windows-threading",
 ]
 
@@ -7941,12 +7953,12 @@ checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
 
 [[package]]
 name = "windows-numerics"
-version = "0.2.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9150af68066c4c5c07ddc0ce30421554771e528bde427614c61038bc2c92c2b1"
+checksum = "6e2e40844ac143cdb44aead537bbf727de9b044e107a0f1220392177d15b0f26"
 dependencies = [
- "windows-core",
- "windows-link 0.1.3",
+ "windows-core 0.62.2",
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -8115,11 +8127,11 @@ dependencies = [
 
 [[package]]
 name = "windows-threading"
-version = "0.1.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b66463ad2e0ea3bbf808b7f1d371311c80e115c0b71d60efc142cafbcfb057a6"
+checksum = "3949bd5b99cafdf1c7ca86b43ca564028dfe27d66958f2470940f73d86d75b37"
 dependencies = [
- "windows-link 0.1.3",
+ "windows-link 0.2.1",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -135,7 +135,7 @@ derive_more = { version = "2.1.1", default-features = false, features = ["from"]
 akin = "0.4.0"
 variantly = "0.4.0"
 derive-new = "0.7.0"
-sysinfo = "0.36.1"
+sysinfo = "0.38.4"
 csv = "1.4.0"
 bytemuck_derive = "1.10.2"
 uuid = "1.19.0"


### PR DESCRIPTION
Fixes #2419.

CPU diagnostics and auto device mapping use `sysinfo::System::available_memory()` as-is. On macOS, sysinfo 0.36.1 computes that as `free + inactive + purgeable - compressor`, which saturates to 0 under compressor pressure. `mistralrs doctor` then shows `0.0 GB available`, and CPU loads fail with `0 MB of usable capacity` even when `memory_pressure` reports free memory.

sysinfo 0.38.3 aligned the macOS value with XNU `AVAILABLE_NON_COMPRESSED_MEMORY` (`active + inactive + free`). This bump uses 0.38.4, the newest release that still fits the workspace MSRV (1.94). 0.39 needs Rust 1.95. Linux and Windows available-memory formulas are unchanged, and call sites did not need updates.

No macOS-specific haircut is added. CPU continues to take sysinfo's portable `available_memory()`; Metal still uses its own working-set budget.

Other sysinfo call sites are doctor-only (CPU brand/cores, OS/kernel, HF-cache disk space). Linux and Windows RAM available is unchanged. Linux 0.38 also tightens CPU `/proc/cpuinfo` parsing and disk size (`f_frsize` instead of `f_bsize`); that can change doctor strings on some ARM layouts or filesystems, not CPU device mapping.

## Test plan
- [x] `mistralrs doctor` on macOS CPU: `0.0 GB available` before, ~20 GB after, in line with `memory_pressure`
- [x] CPU UQFF load that previously failed at 0 MB now loads and generates
- [x] `cargo check` / fmt / diff on the two-file change
- [ ] CI on this PR