### PR TITLE
fix(core): propagate GGUF architecture error instead of panicking

### DIFF
--- a/mistralrs-core/src/gguf/content.rs
+++ b/mistralrs-core/src/gguf/content.rs
@@ -137,21 +137,21 @@ impl<'a, R: std::io::Seek + std::io::Read> Content<'a, R> {
             info!("GGUF file has been split into {} shards", n_splits[0]);
         }
 
-        let mut arch = None;
-        for ct in &contents {
-            if !ct.metadata.contains_key("general.architecture") {
-                continue;
-            }
-
-            arch = Some(
-                ct.metadata["general.architecture"]
-                    .to_string()
+        let arch = contents
+            .iter()
+            .find_map(|ct| ct.metadata.get("general.architecture"))
+            .map(|a| {
+                a.to_string()
                     .context("Model metadata should have declared an architecture")
                     .and_then(GGUFArchitecture::from_value)
-                    .unwrap(),
-            );
-        }
-        let arch = arch.expect("GGUF files must specify `general.architecture`");
+                    .map_err(|e| candle_core::Error::msg(e.to_string()))
+            })
+            .transpose()?
+            .ok_or_else(|| {
+                candle_core::Error::Msg(
+                    "GGUF files must specify `general.architecture`".to_string(),
+                )
+            })?;
 
         let mut all_metadata = HashMap::new();
         for content in &contents {


### PR DESCRIPTION
## What

`Content::from_readers` panicked when a GGUF file declared an unsupported architecture (e.g. `gemma4` from Unsloth's Gemma 4 GGUFs) or when no file provided `general.architecture`:

- `unwrap()` on the architecture lookup → panic on unknown architecture
- `expect()` afterward → panic when no file declared an architecture

## Fix

Replace both panic sites with propagated `Result` errors, so the user gets a clean `Unknown GGUF architecture gemma4` error instead of a thread panic. Refactored the O(n) loop into a `find_map` + `transpose` chain.

## Note

The follow-up (actually supporting `gemma4` GGUFs) is separate; this only turns the crash into a proper error.

Closes #2098